### PR TITLE
storage: remove experimental markers for MVCC range tombstones

### DIFF
--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -649,14 +649,10 @@ func (b *Batch) DelRange(s, e interface{}, returnKeys bool) {
 	b.initResult(1, 0, notRaw, nil)
 }
 
-// ExperimentalDelRangeUsingTombstone deletes the rows between begin (inclusive)
-// and end (exclusive) using an MVCC range tombstone. Callers must check the
+// DelRangeUsingTombstone deletes the rows between begin (inclusive) and end
+// (exclusive) using an MVCC range tombstone. Callers must check the
 // MVCCRangeTombstones version gate before using this.
-//
-// This method is EXPERIMENTAL: range tombstones are under active development,
-// and have severe limitations including being ignored by all KV and MVCC APIs
-// and only being stored in memory.
-func (b *Batch) ExperimentalDelRangeUsingTombstone(s, e interface{}) {
+func (b *Batch) DelRangeUsingTombstone(s, e interface{}) {
 	start, err := marshalKey(s)
 	if err != nil {
 		b.initResult(0, 0, notRaw, err)
@@ -672,7 +668,7 @@ func (b *Batch) ExperimentalDelRangeUsingTombstone(s, e interface{}) {
 			Key:    start,
 			EndKey: end,
 		},
-		UseExperimentalRangeTombstone: true,
+		UseRangeTombstone: true,
 	})
 	b.initResult(1, 0, notRaw, nil)
 }

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -548,18 +548,12 @@ func (db *DB) DelRange(
 	return r.Keys, err
 }
 
-// ExperimentalDelRangeUsingTombstone deletes the rows between begin (inclusive)
-// and end (exclusive) using an MVCC range tombstone. Callers must check the
+// DelRangeUsingTombstone deletes the rows between begin (inclusive) and end
+// (exclusive) using an MVCC range tombstone. Callers must check the
 // MVCCRangeTombstones version gate before using this.
-//
-// This method is EXPERIMENTAL: range tombstones are under active development,
-// and have severe limitations including being ignored by all KV and MVCC APIs
-// and only being stored in memory.
-func (db *DB) ExperimentalDelRangeUsingTombstone(
-	ctx context.Context, begin, end interface{},
-) error {
+func (db *DB) DelRangeUsingTombstone(ctx context.Context, begin, end interface{}) error {
 	b := &Batch{}
-	b.ExperimentalDelRangeUsingTombstone(begin, end)
+	b.DelRangeUsingTombstone(begin, end)
 	_, err := getOneResult(db.Run(ctx, b), b)
 	return err
 }

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -180,9 +180,9 @@ func WithOnSSTable(f OnSSTable) Option {
 }
 
 // OnDeleteRange is called when an MVCC range tombstone is written (e.g. when
-// DeleteRange is called with UseExperimentalRangeTombstone, but not when the
-// range is deleted using point tombstones). If this callback is not provided,
-// an error is emitted when these are encountered.
+// DeleteRange is called with UseRangeTombstone, but not when the range is
+// deleted using point tombstones). If this callback is not provided, an error
+// is emitted when these are encountered.
 //
 // MVCC range tombstones are currently experimental, and requires the
 // MVCCRangeTombstones version gate. They are only expected during certain

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -666,11 +666,11 @@ func TestWithOnDeleteRange(t *testing.T) {
 	// catchup point, and the previous values should respect the range tombstones.
 	require.NoError(t, db.Put(ctx, "covered", "covered"))
 	require.NoError(t, db.Put(ctx, "foo", "covered"))
-	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, "a", "z"))
 	require.NoError(t, db.Put(ctx, "foo", "initial"))
 	rangeFeedTS := db.Clock().Now()
 	require.NoError(t, db.Put(ctx, "covered", "catchup"))
-	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, "a", "z"))
 	require.NoError(t, db.Put(ctx, "foo", "catchup"))
 
 	// We start the rangefeed over a narrower span than the DeleteRanges (c-g),
@@ -767,7 +767,7 @@ func TestWithOnDeleteRange(t *testing.T) {
 
 	// Send another DeleteRange, and wait for the rangefeed event. This should
 	// be truncated to the rangefeed bounds (c-g).
-	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, "a", "z"))
 	select {
 	case e := <-deleteRangeC:
 		require.Equal(t, roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("g")}, e.Span)

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -424,7 +424,7 @@ func EvalAddSSTable(
 				if err != nil {
 					return result.Result{}, err
 				}
-				if err = readWriter.ExperimentalPutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+				if err = readWriter.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
 					return result.Result{}, err
 				}
 				if sstToReqTS.IsSet() {

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -763,7 +763,7 @@ func TestEvalAddSSTable(t *testing.T) {
 								v, err := storage.DecodeMVCCValue(kv.Value)
 								require.NoError(t, err)
 								require.True(t, v.IsTombstone(), "MVCC range keys must be tombstones")
-								require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(
+								require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 									ctx, b, nil, kv.RangeKey.StartKey, kv.RangeKey.EndKey, kv.RangeKey.Timestamp, v.MVCCValueHeader.LocalTimestamp, nil, nil, 0))
 							default:
 								t.Fatalf("unknown KV type %T", kv)

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -148,7 +148,7 @@ func TestCmdClearRange(t *testing.T) {
 				}
 				for _, rk := range rangeTombstones {
 					localTS := hlc.ClockTimestamp{WallTime: rk.Timestamp.WallTime - 1e9} // give range key a value if > 0
-					require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(
+					require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 						ctx, eng, nil, rk.StartKey, rk.EndKey, rk.Timestamp, localTS, nil, nil, 0))
 				}
 

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -44,7 +44,7 @@ func declareKeysDeleteRange(
 	// When writing range tombstones, we must look for adjacent range tombstones
 	// that we merge with or fragment, to update MVCC stats accordingly. But we
 	// make sure to stay within the range bounds.
-	if args.UseExperimentalRangeTombstone {
+	if args.UseRangeTombstone {
 		// NB: The range end key is not available, so this will pessimistically
 		// latch up to args.EndKey.Next(). If EndKey falls on the range end key, the
 		// span will be tightened during evaluation.
@@ -68,7 +68,7 @@ func DeleteRange(
 	reply := resp.(*roachpb.DeleteRangeResponse)
 
 	// Use experimental MVCC range tombstone if requested.
-	if args.UseExperimentalRangeTombstone {
+	if args.UseRangeTombstone {
 		if cArgs.Header.Txn != nil {
 			return result.Result{}, ErrTransactionUnsupported
 		}
@@ -85,7 +85,7 @@ func DeleteRange(
 			args.Key, args.EndKey, desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey())
 		maxIntents := storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 
-		err := storage.ExperimentalMVCCDeleteRangeUsingTombstone(ctx, readWriter, cArgs.Stats,
+		err := storage.MVCCDeleteRangeUsingTombstone(ctx, readWriter, cArgs.Stats,
 			args.Key, args.EndKey, h.Timestamp, cArgs.Now, leftPeekBound, rightPeekBound, maxIntents)
 		return result.Result{}, err
 	}
@@ -119,9 +119,9 @@ func DeleteRange(
 }
 
 // rangeTombstonePeekBounds returns the left and right bounds that
-// ExperimentalMVCCDeleteRangeUsingTombstone can read in order to detect
-// adjacent range tombstones to merge with or fragment. The bounds will be
-// truncated to the Raft range bounds if given.
+// MVCCDeleteRangeUsingTombstone can read in order to detect adjacent range
+// tombstones to merge with or fragment. The bounds will be truncated to the
+// Raft range bounds if given.
 func rangeTombstonePeekBounds(
 	startKey, endKey, rangeStart, rangeEnd roachpb.Key,
 ) (roachpb.Key, roachpb.Key) {

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -60,9 +60,9 @@ func TestDeleteRangeTombstone(t *testing.T) {
 		require.NoError(t, storage.MVCCPut(ctx, rw, nil, roachpb.Key("d"), hlc.Timestamp{WallTime: 2e9}, localTS, roachpb.MakeValueFromString("d2"), nil))
 		require.NoError(t, storage.MVCCDelete(ctx, rw, nil, roachpb.Key("d"), hlc.Timestamp{WallTime: 3e9}, localTS, nil))
 		require.NoError(t, storage.MVCCPut(ctx, rw, nil, roachpb.Key("i"), hlc.Timestamp{WallTime: 5e9}, localTS, roachpb.MakeValueFromString("i5"), &txn))
-		require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("f"), roachpb.Key("h"), hlc.Timestamp{WallTime: 3e9}, localTS, nil, nil, 0))
-		require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("Z"), roachpb.Key("a"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, 0))
-		require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("z"), roachpb.Key("|"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, 0))
+		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("f"), roachpb.Key("h"), hlc.Timestamp{WallTime: 3e9}, localTS, nil, nil, 0))
+		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("Z"), roachpb.Key("a"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, 0))
+		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("z"), roachpb.Key("|"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, 0))
 	}
 
 	now := hlc.ClockTimestamp{Logical: 9}
