### PR TITLE
kvclient: rename all `Del` operations to `Delete`

### DIFF
--- a/pkg/ccl/backupccl/insert_missing_public_schema_namespace_entry_restore_test.go
+++ b/pkg/ccl/backupccl/insert_missing_public_schema_namespace_entry_restore_test.go
@@ -75,8 +75,8 @@ func TestInsertMissingPublicSchemaNamespaceEntry(t *testing.T) {
 	err := tc.Servers[0].DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		codec := keys.SystemSQLCodec
 		b := txn.NewBatch()
-		b.Del(catalogkeys.MakeSchemaNameKey(codec, db1ID, `public`))
-		b.Del(catalogkeys.MakeSchemaNameKey(codec, db2ID, `public`))
+		b.Delete(catalogkeys.MakeSchemaNameKey(codec, db1ID, `public`))
+		b.Delete(catalogkeys.MakeSchemaNameKey(codec, db2ID, `public`))
 		return txn.Run(ctx, b)
 	})
 	require.NoError(t, err)

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2097,7 +2097,7 @@ func (r *restoreResumer) dropDescriptors(
 		// possible. This is safe since the table data was never visible to users,
 		// and so we don't need to preserve MVCC semantics.
 		tableToDrop.DropTime = dropTime
-		b.Del(catalogkeys.EncodeNameKey(codec, tableToDrop))
+		b.Delete(catalogkeys.EncodeNameKey(codec, tableToDrop))
 		descsCol.AddDeletedDescriptor(tableToDrop.GetID())
 	}
 
@@ -2116,10 +2116,10 @@ func (r *restoreResumer) dropDescriptors(
 			return err
 		}
 
-		b.Del(catalogkeys.EncodeNameKey(codec, typDesc))
+		b.Delete(catalogkeys.EncodeNameKey(codec, typDesc))
 		mutType.SetDropped()
 		// Remove the system.descriptor entry.
-		b.Del(catalogkeys.MakeDescMetadataKey(codec, typDesc.ID))
+		b.Delete(catalogkeys.MakeDescMetadataKey(codec, typDesc.ID))
 		descsCol.AddDeletedDescriptor(mutType.GetID())
 	}
 
@@ -2190,8 +2190,8 @@ func (r *restoreResumer) dropDescriptors(
 			return err
 		}
 
-		b.Del(catalogkeys.EncodeNameKey(codec, mutSchema))
-		b.Del(catalogkeys.MakeDescMetadataKey(codec, mutSchema.GetID()))
+		b.Delete(catalogkeys.EncodeNameKey(codec, mutSchema))
+		b.Delete(catalogkeys.MakeDescMetadataKey(codec, mutSchema.GetID()))
 		descsCol.AddDeletedDescriptor(mutSchema.GetID())
 		dbsWithDeletedSchemas[mutSchema.GetParentID()] = append(dbsWithDeletedSchemas[mutSchema.GetParentID()], mutSchema)
 	}
@@ -2261,16 +2261,16 @@ func (r *restoreResumer) dropDescriptors(
 		}
 
 		descKey := catalogkeys.MakeDescMetadataKey(codec, db.GetID())
-		b.Del(descKey)
+		b.Delete(descKey)
 
 		// We have explicitly to delete the system.namespace entry for the public schema
 		// if the database does not have a public schema backed by a descriptor.
 		if !db.(catalog.DatabaseDescriptor).HasPublicSchemaWithDescriptor() {
-			b.Del(catalogkeys.MakeSchemaNameKey(codec, db.GetID(), tree.PublicSchema))
+			b.Delete(catalogkeys.MakeSchemaNameKey(codec, db.GetID(), tree.PublicSchema))
 		}
 
 		nameKey := catalogkeys.MakeDatabaseNameKey(codec, db.GetName())
-		b.Del(nameKey)
+		b.Delete(nameKey)
 		descsCol.AddDeletedDescriptor(db.GetID())
 		deletedDBs[db.GetID()] = struct{}{}
 	}

--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -649,14 +649,10 @@ func (b *Batch) DelRange(s, e interface{}, returnKeys bool) {
 	b.initResult(1, 0, notRaw, nil)
 }
 
-// ExperimentalDelRangeUsingTombstone deletes the rows between begin (inclusive)
-// and end (exclusive) using an MVCC range tombstone. Callers must check the
+// DelRangeUsingTombstone deletes the rows between begin (inclusive) and end
+// (exclusive) using an MVCC range tombstone. Callers must check the
 // MVCCRangeTombstones version gate before using this.
-//
-// This method is EXPERIMENTAL: range tombstones are under active development,
-// and have severe limitations including being ignored by all KV and MVCC APIs
-// and only being stored in memory.
-func (b *Batch) ExperimentalDelRangeUsingTombstone(s, e interface{}) {
+func (b *Batch) DelRangeUsingTombstone(s, e interface{}) {
 	start, err := marshalKey(s)
 	if err != nil {
 		b.initResult(0, 0, notRaw, err)
@@ -672,7 +668,7 @@ func (b *Batch) ExperimentalDelRangeUsingTombstone(s, e interface{}) {
 			Key:    start,
 			EndKey: end,
 		},
-		UseExperimentalRangeTombstone: true,
+		UseRangeTombstone: true,
 	})
 	b.initResult(1, 0, notRaw, nil)
 }

--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -607,13 +607,13 @@ func (b *Batch) ReverseScanForUpdate(s, e interface{}) {
 	b.scan(s, e, true /* isReverse */, true /* forUpdate */)
 }
 
-// Del deletes one or more keys.
+// Delete deletes one or more keys.
 //
 // A new result will be appended to the batch and each key will have a
 // corresponding row in the returned Result.
 //
 // key can be either a byte slice or a string.
