### PR TITLE
ci: update crosstool-ng config. for x86_64 and aarch64

### DIFF
--- a/build/toolchains/toolchainbuild/crosstool-ng/aarch64-unknown-linux-gnueabi.config
+++ b/build/toolchains/toolchainbuild/crosstool-ng/aarch64-unknown-linux-gnueabi.config
@@ -4,6 +4,7 @@
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
+CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
 CT_CONFIGURE_has_make_4_0_or_newer=y
@@ -11,8 +12,11 @@ CT_CONFIGURE_has_libtool_2_4_or_newer=y
 CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
 CT_CONFIGURE_has_autoconf_2_65_or_newer=y
 CT_CONFIGURE_has_autoreconf_2_65_or_newer=y
+CT_CONFIGURE_has_automake_1_15_or_newer=y
 CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
+CT_CONFIGURE_has_python_3_4_or_newer=y
 CT_CONFIGURE_has_bison_2_7_or_newer=y
+CT_CONFIGURE_has_python=y
 CT_CONFIGURE_has_git=y
 CT_CONFIGURE_has_md5sum=y
 CT_CONFIGURE_has_sha1sum=y
@@ -55,6 +59,7 @@ CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 #
 # Downloading
 #
+# CT_DOWNLOAD_AGENT_WGET is not set
 CT_DOWNLOAD_AGENT_CURL=y
 # CT_DOWNLOAD_AGENT_NONE is not set
 # CT_FORBID_DOWNLOAD is not set
@@ -282,16 +287,16 @@ CT_LINUX_PATCH_ORDER="global"
 # CT_LINUX_V_3_13 is not set
 # CT_LINUX_V_3_12 is not set
 # CT_LINUX_V_3_11 is not set
-# CT_LINUX_V_3_10 is not set
+CT_LINUX_V_3_10=y
 # CT_LINUX_V_3_9 is not set
 # CT_LINUX_V_3_8 is not set
-CT_LINUX_V_3_7=y
+# CT_LINUX_V_3_7 is not set
 # CT_LINUX_NO_VERSIONS is not set
-CT_LINUX_VERSION="3.7.10"
+CT_LINUX_VERSION="3.10.108"
 CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
 CT_LINUX_4_8_or_older=y
 CT_LINUX_older_than_4_8=y
@@ -300,7 +305,6 @@ CT_LINUX_3_7_or_later=y
 CT_LINUX_REQUIRE_3_7_or_later=y
 CT_LINUX_later_than_3_2=y
 CT_LINUX_3_2_or_later=y
-CT_LINUX_REQUIRE_3_2_or_later=y
 CT_KERNEL_LINUX_VERBOSITY_0=y
 # CT_KERNEL_LINUX_VERBOSITY_1 is not set
 # CT_KERNEL_LINUX_VERBOSITY_2 is not set
@@ -420,10 +424,11 @@ CT_GLIBC_PATCH_GLOBAL=y
 # CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
 # CT_GLIBC_PATCH_NONE is not set
 CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_29 is not set
 # CT_GLIBC_V_2_28 is not set
 # CT_GLIBC_V_2_27 is not set
 # CT_GLIBC_V_2_26 is not set
-CT_GLIBC_V_2_25=y
+# CT_GLIBC_V_2_25 is not set
 # CT_GLIBC_V_2_24 is not set
 # CT_GLIBC_V_2_23 is not set
 # CT_GLIBC_V_2_22 is not set
@@ -431,7 +436,7 @@ CT_GLIBC_V_2_25=y
 # CT_GLIBC_V_2_20 is not set
 # CT_GLIBC_V_2_19 is not set
 # CT_GLIBC_V_2_18 is not set
-# CT_GLIBC_V_2_17 is not set
+CT_GLIBC_V_2_17=y
 # CT_GLIBC_V_2_16_0 is not set
 # CT_GLIBC_V_2_15 is not set
 # CT_GLIBC_V_2_14_1 is not set