@@ -180,9 +180,9 @@ func TestDeleteRangeTombstone(t *testing.T) {
 					Key:    rangeKey.StartKey,
 					EndKey: rangeKey.EndKey,
 				},
-				UseExperimentalRangeTombstone: true,
-				Inline:                        tc.inline,
-				ReturnKeys:                    tc.returnKeys,
+				UseRangeTombstone: true,
+				Inline:            tc.inline,
+				ReturnKeys:        tc.returnKeys,
 			}
 
 			ms := computeStats(t, engine, rangeStart, rangeEnd, rangeKey.Timestamp.WallTime)

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -1281,7 +1281,7 @@ func TestComputeSplitRangeKeyStatsDelta(t *testing.T) {
 			for _, rkv := range tc.rangeKVs {
 				value, err := storage.DecodeMVCCValue(rkv.Value)
 				require.NoError(t, err)
-				require.NoError(t, engine.ExperimentalPutMVCCRangeKey(rkv.RangeKey, value))
+				require.NoError(t, engine.PutMVCCRangeKey(rkv.RangeKey, value))
 			}
 
 			tc.expect.LastUpdateNanos = nowNanos

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
@@ -41,7 +41,7 @@ func TestRefreshRange(t *testing.T) {
 		ctx, eng, nil, roachpb.Key("b"), hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("value"), nil))
 	require.NoError(t, storage.MVCCPut(
 		ctx, eng, nil, roachpb.Key("c"), hlc.Timestamp{WallTime: 5}, hlc.ClockTimestamp{}, roachpb.Value{}, nil))
-	require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(
+	require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 		ctx, eng, nil, roachpb.Key("d"), roachpb.Key("f"), hlc.Timestamp{WallTime: 7}, hlc.ClockTimestamp{}, nil, nil, 0))
 
 	testcases := map[string]struct {

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5728,7 +5728,7 @@ func TestRaftSnapshotsWithMVCCRangeKeys(t *testing.T) {
 			Key:    roachpb.Key("a"),
 			EndKey: roachpb.Key("d"),
 		},
-		UseExperimentalRangeTombstone: true,
+		UseRangeTombstone: true,
 	})
 	require.NoError(t, pErr.GoError())
 
@@ -5740,7 +5740,7 @@ func TestRaftSnapshotsWithMVCCRangeKeys(t *testing.T) {
 			Key:    roachpb.Key("b"),
 			EndKey: roachpb.Key("e"),
 		},
-		UseExperimentalRangeTombstone: true,
+		UseRangeTombstone: true,
 	})
 	require.NoError(t, pErr.GoError())
 