-func (b *Batch) Del(keys ...interface{}) {
+func (b *Batch) Delete(keys ...interface{}) {
 	reqs := make([]roachpb.Request, 0, len(keys))
 	for _, key := range keys {
 		k, err := marshalKey(key)
@@ -628,13 +628,13 @@ func (b *Batch) Del(keys ...interface{}) {
 	b.initResult(len(reqs), len(reqs), notRaw, nil)
 }
 
-// DelRange deletes the rows between begin (inclusive) and end (exclusive).
+// DeleteRange deletes the rows between begin (inclusive) and end (exclusive).
 //
 // A new result will be appended to the batch which will contain 0 rows and
 // Result.Err will indicate success or failure.
 //
 // key can be either a byte slice or a string.
-func (b *Batch) DelRange(s, e interface{}, returnKeys bool) {
+func (b *Batch) DeleteRange(s, e interface{}, returnKeys bool) {
 	begin, err := marshalKey(s)
 	if err != nil {
 		b.initResult(0, 0, notRaw, err)
@@ -649,10 +649,10 @@ func (b *Batch) DelRange(s, e interface{}, returnKeys bool) {
 	b.initResult(1, 0, notRaw, nil)
 }
 
-// DelRangeUsingTombstone deletes the rows between begin (inclusive) and end
+// DeleteRangeUsingTombstone deletes the rows between begin (inclusive) and end
 // (exclusive) using an MVCC range tombstone. Callers must check the
 // MVCCRangeTombstones version gate before using this.
-func (b *Batch) DelRangeUsingTombstone(s, e interface{}) {
+func (b *Batch) DeleteRangeUsingTombstone(s, e interface{}) {
 	start, err := marshalKey(s)
 	if err != nil {
 		b.initResult(0, 0, notRaw, err)

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -733,7 +733,7 @@ func TestConcurrentIncrements(t *testing.T) {
 	// Convenience loop: Crank up this number for testing this
 	// more often. It'll increase test duration though.
 	for k := 0; k < 5; k++ {
-		if _, err := db.DelRange(context.Background(), testUser+"/value-0", testUser+"/value-1x", false /* returnKeys */); err != nil {
+		if _, err := db.DeleteRange(context.Background(), testUser+"/value-0", testUser+"/value-1x", false /* returnKeys */); err != nil {
 			t.Fatalf("%d: unable to clean up: %s", k, err)
 		}
 		concurrentIncrements(db, t)

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -548,18 +548,12 @@ func (db *DB) DelRange(
 	return r.Keys, err
 }
 
-// ExperimentalDelRangeUsingTombstone deletes the rows between begin (inclusive)
-// and end (exclusive) using an MVCC range tombstone. Callers must check the
+// DelRangeUsingTombstone deletes the rows between begin (inclusive) and end
+// (exclusive) using an MVCC range tombstone. Callers must check the
 // MVCCRangeTombstones version gate before using this.
-//
-// This method is EXPERIMENTAL: range tombstones are under active development,
-// and have severe limitations including being ignored by all KV and MVCC APIs
-// and only being stored in memory.
-func (db *DB) ExperimentalDelRangeUsingTombstone(
-	ctx context.Context, begin, end interface{},
-) error {
+func (db *DB) DelRangeUsingTombstone(ctx context.Context, begin, end interface{}) error {
 	b := &Batch{}
-	b.ExperimentalDelRangeUsingTombstone(begin, end)
+	b.DelRangeUsingTombstone(begin, end)
 	_, err := getOneResult(db.Run(ctx, b), b)
 	return err
 }

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -524,36 +524,36 @@ func (db *DB) ReverseScanForUpdate(
 	return db.scan(ctx, begin, end, maxRows, true /* isReverse */, true /* forUpdate */, roachpb.CONSISTENT)
 }
 
-// Del deletes one or more keys.
+// Delete deletes one or more keys.
 //
 // key can be either a byte slice or a string.
-func (db *DB) Del(ctx context.Context, keys ...interface{}) error {
+func (db *DB) Delete(ctx context.Context, keys ...interface{}) error {
 	b := &Batch{}
-	b.Del(keys...)
+	b.Delete(keys...)
 	return getOneErr(db.Run(ctx, b), b)
 }
 
-// DelRange deletes the rows between begin (inclusive) and end (exclusive).
+// DeleteRange deletes the rows between begin (inclusive) and end (exclusive).
 //
 // The returned []roachpb.Key will contain the keys deleted if the returnKeys
 // parameter is true, or will be nil if the parameter is false.
 //
 // key can be either a byte slice or a string.
-func (db *DB) DelRange(
+func (db *DB) DeleteRange(
 	ctx context.Context, begin, end interface{}, returnKeys bool,
 ) ([]roachpb.Key, error) {
 	b := &Batch{}
-	b.DelRange(begin, end, returnKeys)
+	b.DeleteRange(begin, end, returnKeys)
 	r, err := getOneResult(db.Run(ctx, b), b)
 	return r.Keys, err
 }
 
-// DelRangeUsingTombstone deletes the rows between begin (inclusive) and end
+// DeleteRangeUsingTombstone deletes the rows between begin (inclusive) and end
 // (exclusive) using an MVCC range tombstone. Callers must check the
 // MVCCRangeTombstones version gate before using this.
-func (db *DB) DelRangeUsingTombstone(ctx context.Context, begin, end interface{}) error {
+func (db *DB) DeleteRangeUsingTombstone(ctx context.Context, begin, end interface{}) error {
 	b := &Batch{}
-	b.DelRangeUsingTombstone(begin, end)
+	b.DeleteRangeUsingTombstone(begin, end)
 	_, err := getOneResult(db.Run(ctx, b), b)
 	return err
 }

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -254,7 +254,7 @@ func TestDB_InitPut(t *testing.T) {
 	if err := db.InitPut(ctx, "aa", "2", false); err == nil {
 		t.Fatal("expected error from init put")
 	}
-	if err := db.Del(ctx, "aa"); err != nil {
+	if err := db.Delete(ctx, "aa"); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.InitPut(ctx, "aa", "2", true); err == nil {
@@ -466,7 +466,7 @@ func TestDB_TxnIterate(t *testing.T) {
 	}
 }
 
-func TestDB_Del(t *testing.T) {
+func TestDB_Delete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	s, db := setup(t)
@@ -479,7 +479,7 @@ func TestDB_Del(t *testing.T) {
 	if err := db.Run(context.Background(), b); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.Del(context.Background(), "ab"); err != nil {
+	if err := db.Delete(context.Background(), "ab"); err != nil {
 		t.Fatal(err)
 	}
 	rows, err := db.Scan(context.Background(), "a", "b", 100)
@@ -494,7 +494,7 @@ func TestDB_Del(t *testing.T) {
 	checkLen(t, len(expected), len(rows))
 }
 
-func TestDB_DelRange(t *testing.T) {
+func TestDB_DeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	s, db := setup(t)
@@ -508,7 +508,7 @@ func TestDB_DelRange(t *testing.T) {
 	if err := db.Run(context.Background(), b); err != nil {
 		t.Fatal(err)
 	}
-	deletedKeys, err := db.DelRange(context.Background(), "aa", "ac", true)
+	deletedKeys, err := db.DeleteRange(context.Background(), "aa", "ac", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -528,7 +528,7 @@ func TestDB_DelRange(t *testing.T) {
 	checkRows(t, expected, rows)
 	checkLen(t, len(expected), len(rows))
 
-	deletedKeys, err = db.DelRange(context.Background(), "aa", "ad", false)
+	deletedKeys, err = db.DeleteRange(context.Background(), "aa", "ad", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -651,11 +651,11 @@ func TestDBDecommissionedOperations(t *testing.T) {
 		name string
 		op   func() error
 	}{
-		{"Del", func() error {
-			return db.Del(ctx, key)
+		{"Delete", func() error {
+			return db.Delete(ctx, key)
 		}},
-		{"DelRange", func() error {
-			_, err := db.DelRange(ctx, key, keyEnd, false)
+		{"DeleteRange", func() error {
+			_, err := db.DeleteRange(ctx, key, keyEnd, false)
 			return err
 		}},
 		{"Get", func() error {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -130,7 +130,7 @@ func TestTxnCoordSenderKeyRanges(t *testing.T) {
 
 	for _, rng := range ranges {
 		if rng.end != nil {
-			if _, err := txn.DelRange(ctx, rng.start, rng.end, false /* returnKeys */); err != nil {
+			if _, err := txn.DeleteRange(ctx, rng.start, rng.end, false /* returnKeys */); err != nil {
 				t.Fatal(err)
 			}
 		} else {
@@ -1034,7 +1034,7 @@ func TestTxnCoordSenderNoDuplicateLockSpans(t *testing.T) {
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
-	_, pErr = txn.DelRange(ctx, roachpb.Key("u"), roachpb.Key("w"), false /* returnKeys */)
+	_, pErr = txn.DeleteRange(ctx, roachpb.Key("u"), roachpb.Key("w"), false /* returnKeys */)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1911,13 +1911,13 @@ func TestCommitMutatingTransaction(t *testing.T) {
 			pointWrite: true,
 		},
 		{
-			f:          func(ctx context.Context, txn *kv.Txn) error { return txn.Del(ctx, "a") },
+			f:          func(ctx context.Context, txn *kv.Txn) error { return txn.Delete(ctx, "a") },
 			expMethod:  roachpb.Delete,
 			pointWrite: true,
 		},
 		{
 			f: func(ctx context.Context, txn *kv.Txn) error {
-				_, err := txn.DelRange(ctx, "a", "b", false /* returnKeys */)
+				_, err := txn.DeleteRange(ctx, "a", "b", false /* returnKeys */)
 				return err
 			},
 			expMethod:  roachpb.DeleteRange,

--- a/pkg/kv/kvclient/kvcoord/txn_correctness_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_correctness_test.go
@@ -161,12 +161,12 @@ func readCmd(ctx context.Context, c *cmd, txn *kv.Txn) error {
 
 // deleteCmd deletes the value at the given key from the db.
 func deleteCmd(ctx context.Context, c *cmd, txn *kv.Txn) error {
-	return txn.Del(ctx, c.getKey())
+	return txn.Delete(ctx, c.getKey())
 }
 
 // deleteRngCmd deletes the range of values from the db from [key, endKey).
 func deleteRngCmd(ctx context.Context, c *cmd, txn *kv.Txn) error {
-	_, err := txn.DelRange(ctx, c.getKey(), c.getEndKey(), false /* returnKeys */)
+	_, err := txn.DeleteRange(ctx, c.getKey(), c.getEndKey(), false /* returnKeys */)
 	return err
 }
 

--- a/pkg/kv/kvclient/kvcoord/txn_intercepter_pipeliner_client_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_intercepter_pipeliner_client_test.go
@@ -130,7 +130,7 @@ func TestTxnPipelinerCondenseLockSpans(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		if tc.span.EndKey != nil {
-			if _, err := txn.DelRange(ctx, tc.span.Key, tc.span.EndKey, false /* returnKeys */); err != nil {
+			if _, err := txn.DeleteRange(ctx, tc.span.Key, tc.span.EndKey, false /* returnKeys */); err != nil {
 				t.Fatal(err)
 			}
 		} else {

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -906,7 +906,7 @@ func TestTxnReturnsWriteTooOldErrorOnConflictingDeleteRange(t *testing.T) {
 
 	// The first transaction deletes the value using a delete range operation.
 	b := txn1.NewBatch()
-	b.DelRange("a", "b", true /* returnKeys */)
+	b.DeleteRange("a", "b", true /* returnKeys */)
 	require.NoError(t, txn1.Run(ctx, b))
 	require.Len(t, b.Results[0].Keys, 1)
 	require.Equal(t, roachpb.Key("a"), b.Results[0].Keys[0])
@@ -918,7 +918,7 @@ func TestTxnReturnsWriteTooOldErrorOnConflictingDeleteRange(t *testing.T) {
 	// operation. This should immediately fail with a WriteTooOld error. It
 	// would be incorrect for this to be delayed and for 0 keys to be returned.
 	b = txn2.NewBatch()
-	b.DelRange("a", "b", true /* returnKeys */)
+	b.DeleteRange("a", "b", true /* returnKeys */)
 	err = txn2.Run(ctx, b)
 	require.NotNil(t, err)
 	require.Regexp(t, "TransactionRetryWithProtoRefreshError: WriteTooOldError", err)

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -180,9 +180,9 @@ func WithOnSSTable(f OnSSTable) Option {
 }
 
 // OnDeleteRange is called when an MVCC range tombstone is written (e.g. when
-// DeleteRange is called with UseExperimentalRangeTombstone, but not when the
-// range is deleted using point tombstones). If this callback is not provided,
-// an error is emitted when these are encountered.
+// DeleteRange is called with UseRangeTombstone, but not when the range is
+// deleted using point tombstones). If this callback is not provided, an error
+// is emitted when these are encountered.
 //
 // MVCC range tombstones are currently experimental, and requires the
 // MVCCRangeTombstones version gate. They are only expected during certain

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -666,11 +666,11 @@ func TestWithOnDeleteRange(t *testing.T) {
 	// catchup point, and the previous values should respect the range tombstones.
 	require.NoError(t, db.Put(ctx, "covered", "covered"))
 	require.NoError(t, db.Put(ctx, "foo", "covered"))
-	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, "a", "z"))
 	require.NoError(t, db.Put(ctx, "foo", "initial"))
 	rangeFeedTS := db.Clock().Now()
 	require.NoError(t, db.Put(ctx, "covered", "catchup"))
-	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, "a", "z"))
 	require.NoError(t, db.Put(ctx, "foo", "catchup"))
 
 	// We start the rangefeed over a narrower span than the DeleteRanges (c-g),
@@ -767,7 +767,7 @@ func TestWithOnDeleteRange(t *testing.T) {
 
 	// Send another DeleteRange, and wait for the rangefeed event. This should
 	// be truncated to the rangefeed bounds (c-g).
-	require.NoError(t, db.ExperimentalDelRangeUsingTombstone(ctx, "a", "z"))
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, "a", "z"))
 	select {
 	case e := <-deleteRangeC:
 		require.Equal(t, roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("g")}, e.Span)

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -438,7 +438,7 @@ func TestRangefeedValueTimestamps(t *testing.T) {
 
 	{
 		beforeDelTS := db.Clock().Now()
-		require.NoError(t, db.Del(ctx, mkKey("a")))
+		require.NoError(t, db.Delete(ctx, mkKey("a")))
 		afterDelTS := db.Clock().Now()
 
 		v := <-rows
@@ -453,7 +453,7 @@ func TestRangefeedValueTimestamps(t *testing.T) {
 
 	{
 		beforeDelTS := db.Clock().Now()
-		require.NoError(t, db.Del(ctx, mkKey("a")))
+		require.NoError(t, db.Delete(ctx, mkKey("a")))
 		afterDelTS := db.Clock().Now()
 
 		v := <-rows

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_test.go
@@ -108,10 +108,10 @@ func TestCache(t *testing.T) {
 		require.NoError(t, txn.Put(ctx, mkKey("d"), 1))
 	})
 	writeAndCheck(t, func(t *testing.T, txn *kv.Txn) {
-		require.NoError(t, txn.Del(ctx, mkKey("a")))
+		require.NoError(t, txn.Delete(ctx, mkKey("a")))
 	})
 	writeAndCheck(t, func(t *testing.T, txn *kv.Txn) {
-		_, err := txn.DelRange(ctx, mkKey("a"), mkKey("c"), false)
+		_, err := txn.DeleteRange(ctx, mkKey("a"), mkKey("c"), false)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -159,8 +159,8 @@ type clientI interface {
 	ScanForUpdate(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
 	ReverseScan(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
 	ReverseScanForUpdate(context.Context, interface{}, interface{}, int64) ([]kv.KeyValue, error)
-	Del(context.Context, ...interface{}) error
-	DelRange(context.Context, interface{}, interface{}, bool) ([]roachpb.Key, error)
+	Delete(context.Context, ...interface{}) error
+	DeleteRange(context.Context, interface{}, interface{}, bool) ([]roachpb.Key, error)
 	Run(context.Context, *kv.Batch) error
 }
 
@@ -208,13 +208,13 @@ func applyClientOp(ctx context.Context, db clientI, op *Operation, inTxn bool) {
 			}
 		}
 	case *DeleteOperation:
-		err := db.Del(ctx, o.Key)
+		err := db.Delete(ctx, o.Key)
 		o.Result = resultError(ctx, err)
 	case *DeleteRangeOperation:
 		if !inTxn {
 			panic(errors.AssertionFailedf(`non-transactional DelRange operations currently unsupported`))
 		}
-		deletedKeys, err := db.DelRange(ctx, o.Key, o.EndKey, true /* returnKeys */)
+		deletedKeys, err := db.DeleteRange(ctx, o.Key, o.EndKey, true /* returnKeys */)
 		if err != nil {
 			o.Result = resultError(ctx, err)
 		} else {
@@ -260,12 +260,12 @@ func applyBatchOp(
 				b.Scan(subO.Key, subO.EndKey)
 			}
 		case *DeleteOperation:
-			b.Del(subO.Key)
+			b.Delete(subO.Key)
 		case *DeleteRangeOperation:
 			if !inTxn {
 				panic(errors.AssertionFailedf(`non-transactional batch DelRange operations currently unsupported`))
 			}
-			b.DelRange(subO.Key, subO.EndKey, true /* returnKeys */)
+			b.DeleteRange(subO.Key, subO.EndKey, true /* returnKeys */)
 		default:
 			panic(errors.AssertionFailedf(`unknown batch operation type: %T %v`, subO, subO))
 		}

--- a/pkg/kv/kvnemesis/applier_test.go
+++ b/pkg/kv/kvnemesis/applier_test.go
@@ -85,19 +85,19 @@ func TestApplier(t *testing.T) {
 	check(t, step(reverseScan(`a`, `c`)), `db0.ReverseScan(ctx, "a", "c", 0) // (["b":"2", "a":"1"], nil)`)
 	check(t, step(reverseScanForUpdate(`a`, `b`)), `db1.ReverseScanForUpdate(ctx, "a", "b", 0) // (["a":"1"], nil)`)
 
-	check(t, step(del(`b`)), `db0.Del(ctx, "b") // nil`)
+	check(t, step(del(`b`)), `db0.Delete(ctx, "b") // nil`)
 	check(t, step(get(`b`)), `db1.Get(ctx, "b") // (nil, nil)`)
 
 	check(t, step(put(`c`, `3`)), `db0.Put(ctx, "c", 3) // nil`)
 	check(t, step(put(`d`, `4`)), `db1.Put(ctx, "d", 4) // nil`)
 
-	check(t, step(del(`c`)), `db0.Del(ctx, "c") // nil`)
+	check(t, step(del(`c`)), `db0.Delete(ctx, "c") // nil`)
 	check(t, step(scan(`a`, `e`)), `db1.Scan(ctx, "a", "e", 0) // (["a":"1", "d":"4"], nil)`)
 
 	check(t, step(put(`c`, `5`)), `db0.Put(ctx, "c", 5) // nil`)
 	check(t, step(closureTxn(ClosureTxnType_Commit, delRange(`b`, `d`))), `
 db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-  txn.DelRange(ctx, "b", "d", true) // (["c"], nil)
+  txn.DeleteRange(ctx, "b", "d", true) // (["c"], nil)
   return nil
 }) // nil txnpb:(...)
 		`)
@@ -109,11 +109,11 @@ db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 	checkErr(t, step(reverseScan(`a`, `c`)), `db1.ReverseScan(ctx, "a", "c", 0) // (nil, context canceled)`)
 
 	checkErr(t, step(reverseScanForUpdate(`a`, `c`)), `db0.ReverseScanForUpdate(ctx, "a", "c", 0) // (nil, context canceled)`)
-	checkErr(t, step(del(`b`)), `db1.Del(ctx, "b") // context canceled`)
+	checkErr(t, step(del(`b`)), `db1.Delete(ctx, "b") // context canceled`)
 
 	checkErr(t, step(closureTxn(ClosureTxnType_Commit, delRange(`b`, `d`))), `
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-  txn.DelRange(ctx, "b", "d", true)
+  txn.DeleteRange(ctx, "b", "d", true)
   return nil
 }) // context canceled
 		`)
@@ -127,8 +127,8 @@ db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   b := &Batch{}
   b.Put(ctx, "b", 2) // nil
   b.Get(ctx, "a") // ("1", nil)
-  b.Del(ctx, "b") // nil
-  b.Del(ctx, "c") // nil
+  b.Delete(ctx, "b") // nil
+  b.Delete(ctx, "c") // nil
   b.Scan(ctx, "a", "c") // (["a":"1"], nil)
   b.ReverseScanForUpdate(ctx, "a", "e") // (["d":"4", "a":"1"], nil)
   db1.Run(ctx, b) // nil
@@ -152,7 +152,7 @@ db1.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   {
     b := &Batch{}
     b.Put(ctx, "f", 6) // nil
-    b.DelRange(ctx, "c", "e", true) // (["d"], nil)
+    b.DeleteRange(ctx, "c", "e", true) // (["d"], nil)
     txn.Run(ctx, b) // nil
   }
   return nil

--- a/pkg/kv/kvnemesis/operations.go
+++ b/pkg/kv/kvnemesis/operations.go
@@ -235,12 +235,12 @@ func (op ScanOperation) format(w *strings.Builder, fctx formatCtx) {
 }
 
 func (op DeleteOperation) format(w *strings.Builder, fctx formatCtx) {
-	fmt.Fprintf(w, `%s.Del(ctx, %s)`, fctx.receiver, roachpb.Key(op.Key))
+	fmt.Fprintf(w, `%s.Delete(ctx, %s)`, fctx.receiver, roachpb.Key(op.Key))
 	op.Result.format(w)
 }
 
 func (op DeleteRangeOperation) format(w *strings.Builder, fctx formatCtx) {
-	fmt.Fprintf(w, `%s.DelRange(ctx, %s, %s, true)`, fctx.receiver, roachpb.Key(op.Key), roachpb.Key(op.EndKey))
+	fmt.Fprintf(w, `%s.DeleteRange(ctx, %s, %s, true)`, fctx.receiver, roachpb.Key(op.Key), roachpb.Key(op.EndKey))
 	switch op.Result.Type {
 	case ResultType_Error:
 		err := errors.DecodeError(context.TODO(), *op.Result.Err)

--- a/pkg/kv/kvnemesis/operations_test.go
+++ b/pkg/kv/kvnemesis/operations_test.go
@@ -28,7 +28,7 @@ func TestOperationsFormat(t *testing.T) {
 		expected string
 	}{
 		{step: step(get(`a`)), expected: `db0.Get(ctx, "a")`},
-		{step: step(del(`a`)), expected: `db0.Del(ctx, "a")`},
+		{step: step(del(`a`)), expected: `db0.Delete(ctx, "a")`},
 		{step: step(batch(get(`b`), reverseScanForUpdate(`c`, `e`), get(`f`))), expected: `
 			{
 			  b := &Batch{}
@@ -51,10 +51,10 @@ func TestOperationsFormat(t *testing.T) {
 			    b := &Batch{}
 			    b.Get(ctx, "g")
 			    b.Get(ctx, "h")
-			    b.Del(ctx, "i")
+			    b.Delete(ctx, "i")
 			    txn.Run(ctx, b)
 			  }
-			  txn.DelRange(ctx, "j", "k", true)
+			  txn.DeleteRange(ctx, "j", "k", true)
 			  txn.Put(ctx, "k", l)
 			  return nil
 			})

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -184,7 +184,7 @@ func (p *ProberOps) Write(key interface{}) func(context.Context, *kv.Txn) error 
 		// so we avoid depending on a subtlety of the implementation.
 		b := txn.NewBatch()
 		b.Put(key, putValue)
-		b.Del(key)
+		b.Delete(key)
 		return txn.CommitInBatch(ctx, b)
 	}
 }

--- a/pkg/kv/kvserver/addressing.go
+++ b/pkg/kv/kvserver/addressing.go
@@ -26,7 +26,7 @@ func putMeta(b *kv.Batch, key roachpb.Key, desc *roachpb.RangeDescriptor) {
 }
 
 func delMeta(b *kv.Batch, key roachpb.Key, desc *roachpb.RangeDescriptor) {
-	b.Del(key)
+	b.Delete(key)
 }
 
 // splitRangeAddressing creates (or overwrites if necessary) the meta1

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -424,7 +424,7 @@ func EvalAddSSTable(
 				if err != nil {
 					return result.Result{}, err
 				}
-				if err = readWriter.ExperimentalPutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+				if err = readWriter.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
 					return result.Result{}, err
 				}
 				if sstToReqTS.IsSet() {

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -763,7 +763,7 @@ func TestEvalAddSSTable(t *testing.T) {
 								v, err := storage.DecodeMVCCValue(kv.Value)
 								require.NoError(t, err)
 								require.True(t, v.IsTombstone(), "MVCC range keys must be tombstones")
-								require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(
+								require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 									ctx, b, nil, kv.RangeKey.StartKey, kv.RangeKey.EndKey, kv.RangeKey.Timestamp, v.MVCCValueHeader.LocalTimestamp, nil, nil, 0))
 							default:
 								t.Fatalf("unknown KV type %T", kv)

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -148,7 +148,7 @@ func TestCmdClearRange(t *testing.T) {
 				}
 				for _, rk := range rangeTombstones {
 					localTS := hlc.ClockTimestamp{WallTime: rk.Timestamp.WallTime - 1e9} // give range key a value if > 0
-					require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(
+					require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 						ctx, eng, nil, rk.StartKey, rk.EndKey, rk.Timestamp, localTS, nil, nil, 0))
 				}
 

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -44,7 +44,7 @@ func declareKeysDeleteRange(
 	// When writing range tombstones, we must look for adjacent range tombstones
 	// that we merge with or fragment, to update MVCC stats accordingly. But we
 	// make sure to stay within the range bounds.
-	if args.UseExperimentalRangeTombstone {
+	if args.UseRangeTombstone {
 		// NB: The range end key is not available, so this will pessimistically
 		// latch up to args.EndKey.Next(). If EndKey falls on the range end key, the
 		// span will be tightened during evaluation.
@@ -68,7 +68,7 @@ func DeleteRange(
 	reply := resp.(*roachpb.DeleteRangeResponse)
 
 	// Use experimental MVCC range tombstone if requested.
-	if args.UseExperimentalRangeTombstone {
+	if args.UseRangeTombstone {
 		if cArgs.Header.Txn != nil {
 			return result.Result{}, ErrTransactionUnsupported
 		}
@@ -85,7 +85,7 @@ func DeleteRange(
 			args.Key, args.EndKey, desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey())
 		maxIntents := storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 
-		err := storage.ExperimentalMVCCDeleteRangeUsingTombstone(ctx, readWriter, cArgs.Stats,
+		err := storage.MVCCDeleteRangeUsingTombstone(ctx, readWriter, cArgs.Stats,
 			args.Key, args.EndKey, h.Timestamp, cArgs.Now, leftPeekBound, rightPeekBound, maxIntents)
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -60,9 +60,9 @@ func TestDeleteRangeTombstone(t *testing.T) {
 		require.NoError(t, storage.MVCCPut(ctx, rw, nil, roachpb.Key("d"), hlc.Timestamp{WallTime: 2e9}, localTS, roachpb.MakeValueFromString("d2"), nil))
 		require.NoError(t, storage.MVCCDelete(ctx, rw, nil, roachpb.Key("d"), hlc.Timestamp{WallTime: 3e9}, localTS, nil))
 		require.NoError(t, storage.MVCCPut(ctx, rw, nil, roachpb.Key("i"), hlc.Timestamp{WallTime: 5e9}, localTS, roachpb.MakeValueFromString("i5"), &txn))
-		require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("f"), roachpb.Key("h"), hlc.Timestamp{WallTime: 3e9}, localTS, nil, nil, 0))
-		require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("Z"), roachpb.Key("a"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, 0))
-		require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("z"), roachpb.Key("|"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, 0))
+		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("f"), roachpb.Key("h"), hlc.Timestamp{WallTime: 3e9}, localTS, nil, nil, 0))
+		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("Z"), roachpb.Key("a"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, 0))
+		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, nil, roachpb.Key("z"), roachpb.Key("|"), hlc.Timestamp{WallTime: 100e9}, localTS, nil, nil, 0))
 	}
 
 	now := hlc.ClockTimestamp{Logical: 9}
@@ -180,9 +180,9 @@ func TestDeleteRangeTombstone(t *testing.T) {
 					Key:    rangeKey.StartKey,
 					EndKey: rangeKey.EndKey,
 				},
-				UseExperimentalRangeTombstone: true,
-				Inline:                        tc.inline,
-				ReturnKeys:                    tc.returnKeys,
+				UseRangeTombstone: true,
+				Inline:            tc.inline,
+				ReturnKeys:        tc.returnKeys,
 			}
 
 			ms := computeStats(t, engine, rangeStart, rangeEnd, rangeKey.Timestamp.WallTime)

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -1281,7 +1281,7 @@ func TestComputeSplitRangeKeyStatsDelta(t *testing.T) {
 			for _, rkv := range tc.rangeKVs {
 				value, err := storage.DecodeMVCCValue(rkv.Value)
 				require.NoError(t, err)
-				require.NoError(t, engine.ExperimentalPutMVCCRangeKey(rkv.RangeKey, value))
+				require.NoError(t, engine.PutMVCCRangeKey(rkv.RangeKey, value))
 			}
 
 			tc.expect.LastUpdateNanos = nowNanos

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
@@ -41,7 +41,7 @@ func TestRefreshRange(t *testing.T) {
 		ctx, eng, nil, roachpb.Key("b"), hlc.Timestamp{WallTime: 3}, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("value"), nil))
 	require.NoError(t, storage.MVCCPut(
 		ctx, eng, nil, roachpb.Key("c"), hlc.Timestamp{WallTime: 5}, hlc.ClockTimestamp{}, roachpb.Value{}, nil))
-	require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(
+	require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 		ctx, eng, nil, roachpb.Key("d"), roachpb.Key("f"), hlc.Timestamp{WallTime: 7}, hlc.ClockTimestamp{}, nil, nil, 0))
 
 	testcases := map[string]struct {

--- a/pkg/kv/kvserver/batcheval/transaction.go
+++ b/pkg/kv/kvserver/batcheval/transaction.go
@@ -101,7 +101,7 @@ func UpdateAbortSpan(
 		if !exists {
 			return nil
 		}
-		return rec.AbortSpan().Del(ctx, readWriter, ms, txn.ID)
+		return rec.AbortSpan().Delete(ctx, readWriter, ms, txn.ID)
 	}
 
 	entry := roachpb.AbortSpanEntry{

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4086,10 +4086,10 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 	// Simulate a merge transaction by launching a transaction that lays down
 	// intents on the two copies of the RHS range descriptor.
 	txn := kv.NewTxn(ctx, store.DB(), 0 /* gatewayNodeID */)
-	if err := txn.Del(ctx, keys.RangeDescriptorKey(rhsDesc.StartKey)); err != nil {
+	if err := txn.Delete(ctx, keys.RangeDescriptorKey(rhsDesc.StartKey)); err != nil {
 		t.Fatal(err)
 	}
-	if err := txn.Del(ctx, keys.RangeMetaKey(rhsDesc.StartKey)); err != nil {
+	if err := txn.Delete(ctx, keys.RangeMetaKey(rhsDesc.StartKey)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1319,7 +1319,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 				// we don't end up on the wrong side of the split.
 				delRes <- store.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 					b := txn.NewBatch()
-					b.Del(splitKey)
+					b.Delete(splitKey)
 					return txn.CommitInBatch(ctx, b)
 				})
 			}()

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -505,7 +505,7 @@ func WriteRandomDataToRange(
 					Key:    startKey,
 					EndKey: endKey,
 				},
-				UseExperimentalRangeTombstone: true,
+				UseRangeTombstone: true,
 			}
 		} else {
 			// Write regular point keys.

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp_test.go
@@ -69,7 +69,7 @@ func TestUnresolvedIntentQueue(t *testing.T) {
 
 	// Delete a non-existent txn.
 	txn4 := uuid.MakeV4()
-	adv = uiq.Del(txn4)
+	adv = uiq.Delete(txn4)
 	require.False(t, adv)
 	require.Equal(t, 2, uiq.Len())
 
@@ -136,7 +136,7 @@ func TestUnresolvedIntentQueue(t *testing.T) {
 	require.False(t, adv)
 	require.Equal(t, 3, uiq.Len())
 	require.Equal(t, txn2, uiq.Oldest().txnID)
-	adv = uiq.Del(txn5)
+	adv = uiq.Delete(txn5)
 	require.False(t, adv)
 	require.Equal(t, 2, uiq.Len())
 

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -180,7 +180,7 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 		}
 
 		if len(endKey) > 0 {
-			require.NoError(t, storage.ExperimentalMVCCDeleteRangeUsingTombstone(
+			require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
 				ctx, eng, nil, key, endKey, ts, localTS, nil, nil, 0))
 		} else {
 			require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, ts, localTS, value, nil))

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -616,42 +616,40 @@ func (s spanSetWriter) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 	return s.w.ClearMVCCIteratorRange(start, end)
 }
 
-func (s spanSetWriter) ExperimentalPutMVCCRangeKey(
+func (s spanSetWriter) PutMVCCRangeKey(
 	rangeKey storage.MVCCRangeKey, value storage.MVCCValue,
 ) error {
 	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
 		return err
 	}
-	return s.w.ExperimentalPutMVCCRangeKey(rangeKey, value)
+	return s.w.PutMVCCRangeKey(rangeKey, value)
 }
 
-func (s spanSetWriter) ExperimentalPutEngineRangeKey(
-	start, end roachpb.Key, suffix, value []byte,
-) error {
+func (s spanSetWriter) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	if !s.spansOnly {
-		panic("cannot do timestamp checking for ExperimentalPutEngineRangeKey")
+		panic("cannot do timestamp checking for PutEngineRangeKey")
 	}
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ExperimentalPutEngineRangeKey(start, end, suffix, value)
+	return s.w.PutEngineRangeKey(start, end, suffix, value)
 }
 
-func (s spanSetWriter) ExperimentalClearMVCCRangeKey(rangeKey storage.MVCCRangeKey) error {
+func (s spanSetWriter) ClearMVCCRangeKey(rangeKey storage.MVCCRangeKey) error {
 	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
 		return err
 	}
-	return s.w.ExperimentalClearMVCCRangeKey(rangeKey)
+	return s.w.ClearMVCCRangeKey(rangeKey)
 }
 
-func (s spanSetWriter) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
+func (s spanSetWriter) ClearAllRangeKeys(start, end roachpb.Key) error {
 	if !s.spansOnly {
-		panic("cannot do timestamp checking for ExperimentalClearAllRangeKeys")
+		panic("cannot do timestamp checking for ClearAllRangeKeys")
 	}
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ExperimentalClearAllRangeKeys(start, end)
+	return s.w.ClearAllRangeKeys(start, end)
 }
 
 func (s spanSetWriter) Merge(key storage.MVCCKey, value []byte) error {

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -626,27 +626,27 @@ func (txn *Txn) Iterate(
 	}
 }
 
-// Del deletes one or more keys.
+// Delete deletes one or more keys.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) Del(ctx context.Context, keys ...interface{}) error {
+func (txn *Txn) Delete(ctx context.Context, keys ...interface{}) error {
 	b := txn.NewBatch()
-	b.Del(keys...)
+	b.Delete(keys...)
 	return getOneErr(txn.Run(ctx, b), b)
 }
 
-// DelRange deletes the rows between begin (inclusive) and end (exclusive).
+// DeleteRange deletes the rows between begin (inclusive) and end (exclusive).
 //
 // The returned []roachpb.Key will contain the keys deleted if the returnKeys
 // parameter is true, or will be nil if the parameter is false, and Result.Err
 // will indicate success or failure.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) DelRange(
+func (txn *Txn) DeleteRange(
 	ctx context.Context, begin, end interface{}, returnKeys bool,
 ) ([]roachpb.Key, error) {
 	b := txn.NewBatch()
-	b.DelRange(begin, end, returnKeys)
+	b.DeleteRange(begin, end, returnKeys)
 	r, err := getOneResult(txn.Run(ctx, b), b)
 	return r.Keys, err
 }

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1298,7 +1298,7 @@ func (*DeleteRequest) flags() flag {
 
 func (drr *DeleteRangeRequest) flags() flag {
 	// DeleteRangeRequest using MVCC range tombstones cannot be transactional.
-	if drr.UseExperimentalRangeTombstone {
+	if drr.UseRangeTombstone {
 		return isWrite | isRange | isAlone | appliesTSCache
 	}
 	// DeleteRangeRequest has different properties if the "inline" flag is set.

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -349,17 +349,13 @@ message DeleteRangeRequest {
   // "inline" set to true will fail if it is executed within a transaction.
   bool inline = 4;
   // If enabled, the range is deleted using an MVCC range tombstone, which is a
-  // cheaper constant-time write operation (but still requires a time-bounded
-  // scan to check for conflicts). This option cannot be used in a transaction,
-  // and it cannot be combined with Inline or ReturnKeys.
+  // cheaper constant-time write operation (but still requires a scan to check
+  // for conflicts and adjust MVCC stats). This option cannot be used in a
+  // transaction, and it cannot be combined with Inline or ReturnKeys.
   //
   // The caller must check the MVCCRangeTombstones version gate before using
   // this parameter, as it is new in 22.2.
-  //
-  // This parameter is EXPERIMENTAL: range tombstones are under active
-  // development, and have severe limitations including being ignored by all
-  // KV and MVCC APIs and only being stored in memory.
-  bool use_experimental_range_tombstone = 5;
+  bool use_range_tombstone = 5;
 }
 
 // A DeleteRangeResponse is the return value from the DeleteRange()

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -372,7 +372,7 @@ func TestFlagCombinations(t *testing.T) {
 	reqVariants := []Request{
 		&AddSSTableRequest{SSTTimestampToRequestTimestamp: hlc.Timestamp{Logical: 1}},
 		&DeleteRangeRequest{Inline: true},
-		&DeleteRangeRequest{UseExperimentalRangeTombstone: true},
+		&DeleteRangeRequest{UseRangeTombstone: true},
 		&GetRequest{KeyLocking: lock.Exclusive},
 		&ReverseScanRequest{KeyLocking: lock.Exclusive},
 		&ScanRequest{KeyLocking: lock.Exclusive},

--- a/pkg/server/intent_test.go
+++ b/pkg/server/intent_test.go
@@ -142,8 +142,8 @@ func TestIntentResolution(t *testing.T) {
 					local := rnd.Intn(2) == 0
 					log.Infof(context.Background(), "%d: [%s,%s): local: %t", i, kr[0], kr[1], local)
 					if local {
-						b.DelRange(kr[0], kr[1], false /* returnKeys */)
-					} else if _, err := txn.DelRange(ctx, kr[0], kr[1], false /* returnKeys */); err != nil {
+						b.DeleteRange(kr[0], kr[1], false /* returnKeys */)
+					} else if _, err := txn.DeleteRange(ctx, kr[0], kr[1], false /* returnKeys */); err != nil {
 						return err
 					}
 				}

--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -80,7 +80,7 @@ func TestSettingWatcherOnTenant(t *testing.T) {
 		return filtered
 	}
 	copySettingsFromSystemToFakeTenant := func() int {
-		_, err := db.DelRange(
+		_, err := db.DeleteRange(
 			ctx,
 			fakeTenantPrefix,
 			fakeTenantPrefix.PrefixEnd(),

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2233,7 +2233,7 @@ func runSchemaChangesInTxn(
 		//lint:ignore SA1019 removal of deprecated method call scheduled for 22.2
 		for _, drain := range tableDesc.GetDrainingNames() {
 			key := catalogkeys.EncodeNameKey(planner.ExecCfg().Codec, drain)
-			if err := planner.Txn().Del(ctx, key); err != nil {
+			if err := planner.Txn().Delete(ctx, key); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -439,7 +439,7 @@ func (ibm *IndexBackfillMerger) constructMergeBatch(
 		memUsedInMerge += entryBytes
 		if deleted {
 			deletedCount++
-			wb.Del(mergedEntry.Key)
+			wb.Delete(mergedEntry.Key)
 		} else {
 			wb.Put(mergedEntry.Key, mergedEntry.Value)
 		}

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -167,7 +167,7 @@ func (d *deleteRangeNode) deleteSpans(params runParams, b *kv.Batch, spans roach
 		if traceKV {
 			log.VEventf(ctx, 2, "DelRange %s - %s", span.Key, span.EndKey)
 		}
-		b.DelRange(span.Key, span.EndKey, true /* returnKeys */)
+		b.DeleteRange(span.Key, span.EndKey, true /* returnKeys */)
 	}
 }
 

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -141,7 +141,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 			// The public schema and temporary schemas are cleaned up by just removing
 			// the existing namespace entries.
 			key := catalogkeys.MakeSchemaNameKey(p.ExecCfg().Codec, n.dbDesc.GetID(), schemaToDelete.GetName())
-			if err := p.txn.Del(ctx, key); err != nil {
+			if err := p.txn.Delete(ctx, key); err != nil {
 				return err
 			}
 		case catalog.SchemaUserDefined:

--- a/pkg/sql/gcjob/descriptor_utils.go
+++ b/pkg/sql/gcjob/descriptor_utils.go
@@ -37,7 +37,7 @@ func deleteDatabaseZoneConfig(
 		// Delete the zone config entry for the dropped database associated with the
 		// job, if it exists.
 		dbZoneKeyPrefix := config.MakeZoneKeyPrefix(codec, databaseID)
-		b.DelRange(dbZoneKeyPrefix, dbZoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
+		b.DeleteRange(dbZoneKeyPrefix, dbZoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
 		return txn.Run(ctx, b)
 	})
 }

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -303,11 +303,11 @@ SELECT job_id, status, running_status
 	// Manually delete the table.
 	require.NoError(t, kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		nameKey := catalogkeys.MakePublicObjectNameKey(keys.SystemSQLCodec, dbID, "foo")
-		if err := txn.Del(ctx, nameKey); err != nil {
+		if err := txn.Delete(ctx, nameKey); err != nil {
 			return err
 		}
 		descKey := catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, tableID)
-		return txn.Del(ctx, descKey)
+		return txn.Delete(ctx, descKey)
 	}))
 	// Update the GC TTL to tickle the job to refresh the status and discover that
 	// it has been removed. Use a SucceedsSoon to deal with races between setting

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1536,7 +1536,7 @@ func (r *importResumer) dropTables(
 			// possible. This is safe since the table data was never visible to users,
 			// and so we don't need to preserve MVCC semantics.
 			newTableDesc.DropTime = dropTime
-			b.Del(catalogkeys.EncodeNameKey(execCfg.Codec, newTableDesc))
+			b.Delete(catalogkeys.EncodeNameKey(execCfg.Codec, newTableDesc))
 			tablesToGC = append(tablesToGC, newTableDesc.ID)
 			descsCol.AddDeletedDescriptor(newTableDesc.GetID())
 		} else {
@@ -1630,7 +1630,7 @@ func (r *importResumer) dropSchemas(
 			if dbDesc.Schemas != nil {
 				delete(dbDesc.Schemas, schemaDesc.GetName())
 			}
-			b.Del(catalogkeys.EncodeNameKey(p.ExecCfg().Codec, schemaDesc))
+			b.Delete(catalogkeys.EncodeNameKey(p.ExecCfg().Codec, schemaDesc))
 		} else {
 			//lint:ignore SA1019 removal of deprecated method call scheduled for 22.2
 			schemaDesc.AddDrainingName(descpb.NameInfo{

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -307,16 +307,16 @@ func parseWorkloadConfig(fileName string) (workloadConfig, error) {
 		return c, errors.New(`parameter version is required`)
 	}
 	c.Version = q.Get(`version`)
-	q.Del(`version`)
+	q.Delete(`version`)
 	if s := q.Get(`row-start`); len(s) > 0 {
-		q.Del(`row-start`)
+		q.Delete(`row-start`)
 		var err error
 		if c.BatchBegin, err = strconv.ParseInt(s, 10, 64); err != nil {
 			return c, err
 		}
 	}
 	if e := q.Get(`row-end`); len(e) > 0 {
-		q.Del(`row-end`)
+		q.Delete(`row-end`)
 		var err error
 		if c.BatchEnd, err = strconv.ParseInt(e, 10, 64); err != nil {
 			return c, err

--- a/pkg/sql/name_util.go
+++ b/pkg/sql/name_util.go
@@ -61,5 +61,5 @@ func deleteNamespaceEntryAndMaybeAddDrainingName(
 	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "Del %s", marshalledKey)
 	}
-	b.Del(marshalledKey)
+	b.Delete(marshalledKey)
 }

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -620,7 +620,7 @@ func (p *planner) UnsafeDeleteNamespaceEntry(
 		return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 			"refusing to delete namespace entry for non-dropped descriptor")
 	}
-	if err := p.txn.Del(ctx, key); err != nil {
+	if err := p.txn.Delete(ctx, key); err != nil {
 		return errors.Wrap(err, "failed to delete entry")
 	}
 
@@ -669,7 +669,7 @@ func (p *planner) UnsafeDeleteDescriptor(ctx context.Context, descID int64, forc
 		}
 	}
 	descKey := catalogkeys.MakeDescMetadataKey(p.execCfg.Codec, id)
-	if err := p.txn.Del(ctx, descKey); err != nil {
+	if err := p.txn.Delete(ctx, descKey); err != nil {
 		return err
 	}
 

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -264,7 +264,7 @@ func (n *reparentDatabaseNode) startExec(params runParams) error {
 
 	// Delete the public schema namespace entry for this database. Per our check
 	// during initialization, this is the only schema present under n.db.
-	b.Del(catalogkeys.MakeSchemaNameKey(codec, n.db.ID, tree.PublicSchema))
+	b.Delete(catalogkeys.MakeSchemaNameKey(codec, n.db.ID, tree.PublicSchema))
 
 	// This command can only be run when database leasing is supported, so we don't
 	// have to handle the case where it isn't.

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -157,7 +157,7 @@ func (rd *Deleter) DeleteRow(
 		if traceKV {
 			log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(rd.Helper.primIndexValDirs, rd.key))
 		}
-		b.Del(&rd.key)
+		b.Delete(&rd.key)
 		rd.key = nil
 		return nil
 	})

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -338,7 +338,7 @@ func (rh *rowHelper) deleteIndexEntry(
 			}
 		}
 
-		batch.Del(entry.Key)
+		batch.Delete(entry.Key)
 	}
 	return nil
 }

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -99,7 +99,7 @@ func insertDelFn(ctx context.Context, b putter, key *roachpb.Key, traceKV bool) 
 	if traceKV {
 		log.VEventfDepth(ctx, 1, 2, "Del %s", *key)
 	}
-	b.Del(key)
+	b.Delete(key)
 }
 
 // insertPutFn is used by insertRow when conflicts should be ignored.
@@ -116,7 +116,7 @@ type putter interface {
 	CPut(key, value interface{}, expValue []byte)
 	Put(key, value interface{})
 	InitPut(key, value interface{}, failOnTombstones bool)
-	Del(key ...interface{})
+	Delete(key ...interface{})
 }
 
 // InsertRow adds to the batch the kv operations necessary to insert a table row

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -40,8 +40,8 @@ func (i KVInserter) CPut(key, value interface{}, expValue []byte) {
 	panic("unimplemented")
 }
 
-// Del is not implemented.
-func (i KVInserter) Del(key ...interface{}) {
+// Delete is not implemented.
+func (i KVInserter) Delete(key ...interface{}) {
 	// This is called when there are multiple column families to ensure that
 	// existing data is cleared. With the exception of IMPORT INTO, the entire
 	// existing keyspace in any IMPORT is guaranteed to be empty, so we don't have

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -537,7 +537,7 @@ func drainNamesForDescriptor(
 
 		// Reclaim all old names.
 		for _, drain := range namesToReclaim {
-			b.Del(catalogkeys.EncodeNameKey(codec, drain))
+			b.Delete(catalogkeys.EncodeNameKey(codec, drain))
 		}
 
 		// If the descriptor to drain is a schema, then we need to delete the
@@ -768,7 +768,7 @@ func (sc *SchemaChanger) exec(ctx context.Context) error {
 		switch desc.(type) {
 		case catalog.SchemaDescriptor, catalog.DatabaseDescriptor:
 			if desc.Dropped() {
-				if err := sc.execCfg.DB.Del(ctx, catalogkeys.MakeDescMetadataKey(sc.execCfg.Codec, desc.GetID())); err != nil {
+				if err := sc.execCfg.DB.Delete(ctx, catalogkeys.MakeDescMetadataKey(sc.execCfg.Codec, desc.GetID())); err != nil {
 					return err
 				}
 			}
@@ -1122,7 +1122,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(ctx context.Context, err error) er
 		if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace */, scTable, b); err != nil {
 			return err
 		}
-		b.Del(catalogkeys.EncodeNameKey(sc.execCfg.Codec, scTable))
+		b.Delete(catalogkeys.EncodeNameKey(sc.execCfg.Codec, scTable))
 
 		// Queue a GC job.
 		jobRecord := CreateGCJobRecord(
@@ -2756,7 +2756,7 @@ func (r schemaChangeResumer) Resume(ctx context.Context, execCtx interface{}) er
 					log.VEventf(ctx, 2, "DelRange %s", zoneKeyPrefix)
 				}
 				// Delete the zone config entry for this database.
-				if _, err := p.ExecCfg().DB.DelRange(ctx, zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */); err != nil {
+				if _, err := p.ExecCfg().DB.DeleteRange(ctx, zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */); err != nil {
 					return err
 				}
 			}
@@ -3062,11 +3062,11 @@ func DeleteTableDescAndZoneConfig(
 
 		// Delete the descriptor.
 		descKey := catalogkeys.MakeDescMetadataKey(codec, tableDesc.GetID())
-		b.Del(descKey)
+		b.Delete(descKey)
 		// Delete the zone config entry for this table, if necessary.
 		if codec.ForSystemTenant() {
 			zoneKeyPrefix := config.MakeZoneKeyPrefix(codec, tableDesc.GetID())
-			b.DelRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
+			b.DeleteRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
 		}
 		return txn.Run(ctx, b)
 	})

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5253,7 +5253,7 @@ func TestIndexBackfillValidation(t *testing.T) {
 					if err != nil {
 						t.Error(err)
 					}
-					if err := db.Del(context.Background(), kv[0].Key); err != nil {
+					if err := db.Delete(context.Background(), kv[0].Key); err != nil {
 						t.Error(err)
 					}
 				}
@@ -5324,7 +5324,7 @@ func TestInvertedIndexBackfillValidation(t *testing.T) {
 					if err != nil {
 						t.Error(err)
 					}
-					if err := db.Del(context.Background(), kv[0].Key); err != nil {
+					if err := db.Delete(context.Background(), kv[0].Key); err != nil {
 						t.Error(err)
 					}
 				}

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -241,14 +241,14 @@ func (b *catalogChangeBatcher) DeleteName(
 	if b.kvTrace {
 		log.VEventf(ctx, 2, "Del %s", marshalledKey)
 	}
-	b.batch.Del(marshalledKey)
+	b.batch.Delete(marshalledKey)
 	return nil
 }
 
 // DeleteDescriptor implements the scexec.CatalogChangeBatcher interface.
 func (b *catalogChangeBatcher) DeleteDescriptor(ctx context.Context, id descpb.ID) error {
 	marshalledKey := catalogkeys.MakeDescMetadataKey(b.codec, id)
-	b.batch.Del(marshalledKey)
+	b.batch.Delete(marshalledKey)
 	if b.kvTrace {
 		log.VEventf(ctx, 2, "Del %s", marshalledKey)
 	}
@@ -263,7 +263,7 @@ func (b *catalogChangeBatcher) DeleteZoneConfig(ctx context.Context, id descpb.I
 	if b.kvTrace {
 		log.VEventf(ctx, 2, "DelRange %s", zoneKeyPrefix)
 	}
-	b.batch.DelRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
+	b.batch.DeleteRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
 	return nil
 }
 

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -247,7 +247,7 @@ func removeIndexEntryForDatums(
 	if err != nil {
 		return err
 	}
-	return kvDB.Del(context.Background(), entry.Key)
+	return kvDB.Delete(context.Background(), entry.Key)
 }
 
 // addIndexEntryForDatums adds an index entry for the given datums. It assumes the datums are in the

--- a/pkg/sql/sem/tree/regexp_cache.go
+++ b/pkg/sql/sem/tree/regexp_cache.go
@@ -92,7 +92,7 @@ func (rc *RegexpCache) lookup(key RegexpCacheKey) *regexp.Regexp {
 func (rc *RegexpCache) update(key RegexpCacheKey, re *regexp.Regexp) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
-	rc.cache.Del(key)
+	rc.cache.Delete(key)
 	if re != nil {
 		rc.cache.Add(key, re)
 	}

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -230,7 +230,7 @@ func (s *Storage) getAllInstanceRows(
 func (s *Storage) ReleaseInstanceID(ctx context.Context, id base.SQLInstanceID) error {
 	key := makeInstanceKey(s.codec, s.tableID, id)
 	ctx = multitenant.WithTenantCostControlExemption(ctx)
-	if err := s.db.Del(ctx, key); err != nil {
+	if err := s.db.Delete(ctx, key); err != nil {
 		return errors.Wrapf(err, "could not delete instance %d", id)
 	}
 	return nil

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -247,7 +247,7 @@ func (s *Storage) isAlive(
 		if live {
 			s.mu.liveSessions.Add(sid, expiration)
 		} else {
-			s.mu.deadSessions.Del(sid)
+			s.mu.deadSessions.Delete(sid)
 			s.mu.deadSessions.Add(sid, nil)
 		}
 		return live, nil
@@ -306,7 +306,7 @@ func (s *Storage) deleteOrFetchSession(
 		// The session is expired and needs to be deleted.
 		deleted = true
 		expiration = hlc.Timestamp{}
-		return txn.Del(ctx, k)
+		return txn.Delete(ctx, k)
 	}); err != nil {
 		return false, hlc.Timestamp{}, errors.Wrapf(err,
 			"could not query session id: %s", sid)
@@ -370,7 +370,7 @@ func (s *Storage) deleteExpiredSessions(ctx context.Context) {
 					deleted++
 				}
 			}
-			if err := txn.Del(ctx, toDel...); err != nil {
+			if err := txn.Delete(ctx, toDel...); err != nil {
 				return err
 			}
 			start = rows[len(rows)-1].Key.Next()

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -380,7 +380,7 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 
 	if err != nil {
 		// Don't keep the cache entry around, so that we retry the query.
-		sc.mu.cache.Del(tableID)
+		sc.mu.cache.Delete(tableID)
 	}
 
 	return stats, err
@@ -448,7 +448,7 @@ func (sc *TableStatisticsCache) refreshCacheEntry(
 
 	if err != nil {
 		// Don't keep the cache entry around, so that we retry the query.
-		sc.mu.cache.Del(tableID)
+		sc.mu.cache.Delete(tableID)
 	}
 }
 
@@ -471,7 +471,7 @@ func (sc *TableStatisticsCache) InvalidateTableStats(ctx context.Context, tableI
 	log.VEventf(ctx, 1, "evicting statistics for table %d", tableID)
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	sc.mu.cache.Del(tableID)
+	sc.mu.cache.Delete(tableID)
 }
 
 const (

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -74,7 +74,7 @@ func (td *tableDeleter) deleteIndex(
 	if traceKV {
 		log.VEventf(ctx, 2, "DelRange %s - %s", resume.Key, resume.EndKey)
 	}
-	td.b.DelRange(resume.Key, resume.EndKey, false /* returnKeys */)
+	td.b.DeleteRange(resume.Key, resume.EndKey, false /* returnKeys */)
 	td.b.Header.MaxSpanRequestKeys = limit
 	if err := td.finalize(ctx); err != nil {
 		return resume, err

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -207,7 +207,7 @@ func cleanupSessionTempObjects(
 			// dropped). So we remove the namespace table entry of the temporary
 			// schema.
 			key := catalogkeys.MakeSchemaNameKey(codec, dbDesc.GetID(), tempSchemaName)
-			if err := txn.Del(ctx, key); err != nil {
+			if err := txn.Delete(ctx, key); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/tests/kv_test.go
+++ b/pkg/sql/tests/kv_test.go
@@ -102,7 +102,7 @@ func (kv *kvNative) Delete(rows, run int) error {
 	err := kv.db.Txn(context.Background(), func(ctx context.Context, txn *kv2.Txn) error {
 		b := txn.NewBatch()
 		for i := firstRow; i < lastRow; i++ {
-			b.Del(fmt.Sprintf("%s%08d", kv.prefix, i))
+			b.Delete(fmt.Sprintf("%s%08d", kv.prefix, i))
 		}
 		return txn.CommitInBatch(ctx, b)
 	})

--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -498,7 +498,7 @@ func (t *typeSchemaChanger) exec(ctx context.Context) error {
 	if typeDesc.Dropped() {
 		if err := t.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			b := txn.NewBatch()
-			b.Del(catalogkeys.MakeDescMetadataKey(codec, typeDesc.GetID()))
+			b.Delete(catalogkeys.MakeDescMetadataKey(codec, typeDesc.GetID()))
 			return txn.Run(ctx, b)
 		}); err != nil {
 			return err

--- a/pkg/sql/type_change_test.go
+++ b/pkg/sql/type_change_test.go
@@ -107,7 +107,7 @@ CREATE TYPE d.t AS ENUM();
 	desc := desctestutils.TestingGetPublicTypeDescriptor(kvDB, keys.SystemSQLCodec, "d", "t")
 	delTypeDesc = func() {
 		// Delete the descriptor.
-		if err := kvDB.Del(ctx, catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, desc.GetID())); err != nil {
+		if err := kvDB.Delete(ctx, catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, desc.GetID())); err != nil {
 			t.Error(err)
 		}
 	}

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1649,12 +1649,12 @@ func TestEngineClearRange(t *testing.T) {
 		var localTS hlc.ClockTimestamp
 		txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, wallTS(6), 1, 1)
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("c"), wallTS(1), localTS, stringValue("c1").Value, nil))
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("d", "h", 1), MVCCValue{}))
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "f", 2), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("d", "h", 1), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 2), MVCCValue{}))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("g"), wallTS(2), localTS, stringValue("g2").Value, nil))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("e"), wallTS(3), localTS, stringValue("e3").Value, nil))
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "f", 4), MVCCValue{}))
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("g", "h", 4), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 4), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("g", "h", 4), MVCCValue{}))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("a"), wallTS(5), localTS, stringValue("a2").Value, nil))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("b"), wallTS(5), localTS, stringValue("b2").Value, nil))
 		require.NoError(t, MVCCPut(ctx, rw, nil, roachpb.Key("c"), wallTS(5), localTS, stringValue("c2").Value, nil))
@@ -1817,7 +1817,7 @@ func TestEngineIteratorVisibility(t *testing.T) {
 
 				// Write initial point and range keys.
 				require.NoError(t, eng.PutMVCC(pointKey("a", 1), stringValue("a1")))
-				require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 1), MVCCValue{}))
+				require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 1), MVCCValue{}))
 
 				// Set up two readers: one regular and one which will be pinned.
 				r := tc.makeReader(eng)
@@ -1847,7 +1847,7 @@ func TestEngineIteratorVisibility(t *testing.T) {
 
 				// Write a new key to the engine, and set up the expected results.
 				require.NoError(t, eng.PutMVCC(pointKey("a", 2), stringValue("a2")))
-				require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 2), MVCCValue{}))
+				require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 2), MVCCValue{}))
 
 				expectOld := []interface{}{
 					pointKV("a", 1, "a1"),
@@ -1896,7 +1896,7 @@ func TestEngineIteratorVisibility(t *testing.T) {
 					// Write a new point and range key to the writer (not engine), and set
 					// up expected results.
 					require.NoError(t, w.PutMVCC(pointKey("a", 3), stringValue("a3")))
-					require.NoError(t, w.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 3), MVCCValue{}))
+					require.NoError(t, w.PutMVCCRangeKey(rangeKey("b", "c", 3), MVCCValue{}))
 					expectNewAndOwn := []interface{}{
 						pointKV("a", 3, "a3"),
 						pointKV("a", 2, "a2"),
@@ -1973,24 +1973,24 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		invalid := rangeKey("b", "a", 1)
 		zeroLength := rangeKey("a", "a", 1)
 
-		require.Error(t, rw.ExperimentalPutMVCCRangeKey(empty, MVCCValue{}))
-		require.Error(t, rw.ExperimentalPutMVCCRangeKey(invalid, MVCCValue{}))
-		require.Error(t, rw.ExperimentalPutMVCCRangeKey(zeroLength, MVCCValue{}))
+		require.Error(t, rw.PutMVCCRangeKey(empty, MVCCValue{}))
+		require.Error(t, rw.PutMVCCRangeKey(invalid, MVCCValue{}))
+		require.Error(t, rw.PutMVCCRangeKey(zeroLength, MVCCValue{}))
 
-		require.Error(t, rw.ExperimentalPutEngineRangeKey(empty.StartKey, empty.EndKey, nil, nil))
-		require.Error(t, rw.ExperimentalPutEngineRangeKey(invalid.StartKey, invalid.EndKey, nil, nil))
-		require.Error(t, rw.ExperimentalPutEngineRangeKey(zeroLength.StartKey, zeroLength.EndKey, nil, nil))
+		require.Error(t, rw.PutEngineRangeKey(empty.StartKey, empty.EndKey, nil, nil))
+		require.Error(t, rw.PutEngineRangeKey(invalid.StartKey, invalid.EndKey, nil, nil))
+		require.Error(t, rw.PutEngineRangeKey(zeroLength.StartKey, zeroLength.EndKey, nil, nil))
 
-		require.Error(t, rw.ExperimentalClearMVCCRangeKey(empty))
-		require.Error(t, rw.ExperimentalClearMVCCRangeKey(invalid))
-		require.Error(t, rw.ExperimentalClearMVCCRangeKey(zeroLength))
+		require.Error(t, rw.ClearMVCCRangeKey(empty))
+		require.Error(t, rw.ClearMVCCRangeKey(invalid))
+		require.Error(t, rw.ClearMVCCRangeKey(zeroLength))
 
-		require.Error(t, rw.ExperimentalClearAllRangeKeys(empty.StartKey, empty.EndKey))
-		require.Error(t, rw.ExperimentalClearAllRangeKeys(invalid.StartKey, invalid.EndKey))
-		require.Error(t, rw.ExperimentalClearAllRangeKeys(zeroLength.StartKey, zeroLength.EndKey))
+		require.Error(t, rw.ClearAllRangeKeys(empty.StartKey, empty.EndKey))
+		require.Error(t, rw.ClearAllRangeKeys(invalid.StartKey, invalid.EndKey))
+		require.Error(t, rw.ClearAllRangeKeys(zeroLength.StartKey, zeroLength.EndKey))
 
 		// Check that non-tombstone values error.
-		require.Error(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "b", 1), stringValue("foo")))
+		require.Error(t, rw.PutMVCCRangeKey(rangeKey("a", "b", 1), stringValue("foo")))
 
 		// Check that nothing got written during the errors above.
 		require.Empty(t, scanRangeKeys(t, rw))
@@ -2001,7 +2001,7 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 			rangeKey("f", "h", 1),
 			rangeKey("c", "g", 2),
 		} {
-			require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey, MVCCValue{}))
+			require.NoError(t, rw.PutMVCCRangeKey(rangeKey, MVCCValue{}))
 		}
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "c", 1, MVCCValue{}),
@@ -2016,8 +2016,8 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		// Clear the f-g portion of [f-h)@1, twice for idempotency. This should not
 		// affect any other range keys, apart from removing the fragment boundary
 		// at f for [d-g)@2.
-		require.NoError(t, rw.ExperimentalClearMVCCRangeKey(rangeKey("f", "g", 1)))
-		require.NoError(t, rw.ExperimentalClearMVCCRangeKey(rangeKey("f", "g", 1)))
+		require.NoError(t, rw.ClearMVCCRangeKey(rangeKey("f", "g", 1)))
+		require.NoError(t, rw.ClearMVCCRangeKey(rangeKey("f", "g", 1)))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "c", 1, MVCCValue{}),
 			rangeKV("c", "d", 2, MVCCValue{}),
@@ -2027,7 +2027,7 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		}, scanRangeKeys(t, rw))
 
 		// Write [e-f)@2 on top of existing [d-g)@2. This should be a noop.
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("e", "f", 2), MVCCValue{}))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("e", "f", 2), MVCCValue{}))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "c", 1, MVCCValue{}),
 			rangeKV("c", "d", 2, MVCCValue{}),
@@ -2037,8 +2037,8 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		}, scanRangeKeys(t, rw))
 
 		// Clear all range keys in the [c-f) span. Twice for idempotency.
-		require.NoError(t, rw.ExperimentalClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
-		require.NoError(t, rw.ExperimentalClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
+		require.NoError(t, rw.ClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
+		require.NoError(t, rw.ClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "c", 1, MVCCValue{}),
 			rangeKV("f", "g", 2, MVCCValue{}),
@@ -2049,7 +2049,7 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 		// a raw engine key rather than an MVCC key, to test that too.
 		valueRaw, err := EncodeMVCCValue(MVCCValue{})
 		require.NoError(t, err)
-		require.NoError(t, rw.ExperimentalPutEngineRangeKey(
+		require.NoError(t, rw.PutEngineRangeKey(
 			roachpb.Key("c"), roachpb.Key("g"), EncodeMVCCTimestampSuffix(wallTS(1)), valueRaw))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "f", 1, MVCCValue{}),
@@ -2060,7 +2060,7 @@ func TestEngineRangeKeyMutations(t *testing.T) {
 
 		// Writing a range key [a-f)@2 which abuts [f-g)@2 should not merge if it
 		// has a different value (local timestamp).
-		require.NoError(t, rw.ExperimentalPutMVCCRangeKey(rangeKey("a", "f", 2), withLocalTS(MVCCValue{}, 7)))
+		require.NoError(t, rw.PutMVCCRangeKey(rangeKey("a", "f", 2), withLocalTS(MVCCValue{}, 7)))
 		require.Equal(t, []MVCCRangeKeyValue{
 			rangeKV("a", "f", 2, withLocalTS(MVCCValue{}, 7)),
 			rangeKV("a", "f", 1, MVCCValue{}),
@@ -2124,16 +2124,16 @@ func TestEngineRangeKeysUnsupported(t *testing.T) {
 		t.Run(fmt.Sprintf("write/%s", name), func(t *testing.T) {
 			rangeKey := rangeKey("a", "b", 2)
 
-			err := w.ExperimentalPutMVCCRangeKey(rangeKey, MVCCValue{})
+			err := w.PutMVCCRangeKey(rangeKey, MVCCValue{})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "range keys not supported")
 
-			err = w.ExperimentalPutEngineRangeKey(rangeKey.StartKey, rangeKey.EndKey, nil, nil)
+			err = w.PutEngineRangeKey(rangeKey.StartKey, rangeKey.EndKey, nil, nil)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "range keys not supported")
 
-			require.NoError(t, w.ExperimentalClearMVCCRangeKey(rangeKey))
-			require.NoError(t, w.ExperimentalClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
+			require.NoError(t, w.ClearMVCCRangeKey(rangeKey))
+			require.NoError(t, w.ClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
 		})
 	}
 
@@ -2234,9 +2234,9 @@ func TestEngineRangeKeysUnsupported(t *testing.T) {
 
 // TestUnindexedBatchClearAllRangeKeys tests that range keys are properly
 // cleared via an unindexed batch. This tests an optimization in
-// pebbleBatch.ExperimentalClearAllRangeKeys that tightens the span bounds
-// to existing keys to avoid dropping unnecessary Pebble range tombstones, which
-// must handle the range keys in the unindexed batch correctly.
+// pebbleBatch.ClearAllRangeKeys that tightens the span bounds to existing keys
+// to avoid dropping unnecessary Pebble range tombstones, which must handle the
+// range keys in the unindexed batch correctly.
 func TestUnindexedBatchClearAllRangeKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2245,15 +2245,15 @@ func TestUnindexedBatchClearAllRangeKeys(t *testing.T) {
 	defer eng.Close()
 
 	// Write a range key [a-d)@1 into the engine.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("a", "d", 1), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("a", "d", 1), MVCCValue{}))
 
 	// Set up an unindexed batch, and write [e-h)@2 into it. Then clear
 	// all range keys in the [c-f) span via the batch and commit it.
 	batch := eng.NewUnindexedBatch(true /* writeOnly */)
 	defer batch.Close()
 
-	require.NoError(t, batch.ExperimentalPutMVCCRangeKey(rangeKey("e", "h", 2), MVCCValue{}))
-	require.NoError(t, batch.ExperimentalClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
+	require.NoError(t, batch.PutMVCCRangeKey(rangeKey("e", "h", 2), MVCCValue{}))
+	require.NoError(t, batch.ClearAllRangeKeys(roachpb.Key("c"), roachpb.Key("f")))
 	require.NoError(t, batch.Commit(false /* sync */))
 
 	// Read range keys back from engine. We should find [a-c)@1 and [f-h)@2.
@@ -2267,7 +2267,7 @@ func TestUnindexedBatchClearAllRangeKeys(t *testing.T) {
 	batch = eng.NewUnindexedBatch(true /* writeOnly */)
 	defer batch.Close()
 
-	require.NoError(t, batch.ExperimentalClearAllRangeKeys(roachpb.Key("b"), roachpb.Key("g")))
+	require.NoError(t, batch.ClearAllRangeKeys(roachpb.Key("b"), roachpb.Key("g")))
 	require.NoError(t, batch.Commit(false /* sync */))
 
 	// Read range keys back from engine. We should find [a-b)@1 and [g-h)@2.
@@ -2279,12 +2279,12 @@ func TestUnindexedBatchClearAllRangeKeys(t *testing.T) {
 	// Now clear everything. Twice, for idempotency.
 	batch = eng.NewUnindexedBatch(true /* writeOnly */)
 	defer batch.Close()
-	require.NoError(t, batch.ExperimentalClearAllRangeKeys(roachpb.Key("a"), roachpb.Key("z")))
+	require.NoError(t, batch.ClearAllRangeKeys(roachpb.Key("a"), roachpb.Key("z")))
 	require.NoError(t, batch.Commit(false /* sync */))
 
 	batch = eng.NewUnindexedBatch(true /* writeOnly */)
 	defer batch.Close()
-	require.NoError(t, batch.ExperimentalClearAllRangeKeys(roachpb.Key("a"), roachpb.Key("z")))
+	require.NoError(t, batch.ClearAllRangeKeys(roachpb.Key("a"), roachpb.Key("z")))
 	require.NoError(t, batch.Commit(false /* sync */))
 
 	require.Empty(t, scanRangeKeys(t, eng))

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2466,21 +2466,16 @@ func MVCCDeleteRange(
 	return keys, res.ResumeSpan, res.NumKeys, nil
 }
 
-// ExperimentalMVCCDeleteRangeUsingTombstone deletes the given MVCC keyspan at
-// the given timestamp using an MVCC range tombstone (rather than MVCC point
-// tombstones). This operation is non-transactional, but will check for
-// existing intents and return a WriteIntentError containing up to maxIntents
-// intents.
+// MVCCDeleteRangeUsingTombstone deletes the given MVCC keyspan at the given
+// timestamp using an MVCC range tombstone (rather than MVCC point tombstones).
+// This operation is non-transactional, but will check for existing intents and
+// return a WriteIntentError containing up to maxIntents intents.
 //
 // The leftPeekBound and rightPeekBound parameters are used when looking for
 // range tombstones that we'll merge or overlap with. These are provided to
 // prevent the command from reading outside of the CRDB range bounds and latch
 // bounds. nil means no bounds.
-//
-// This method is EXPERIMENTAL: range keys are under active development, and
-// have severe limitations including being ignored by all KV and MVCC APIs and
-// only being stored in memory.
-func ExperimentalMVCCDeleteRangeUsingTombstone(
+func MVCCDeleteRangeUsingTombstone(
 	ctx context.Context,
 	rw ReadWriter,
 	ms *enginepb.MVCCStats,
@@ -2763,7 +2758,7 @@ func ExperimentalMVCCDeleteRangeUsingTombstone(
 		}
 	}
 
-	if err := rw.ExperimentalPutMVCCRangeKey(rangeKey, value); err != nil {
+	if err := rw.PutMVCCRangeKey(rangeKey, value); err != nil {
 		return err
 	}
 
@@ -4839,7 +4834,7 @@ func MVCCExportToSST(
 				}
 				// Export only the inner roachpb.Value, not the MVCCValue header.
 				mvccValue = MVCCValue{Value: mvccValue.Value}
-				if err := sstWriter.ExperimentalPutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+				if err := sstWriter.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
 					return roachpb.BulkOpSummary{}, MVCCKey{}, err
 				}
 			}
@@ -5009,7 +5004,7 @@ func MVCCExportToSST(
 			}
 			// Export only the inner roachpb.Value, not the MVCCValue header.
 			mvccValue = MVCCValue{Value: mvccValue.Value}
-			if err := sstWriter.ExperimentalPutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+			if err := sstWriter.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
 				return roachpb.BulkOpSummary{}, MVCCKey{}, err
 			}
 		}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -902,8 +902,7 @@ func cmdClearRange(e *evalCtx) error {
 func cmdClearRangeKey(e *evalCtx) error {
 	key, endKey := e.getKeyRange()
 	ts := e.getTs(nil)
-	return e.engine.ExperimentalClearMVCCRangeKey(
-		MVCCRangeKey{StartKey: key, EndKey: endKey, Timestamp: ts})
+	return e.engine.ClearMVCCRangeKey(MVCCRangeKey{StartKey: key, EndKey: endKey, Timestamp: ts})
 }
 
 func cmdCPut(e *evalCtx) error {
@@ -1013,7 +1012,7 @@ func cmdDeleteRangeTombstone(e *evalCtx) error {
 	localTs := hlc.ClockTimestamp(e.getTsWithName("localTs"))
 
 	return e.withWriter("del_range_ts", func(rw ReadWriter) error {
-		return ExperimentalMVCCDeleteRangeUsingTombstone(e.ctx, rw, e.ms, key, endKey, ts, localTs, nil, nil, 0)
+		return MVCCDeleteRangeUsingTombstone(e.ctx, rw, e.ms, key, endKey, ts, localTs, nil, nil, 0)
 	})
 }
 
@@ -1280,7 +1279,7 @@ func cmdPutRangeKey(e *evalCtx) error {
 	value.MVCCValueHeader.LocalTimestamp = hlc.ClockTimestamp(e.getTsWithName("localTs"))
 
 	return e.withWriter("put_rangekey", func(rw ReadWriter) error {
-		return rw.ExperimentalPutMVCCRangeKey(rangeKey, value)
+		return rw.PutMVCCRangeKey(rangeKey, value)
 	})
 }
 
@@ -1479,7 +1478,7 @@ func cmdSSTPutRangeKey(e *evalCtx) error {
 	var value MVCCValue
 	value.MVCCValueHeader.LocalTimestamp = hlc.ClockTimestamp(e.getTsWithName("localTs"))
 
-	return e.sst().ExperimentalPutMVCCRangeKey(rangeKey, value)
+	return e.sst().PutMVCCRangeKey(rangeKey, value)
 }
 
 func cmdSSTClearRange(e *evalCtx) error {
@@ -1492,7 +1491,7 @@ func cmdSSTClearRangeKey(e *evalCtx) error {
 	rangeKey.StartKey, rangeKey.EndKey = e.getKeyRange()
 	rangeKey.Timestamp = e.getTs(nil)
 
-	return e.sst().ExperimentalClearMVCCRangeKey(rangeKey)
+	return e.sst().ClearMVCCRangeKey(rangeKey)
 }
 
 func cmdSSTFinish(e *evalCtx) error {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1136,7 +1136,7 @@ func (p *Pebble) ClearRawRange(start, end roachpb.Key) error {
 	if err := p.db.DeleteRange(startKey, endKey, pebble.Sync); err != nil {
 		return err
 	}
-	return p.ExperimentalClearAllRangeKeys(start, end)
+	return p.ClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Engine interface.
@@ -1162,8 +1162,8 @@ func (p *Pebble) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 	return batch.Commit(true)
 }
 
-// ExperimentalClearMVCCRangeKey implements the Engine interface.
-func (p *Pebble) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
+// ClearMVCCRangeKey implements the Engine interface.
+func (p *Pebble) ClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 	if !p.SupportsRangeKeys() {
 		// These databases cannot contain range keys, so clearing is a noop.
 		return nil
@@ -1178,8 +1178,8 @@ func (p *Pebble) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 		pebble.Sync)
 }
 
-// ExperimentalClearAllRangeKeys implements the Engine interface.
-func (p *Pebble) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
+// ClearAllRangeKeys implements the Engine interface.
+func (p *Pebble) ClearAllRangeKeys(start, end roachpb.Key) error {
 	if !p.SupportsRangeKeys() {
 		return nil // noop
 	}
@@ -1202,8 +1202,8 @@ func (p *Pebble) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
 	return p.db.Experimental().RangeKeyDelete(clearFrom, clearTo, pebble.Sync)
 }
 
-// ExperimentalPutMVCCRangeKey implements the Engine interface.
-func (p *Pebble) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
+// PutMVCCRangeKey implements the Engine interface.
+func (p *Pebble) PutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
 	if !p.SupportsRangeKeys() {
 		return errors.Errorf("range keys not supported by Pebble database version %s",
 			p.db.FormatMajorVersion())
@@ -1283,8 +1283,8 @@ func (p *Pebble) put(key MVCCKey, value []byte) error {
 	return p.db.Set(EncodeMVCCKey(key), value, pebble.Sync)
 }
 
-// ExperimentalPutEngineRangeKey implements the Engine interface.
-func (p *Pebble) ExperimentalPutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
+// PutEngineRangeKey implements the Engine interface.
+func (p *Pebble) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	if !p.SupportsRangeKeys() {
 		return errors.Errorf("range keys not supported by Pebble database version %s",
 			p.db.FormatMajorVersion())
@@ -2102,21 +2102,19 @@ func (p *pebbleReadOnly) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalPutMVCCRangeKey(MVCCRangeKey, MVCCValue) error {
+func (p *pebbleReadOnly) PutMVCCRangeKey(MVCCRangeKey, MVCCValue) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalPutEngineRangeKey(
-	roachpb.Key, roachpb.Key, []byte, []byte,
-) error {
+func (p *pebbleReadOnly) PutEngineRangeKey(roachpb.Key, roachpb.Key, []byte, []byte) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalClearMVCCRangeKey(MVCCRangeKey) error {
+func (p *pebbleReadOnly) ClearMVCCRangeKey(MVCCRangeKey) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ExperimentalClearAllRangeKeys(roachpb.Key, roachpb.Key) error {
+func (p *pebbleReadOnly) ClearAllRangeKeys(roachpb.Key, roachpb.Key) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -368,7 +368,7 @@ func (p *pebbleBatch) ClearRawRange(start, end roachpb.Key) error {
 	if err := p.batch.DeleteRange(p.buf, EncodeMVCCKey(MVCCKey{Key: end}), nil); err != nil {
 		return err
 	}
-	return p.ExperimentalClearAllRangeKeys(start, end)
+	return p.ClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Batch interface.
@@ -405,11 +405,11 @@ func (p *pebbleBatch) ClearMVCCIteratorRange(start, end roachpb.Key) error {
 			return err
 		}
 	}
-	return p.ExperimentalClearAllRangeKeys(start, end)
+	return p.ClearAllRangeKeys(start, end)
 }
 
-// ExperimentalClearMVCCRangeKey implements the Engine interface.
-func (p *pebbleBatch) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
+// ClearMVCCRangeKey implements the Engine interface.
+func (p *pebbleBatch) ClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 	if !p.SupportsRangeKeys() {
 		return nil // noop
 	}
@@ -423,8 +423,8 @@ func (p *pebbleBatch) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error
 		nil)
 }
 
-// ExperimentalClearAllRangeKeys implements the Engine interface.
-func (p *pebbleBatch) ExperimentalClearAllRangeKeys(start, end roachpb.Key) error {
+// ClearAllRangeKeys implements the Engine interface.
+func (p *pebbleBatch) ClearAllRangeKeys(start, end roachpb.Key) error {
 	if !p.SupportsRangeKeys() {
 		return nil // noop
 	}
@@ -458,8 +458,8 @@ func (p *pebbleBatch) ExperimentalClearAllRangeKeys(start, end roachpb.Key) erro
 	return p.batch.Experimental().RangeKeyDelete(clearFrom, clearTo, nil)
 }
 
-// ExperimentalPutMVCCRangeKey implements the Batch interface.
-func (p *pebbleBatch) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
+// PutMVCCRangeKey implements the Batch interface.
+func (p *pebbleBatch) PutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
 	if !p.SupportsRangeKeys() {
 		return errors.Errorf("range keys not supported by Pebble database version %s",
 			p.db.FormatMajorVersion())
@@ -483,16 +483,13 @@ func (p *pebbleBatch) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value M
 		nil); err != nil {
 		return err
 	}
-	// Mark the batch as containing range keys. See
-	// ExperimentalClearAllRangeKeys for why.
+	// Mark the batch as containing range keys. See ClearAllRangeKeys for why.
 	p.containsRangeKeys = true
 	return nil
 }
 
-// ExperimentalPutEngineRangeKey implements the Engine interface.
-func (p *pebbleBatch) ExperimentalPutEngineRangeKey(
-	start, end roachpb.Key, suffix, value []byte,
-) error {
+// PutEngineRangeKey implements the Engine interface.
+func (p *pebbleBatch) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	if !p.SupportsRangeKeys() {
 		return errors.Errorf("range keys not supported by Pebble database version %s",
 			p.db.FormatMajorVersion())
@@ -510,8 +507,7 @@ func (p *pebbleBatch) ExperimentalPutEngineRangeKey(
 	); err != nil {
 		return err
 	}
-	// Mark the batch as containing range keys. See ExperimentalClearAllRangeKeys
-	// for why.
+	// Mark the batch as containing range keys. See ClearAllRangeKeys for why.
 	p.containsRangeKeys = true
 	return nil
 }

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -632,14 +632,14 @@ func TestPebbleMVCCTimeIntervalCollectorAndFilter(t *testing.T) {
 	require.NoError(t, eng.Flush())
 
 	// Separate range keys [b-c)@5, [c-d)@7, [d-e)@9 share a block in a single SST.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
 	require.NoError(t, eng.Flush())
 
 	// Overlapping range keys [x-z)@5, [x-z)@7 share a block in a single SST.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("x", "z", 5), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("x", "z", 7), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("x", "z", 5), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("x", "z", 7), MVCCValue{}))
 	require.NoError(t, eng.Flush())
 
 	testcases := map[string]struct {
@@ -752,14 +752,14 @@ func TestPebbleMVCCTimeIntervalWithClears(t *testing.T) {
 	require.NoError(t, eng.Flush())
 
 	// Separate range keys [b-c)@5, [c-d)@7, [d-e)@9 in a single block in a single SST.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
 	require.NoError(t, eng.Flush())
 
 	// Clear a@5 and [c-d)@7 in a separate SST.
 	require.NoError(t, eng.ClearMVCC(pointKey("a", 5)))
-	require.NoError(t, eng.ExperimentalClearMVCCRangeKey(rangeKey("c", "d", 7)))
+	require.NoError(t, eng.ClearMVCCRangeKey(rangeKey("c", "d", 7)))
 	require.NoError(t, eng.Flush())
 
 	testcases := map[string]struct {
@@ -868,9 +868,9 @@ func TestPebbleMVCCTimeIntervalWithRangeClears(t *testing.T) {
 	require.NoError(t, eng.Flush())
 
 	// Separate range keys [b-c)@5, [c-d)@7, [d-e)@9 in a single block in a single SST.
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
-	require.NoError(t, eng.ExperimentalPutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("b", "c", 5), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("c", "d", 7), MVCCValue{}))
+	require.NoError(t, eng.PutMVCCRangeKey(rangeKey("d", "e", 9), MVCCValue{}))
 	require.NoError(t, eng.Flush())
 
 	// Clear [a-z) in a separate SST.

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -422,7 +422,7 @@ func UpdateSSTTimestamps(
 			if err != nil {
 				return nil, err
 			}
-			if err = writer.ExperimentalPutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+			if err = writer.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -140,7 +140,7 @@ func (fw *SSTWriter) ClearRawRange(start, end roachpb.Key) error {
 	if err := fw.clearRange(MVCCKey{Key: start}, MVCCKey{Key: end}); err != nil {
 		return err
 	}
-	return fw.ExperimentalClearAllRangeKeys(start, end)
+	return fw.ClearAllRangeKeys(start, end)
 }
 
 // ClearMVCCRange implements the Writer interface.
@@ -153,8 +153,8 @@ func (fw *SSTWriter) ClearMVCCVersions(start, end MVCCKey) error {
 	return fw.clearRange(start, end)
 }
 
-// ExperimentalPutMVCCRangeKey implements the Writer interface.
-func (fw *SSTWriter) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
+// PutMVCCRangeKey implements the Writer interface.
+func (fw *SSTWriter) PutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
 	if !fw.supportsRangeKeys {
 		return errors.New("range keys not supported by SST writer")
 	}
@@ -177,8 +177,8 @@ func (fw *SSTWriter) ExperimentalPutMVCCRangeKey(rangeKey MVCCRangeKey, value MV
 		valueRaw)
 }
 
-// ExperimentalClearMVCCRangeKey implements the Writer interface.
-func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
+// ClearMVCCRangeKey implements the Writer interface.
+func (fw *SSTWriter) ClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 	if !fw.supportsRangeKeys {
 		return nil // noop
 	}
@@ -192,8 +192,8 @@ func (fw *SSTWriter) ExperimentalClearMVCCRangeKey(rangeKey MVCCRangeKey) error 
 		EncodeMVCCTimestampSuffix(rangeKey.Timestamp))
 }
 
-// ExperimentalClearAllRangeKeys implements the Writer interface.
-func (fw *SSTWriter) ExperimentalClearAllRangeKeys(start roachpb.Key, end roachpb.Key) error {
+// ClearAllRangeKeys implements the Writer interface.
+func (fw *SSTWriter) ClearAllRangeKeys(start roachpb.Key, end roachpb.Key) error {
 	if !fw.supportsRangeKeys {
 		return nil // noop
 	}
@@ -209,10 +209,8 @@ func (fw *SSTWriter) ExperimentalClearAllRangeKeys(start roachpb.Key, end roachp
 	return fw.fw.RangeKeyDelete(EncodeMVCCKeyPrefix(start), EncodeMVCCKeyPrefix(end))
 }
 
-// ExperimentalPutEngineRangeKey implements the Writer interface.
-func (fw *SSTWriter) ExperimentalPutEngineRangeKey(
-	start, end roachpb.Key, suffix, value []byte,
-) error {
+// PutEngineRangeKey implements the Writer interface.
+func (fw *SSTWriter) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -134,11 +134,11 @@ func TestSSTWriterRangeKeysUnsupported(t *testing.T) {
 			rangeKey := rangeKey("a", "b", 2)
 
 			// Put should error, but clears are noops.
-			err := w.ExperimentalPutMVCCRangeKey(rangeKey, MVCCValue{})
+			err := w.PutMVCCRangeKey(rangeKey, MVCCValue{})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "range keys not supported")
-			require.NoError(t, w.ExperimentalClearMVCCRangeKey(rangeKey))
-			require.NoError(t, w.ExperimentalClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
+			require.NoError(t, w.ClearMVCCRangeKey(rangeKey))
+			require.NoError(t, w.ClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
 		})
 	}
 }
@@ -153,7 +153,7 @@ func TestSSTWriterRangeKeys(t *testing.T) {
 	sst := MakeIngestionSSTWriter(ctx, st, sstFile)
 	defer sst.Close()
 
-	require.NoError(t, sst.ExperimentalPutMVCCRangeKey(rangeKey("a", "e", 1), MVCCValue{}))
+	require.NoError(t, sst.PutMVCCRangeKey(rangeKey("a", "e", 1), MVCCValue{}))
 	require.NoError(t, sst.Put(pointKey("a", 2), stringValueRaw("foo")))
 	require.NoError(t, sst.Finish())
 

--- a/pkg/testutils/storageutils/sst.go
+++ b/pkg/testutils/storageutils/sst.go
@@ -52,7 +52,7 @@ func MakeSST(
 		case storage.MVCCRangeKeyValue:
 			v, err := storage.DecodeMVCCValue(kv.Value)
 			require.NoError(t, err)
-			require.NoError(t, writer.ExperimentalPutMVCCRangeKey(kv.RangeKey, v))
+			require.NoError(t, writer.PutMVCCRangeKey(kv.RangeKey, v))
 			s, e = kv.RangeKey.StartKey, kv.RangeKey.EndKey
 
 		default:

--- a/pkg/upgrade/upgrades/public_schema_migration.go
+++ b/pkg/upgrade/upgrades/public_schema_migration.go
@@ -122,7 +122,7 @@ func createPublicSchemaDescriptor(
 	newKey := catalogkeys.MakeSchemaNameKey(d.Codec, dbID, publicSchemaDesc.GetName())
 	oldKey := catalogkeys.EncodeNameKey(d.Codec, catalogkeys.NewNameKeyComponents(dbID, keys.RootNamespaceID, tree.PublicSchema))
 	// Remove namespace entry for old public schema.
-	b.Del(oldKey)
+	b.Delete(oldKey)
 	b.CPut(newKey, publicSchemaID, nil)
 	if err := descriptors.Direct().WriteNewDescToBatch(
 		ctx,
@@ -181,7 +181,7 @@ func migrateObjectsInDatabase(
 		b := desc.NewBuilder()
 		updateDesc := func(mut catalog.MutableDescriptor, newPublicSchemaID descpb.ID) {
 			oldKey := catalogkeys.MakeObjectNameKey(d.Codec, mut.GetParentID(), mut.GetParentSchemaID(), mut.GetName())
-			batch.Del(oldKey)
+			batch.Delete(oldKey)
 			newKey := catalogkeys.MakeObjectNameKey(d.Codec, mut.GetParentID(), newPublicSchemaID, mut.GetName())
 			batch.Put(newKey, mut.GetID())
 			modifiedDescs = append(modifiedDescs, mut)


### PR DESCRIPTION
The first commit is #83772.

---

This patch renames the following client methods on `DB`, `Batch`, and
`Txn`:

* `Del` → `Delete`
* `DelRange` → `DeleteRange`
* `DelRangeUsingTombstone` → `DeleteRangeUsingTombstone`

The actual gRPC and MVCC APIs all use the full `Delete` term for these
operations, with the client library being the odd one out. This can
often lead to inconsistent terminology being used by teams on either
side of the KV API boundary.

Release note: None