### PR TITLE
sql/stats: convert between histograms and quantile functions

### DIFF
--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -11,8 +11,10 @@
 package stats
 
 import (
+	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -418,6 +420,23 @@ func (h histogram) toHistogramData(colType *types.T) (HistogramData, error) {
 	}
 
 	return histogramData, nil
+}
+
+// String prints a histogram to a string.
+func (h histogram) String() string {
+	var b strings.Builder
+	b.WriteString("{[")
+	for i, bucket := range h.buckets {
+		if i > 0 {
+			b.WriteRune(' ')
+		}
+		fmt.Fprintf(
+			&b, "{%v %v %v %v}",
+			bucket.NumEq, bucket.NumRange, bucket.DistinctRange, bucket.UpperBound.String(),
+		)
+	}
+	b.WriteString("]}")
+	return b.String()
 }
 
 // estimatedDistinctValuesInRange returns the estimated number of distinct

--- a/pkg/sql/stats/quantile.go
+++ b/pkg/sql/stats/quantile.go
@@ -14,6 +14,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -21,10 +23,89 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// CanMakeQuantile returns true if a quantile function can be created for a
+// quantile is a piecewise quantile function with float64 values.
+//
+// A quantile function is a way of representing a probability distribution. It
+// is a function from p to v, over (p=0, p=1], where p is the probability that
+// an item in the distribution will have value <= v. The quantile function for a
+// probability distribution is the inverse of the cumulative distribution
+// function for the same probability distribution. See
+// https://en.wikipedia.org/wiki/Quantile_function for more background.
+//
+// We use quantile functions within our modeling for a few reasons:
+// * Unlike histograms, quantile functions are independent of the absolute
+//   counts. They are a "shape" not a "size".
+// * Unlike cumulative distribution functions or probability density functions,
+//   we can always take the definite integral of a quantile function from p=0 to
+//   p=1. We use this when performing linear regression over quantiles.
+//
+// Type quantile represents a piecewise quantile function with float64 values as
+// a series of quantilePoints from p=0 (exclusive) to p=1 (inclusive). A
+// well-formed quantile is non-decreasing in both p and v. A quantile must have
+// at least two points. The first point must have p=0, and the last point must
+// have p=1. The pieces of the quantile function are line segments between
+// subsequent points (exclusive and inclusive, respectively).
+//
+// Subsequent points may have the same p (a vertical line, or discontinuity),
+// meaning the probability of finding a value > v₁ and <= v₂ is zero. Subsequent
+// points may have the same v (a horizontal line), meaning the probability of
+// finding exactly that v is p₂ - p₁. To put it in terms of our histograms:
+// NumRange = 0 becomes a vertical line, NumRange > 0 becomes a slanted line
+// with positive slope, NumEq = 0 goes away, and NumEq > 0 becomes a horizontal
+// line.
+//
+// For example, given this population of 10 values:
+//
+//  {200, 200, 210, 210, 210, 211, 212, 221, 222, 230}
+//
+// One possible histogram might be:
+//
+//   {{UpperBound: 200, NumRange: 0, NumEq: 2},
+//    {UpperBound: 210, NumRange: 0, NumEq: 3},
+//    {UpperBound: 220, NumRange: 2, NumEq: 0},
+//    {UpperBound: 230, NumRange: 2, NumEq: 1}}
+//
+// And the corresponding quantile function would be:
+//
+//   {{0, 200}, {0.2, 200}, {0.2, 210}, {0.5, 210}, {0.7, 220}, {0.9, 230}, {1, 230}}
+//
+//   230 |                 *-*
+//       |               /
+//   220 |             *
+//       |           /
+//   210 |   o-----*
+//       |
+//   200 o---*
+//       |
+//   190 + - - - - - - - - - -
+//       0  .2  .4  .6  .8   1
+//
+type quantile []quantilePoint
+
+// quantilePoint is an endpoint of a piece (line segment) in a piecewise
+// quantile function.
+type quantilePoint struct {
+	p, v float64
+}
+
+// quantileIndex is the ordinal position of a quantilePoint within a
+// quantile.
+type quantileIndex = int
+
+// zeroQuantile is what we use for empty tables. Technically it says nothing
+// about the number of rows in the table / items in the probability
+// distribution, only that they all equal the zero value.
+var zeroQuantile = quantile{{p: 0, v: 0}, {p: 1, v: 0}}
+
+// If you are introducing a new histogram version, please check whether
+// makeQuantile and quantile.toHistogram need to change, and then increase the
+// version number in this check.
+const _ uint = 1 - uint(histVersion)
+
+// canMakeQuantile returns true if a quantile function can be created for a
 // histogram of the given type.
 // TODO(michae2): Add support for DECIMAL, TIME, TIMETZ, and INTERVAL.