@@ -439,7 +444,7 @@ CT_GLIBC_V_2_25=y
 # CT_GLIBC_V_2_12_2 is not set
 # CT_GLIBC_V_2_12_1 is not set
 # CT_GLIBC_NO_VERSIONS is not set
-CT_GLIBC_VERSION="2.25"
+CT_GLIBC_VERSION="2.17"
 CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
 CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -447,31 +452,32 @@ CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
 CT_GLIBC_2_29_or_older=y
 CT_GLIBC_older_than_2_29=y
-CT_GLIBC_REQUIRE_older_than_2_29=y
 CT_GLIBC_2_27_or_older=y
 CT_GLIBC_older_than_2_27=y
 CT_GLIBC_2_26_or_older=y
 CT_GLIBC_older_than_2_26=y
-CT_GLIBC_2_25_or_later=y
 CT_GLIBC_2_25_or_older=y
-CT_GLIBC_later_than_2_24=y
-CT_GLIBC_2_24_or_later=y
-CT_GLIBC_later_than_2_23=y
-CT_GLIBC_2_23_or_later=y
-CT_GLIBC_later_than_2_20=y
-CT_GLIBC_2_20_or_later=y
-CT_GLIBC_later_than_2_17=y
+CT_GLIBC_older_than_2_25=y
+CT_GLIBC_2_24_or_older=y
+CT_GLIBC_older_than_2_24=y
+CT_GLIBC_2_23_or_older=y
+CT_GLIBC_older_than_2_23=y
+CT_GLIBC_2_20_or_older=y
+CT_GLIBC_older_than_2_20=y
 CT_GLIBC_2_17_or_later=y
+CT_GLIBC_2_17_or_older=y
 CT_GLIBC_later_than_2_14=y
 CT_GLIBC_2_14_or_later=y
 CT_GLIBC_DEP_KERNEL_HEADERS_VERSION=y
 CT_GLIBC_DEP_BINUTILS=y
 CT_GLIBC_DEP_GCC=y
 CT_GLIBC_DEP_PYTHON=y
-CT_GLIBC_BUILD_SSP=y
+CT_GLIBC_HAS_NPTL_ADDON=y
+CT_GLIBC_HAS_PORTS_ADDON=y
 CT_GLIBC_HAS_LIBIDN_ADDON=y
+CT_GLIBC_USE_PORTS_ADDON=y
+CT_GLIBC_USE_NPTL_ADDON=y
 # CT_GLIBC_USE_LIBIDN_ADDON is not set
-CT_GLIBC_NO_SPARC_V8=y
 CT_GLIBC_HAS_OBSOLETE_RPC=y
 CT_GLIBC_EXTRA_CONFIG_ARRAY=""
 CT_GLIBC_CONFIGPARMS=""
@@ -485,13 +491,12 @@ CT_GLIBC_FORCE_UNWIND=y
 # CT_GLIBC_KERNEL_VERSION_NONE is not set
 CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
 # CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
-CT_GLIBC_MIN_KERNEL="3.7.10"
-CT_GLIBC_SSP_DEFAULT=y
+CT_GLIBC_MIN_KERNEL="3.10.108"
+# CT_GLIBC_SSP_DEFAULT is not set
 # CT_GLIBC_SSP_NO is not set
 # CT_GLIBC_SSP_YES is not set
 # CT_GLIBC_SSP_ALL is not set
 # CT_GLIBC_SSP_STRONG is not set
-CT_GLIBC_ENABLE_WERROR=y
 CT_ALL_LIBC_CHOICES="AVR_LIBC BIONIC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC"
 CT_LIBC_SUPPORT_THREADS_ANY=y
 CT_LIBC_SUPPORT_THREADS_NATIVE=y

