### PR TITLE
sql/builtins: tenant-related builtins require admin role

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
@@ -26,3 +26,8 @@ SELECT crdb_internal.destroy_tenant(5)
 
 query error tenant "5" is not active
 SELECT crdb_internal.update_tenant_resource_limits(5, 1000, 100, 0, now(), 0)
+
+user testuser
+
+statement error only users with the admin role are allowed to update tenant resource limits
+SELECT crdb_internal.update_tenant_resource_limits(5, 1000, 100, 0, now(), 0)

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -122,6 +122,10 @@ RANGE tenants  ALTER RANGE tenants CONFIGURE ZONE USING
                constraints = '[]',
                lease_preferences = '[]'
 
+# Set the jobs adopt interval so that this test doesn't take 30 seconds.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '1s'
+
 query T
 SELECT status FROM [
   SHOW JOB WHEN COMPLETE (
@@ -145,3 +149,14 @@ id  active  crdb_internal.pb_to_json
 
 query error tenant resource limits require a CCL binary
 SELECT crdb_internal.update_tenant_resource_limits(10, 1000, 100, 0, now(), 0)
+
+user testuser
+
+statement error only users with the admin role are allowed to create tenant
+SELECT crdb_internal.create_tenant(314)
+
+statement error only users with the admin role are allowed to destroy tenant
+SELECT crdb_internal.destroy_tenant(314)
+
+statement error only users with the admin role are allowed to gc tenant
+SELECT crdb_internal.gc_tenant(314)

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -223,6 +223,10 @@ func updateTenantRecord(
 
 // CreateTenant implements the tree.TenantOperator interface.
 func (p *planner) CreateTenant(ctx context.Context, tenID uint64) error {
+	if err := p.RequireAdminRole(ctx, "create tenant"); err != nil {
+		return err
+	}
+
 	info := &descpb.TenantInfoWithUsage{
 		TenantInfo: descpb.TenantInfo{
 			ID: tenID,
@@ -334,6 +338,9 @@ func generateTenantClusterSettingKV(
 }
 
 // ActivateTenant marks a tenant active.
+//
+// The caller is responsible for checking that the user is authorized
+// to take this action.
 func ActivateTenant(ctx context.Context, execCfg *ExecutorConfig, txn *kv.Txn, tenID uint64) error {
 	const op = "activate"
 	if err := rejectIfCantCoordinateMultiTenancy(execCfg.Codec, op); err != nil {
@@ -384,6 +391,9 @@ func clearTenant(ctx context.Context, execCfg *ExecutorConfig, info *descpb.Tena
 // DestroyTenant implements the tree.TenantOperator interface.
 func (p *planner) DestroyTenant(ctx context.Context, tenID uint64, synchronous bool) error {
 	const op = "destroy"
+	if err := p.RequireAdminRole(ctx, "destroy tenant"); err != nil {
+		return err
+	}
 	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, op); err != nil {
 		return err
 	}
@@ -418,6 +428,9 @@ func (p *planner) DestroyTenant(ctx context.Context, tenID uint64, synchronous b
 }
 
 // GCTenantSync clears the tenant's data and removes its record.
+//
+// The caller is responsible for checking that the user is authorized
+// to take this action.
 func GCTenantSync(ctx context.Context, execCfg *ExecutorConfig, info *descpb.TenantInfo) error {
 	const op = "gc"
 	if err := rejectIfCantCoordinateMultiTenancy(execCfg.Codec, op); err != nil {
@@ -534,11 +547,15 @@ func gcTenantJob(
 }
 
 // GCTenant implements the tree.TenantOperator interface.
+//
+// TODO(jeffswenson): Delete internal_crdb.gc_tenant after the DestroyTenant
+// changes are deployed to all Cockroach Cloud serverless hosts.
 func (p *planner) GCTenant(ctx context.Context, tenID uint64) error {
-	// TODO(jeffswenson): Delete internal_crdb.gc_tenant after the DestroyTenant
-	// changes are deployed to all Cockroach Cloud serverless hosts.
 	if !p.extendedEvalCtx.TxnIsSingleStmt {
 		return errors.Errorf("gc_tenant cannot be used inside a multi-statement transaction")
+	}
+	if err := p.RequireAdminRole(ctx, "gc tenant"); err != nil {
+		return err
 	}
 	var info *descpb.TenantInfo
 	if txnErr := p.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -571,6 +588,10 @@ func (p *planner) UpdateTenantResourceLimits(
 	asOfConsumedRequestUnits float64,
 ) error {
 	const op = "update-resource-limits"
+	if err := p.RequireAdminRole(ctx, "update tenant resource limits"); err != nil {
+		return err
+	}
+
 	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, op); err != nil {
 		return err
 	}


### PR DESCRIPTION
The following builtins now require the admin role:

- crdb_internal.create_tenant
- crdb_internal.destroy_tenant
- crdb_internal.gc_tenant
- crdb_internal.update_tenant_resource_limits

Release note (ops change): Tenant-related crdb_internal functions now
require the admin role to use.