@@ -5833,7 +5833,7 @@ func TestRaftSnapshotsWithMVCCRangeKeysEverywhere(t *testing.T) {
 	for _, desc := range descs {
 		for _, keyRange := range rditer.MakeReplicatedKeyRanges(&desc) {
 			prefix := append(keyRange.Start.Clone(), ':')
-			require.NoError(t, engine.ExperimentalPutMVCCRangeKey(storage.MVCCRangeKey{
+			require.NoError(t, engine.PutMVCCRangeKey(storage.MVCCRangeKey{
 				StartKey:  append(prefix.Clone(), 'a'),
 				EndKey:    append(prefix.Clone(), 'z'),
 				Timestamp: now,

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -505,7 +505,7 @@ func WriteRandomDataToRange(
 					Key:    startKey,
 					EndKey: endKey,
 				},
-				UseExperimentalRangeTombstone: true,
+				UseRangeTombstone: true,
 			}
 		} else {
 			// Write regular point keys.

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -111,7 +111,7 @@ func createRangeData(
 				replicatedKeys = append(replicatedKeys, key)
 			}
 		case storage.MVCCRangeKey:
-			require.NoError(t, eng.ExperimentalPutMVCCRangeKey(key, storage.MVCCValue{}))
+			require.NoError(t, eng.PutMVCCRangeKey(key, storage.MVCCValue{}))
 			if !bytes.HasPrefix(key.StartKey, unreplicatedPrefix) {
 				replicatedKeys = append(replicatedKeys, key)
 			}
@@ -316,7 +316,7 @@ func TestReplicaDataIteratorGlobalRangeKey(t *testing.T) {
 	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
-	require.NoError(t, eng.ExperimentalPutEngineRangeKey(keys.MinKey.Next(), keys.MaxKey, []byte{1}, []byte{}))
+	require.NoError(t, eng.PutEngineRangeKey(keys.MinKey.Next(), keys.MaxKey, []byte{1}, []byte{}))
 
 	// Use a snapshot for the iteration, because we need consistent
 	// iterators.

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -180,7 +180,7 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 		}
 
 		if len(endKey) > 0 {
-			require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(
+			require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 				ctx, eng, nil, key, endKey, ts, localTS, nil, nil, 0))
 		} else {
 			require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, ts, localTS, value, nil))

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1736,7 +1736,7 @@ func getExpectedSnapshotSizeBytes(
 				return 0, err
 			}
 			for _, rkv := range iter.RangeKeys() {
-				err := b.ExperimentalPutEngineRangeKey(bounds.Key, bounds.EndKey, rkv.Version, rkv.Value)
+				err := b.PutEngineRangeKey(bounds.Key, bounds.EndKey, rkv.Version, rkv.Value)
 				if err != nil {
 					return 0, err
 				}

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -616,42 +616,40 @@ func (s spanSetWriter) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 	return s.w.ClearMVCCIteratorRange(start, end)
 }
 
-func (s spanSetWriter) ExperimentalPutMVCCRangeKey(
+func (s spanSetWriter) PutMVCCRangeKey(
 	rangeKey storage.MVCCRangeKey, value storage.MVCCValue,
 ) error {
 	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
 		return err
 	}
-	return s.w.ExperimentalPutMVCCRangeKey(rangeKey, value)
+	return s.w.PutMVCCRangeKey(rangeKey, value)
 }
 
-func (s spanSetWriter) ExperimentalPutEngineRangeKey(
-	start, end roachpb.Key, suffix, value []byte,
-) error {
+func (s spanSetWriter) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	if !s.spansOnly {
-		panic("cannot do timestamp checking for ExperimentalPutEngineRangeKey")
+		panic("cannot do timestamp checking for PutEngineRangeKey")
 	}
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ExperimentalPutEngineRangeKey(start, end, suffix, value)
+	return s.w.PutEngineRangeKey(start, end, suffix, value)
 }
 
-func (s spanSetWriter) ExperimentalClearMVCCRangeKey(rangeKey storage.MVCCRangeKey) error {
+func (s spanSetWriter) ClearMVCCRangeKey(rangeKey storage.MVCCRangeKey) error {
 	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
 		return err
 	}
-	return s.w.ExperimentalClearMVCCRangeKey(rangeKey)
+	return s.w.ClearMVCCRangeKey(rangeKey)
 }
 
-func (s spanSetWriter) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
+func (s spanSetWriter) ClearAllRangeKeys(start, end roachpb.Key) error {
 	if !s.spansOnly {
-		panic("cannot do timestamp checking for ExperimentalClearAllRangeKeys")
+		panic("cannot do timestamp checking for ClearAllRangeKeys")
 	}
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ExperimentalClearAllRangeKeys(start, end)
+	return s.w.ClearAllRangeKeys(start, end)
 }
 
 func (s spanSetWriter) Merge(key storage.MVCCKey, value []byte) error {

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -240,7 +240,7 @@ func (msstw *multiSSTWriter) PutRangeKey(
 		return errors.AssertionFailedf("client error: expected %s to fall in one of %s",
 			roachpb.Span{Key: start, EndKey: end}, msstw.keyRanges)
 	}
-	if err := msstw.currSST.ExperimentalPutEngineRangeKey(start, end, suffix, value); err != nil {
+	if err := msstw.currSST.PutEngineRangeKey(start, end, suffix, value); err != nil {
 		return errors.Wrap(err, "failed to put range key in sst")
 	}
 	return nil
@@ -463,7 +463,7 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 			}
 			for _, rkv := range iter.RangeKeys() {
 				rangeKVs++
-				err := b.ExperimentalPutEngineRangeKey(bounds.Key, bounds.EndKey, rkv.Version, rkv.Value)
+				err := b.PutEngineRangeKey(bounds.Key, bounds.EndKey, rkv.Version, rkv.Value)
 				if err != nil {
 					return 0, err
 				}

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1298,7 +1298,7 @@ func (*DeleteRequest) flags() flag {
 
 func (drr *DeleteRangeRequest) flags() flag {
 	// DeleteRangeRequest using MVCC range tombstones cannot be transactional.
-	if drr.UseExperimentalRangeTombstone {
+	if drr.UseRangeTombstone {
 		return isWrite | isRange | isAlone | appliesTSCache
 	}
 	// DeleteRangeRequest has different properties if the "inline" flag is set.

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -349,17 +349,13 @@ message DeleteRangeRequest {
   // "inline" set to true will fail if it is executed within a transaction.
   bool inline = 4;
   // If enabled, the range is deleted using an MVCC range tombstone, which is a
-  // cheaper constant-time write operation (but still requires a time-bounded
-  // scan to check for conflicts). This option cannot be used in a transaction,
-  // and it cannot be combined with Inline or ReturnKeys.
+  // cheaper constant-time write operation (but still requires a scan to check
+  // for conflicts and adjust MVCC stats). This option cannot be used in a
+  // transaction, and it cannot be combined with Inline or ReturnKeys.
   //
   // The caller must check the MVCCRangeTombstones version gate before using
   // this parameter, as it is new in 22.2.
-  //
-  // This parameter is EXPERIMENTAL: range tombstones are under active
-  // development, and have severe limitations including being ignored by all
-  // KV and MVCC APIs and only being stored in memory.
-  bool use_experimental_range_tombstone = 5;
+  bool use_range_tombstone = 5;
 }
 
 // A DeleteRangeResponse is the return value from the DeleteRange()

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -372,7 +372,7 @@ func TestFlagCombinations(t *testing.T) {
 	reqVariants := []Request{
 		&AddSSTableRequest{SSTTimestampToRequestTimestamp: hlc.Timestamp{Logical: 1}},
 		&DeleteRangeRequest{Inline: true},
-		&DeleteRangeRequest{UseExperimentalRangeTombstone: true},
+		&DeleteRangeRequest{UseRangeTombstone: true},
 		&GetRequest{KeyLocking: lock.Exclusive},
 		&ReverseScanRequest{KeyLocking: lock.Exclusive},
 		&ScanRequest{KeyLocking: lock.Exclusive},

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -1126,11 +1126,11 @@ func TestPebbleBatchReader(t *testing.T) {
 	require.NoError(t, b.PutEngineKey(engineKey("engineKey", 0), []byte("engineValue")))
 	require.NoError(t, b.PutMVCC(pointKey("mvccKey", 1), stringValue("mvccValue")))
 	require.NoError(t, b.PutMVCC(pointKey("mvccTombstone", 1), MVCCValue{}))
-	require.NoError(t, b.ExperimentalPutEngineRangeKey(roachpb.Key("rangeFrom"), roachpb.Key("rangeTo"), []byte{7}, []byte("engineRangeKey")))
+	require.NoError(t, b.PutEngineRangeKey(roachpb.Key("rangeFrom"), roachpb.Key("rangeTo"), []byte{7}, []byte("engineRangeKey")))
 
 	// Clear some already empty keys.
 	require.NoError(t, b.ClearMVCC(pointKey("mvccKey", 9)))
-	require.NoError(t, b.ExperimentalClearMVCCRangeKey(rangeKey("rangeFrom", "rangeTo", 9)))
+	require.NoError(t, b.ClearMVCCRangeKey(rangeKey("rangeFrom", "rangeTo", 9)))
 	require.NoError(t, b.ClearRawRange(roachpb.Key("clearFrom"), roachpb.Key("clearTo"))) // both points and ranges
 
 	// Read it back.

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1649,12 +1649,12 @@ func TestEngineClearRange(t *testing.T) {
 		var localTS hlc.ClockTimestamp
 		txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, wallTS(6), 1, 1)
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("c"), wallTS(1), localTS, stringValue("c1").Value, nil))
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("d", "h", 1), MVCCValue{}))
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "f", 2), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("d", "h", 1), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 2), MVCCValue{}))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("g"), wallTS(2), localTS, stringValue("g2").Value, nil))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("e"), wallTS(3), localTS, stringValue("e3").Value, nil))
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "f", 4), MVCCValue{}))
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("g", "h", 4), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 4), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("g", "h", 4), MVCCValue{}))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("a"), wallTS(5), localTS, stringValue("a2").Value, nil))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("b"), wallTS(5), localTS, stringValue("b2").Value, nil))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("c"), wallTS(5), localTS, stringValue("c2").Value, nil))
@@ -1817,7 +1817,7 @@ func TestEngineIteratorVisibility(t *testing.T) {
 
 				// Write initial point and range keys.
 				require.NoError(t, eng.PutMVCC(pointKey("a", 1), stringValue("a1")))
-				require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 1), MVCCValue{}))
+				require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 1), MVCCValue{}))
 
 				// Set up two readers: one regular and one which will be pinned.
 				r := tc.makeReader(eng)