--- a/build/toolchains/toolchainbuild/crosstool-ng/x86_64-unknown-linux-gnu.config
+++ b/build/toolchains/toolchainbuild/crosstool-ng/x86_64-unknown-linux-gnu.config
@@ -4,6 +4,7 @@
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
+CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
 CT_CONFIGURE_has_make_4_0_or_newer=y
@@ -11,8 +12,11 @@ CT_CONFIGURE_has_libtool_2_4_or_newer=y
 CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
 CT_CONFIGURE_has_autoconf_2_65_or_newer=y
 CT_CONFIGURE_has_autoreconf_2_65_or_newer=y
+CT_CONFIGURE_has_automake_1_15_or_newer=y
 CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
+CT_CONFIGURE_has_python_3_4_or_newer=y
 CT_CONFIGURE_has_bison_2_7_or_newer=y
+CT_CONFIGURE_has_python=y
 CT_CONFIGURE_has_git=y
 CT_CONFIGURE_has_md5sum=y
 CT_CONFIGURE_has_sha1sum=y
@@ -55,6 +59,7 @@ CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 #
 # Downloading
 #
+# CT_DOWNLOAD_AGENT_WGET is not set
 CT_DOWNLOAD_AGENT_CURL=y
 # CT_DOWNLOAD_AGENT_NONE is not set
 # CT_FORBID_DOWNLOAD is not set
@@ -274,7 +279,7 @@ CT_LINUX_PATCH_ORDER="global"
 # CT_LINUX_V_3_13 is not set
 # CT_LINUX_V_3_12 is not set
 # CT_LINUX_V_3_11 is not set
-# CT_LINUX_V_3_10 is not set
+CT_LINUX_V_3_10=y
 # CT_LINUX_V_3_9 is not set
 # CT_LINUX_V_3_8 is not set
 # CT_LINUX_V_3_7 is not set
@@ -292,9 +297,9 @@ CT_LINUX_PATCH_ORDER="global"
 # CT_LINUX_V_2_6_35 is not set
 # CT_LINUX_V_2_6_34 is not set
 # CT_LINUX_V_2_6_33 is not set
-CT_LINUX_V_2_6_32=y
+# CT_LINUX_V_2_6_32 is not set
 # CT_LINUX_NO_VERSIONS is not set
-CT_LINUX_VERSION="2.6.32.71"
+CT_LINUX_VERSION="3.10.108"
 CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -302,10 +307,10 @@ CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
 CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
 CT_LINUX_4_8_or_older=y
 CT_LINUX_older_than_4_8=y
-CT_LINUX_3_7_or_older=y
-CT_LINUX_older_than_3_7=y
-CT_LINUX_3_2_or_older=y
-CT_LINUX_older_than_3_2=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
 CT_KERNEL_LINUX_VERBOSITY_0=y
 # CT_KERNEL_LINUX_VERBOSITY_1 is not set
 # CT_KERNEL_LINUX_VERBOSITY_2 is not set
@@ -427,6 +432,7 @@ CT_GLIBC_PATCH_GLOBAL=y
 # CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
 # CT_GLIBC_PATCH_NONE is not set
 CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_29 is not set
 # CT_GLIBC_V_2_28 is not set
 # CT_GLIBC_V_2_27 is not set
 # CT_GLIBC_V_2_26 is not set
@@ -438,15 +444,15 @@ CT_GLIBC_PATCH_ORDER="global"
 # CT_GLIBC_V_2_20 is not set
 # CT_GLIBC_V_2_19 is not set
 # CT_GLIBC_V_2_18 is not set
-# CT_GLIBC_V_2_17 is not set
+CT_GLIBC_V_2_17=y
 # CT_GLIBC_V_2_16_0 is not set
 # CT_GLIBC_V_2_15 is not set
 # CT_GLIBC_V_2_14_1 is not set
 # CT_GLIBC_V_2_13 is not set
-CT_GLIBC_V_2_12_2=y
+# CT_GLIBC_V_2_12_2 is not set
 # CT_GLIBC_V_2_12_1 is not set
 # CT_GLIBC_NO_VERSIONS is not set