-func CanMakeQuantile(colType *types.T) bool {
+func canMakeQuantile(colType *types.T) bool {
 	if colType.UserDefined() {
 		return false
 	}
@@ -34,20 +115,246 @@ func CanMakeQuantile(colType *types.T) bool {
 		types.DateFamily,
 		types.TimestampFamily,
 		types.TimestampTZFamily:
+		// TODO(michae2): Even if the column is one of these types, explicit or
+		// implicit constraints could make it behave like an ENUM. For example, the
+		// hidden shard column of a hash-sharded index is INT8 and yet will only
+		// ever contain a few specific values which do not make sense to compare
+		// using < or > operators. Histogram prediction will likely not work well
+		// for these de facto ENUM columns, so we should skip them.
+		//
+		// One way to detect these columns would be to watch out for histograms with
+		// NumRange == 0 in every bucket.
 		return true
 	default:
 		return false
 	}
 }
 
-// ToQuantileValue converts from a datum to a float suitable for use in a quantile
+// makeQuantile converts a histogram to a quantile function, or returns an error
+// if it cannot. The histogram must not contain a bucket for NULL values, and
+// the row count must not include NULL values. The first bucket of the histogram
+// must have NumRange == 0.
+func makeQuantile(hist histogram, rowCount float64) (quantile, error) {
+	if !isValidCount(rowCount) {
+		return nil, errors.AssertionFailedf("invalid rowCount: %v", rowCount)
+	}
+
+	// Empty table cases.
+	if len(hist.buckets) == 0 || rowCount < 1 {
+		return zeroQuantile, nil
+	}
+
+	// To produce a quantile with first point at p=0 and at least two points, we
+	// need the first bucket to have NumRange == 0.
+	if hist.buckets[0].NumRange != 0 {
+		return nil, errors.AssertionFailedf(
+			"histogram with non-zero NumRange in first bucket: %v", hist.buckets[0].NumRange,
+		)
+	}
+
+	var (
+		// qfTrimLo and qfTrimHi are indexes to slice the quantile to when trimming
+		// zero-row buckets from the beginning and end of the histogram.
+		qfTrimLo, qfTrimHi quantileIndex
+		qf                 = make(quantile, 0, len(hist.buckets)*2)
+		prevV              = math.Inf(-1)
+		p                  float64
+	)
+
+	// Add a point counting num rows with value <= v.
+	addPoint := func(num, v float64) error {
+		if !isValidCount(num) {
+			return errors.AssertionFailedf("invalid histogram num: %v", num)
+		}
+		// Advance p by the proportion of rows counted by num.
+		p += num / rowCount
+		// Fix any floating point errors or histogram errors (e.g. sum of bucket row
+		// counts > total row count) causing p to go above 1.
+		if p > 1 {
+			p = 1
+		}
+		qf = append(qf, quantilePoint{p: p, v: v})
+		if p == 0 {
+			qfTrimLo = len(qf) - 1
+		}
+		if num > 0 {
+			qfTrimHi = len(qf)
+		}
+		return nil
+	}
+
+	// For each histogram bucket, add two points to the quantile: (1) an endpoint
+	// for NumRange and (2) an endpoint for NumEq. If NumEq == 0 we can skip the
+	// second point, but we must always add the first point even if NumRange == 0.
+	for i := range hist.buckets {
+		if hist.buckets[i].NumRange < 0 || hist.buckets[i].NumEq < 0 {
+			return nil, errors.AssertionFailedf("histogram bucket with negative row count")
+		}
+		v, err := toQuantileValue(hist.buckets[i].UpperBound)
+		if err != nil {
+			return nil, err
+		}
+		if v <= prevV {
+			return nil, errors.AssertionFailedf("non-increasing quantile values")
+		}
+		prevV = v
+
+		if err := addPoint(hist.buckets[i].NumRange, v); err != nil {
+			return nil, err
+		}
+		if hist.buckets[i].NumEq == 0 {
+			// Small optimization: skip adding a duplicate point to the quantile.
+			continue
+		}
+		if err := addPoint(hist.buckets[i].NumEq, v); err != nil {
+			return nil, err
+		}
+	}
+
+	if qfTrimHi <= qfTrimLo {
+		// In the unlikely case that every bucket had zero rows we simply return the
+		// zeroQuantile.
+		qf = zeroQuantile
+	} else {
+		// Trim any zero-row buckets from the beginning and end.
+		qf = qf[qfTrimLo:qfTrimHi]
+		// Fix any floating point errors or histogram errors (e.g. sum of bucket row
+		// counts < total row count) causing p to be below 1 at the end.
+		qf[len(qf)-1].p = 1
+	}
+	return qf, nil
+}
+
+// toHistogram converts a quantile into a histogram, using the provided type and
+// row count. It returns an error if the conversion fails.
+func (qf quantile) toHistogram(
+	evalCtx *eval.Context, colType *types.T, rowCount float64,
+) (histogram, error) {
+	if len(qf) < 2 || qf[0].p != 0 || qf[len(qf)-1].p != 1 {
+		return histogram{}, errors.AssertionFailedf("invalid quantile: %v", qf)
+	}
+
+	// Empty table case.
+	if rowCount < 1 {
+		return histogram{}, nil
+	}
+
+	hist := histogram{buckets: make([]cat.HistogramBucket, 0, len(qf)-1)}
+
+	var i quantileIndex
+	// Skip any leading p=0 points instead of emitting zero-row buckets.
+	for qf[i].p == 0 {
+		i++
+	}
+
+	// Create the first bucket of the histogram. The first bucket must always have
+	// NumRange == 0. Sometimes we will emit a zero-row bucket to make this true.
+	var currentLowerBound tree.Datum
+	currentUpperBound, err := fromQuantileValue(colType, qf[i-1].v)
+	if err != nil {
+		return histogram{}, err
+	}
+	currentBucket := cat.HistogramBucket{
+		NumEq:         0,
+		NumRange:      0,
+		DistinctRange: 0,
+		UpperBound:    currentUpperBound,
+	}
+
+	var pEq float64
+
+	// Set NumEq of the current bucket before creating a new current bucket.
+	closeCurrentBucket := func() error {
+		numEq := pEq * rowCount
+		if !isValidCount(numEq) {
+			return errors.AssertionFailedf("invalid histogram NumEq: %v", numEq)
+		}
+		if numEq < 1 && currentBucket.NumRange+numEq >= 2 {
+			// Steal from NumRange so that NumEq is at least 1, if it wouldn't make
+			// NumRange 0. This makes the histogram look more like something
+			// EquiDepthHistogram would produce.
+			currentBucket.NumRange -= 1 - numEq
+			numEq = 1
+		}
+		currentBucket.NumEq = numEq
+
+		// Calculate DistinctRange for this bucket now that NumRange is finalized.
+		distinctRange := estimatedDistinctValuesInRange(
+			evalCtx, currentBucket.NumRange, currentLowerBound, currentUpperBound,
+		)
+		if !isValidCount(distinctRange) {
+			return errors.AssertionFailedf("invalid histogram DistinctRange: %v", distinctRange)
+		}
+		currentBucket.DistinctRange = distinctRange
+
+		hist.buckets = append(hist.buckets, currentBucket)
+		pEq = 0
+		return nil
+	}
+
+	// For each point in the quantile, if its value is equal to the current
+	// upperBound then add to NumEq of the current bucket. Otherwise close the
+	// current bucket and add to NumRange of a new current bucket.
+	for ; i < len(qf); i++ {
+		upperBound, err := fromQuantileValue(colType, qf[i].v)
+		if err != nil {
+			return histogram{}, err
+		}
+		cmp, err := upperBound.CompareError(evalCtx, currentUpperBound)
+		if err != nil {
+			return histogram{}, err
+		}
+		if cmp < 0 {
+			return histogram{}, errors.AssertionFailedf("decreasing histogram values")
+		}
+		if cmp == 0 {
+			pEq += qf[i].p - qf[i-1].p
+		} else {
+			if err := closeCurrentBucket(); err != nil {
+				return histogram{}, err
+			}
+
+			// Start a new current bucket.
+			pRange := qf[i].p - qf[i-1].p
+			numRange := pRange * rowCount
+			if !isValidCount(numRange) {
+				return histogram{}, errors.AssertionFailedf("invalid histogram NumRange: %v", numRange)
+			}
+			currentLowerBound = getNextLowerBound(evalCtx, currentUpperBound)
+			currentUpperBound = upperBound
+			currentBucket = cat.HistogramBucket{
+				NumEq:         0,
+				NumRange:      numRange,
+				DistinctRange: 0,
+				UpperBound:    currentUpperBound,
+			}
+		}
+		// Skip any trailing p=1 points instead of emitting zero-row buckets.
+		if qf[i].p == 1 {
+			break
+		}
+	}
+
+	// Close the last bucket.
+	if err := closeCurrentBucket(); err != nil {
+		return histogram{}, err
+	}
+
+	return hist, nil
+}
+
+func isValidCount(x float64) bool {
+	return x >= 0 && !math.IsInf(x, 0) && !math.IsNaN(x)
+}
+
+// toQuantileValue converts from a datum to a float suitable for use in a quantile
 // function. It differs from eval.PerformCast in a few ways:
 // 1. It supports conversions that are not legal casts (e.g. DATE to FLOAT).
 // 2. It errors on NaN and infinite values because they will break our model.
-// FromQuantileValue is the inverse of this function, and together they should
+// fromQuantileValue is the inverse of this function, and together they should
 // support round-trip conversions.
 // TODO(michae2): Add support for DECIMAL, TIME, TIMETZ, and INTERVAL.
-func ToQuantileValue(d tree.Datum) (float64, error) {
+func toQuantileValue(d tree.Datum) (float64, error) {
 	switch v := d.(type) {
 	case *tree.DInt:
 		return float64(*v), nil
@@ -90,8 +397,8 @@ var (
 	quantileMaxTimestampSec = float64(quantileMaxTimestamp.Unix())
 )
 
-// FromQuantileValue converts from a quantile value back to a datum suitable for
-// use in a histogram. It is the inverse of ToQuantileValue. It differs from
+// fromQuantileValue converts from a quantile value back to a datum suitable for
+// use in a histogram. It is the inverse of toQuantileValue. It differs from
 // eval.PerformCast in a few ways:
 // 1. It supports conversions that are not legal casts (e.g. FLOAT to DATE).
 // 2. It errors on NaN and infinite values because they indicate a problem with
@@ -99,7 +406,7 @@ var (
 // 3. On overflow or underflow it clamps to maximum or minimum finite values
 //    rather than failing the conversion (and thus the entire histogram).
 // TODO(michae2): Add support for DECIMAL, TIME, TIMETZ, and INTERVAL.
-func FromQuantileValue(colType *types.T, val float64) (tree.Datum, error) {
+func fromQuantileValue(colType *types.T, val float64) (tree.Datum, error) {
 	if math.IsNaN(val) || math.IsInf(val, 0) {
 		return nil, tree.ErrFloatOutOfRange
 	}

--- a/pkg/sql/stats/quantile_test.go
+++ b/pkg/sql/stats/quantile_test.go
@@ -11,19 +11,561 @@
 package stats
 
 import (
+	"fmt"
 	"math"
+	"math/bits"
+	"math/rand"
+	"reflect"
+	"sort"
 	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 )
 
-// TODO(michae2): Test that a random histogram can round-trip to quantile
-// and back.
+// TestRandomQuantileRoundTrip creates a random histogram of each type, and
+// tests that each can be converted to a quantile function and back without
+// changing.
+func TestRandomQuantileRoundTrip(t *testing.T) {
+	colTypes := []*types.T{
+		// Types not in types.Scalar.
+		types.Int4,
+		types.Int2,
+		types.Float4,
+	}
+	colTypes = append(colTypes, types.Scalar...)
+	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	rng, seed := randutil.NewTestRand()
+	for _, colType := range colTypes {
+		if canMakeQuantile(colType) {
+			for i := 0; i < 5; i++ {
+				t.Run(fmt.Sprintf("%v/%v", colType.Name(), i), func(t *testing.T) {
+					hist, rowCount := randHist(evalCtx, colType, rng)
+					qfun, err := makeQuantile(hist, rowCount)
+					if err != nil {
+						t.Errorf("seed: %v unexpected makeQuantile error: %v", seed, err)
+						return
+					}
+					hist2, err := qfun.toHistogram(evalCtx, colType, rowCount)
+					if err != nil {
+						t.Errorf("seed: %v unexpected quantile.toHistogram error: %v", seed, err)
+						return
+					}
+					if !reflect.DeepEqual(hist, hist2) {
+						t.Errorf("seed: %v incorrect histogram:\n%v\nexpected:\n%v", seed, hist2, hist)
+					}
+				})
+			}
+		}
+	}
+}
+
+// randHist makes a random histogram of the specified type, with [1, 200]
+// buckets. Not all types are supported. Every bucket will have NumEq > 0 but
+// could have NumRange == 0.
+func randHist(evalCtx *eval.Context, colType *types.T, rng *rand.Rand) (histogram, float64) {
+	numBuckets := rng.Intn(200) + 1
+	buckets := make([]cat.HistogramBucket, numBuckets)
+	bounds := randBounds(evalCtx, colType, rng, numBuckets)
+	buckets[0].NumEq = float64(rng.Intn(100) + 1)
+	buckets[0].UpperBound = bounds[0]
+	rowCount := buckets[0].NumEq
+	for i := 1; i < len(buckets); i++ {
+		buckets[i].NumEq = float64(rng.Intn(100) + 1)
+		buckets[i].NumRange = float64(rng.Intn(1000))
+		buckets[i].UpperBound = bounds[i]
+		rowCount += buckets[i].NumEq + buckets[i].NumRange
+	}
+	// Adjust counts so that we have a power-of-two rowCount to avoid floating point errors.
+	targetRowCount := 1 << int(math.Ceil(math.Log2(rowCount)))
+	for rowCount < float64(targetRowCount) {
+		rows := float64(rng.Intn(targetRowCount - int(rowCount) + 1))
+		bucket := rng.Intn(numBuckets)
+		if bucket == 0 || rng.Float32() < 0.1 {
+			buckets[bucket].NumEq += rows
+		} else {
+			buckets[bucket].NumRange += rows
+		}
+		rowCount += rows
+	}
+	// Set DistinctRange in all buckets.
+	for i := 1; i < len(buckets); i++ {
+		lowerBound := getNextLowerBound(evalCtx, buckets[i-1].UpperBound)
+		buckets[i].DistinctRange = estimatedDistinctValuesInRange(
+			evalCtx, buckets[i].NumRange, lowerBound, buckets[i].UpperBound,
+		)
+	}
+	return histogram{buckets: buckets}, rowCount
+}
+
+// randBounds creates an ordered slice of num distinct Datums of the specified
+// type. Not all types are supported. This differs from randgen.RandDatum in
+// that it generates no "interesting" Datums, and differs from
+// randgen.RandDatumSimple in that it generates distinct Datums without repeats.
+func randBounds(evalCtx *eval.Context, colType *types.T, rng *rand.Rand, num int) tree.Datums {
+	datums := make(tree.Datums, num)
+
+	// randInts creates an ordered slice of num distinct random ints in the closed
+	// interval [lo, hi].
+	randInts := func(num, lo, hi int) []int {
+		vals := make([]int, 0, num)
+		set := make(map[int]struct{}, num)
+		span := hi - lo + 1
+		for len(vals) < num {
+			val := rng.Intn(span) + lo
+			if _, ok := set[val]; !ok {
+				set[val] = struct{}{}
+				vals = append(vals, val)
+			}
+		}
+		sort.Ints(vals)
+		return vals
+	}
+
+	// randFloat64s creates an ordered slice of num distinct random float64s in
+	// the half-open interval [lo, hi). If single is true they will also work as
+	// float32s.
+	randFloat64s := func(num int, lo, hi float64, single bool) []float64 {
+		vals := make([]float64, 0, num)
+		set := make(map[float64]struct{}, num)
+		span := hi - lo
+		for len(vals) < num {
+			val := rng.Float64()*span + lo
+			if single {
+				val = float64(float32(val))
+			}
+			if _, ok := set[val]; !ok {
+				set[val] = struct{}{}
+				vals = append(vals, val)
+			}
+		}
+		sort.Float64s(vals)
+		return vals
+	}
+
+	switch colType.Family() {
+	case types.IntFamily:
+		// First make sure we won't overflow in randInts (i.e. make sure that
+		// hi - lo + 1 <= math.MaxInt which requires -2 for hi).
+		w := int(bits.UintSize) - 2
+		lo := -1 << w
+		hi := (1 << w) - 2
+		// Then make sure hi and lo are representable by float64.
+		if w > 53 {
+			w = 53
+			lo = -1 << w
+			hi = 1 << w
+		}
+		// Finally make sure hi and low are representable by this type.
+		if w > int(colType.Width())-1 {
+			w = int(colType.Width()) - 1
+			lo = -1 << w
+			hi = (1 << w) - 1
+		}
+		vals := randInts(num, lo, hi)
+		for i := range datums {
+			datums[i] = tree.NewDInt(tree.DInt(int64(vals[i])))
+		}
+	case types.FloatFamily:
+		var lo, hi float64
+		if colType.Width() == 32 {
+			lo = -math.MaxFloat32
+			hi = math.MaxFloat32
+		} else {
+			// Divide by 2 to make sure we won't overflow in randFloat64s.
+			lo = -math.MaxFloat64 / 2
+			hi = math.MaxFloat64 / 2
+		}
+		vals := randFloat64s(num, lo, hi, colType.Width() == 32)
+		for i := range datums {
+			datums[i] = tree.NewDFloat(tree.DFloat(vals[i]))
+		}
+	case types.DateFamily:
+		lo := int(pgdate.LowDate.PGEpochDays())
+		hi := int(pgdate.HighDate.PGEpochDays())
+		vals := randInts(num, lo, hi)
+		for i := range datums {
+			datums[i] = tree.NewDDate(pgdate.MakeDateFromPGEpochClampFinite(int32(vals[i])))
+		}
+	case types.TimestampFamily, types.TimestampTZFamily:
+		roundTo := tree.TimeFamilyPrecisionToRoundDuration(colType.Precision())
+		var lo, hi int
+		if quantileMaxTimestampSec < math.MaxInt/2 {
+			lo = int(quantileMinTimestampSec)
+			hi = int(quantileMaxTimestampSec)
+		} else {
+			// Make sure we won't overflow in randInts (i.e. make sure that
+			// hi - lo + 1 <= math.MaxInt which requires -2 for hi).
+			w := int(bits.UintSize) - 2
+			lo = -1 << w
+			hi = (1 << w) - 2
+		}
+		secs := randInts(num, lo, hi)
+		for i := range datums {
+			t := timeutil.Unix(int64(secs[i]), 0)
+			var err error
+			if colType.Family() == types.TimestampFamily {
+				datums[i], err = tree.MakeDTimestamp(t, roundTo)
+			} else {
+				datums[i], err = tree.MakeDTimestampTZ(t, roundTo)
+			}
+			if err != nil {
+				panic(err)
+			}
+		}
+	default:
+		panic(colType.Name())
+	}
+	return datums
+}
+
+// Test basic conversions from histogram to quantile.
+func TestMakeQuantile(t *testing.T) {
+	// We use all floats here. TestToQuantileValue and TestFromQuantileValue test
+	// conversions to other datatypes.
+	testCases := []struct {
+		hist testHistogram
+		rows float64
+		qfun quantile
+		err  bool
+	}{
+		{
+			hist: nil,
+			rows: 0,
+			qfun: zeroQuantile,
+		},
+		{
+			hist: testHistogram{},
+			rows: 0,
+			qfun: zeroQuantile,
+		},
+		{
+			hist: testHistogram{{0, 0, 0, 0}},
+			rows: 0,
+			qfun: zeroQuantile,
+		},
+		{
+			hist: testHistogram{{0, 0, 0, 100}, {0, 0, 0, 200}},
+			rows: 10,
+			qfun: zeroQuantile,
+		},
+		{
+			hist: testHistogram{{1, 0, 0, 0}},
+			rows: 1,
+			qfun: zeroQuantile,
+		},
+		{
+			hist: testHistogram{{2, 0, 0, 0}},
+			rows: 2,
+			qfun: zeroQuantile,
+		},
+		{
+			hist: testHistogram{{1, 0, 0, 100}},
+			rows: 1,
+			qfun: quantile{{0, 100}, {1, 100}},
+		},
+		{
+			hist: testHistogram{{1, 0, 0, 100}, {0, 1, 1, 200}},
+			rows: 2,
+			qfun: quantile{{0, 100}, {0.5, 100}, {1, 200}},
+		},
+		{
+			hist: testHistogram{{1, 0, 0, 100}, {2, 1, 1, 200}},
+			rows: 4,
+			qfun: quantile{{0, 100}, {0.25, 100}, {0.5, 200}, {1, 200}},
+		},
+		{
+			hist: testHistogram{{0, 0, 0, 100}, {6, 2, 2, 200}},
+			rows: 8,
+			qfun: quantile{{0, 100}, {0.25, 200}, {1, 200}},
+		},
+		{
+			hist: testHistogram{{0, 0, 0, 100}, {6, 2, 2, 200}},
+			rows: 8,
+			qfun: quantile{{0, 100}, {0.25, 200}, {1, 200}},
+		},
+		{
+			hist: testHistogram{{2, 0, 0, 100}, {6, 2, 2, 200}, {2, 0, 0, 300}, {0, 4, 4, 400}},
+			rows: 16,
+			qfun: quantile{{0, 100}, {0.125, 100}, {0.25, 200}, {0.625, 200}, {0.625, 300}, {0.75, 300}, {1, 400}},
+		},
+		// Cases where we trim leading and trailing zero buckets.
+		{
+			hist: testHistogram{{0, 0, 0, 0}, {0, 0, 0, 100}, {2, 2, 2, 200}},
+			rows: 4,
+			qfun: quantile{{0, 100}, {0.5, 200}, {1, 200}},
+		},
+		{
+			hist: testHistogram{{0, 0, 0, 100}, {2, 6, 6, 200}, {0, 0, 0, 300}},
+			rows: 8,
+			qfun: quantile{{0, 100}, {0.75, 200}, {1, 200}},
+		},
+		{
+			hist: testHistogram{{0, 0, 0, 0}, {4, 0, 0, 100}, {1, 3, 3, 200}, {0, 0, 0, 300}},
+			rows: 8,
+			qfun: quantile{{0, 100}, {0.5, 100}, {0.875, 200}, {1, 200}},
+		},
+		// Cases where we clamp p to 1 to fix histogram errors.
+		{
+			hist: testHistogram{{2, 0, 0, 100}},
+			rows: 1,
+			qfun: quantile{{0, 100}, {1, 100}},
+		},
+		{
+			hist: testHistogram{{1, 0, 0, 100}, {0, 1, 1, 200}},
+			rows: 1,
+			qfun: quantile{{0, 100}, {1, 100}, {1, 200}},
+		},
+		// Error cases.
+		{
+			hist: testHistogram{},
+			rows: math.Inf(1),
+			err:  true,
+		},
+		{
+			hist: testHistogram{},
+			rows: math.NaN(),
+			err:  true,
+		},
+		{
+			hist: testHistogram{},
+			rows: -1,
+			err:  true,
+		},
+		{
+			hist: testHistogram{{0, 1, 1, 100}},
+			rows: 1,
+			err:  true,
+		},
+		{
+			hist: testHistogram{{-1, 0, 0, 100}},
+			rows: 1,
+			err:  true,
+		},
+		{
+			hist: testHistogram{{math.Inf(1), 0, 0, 100}},
+			rows: 1,
+			err:  true,
+		},
+		{
+			hist: testHistogram{{1, 0, 0, 100}, {1, 0, 0, 99}},
+			rows: 2,
+			err:  true,
+		},
+		{
+			hist: testHistogram{{1, 0, 0, 100}, {0, 1, 1, 100}},
+			rows: 2,
+			err:  true,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			qfun, err := makeQuantile(tc.hist.toHistogram(), tc.rows)
+			if err != nil {
+				if !tc.err {
+					t.Errorf("test case %d unexpected makeQuantile err: %v", i, err)
+				}
+				return
+			}
+			if tc.err {
+				t.Errorf("test case %d expected makeQuantile err", i)
+				return
+			}
+			if !reflect.DeepEqual(qfun, tc.qfun) {
+				t.Errorf("test case %d incorrect quantile %v expected %v", i, qfun, tc.qfun)
+			}
+		})
+	}
+}
+
+// Test basic conversions from quantile to histogram.
+func TestQuantileToHistogram(t *testing.T) {
+	// We use all floats here. TestToQuantileValue and TestFromQuantileValue test
+	// conversions to other datatypes.
+	testCases := []struct {
+		qfun quantile
+		rows float64
+		hist testHistogram
+		err  bool
+	}{
+		{
+			qfun: zeroQuantile,
+			rows: 0,
+			hist: nil,
+		},
+		{
+			qfun: zeroQuantile,
+			rows: 1,
+			hist: testHistogram{{1, 0, 0, 0}},
+		},
+		{
+			qfun: zeroQuantile,
+			rows: 2,
+			hist: testHistogram{{2, 0, 0, 0}},
+		},
+		{
+			qfun: quantile{{0, 100}, {1, 100}},
+			rows: 1,
+			hist: testHistogram{{1, 0, 0, 100}},
+		},
+		{
+			qfun: quantile{{0, 0}, {0, 100}, {1, 100}},
+			rows: 1,
+			hist: testHistogram{{1, 0, 0, 100}},
+		},
+		{
+			qfun: quantile{{0, 100}, {1, 100}, {1, 100}},
+			rows: 1,
+			hist: testHistogram{{1, 0, 0, 100}},
+		},
+		{
+			qfun: quantile{{0, 100}, {1, 100}, {1, 200}},
+			rows: 1,
+			hist: testHistogram{{1, 0, 0, 100}},
+		},
+		{
+			qfun: quantile{{0, 0}, {1, 100}},
+			rows: 1,
+			hist: testHistogram{{0, 0, 0, 0}, {0, 1, 1, 100}},
+		},
+		{
+			qfun: quantile{{0, 0}, {0.5, 100}, {1, 100}},
+			rows: 2,
+			hist: testHistogram{{0, 0, 0, 0}, {1, 1, 1, 100}},
+		},
+		{
+			qfun: quantile{{0, 0}, {0.9, 100}, {1, 100}},
+			rows: 10,
+			hist: testHistogram{{0, 0, 0, 0}, {1, 9, 9, 100}},
+		},
+		{
+			qfun: quantile{{0, 100}, {0.25, 100}, {0.75, 200}, {1, 200}},
+			rows: 16,
+			hist: testHistogram{{4, 0, 0, 100}, {4, 8, 8, 200}},
+		},
+		{
+			qfun: quantile{{0, 100}, {0.25, 100}, {0.5, 200}, {0.75, 200}, {0.75, 300}, {1, 300}},
+			rows: 16,
+			hist: testHistogram{{4, 0, 0, 100}, {4, 4, 4, 200}, {4, 0, 0, 300}},
+		},
+		{
+			qfun: quantile{{0, 500}, {0.125, 500}, {0.25, 600}, {0.5, 600}, {0.75, 800}, {1, 800}},
+			rows: 16,
+			hist: testHistogram{{2, 0, 0, 500}, {4, 2, 2, 600}, {4, 4, 4, 800}},
+		},
+		{
+			qfun: quantile{{0, 300}, {0, 310}, {0.125, 310}, {0.125, 320}, {0.25, 320}, {0.25, 330}, {0.5, 330}, {0.5, 340}, {0.625, 340}, {0.625, 350}, {0.75, 350}, {0.75, 360}, {0.875, 360}, {0.875, 370}, {1, 370}},
+			rows: 32,
+			hist: testHistogram{{4, 0, 0, 310}, {4, 0, 0, 320}, {8, 0, 0, 330}, {4, 0, 0, 340}, {4, 0, 0, 350}, {4, 0, 0, 360}, {4, 0, 0, 370}},
+		},
+		// Cases where we steal a row from NumRange to give to NumEq.
+		{
+			qfun: quantile{{0, 0}, {1, 100}},
+			rows: 2,
+			hist: testHistogram{{0, 0, 0, 0}, {1, 1, 1, 100}},
+		},
+		{
+			qfun: quantile{{0, 100}, {0.5, 100}, {1, 200}, {1, 300}},
+			rows: 4,
+			hist: testHistogram{{2, 0, 0, 100}, {1, 1, 1, 200}},
+		},
+		{
+			qfun: quantile{{0, 0}, {0.875, 87.5}, {1, 100}},
+			rows: 8,
+			hist: testHistogram{{0, 0, 0, 0}, {1, 6, 6, 87.5}, {0, 1, 1, 100}},
+		},
+		{
+			qfun: quantile{{0, 400}, {0.5, 600}, {0.75, 700}, {1, 800}},
+			rows: 16,
+			hist: testHistogram{{0, 0, 0, 400}, {1, 7, 7, 600}, {1, 3, 3, 700}, {1, 3, 3, 800}},
+		},
+		// Error cases.
+		{
+			qfun: quantile{},
+			rows: 1,
+			err:  true,
+		},
+		{
+			qfun: quantile{{0, 0}},
+			rows: 1,
+			err:  true,
+		},
+		{
+			qfun: quantile{{1, 0}, {0, 0}},
+			rows: 1,
+			err:  true,
+		},
+		{
+			qfun: quantile{{0, 100}, {0, 200}},
+			rows: 1,
+			err:  true,
+		},
+		{
+			qfun: quantile{{0, 100}, {math.NaN(), 100}, {1, 100}},
+			rows: 1,
+			err:  true,
+		},
+		{
+			qfun: quantile{{0, 0}, {0.75, 25}, {0.25, 75}, {1, 100}},
+			rows: 1,
+			err:  true,
+		},
+		{
+			qfun: quantile{{0, 100}, {1, 99}},
+			rows: 1,
+			err:  true,
+		},
+	}
+	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			hist, err := tc.qfun.toHistogram(evalCtx, types.Float, tc.rows)
+			if err != nil {
+				if !tc.err {
+					t.Errorf("test case %d unexpected quantile.toHistogram err: %v", i, err)
+				}
+				return
+			}
+			if tc.err {
+				t.Errorf("test case %d expected quantile.toHistogram err", i)
+				return
+			}
+			hist2 := tc.hist.toHistogram()
+			if !reflect.DeepEqual(hist, hist2) {
+				t.Errorf("test case %d incorrect histogram %v expected %v", i, hist, hist2)
+			}
+		})
+	}
+}
+
+// testHistogram is a float64-only histogram, which is a little more convenient
+// to construct than a normal histogram with tree.Datum UpperBounds.
+type testHistogram []testBucket
+
+type testBucket struct {
+	NumEq, NumRange, DistinctRange, UpperBound float64
+}
+
+func (th testHistogram) toHistogram() histogram {
+	if th == nil {
+		return histogram{}
+	}
+	h := histogram{buckets: make([]cat.HistogramBucket, len(th))}
+	for i := range th {
+		h.buckets[i].NumEq = th[i].NumEq
+		h.buckets[i].NumRange = th[i].NumRange
+		h.buckets[i].DistinctRange = th[i].DistinctRange
+		h.buckets[i].UpperBound = tree.NewDFloat(tree.DFloat(th[i].UpperBound))
+	}
+	return h
+}
 
 // Test conversions from datum to quantile value and back.
 func TestQuantileValueRoundTrip(t *testing.T) {
@@ -261,15 +803,15 @@ func TestQuantileValueRoundTrip(t *testing.T) {
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			val, err := ToQuantileValue(tc.dat)
+			val, err := toQuantileValue(tc.dat)
 			if err != nil {
 				if !tc.err {
-					t.Errorf("test case %d (%v) unexpected ToQuantileValue err: %v", i, tc.typ.Name(), err)
+					t.Errorf("test case %d (%v) unexpected toQuantileValue err: %v", i, tc.typ.Name(), err)
 				}
 				return
 			}
 			if tc.err {
-				t.Errorf("test case %d (%v) expected ToQuantileValue err", i, tc.typ.Name())
+				t.Errorf("test case %d (%v) expected toQuantileValue err", i, tc.typ.Name())
 				return
 			}
 			if val != tc.val {
@@ -277,9 +819,9 @@ func TestQuantileValueRoundTrip(t *testing.T) {
 				return
 			}
 			// Check that we can make the round trip.
-			res, err := FromQuantileValue(tc.typ, val)
+			res, err := fromQuantileValue(tc.typ, val)
 			if err != nil {
-				t.Errorf("test case %d (%v) unexpected FromQuantileValue err: %v", i, tc.typ.Name(), err)
+				t.Errorf("test case %d (%v) unexpected fromQuantileValue err: %v", i, tc.typ.Name(), err)
 				return
 			}
 			cmp, err := res.CompareError(evalCtx, tc.dat)
@@ -538,15 +1080,15 @@ func TestQuantileValueRoundTripOverflow(t *testing.T) {
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			d, err := FromQuantileValue(tc.typ, tc.val)
+			d, err := fromQuantileValue(tc.typ, tc.val)
 			if err != nil {
 				if !tc.err {
-					t.Errorf("test case %d (%v) unexpected FromQuantileValue err: %v", i, tc.typ.Name(), err)
+					t.Errorf("test case %d (%v) unexpected fromQuantileValue err: %v", i, tc.typ.Name(), err)
 				}
 				return
 			}
 			if tc.err {
-				t.Errorf("test case %d (%v) expected FromQuantileValue err", i, tc.typ.Name())
+				t.Errorf("test case %d (%v) expected fromQuantileValue err", i, tc.typ.Name())
 				return
 			}
 			cmp, err := d.CompareError(evalCtx, tc.dat)
@@ -559,9 +1101,9 @@ func TestQuantileValueRoundTripOverflow(t *testing.T) {
 				return
 			}
 			// Check that we can make the round trip with the clamped value.
-			res, err := ToQuantileValue(d)
+			res, err := toQuantileValue(d)
 			if err != nil {
-				t.Errorf("test case %d (%v) unexpected ToQuantileValue err: %v", i, tc.typ.Name(), err)
+				t.Errorf("test case %d (%v) unexpected toQuantileValue err: %v", i, tc.typ.Name(), err)
 				return
 			}
 			if res != tc.res {


### PR DESCRIPTION
To predict histograms in statistics forecasts, we will use linear
regression over quantile functions. (Quantile functions are another
representation of histogram data, in a form more amenable to statistical
manipulation.)

This commit defines quantile functions and adds methods to convert
between histograms and quantile functions.

This code was originally part of https://github.com/cockroachdb/cockroach/pull/77070 but has been pulled out to
simplify that PR. A few changes have been made:
- Common code has been factored into closures.
- More checks have been added for positive values.
- In `makeQuantile` we now trim leading empty buckets as well as
  trailing empty buckets.
- The logic in `quantile.toHistogram` to steal from `NumRange` if
  `NumEq` is zero now checks that `NumRange` will still be >= 1.
- More tests have been added.

Assists: #79872

Release note: None