@@ -1847,7 +1847,7 @@ func TestEngineIteratorVisibility(t *testing.T) {
 
 				// Write a new key to the engine, and set up the expected results.
 				require.NoError(t, eng.PutMVCC(pointKey("a", 2), stringValue("a2")))
-				require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 2), MVCCValue{}))
+				require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 2), MVCCValue{}))
 
 				expectOld := []interface{}{
 					pointKV("a", 1, "a1"),
@@ -1896,7 +1896,7 @@ func TestEngineIteratorVisibility(t *testing.T) {
 					// Write a new point and range key to the writer (not engine), and set
 					// up expected results.
 					require.NoError(t, w.PutMVCC(pointKey("a", 3), stringValue("a3")))
-					require.NoError(t, w.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 3), MVCCValue{}))
+					require.NoError(t, w.PutMVCCRangeKey(rangeKey("b", "c", 3), MVCCValue{}))
 					expectNewAndOwn := []interface{}{
 						pointKV("a", 3, "a3"),
 						pointKV("a", 2, "a2"),
@@ -1973,24 +1973,24 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		invalid := rangeKey("b", "a", 1)
 		zeroLength := rangeKey("a", "a", 1)
 
-		require.Error(t, rw.ExperimentalPutMVCCRangeKey(empty, MVCCValue{}))
-		require.Error(t, rw.ExperimentalPutMVCCRangeKey(invalid, MVCCValue{}))
-		require.Error(t, rw.ExperimentalPutMVCCRangeKey(zeroLength, MVCCValue{}))
+		require.Error(t, rw.PutMVCCRangeKey(empty, MVCCValue{}))
+		require.Error(t, rw.PutMVCCRangeKey(invalid, MVCCValue{}))
+		require.Error(t, rw.PutMVCCRangeKey(zeroLength, MVCCValue{}))
 
-		require.Error(t, rw.ExperimentalPutEngineRangeKey(empty.StartKey, empty.EndKey, nil, nil))
-		require.Error(t, rw.ExperimentalPutEngineRangeKey(invalid.StartKey, invalid.EndKey, nil, nil))
-		require.Error(t, rw.ExperimentalPutEngineRangeKey(zeroLength.StartKey, zeroLength.EndKey, nil, nil))
+		require.Error(t, rw.PutEngineRangeKey(empty.StartKey, empty.EndKey, nil, nil))
+		require.Error(t, rw.PutEngineRangeKey(invalid.StartKey, invalid.EndKey, nil, nil))
+		require.Error(t, rw.PutEngineRangeKey(zeroLength.StartKey, zeroLength.EndKey, nil, nil))
 
-		require.Error(t, rw.ExperimentalClearMVCCRangeKey(empty))
-		require.Error(t, rw.ExperimentalClearMVCCRangeKey(invalid))
-		require.Error(t, rw.ExperimentalClearMVCCRangeKey(zeroLength))
+		require.Error(t, rw.ClearMVCCRangeKey(empty))
+		require.Error(t, rw.ClearMVCCRangeKey(invalid))
+		require.Error(t, rw.ClearMVCCRangeKey(zeroLength))
 
-		require.Error(t, rw.ExperimentalClearAllRangeKeys(empty.StartKey, empty.EndKey))
-		require.Error(t, rw.ExperimentalClearAllRangeKeys(invalid.StartKey, invalid.EndKey))
-		require.Error(t, rw.ExperimentalClearAllRangeKeys(zeroLength.StartKey, zeroLength.EndKey))
+		require.Error(t, rw.ClearAllRangeKeys(empty.StartKey, empty.EndKey))
+		require.Error(t, rw.ClearAllRangeKeys(invalid.StartKey, invalid.EndKey))
+		require.Error(t, rw.ClearAllRangeKeys(zeroLength.StartKey, zeroLength.EndKey))
 
 		// Check that non-tombstone values error.
-		require.Error(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "b", 1), stringValue("foo")))
+		require.Error(t, rw.PutMVCCRangeKey(rangeKey("a", "b", 1), stringValue("foo")))
 
 		// Check that nothing got written during the errors above.
 		require.Empty(t, scanRangeKeys(t, rw))
