### PR TITLE
ci: ensure jemalloc is configured _without_ MADV_FREE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -618,7 +618,13 @@ $(JEMALLOC_DIR)/Makefile: $(C_DEPS_DIR)/jemalloc-rebuild $(JEMALLOC_SRC_DIR)/con
 	mkdir -p $(JEMALLOC_DIR)
 	@# NOTE: If you change the configure flags below, bump the version in
 	@# $(C_DEPS_DIR)/jemalloc-rebuild. See above for rationale.
-	cd $(JEMALLOC_DIR) && $(JEMALLOC_SRC_DIR)/configure $(xconfigure-flags) --enable-prof
+	@# NOTE: we disable MADV_FREE; see https://github.com/cockroachdb/cockroach/issues/83790
+	export je_cv_madv_free="no" && cd $(JEMALLOC_DIR) && $(JEMALLOC_SRC_DIR)/configure $(xconfigure-flags) --enable-prof
+	JEMALLOC_MADV_FREE_ENABLED=$$(grep -E "^je_cv_madv_free=no$$" $(JEMALLOC_DIR)/config.log | awk -F'=' '{print $$2}'); \
+	if [[ "$$JEMALLOC_MADV_FREE_ENABLED" != "no" ]]; then \
+		echo "NOTE: using MADV_FREE with jemalloc can lead to surprising results; see https://github.com/cockroachdb/cockroach/issues/83790"; \
+		exit 1; \
+	fi
 
 $(KRB5_SRC_DIR)/src/configure.in: | bin/.submodules-initialized
 

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -41,8 +41,14 @@ configure_make(
         "//conditions:default": [],
     }),
     env = select({
-        "//build/toolchains:dev": {"AR": ""},
-        "//conditions:default": {},
+        "//build/toolchains:dev": {
+            "AR": "",
+            # NOTE: we disable MADV_FREE; see https://github.com/cockroachdb/cockroach/issues/83790
+            "je_cv_madv_free": "no",
+        },
+        "//conditions:default": {
+            "je_cv_madv_free": "no",
+        },
     }),
     lib_source = "@jemalloc//:all",
     out_static_libs = select({

--- a/c-deps/jemalloc-rebuild
+++ b/c-deps/jemalloc-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing jemalloc configure flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-5
+6


### PR DESCRIPTION
Previously, jemalloc would default to MADV_FREE which could lead
to surprising results; i.e., no reduction in RSS until memory pressure.
This change ensures that jemalloc is always compiled with MADV_FREE
disabled, thus using MADV_DONTNEED.
See the corresponding issue for further details.

Release note: None
Resolves: https://github.com/cockroachdb/cockroach/issues/83790