-CT_GLIBC_VERSION="2.12.2"
+CT_GLIBC_VERSION="2.17"
 CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
 CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -454,7 +460,6 @@ CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
 CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
 CT_GLIBC_2_29_or_older=y
 CT_GLIBC_older_than_2_29=y
-CT_GLIBC_REQUIRE_older_than_2_29=y
 CT_GLIBC_2_27_or_older=y
 CT_GLIBC_older_than_2_27=y
 CT_GLIBC_2_26_or_older=y
@@ -467,23 +472,24 @@ CT_GLIBC_2_23_or_older=y
 CT_GLIBC_older_than_2_23=y
 CT_GLIBC_2_20_or_older=y
 CT_GLIBC_older_than_2_20=y
+CT_GLIBC_2_17_or_later=y
 CT_GLIBC_2_17_or_older=y
-CT_GLIBC_older_than_2_17=y
-CT_GLIBC_2_14_or_older=y
-CT_GLIBC_older_than_2_14=y
+CT_GLIBC_later_than_2_14=y
+CT_GLIBC_2_14_or_later=y
 CT_GLIBC_DEP_KERNEL_HEADERS_VERSION=y
 CT_GLIBC_DEP_BINUTILS=y
 CT_GLIBC_DEP_GCC=y
 CT_GLIBC_DEP_PYTHON=y
 CT_GLIBC_HAS_NPTL_ADDON=y
 CT_GLIBC_HAS_PORTS_ADDON=y
-CT_GLIBC_HAS_PORTS_ADDON_EXTERNAL=y
 CT_GLIBC_HAS_LIBIDN_ADDON=y
 CT_GLIBC_USE_NPTL_ADDON=y
 # CT_GLIBC_USE_LIBIDN_ADDON is not set
+CT_GLIBC_HAS_OBSOLETE_RPC=y
 CT_GLIBC_EXTRA_CONFIG_ARRAY=""
 CT_GLIBC_CONFIGPARMS=""
 CT_GLIBC_EXTRA_CFLAGS=""
+CT_GLIBC_ENABLE_OBSOLETE_RPC=y
 # CT_GLIBC_ENABLE_FORTIFIED_BUILD is not set
 # CT_GLIBC_DISABLE_VERSIONING is not set
 CT_GLIBC_OLDEST_ABI=""
@@ -492,7 +498,12 @@ CT_GLIBC_FORCE_UNWIND=y
 # CT_GLIBC_KERNEL_VERSION_NONE is not set
 CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
 # CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
-CT_GLIBC_MIN_KERNEL="2.6.32.71"
+CT_GLIBC_MIN_KERNEL="3.10.108"
+# CT_GLIBC_SSP_DEFAULT is not set
+# CT_GLIBC_SSP_NO is not set
+# CT_GLIBC_SSP_YES is not set
+# CT_GLIBC_SSP_ALL is not set
+# CT_GLIBC_SSP_STRONG is not set
 CT_ALL_LIBC_CHOICES="AVR_LIBC BIONIC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC"
 CT_LIBC_SUPPORT_THREADS_ANY=y
 CT_LIBC_SUPPORT_THREADS_NATIVE=y


### PR DESCRIPTION
Previously, x86_64 and aarch64 used different kernel and glibc versions.
This resulted in inconsistent builds of jemalloc, x86_64 using
MADV_DONTNEED and aarch64 using MADV_FREE. The glibc version
is outdated; this became an issue for linking against Antithesis'
instrumentation library which had a dependency on a newer version.

This change brings both the kernel and the glibc versions in-sync
between the two target. The new kernel and the glibc versions are
both compatible with RHEL 7.
Update kernel version to 3.10.108.
Update glibc version to 2.17

Release note: None
Resolves: https://github.com/cockroachdb/cockroach/issues/42430
Resolves: https://github.com/cockroachdb/cockroach/issues/83750