@@ -2001,7 +2001,7 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 			rangeKey("f", "h", 1),
 			rangeKey("c", "g", 2),
 		} {
-			require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey, MVCCValue{}))
+			require.NoError(t, rw.PutMVCCRangeKey(rangeKey, MVCCValue{}))
 		}
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "c", 1, MVCCValue{}),
@@ -2016,8 +2016,8 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		// Clear the f-g portion of [f-h)@1, twice for idempotency. This should not
 		// affect any other range keys, apart from removing the fragment boundary
 		// at f for [d-g)@2.
-		require.NoError(t, rw.ExperimentalClearMVCCRangeKey(rangeKey("f", "g", 1)))
-		require.NoError(t, rw.ExperimentalClearMVCCRangeKey(rangeKey("f", "g", 1)))
+		require.NoError(t, rw.ClearMVCCRangeKey(rangeKey("f", "g", 1)))
+		require.NoError(t, rw.ClearMVCCRangeKey(rangeKey("f", "g", 1)))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "c", 1, MVCCValue{}),
 			rangeKV("c", "d", 2, MVCCValue{}),
@@ -2027,7 +2027,7 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		}, scanRangeKeys(t, rw))
 
 		// Write [e-f)@2 on top of existing [d-g)@2. This should be a noop.
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("e", "f", 2), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("e", "f", 2), MVCCValue{}))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "c", 1, MVCCValue{}),
 			rangeKV("c", "d", 2, MVCCValue{}),
@@ -2037,8 +2037,8 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		}, scanRangeKeys(t, rw))
 
 		// Clear all range keys in the [c-f) span. Twice for idempotency.
-		require.NoError(t, rw.ExperimentalClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
-		require.NoError(t, rw.ExperimentalClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
+		require.NoError(t, rw.ClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
+		require.NoError(t, rw.ClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "c", 1, MVCCValue{}),
 			rangeKV("f", "g", 2, MVCCValue{}),
@@ -2049,7 +2049,7 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		// a raw engine key rather than an MVCC key, to test that too.
 		valueRaw, err := EncodeMVCCValue(MVCCValue{})
 		require.NoError(t, err)
-		require.NoError(t, rw.ExperimentalPutEngineRangeKey(
+		require.NoError(t, rw.PutEngineRangeKey(
 			roachpb.Key("c"), roachpb.Key("g"), EncodeMVCCTimestampSuffix(wallTS(1)), valueRaw))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "f", 1, MVCCValue{}),
@@ -2060,7 +2060,7 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 
 		// Writing a range key [a-f)@2 which abuts [f-g)@2 should not merge if it
 		// has a different value (local timestamp).
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "f", 2), tombstoneLocalTS(7)))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 2), tombstoneLocalTS(7)))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "f", 2, tombstoneLocalTS(7)),
 			rangeKV("a", "f", 1, MVCCValue{}),
@@ -2124,16 +2124,16 @@ func TestEngineRangeKeysUnsupported(t *testing.T) {
 		t.Run(fmt.Sprintf("write/%s", name), func(t *testing.T) {
 			rangeKey := rangeKey("a", "b", 2)
 
-			err := w.ExperimentalPutMVCCRangeKey(rangeKey, MVCCValue{})
+			err := w.PutMVCCRangeKey(rangeKey, MVCCValue{})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "range keys not supported")
 
-			err = w.ExperimentalPutEngineRangeKey(rangeKey.StartKey, rangeKey.EndKey, nil, nil)
+			err = w.PutEngineRangeKey(rangeKey.StartKey, rangeKey.EndKey, nil, nil)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "range keys not supported")
 
-			require.NoError(t, w.ExperimentalClearMVCCRangeKey(rangeKey))
-			require.NoError(t, w.ExperimentalClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
+			require.NoError(t, w.ClearMVCCRangeKey(rangeKey))
+			require.NoError(t, w.ClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
 		})
 	}
 
