### PR TITLE
release-22.1:  ui: format rows processed

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -16,6 +16,7 @@ import {
   longToInt,
   StatementSummary,
   StatementStatistics,
+  Count,
 } from "src/util";
 import {
   countBarChart,
@@ -104,7 +105,7 @@ function makeCommonColumns(
       title: statisticsTableTitles.rowsProcessed(statType),
       className: cx("statements-table__col-rows-read"),
       cell: (stmt: AggregateStatistics) =>
-        `${FixLong(Number(stmt.stats.rows_read.mean))} Reads / ${FixLong(
+        `${Count(Number(stmt.stats.rows_read.mean))} Reads / ${Count(
           Number(stmt.stats.rows_written?.mean),
         )} Writes`,
       sort: (stmt: AggregateStatistics) =>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -28,7 +28,7 @@ import {
 import { statisticsTableTitles } from "../statsTableUtil/statsTableUtil";
 import { tableClasses } from "./transactionsTableClasses";
 import { transactionLink } from "./transactionsCells";
-import { FixLong, longToInt, TimestampToString } from "src/util";
+import { Count, FixLong, longToInt, TimestampToString } from "src/util";
 import { SortSetting } from "../sortedtable";
 import {
   getStatementsByFingerprintId,
@@ -153,9 +153,7 @@ export function makeTransactionsColumns(
       name: "rowsProcessed",
       title: statisticsTableTitles.rowsProcessed(statType),
       cell: (item: TransactionInfo) =>
-        `${FixLong(
-          Number(item.stats_data.stats.rows_read.mean),
-        )} Reads / ${FixLong(
+        `${Count(Number(item.stats_data.stats.rows_read.mean))} Reads / ${Count(
           Number(item.stats_data.stats.rows_written?.mean),
         )} Writes`,
       className: cx("statements-table__col-rows-read"),


### PR DESCRIPTION
Backport 1/1 commits from #83647

/cc @cockroachdb/release 

---

Previously, the rows processed could show a really
long number. This commit adds formatting to it, so
it can have the proper unit.

Release note: None

---

Release justification: bug fix