@@ -2234,9 +2234,9 @@ func TestEngineRangeKeysUnsupported(t *testing.T) {
 
 // TestUnindexedBatchClearAllRangeKeys tests that range keys are properly
 // cleared via an unindexed batch. This tests an optimization in
-// pebbleBatch.ExperimentalClearAllRangeKeys that tightens the span bounds
-// to existing keys to avoid dropping unnecessary Pebble range tombstones, which
-// must handle the range keys in the unindexed batch correctly.
+// pebbleBatch.ClearAllRangeKeys that tightens the span bounds to existing keys
+// to avoid dropping unnecessary Pebble range tombstones, which must handle the
+// range keys in the unindexed batch correctly.
 func TestUnindexedBatchClearAllRangeKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2245,15 +2245,15 @@ func TestUnindexedBatchClearAllRangeKeys(t *testing.T) {
 	defer eng.Close()
 
 	// Write a range key [a-d)@1 into the engine.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("a", "d", 1), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("a", "d", 1), MVCCValue{}))
 
 	// Set up an unindexed batch, and write [e-h)@2 into it. Then clear
 	// all range keys in the [c-f) span via the batch and commit it.
 	batch := eng.NewUnindexedBatch(true /* writeOnly */)
 	defer batch.Close()
 
-	require.NoError(t, batch.ExperimentalPutMVCCRangeKey(rangeKey("e", "h", 2), MVCCValue{}))
-	require.NoError(t, batch.ExperimentalClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
+	require.NoError(t, batch.PutMVCCRangeKey(rangeKey("e", "h", 2), MVCCValue{}))
+	require.NoError(t, batch.ClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
 	require.NoError(t, batch.Commit(false /* sync */))
 
 	// Read range keys back from engine. We should find [a-c)@1 and [f-h)@2.
@@ -2267,7 +2267,7 @@ func TestUnindexedBatchClearAllRangeKeys(t *testing.T) {
 	batch = eng.NewUnindexedBatch(true /* writeOnly */)
 	defer batch.Close()
 
-	require.NoError(t, batch.ExperimentalClearAllRangeKeys(roachpb.Key("b"), roachpb.Key("g")))
+	require.NoError(t, batch.ClearAllRangeKeys(roachpb.Key("b"), roachpb.Key("g")))
 	require.NoError(t, batch.Commit(false /* sync */))
 
 	// Read range keys back from engine. We should find [a-b)@1 and [g-h)@2.
@@ -2279,12 +2279,12 @@ func TestUnindexedBatchClearAllRangeKeys(t *testing.T) {
 	// Now clear everything. Twice, for idempotency.
 	batch = eng.NewUnindexedBatch(true /* writeOnly */)
 	defer batch.Close()
-	require.NoError(t, batch.ExperimentalClearAllRangeKeys(roachpb.Key("a"), roachpb.Key("z")))
+	require.NoError(t, batch.ClearAllRangeKeys(roachpb.Key("a"), roachpb.Key("z")))
 	require.NoError(t, batch.Commit(false /* sync */))
 
 	batch = eng.NewUnindexedBatch(true /* writeOnly */)
 	defer batch.Close()
-	require.NoError(t, batch.ExperimentalClearAllRangeKeys(roachpb.Key("a"), roachpb.Key("z")))
+	require.NoError(t, batch.ClearAllRangeKeys(roachpb.Key("a"), roachpb.Key("z")))
 	require.NoError(t, batch.Commit(false /* sync */))
 
 	require.Empty(t, scanRangeKeys(t, eng))

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2466,21 +2466,16 @@ func MVCCDeleteRange(
 	return keys, res.ResumeSpan, res.NumKeys, nil
 }
 
-// ExperimentalMVCCDeleteRangeUsingTombstone deletes the given MVCC keyspan at
-// the given timestamp using an MVCC range tombstone (rather than MVCC point
-// tombstones). This operation is non-transactional, but will check for
-// existing intents and return a WriteIntentError containing up to maxIntents
-// intents.
+// MVCCDeleteRangeUsingTombstone deletes the given MVCC keyspan at the given
+// timestamp using an MVCC range tombstone (rather than MVCC point tombstones).
+// This operation is non-transactional, but will check for existing intents and
+// return a WriteIntentError containing up to maxIntents intents.
 //
 // The leftPeekBound and rightPeekBound parameters are used when looking for
 // range tombstones that we'll merge or overlap with. These are provided to
 // prevent the command from reading outside of the CRDB range bounds and latch
 // bounds. nil means no bounds.
-//
-// This method is EXPERIMENTAL: range keys are under active development, and
-// have severe limitations including being ignored by all KV and MVCC APIs and
-// only being stored in memory.
-func ExperimentalMVCCDeleteRangeUsingTombstone(
+func MVCCDeleteRangeUsingTombstone(
 	ctx context.Context,
 	rw ReadWriter,
 	ms *enginepb.MVCCStats,
@@ -2763,7 +2758,7 @@ func ExperimentalMVCCDeleteRangeUsingTombstone(
 		}
 	}
 
-	if err := rw.ExperimentalPutMVCCRangeKey(rangeKey, value); err != nil {
+	if err := rw.PutMVCCRangeKey(rangeKey, value); err != nil {
 		return err
 	}
 
@@ -4839,7 +4834,7 @@ func MVCCExportToSST(
 				}
 				// Export only the inner roachpb.Value, not the MVCCValue header.
 				mvccValue = MVCCValue{Value: mvccValue.Value}
-				if err := sstWriter.ExperimentalPutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+				if err := sstWriter.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
 					return roachpb.BulkOpSummary{}, MVCCKey{}, err
 				}
 			}
@@ -5009,7 +5004,7 @@ func MVCCExportToSST(
 			}
 			// Export only the inner roachpb.Value, not the MVCCValue header.
 			mvccValue = MVCCValue{Value: mvccValue.Value}
-			if err := sstWriter.ExperimentalPutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+			if err := sstWriter.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
 				return roachpb.BulkOpSummary{}, MVCCKey{}, err
 			}
 		}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -902,8 +902,7 @@ func cmdClearRange(e *evalCtx) error {
 func cmdClearRangeKey(e *evalCtx) error {
 	key, endKey := e.getKeyRange()
 	ts := e.getTs(nil)
-	return e.engine.ExperimentalClearMVCCRangeKey(
-		MVCCRangeKey{StartKey: key, EndKey: endKey, Timestamp: ts})
+	return e.engine.ClearMVCCRangeKey(MVCCRangeKey{StartKey: key, EndKey: endKey, Timestamp: ts})
 }
 
 func cmdCPut(e *evalCtx) error {
@@ -1013,7 +1012,7 @@ func cmdDeleteRangeTombstone(e *evalCtx) error {
 	localTs := hlc.ClockTimestamp(e.getTsWithName("localTs"))
 
 	return e.withWriter("del_range_ts", func(rw ReadWriter) error {
-		return ExperimentalMVCCDeleteRangeUsingTombstone(e.ctx, rw, e.ms, key, endKey, ts, localTs, nil, nil, 0)
+		return MVCCDeleteRangeUsingTombstone(e.ctx, rw, e.ms, key, endKey, ts, localTs, nil, nil, 0)
 	})
 }
 
@@ -1280,7 +1279,7 @@ func cmdPutRangeKey(e *evalCtx) error {
 	value.MVCCValueHeader.LocalTimestamp = hlc.ClockTimestamp(e.getTsWithName("localTs"))
 
 	return e.withWriter("put_rangekey", func(rw ReadWriter) error {
-		return rw.ExperimentalPutMVCCRangeKey(rangeKey, value)
+		return rw.PutMVCCRangeKey(rangeKey, value)
 	})
 }
 
@@ -1479,7 +1478,7 @@ func cmdSSTPutRangeKey(e *evalCtx) error {
 	var value MVCCValue
 	value.MVCCValueHeader.LocalTimestamp = hlc.ClockTimestamp(e.getTsWithName("localTs"))
 
-	return e.sst().ExperimentalPutMVCCRangeKey(rangeKey, value)
+	return e.sst().PutMVCCRangeKey(rangeKey, value)
 }
 
 func cmdSSTClearRange(e *evalCtx) error {
@@ -1492,7 +1491,7 @@ func cmdSSTClearRangeKey(e *evalCtx) error {
 	rangeKey.StartKey, rangeKey.EndKey = e.getKeyRange()
 	rangeKey.Timestamp = e.getTs(nil)
 
-	return e.sst().ExperimentalClearMVCCRangeKey(rangeKey)
+	return e.sst().ClearMVCCRangeKey(rangeKey)
 }
 
 func cmdSSTFinish(e *evalCtx) error {

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1628,8 +1628,8 @@ func (s *randomTest) step(t *testing.T) {
 	}
 }
 
-// TODO(erikgrinaker): Add ExperimentalMVCCDeleteRangeUsingTombstone operations
-// once they are fully integrated with other MVCC operations.
+// TODO(erikgrinaker): Add MVCCDeleteRangeUsingTombstone operations once they
+// are fully integrated with other MVCC operations.
 func TestMVCCStatsRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1136,7 +1136,7 @@ func (p *Pebble) ClearRawRange(start, end roachpb.Key) error {
 	if err := p.db.DeleteRange(startKey, endKey, pebble.Sync); err != nil {
 		return err
 	}
-	return p.ExperimentalClearAllRangeKeys(start, end)
+	return p.ClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Engine interface.
@@ -1162,8 +1162,8 @@ func (p *Pebble) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 	return batch.Commit(true)
 }
 
-// ExperimentalClearMVCCRangeKey implements the Engine interface.
-func (p *Pebble) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
+// ClearMVCCRangeKey implements the Engine interface.
+func (p *Pebble) ClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 	if !p.SupportsRangeKeys() {
 		// These databases cannot contain range keys, so clearing is a noop.
 		return nil
@@ -1178,8 +1178,8 @@ func (p *Pebble) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 		pebble.Sync)
 }
 
-// ExperimentalClearAllRangeKeys implements the Engine interface.
-func (p *Pebble) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
+// ClearAllRangeKeys implements the Engine interface.
+func (p *Pebble) ClearAllRangeKeys(start, end roachpb.Key) error {
 	if !p.SupportsRangeKeys() {
 		return nil // noop
 	}
@@ -1202,8 +1202,8 @@ func (p *Pebble) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
 	return p.db.Experimental().RangeKeyDelete(clearFrom, clearTo, pebble.Sync)
 }
 
-// ExperimentalPutMVCCRangeKey implements the Engine interface.
-func (p *Pebble) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
+// PutMVCCRangeKey implements the Engine interface.
+func (p *Pebble) PutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
 	if !p.SupportsRangeKeys() {
 		return errors.Errorf("range keys not supported by Pebble database version %s",
 			p.db.FormatMajorVersion())
@@ -1283,8 +1283,8 @@ func (p *Pebble) put(key MVCCKey, value []byte) error {
 	return p.db.Set(EncodeMVCCKey(key), value, pebble.Sync)
 }
 
-// ExperimentalPutEngineRangeKey implements the Engine interface.
-func (p *Pebble) ExperimentalPutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
+// PutEngineRangeKey implements the Engine interface.
+func (p *Pebble) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	if !p.SupportsRangeKeys() {
 		return errors.Errorf("range keys not supported by Pebble database version %s",
 			p.db.FormatMajorVersion())
@@ -2102,21 +2102,19 @@ func (p *pebbleReadOnly) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalPutMVCCRangeKey(MVCCRangeKey, MVCCValue) error {
+func (p *pebbleReadOnly) PutMVCCRangeKey(MVCCRangeKey, MVCCValue) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalPutEngineRangeKey(
-	roachpb.Key, roachpb.Key, []byte, []byte,
-) error {
+func (p *pebbleReadOnly) PutEngineRangeKey(roachpb.Key, roachpb.Key, []byte, []byte) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalClearMVCCRangeKey(MVCCRangeKey) error {
+func (p *pebbleReadOnly) ClearMVCCRangeKey(MVCCRangeKey) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalClearAllRangeKeys(roachpb.Key, roachpb.Key) error {
+func (p *pebbleReadOnly) ClearAllRangeKeys(roachpb.Key, roachpb.Key) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -368,7 +368,7 @@ func (p *pebbleBatch) ClearRawRange(start, end roachpb.Key) error {
 	if err := p.batch.DeleteRange(p.buf, EncodeMVCCKey(MVCCKey{Key: end}), nil); err != nil {
 		return err
 	}
-	return p.ExperimentalClearAllRangeKeys(start, end)
+	return p.ClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Batch interface.
@@ -405,11 +405,11 @@ func (p *pebbleBatch) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 			return err
 		}
 	}
-	return p.ExperimentalClearAllRangeKeys(start, end)
+	return p.ClearAllRangeKeys(start, end)
 }
 
-// ExperimentalClearMVCCRangeKey implements the Engine interface.
-func (p *pebbleBatch) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
+// ClearMVCCRangeKey implements the Engine interface.
+func (p *pebbleBatch) ClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 	if !p.SupportsRangeKeys() {
 		return nil // noop
 	}
@@ -423,8 +423,8 @@ func (p *pebbleBatch) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error
 		nil)
 }
 
-// ExperimentalClearAllRangeKeys implements the Engine interface.
-func (p *pebbleBatch) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
+// ClearAllRangeKeys implements the Engine interface.
+func (p *pebbleBatch) ClearAllRangeKeys(start, end roachpb.Key) error {
 	if !p.SupportsRangeKeys() {
 		return nil // noop
 	}
@@ -458,8 +458,8 @@ func (p *pebbleBatch) ExperimentalClearAllRangeKeys(start, end roachpb.Key) erro
 	return p.batch.Experimental().RangeKeyDelete(clearFrom, clearTo, nil)
 }
 
-// ExperimentalPutMVCCRangeKey implements the Batch interface.
-func (p *pebbleBatch) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
+// PutMVCCRangeKey implements the Batch interface.
+func (p *pebbleBatch) PutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
 	if !p.SupportsRangeKeys() {
 		return errors.Errorf("range keys not supported by Pebble database version %s",
 			p.db.FormatMajorVersion())
@@ -483,16 +483,13 @@ func (p *pebbleBatch) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value M
 		nil); err != nil {
 		return err
 	}
-	// Mark the batch as containing range keys. See
-	// ExperimentalClearAllRangeKeys for why.
+	// Mark the batch as containing range keys. See ClearAllRangeKeys for why.
 	p.containsRangeKeys = true
 	return nil
 }
 
-// ExperimentalPutEngineRangeKey implements the Engine interface.
-func (p *pebbleBatch) ExperimentalPutEngineRangeKey(
-	start, end roachpb.Key, suffix, value []byte,
-) error {
+// PutEngineRangeKey implements the Engine interface.
+func (p *pebbleBatch) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	if !p.SupportsRangeKeys() {
 		return errors.Errorf("range keys not supported by Pebble database version %s",
 			p.db.FormatMajorVersion())
@@ -510,8 +507,7 @@ func (p *pebbleBatch) ExperimentalPutEngineRangeKey(
 	); err != nil {
 		return err
 	}
-	// Mark the batch as containing range keys. See ExperimentalClearAllRangeKeys
-	// for why.
+	// Mark the batch as containing range keys. See ClearAllRangeKeys for why.
 	p.containsRangeKeys = true
 	return nil
 }

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -632,14 +632,14 @@ func TestPebbleMVCCTimeIntervalCollectorAndFilter(t *testing.T) {
 	require.NoError(t, eng.Flush())
 
 	// Separate range keys [b-c)@5, [c-d)@7, [d-e)@9 share a block in a single SST.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
 	require.NoError(t, eng.Flush())
 
 	// Overlapping range keys [x-z)@5, [x-z)@7 share a block in a single SST.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("x", "z", 5), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("x", "z", 7), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("x", "z", 5), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("x", "z", 7), MVCCValue{}))
 	require.NoError(t, eng.Flush())
 
 	testcases := map[string]struct {
@@ -752,14 +752,14 @@ func TestPebbleMVCCTimeIntervalWithClears(t *testing.T) {
 	require.NoError(t, eng.Flush())
 
 	// Separate range keys [b-c)@5, [c-d)@7, [d-e)@9 in a single block in a single SST.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
 	require.NoError(t, eng.Flush())
 
 	// Clear a@5 and [c-d)@7 in a separate SST.
 	require.NoError(t, eng.ClearMVCC(pointKey("a", 5)))
-	require.NoError(t, eng.ExperimentalClearMVCCRangeKey(rangeKey("c", "d", 7)))
+	require.NoError(t, eng.ClearMVCCRangeKey(rangeKey("c", "d", 7)))
 	require.NoError(t, eng.Flush())
 
 	testcases := map[string]struct {
@@ -868,9 +868,9 @@ func TestPebbleMVCCTimeIntervalWithRangeClears(t *testing.T) {
 	require.NoError(t, eng.Flush())
 
 	// Separate range keys [b-c)@5, [c-d)@7, [d-e)@9 in a single block in a single SST.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
 	require.NoError(t, eng.Flush())
 
 	// Clear [a-z) in a separate SST.

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -422,7 +422,7 @@ func UpdateSSTTimestamps(
 			if err != nil {
 				return nil, err
 			}
-			if err = writer.ExperimentalPutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+			if err = writer.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -140,7 +140,7 @@ func (fw *SSTWriter) ClearRawRange(start, end roachpb.Key) error {
 	if err := fw.clearRange(MVCCKey{Key: start}, MVCCKey{Key: end}); err != nil {
 		return err
 	}
-	return fw.ExperimentalClearAllRangeKeys(start, end)
+	return fw.ClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Writer interface.
@@ -153,8 +153,8 @@ func (fw *SSTWriter) ClearMVCCVersions(start, end MVCCKey) error {
 	return fw.clearRange(start, end)
 }
 
-// ExperimentalPutMVCCRangeKey implements the Writer interface.
-func (fw *SSTWriter) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
+// PutMVCCRangeKey implements the Writer interface.
+func (fw *SSTWriter) PutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
 	if !fw.supportsRangeKeys {
 		return errors.New("range keys not supported by SST writer")
 	}
@@ -177,8 +177,8 @@ func (fw *SSTWriter) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MV
 		valueRaw)
 }
 
-// ExperimentalClearMVCCRangeKey implements the Writer interface.
-func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
+// ClearMVCCRangeKey implements the Writer interface.
+func (fw *SSTWriter) ClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 	if !fw.supportsRangeKeys {
 		return nil // noop
 	}
@@ -192,8 +192,8 @@ func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error 
 		EncodeMVCCTimestampSuffix(rangeKey.Timestamp))
 }
 
-// ExperimentalClearAllRangeKeys implements the Writer interface.
-func (fw *SSTWriter) ExperimentalClearAllRangeKeys(start roachpb.Key, end roachpb.Key) error {
+// ClearAllRangeKeys implements the Writer interface.
+func (fw *SSTWriter) ClearAllRangeKeys(start roachpb.Key, end roachpb.Key) error {
 	if !fw.supportsRangeKeys {
 		return nil // noop
 	}
@@ -209,10 +209,8 @@ func (fw *SSTWriter) ExperimentalClearAllRangeKeys(start roachpb.Key, end roachp
 	return fw.fw.RangeKeyDelete(EncodeMVCCKeyPrefix(start), EncodeMVCCKeyPrefix(end))
 }
 
-// ExperimentalPutEngineRangeKey implements the Writer interface.
-func (fw *SSTWriter) ExperimentalPutEngineRangeKey(
-	start, end roachpb.Key, suffix, value []byte,
-) error {
+// PutEngineRangeKey implements the Writer interface.
+func (fw *SSTWriter) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	// MVCC values don't account for the timestamp, so we don't account
 	// for the suffix here.
 	fw.DataSize += int64(len(start)) + int64(len(end)) + int64(len(value))

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -134,11 +134,11 @@ func TestSSTWriterRangeKeysUnsupported(t *testing.T) {
 			rangeKey := rangeKey("a", "b", 2)
 
 			// Put should error, but clears are noops.
-			err := w.ExperimentalPutMVCCRangeKey(rangeKey, MVCCValue{})
+			err := w.PutMVCCRangeKey(rangeKey, MVCCValue{})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "range keys not supported")
-			require.NoError(t, w.ExperimentalClearMVCCRangeKey(rangeKey))
-			require.NoError(t, w.ExperimentalClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
+			require.NoError(t, w.ClearMVCCRangeKey(rangeKey))
+			require.NoError(t, w.ClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
 		})
 	}
 }
@@ -158,10 +158,10 @@ func TestSSTWriterRangeKeys(t *testing.T) {
 	require.NoError(t, sst.Put(pointKey("a", 1), stringValueRaw("foo")))
 	require.EqualValues(t, 9, sst.DataSize)
 
-	require.NoError(t, sst.ExperimentalPutMVCCRangeKey(rangeKey("a", "e", 2), tombstoneLocalTS(1)))
+	require.NoError(t, sst.PutMVCCRangeKey(rangeKey("a", "e", 2), tombstoneLocalTS(1)))
 	require.EqualValues(t, 20, sst.DataSize)
 
-	require.NoError(t, sst.ExperimentalPutEngineRangeKey(roachpb.Key("f"), roachpb.Key("g"),
+	require.NoError(t, sst.PutEngineRangeKey(roachpb.Key("f"), roachpb.Key("g"),
 		wallTSRaw(2), tombstoneLocalTSRaw(1)))
 	require.EqualValues(t, 31, sst.DataSize)
 

--- a/pkg/testutils/storageutils/sst.go
+++ b/pkg/testutils/storageutils/sst.go
@@ -52,7 +52,7 @@ func MakeSST(
 		case storage.MVCCRangeKeyValue:
 			v, err := storage.DecodeMVCCValue(kv.Value)
 			require.NoError(t, err)
-			require.NoError(t, writer.ExperimentalPutMVCCRangeKey(kv.RangeKey, v))
+			require.NoError(t, writer.PutMVCCRangeKey(kv.RangeKey, v))
 			s, e = kv.RangeKey.StartKey, kv.RangeKey.EndKey
 
 		default:


### PR DESCRIPTION
GC is still under development, but I think it's fine to remove the marker before GC works to let people start building with it.

---

This removes the experimental markers for MVCC range tombstones, by
renaming functions, methods, and parameters to not include
`experimental`, as well as warning comments.

The changes are entirely mechanical.

Release note: None