### PR TITLE
kvserver: set StoresInterval to 10s

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -123,7 +123,9 @@ const (
 	NodeDescriptorTTL = 2 * NodeDescriptorInterval
 
 	// StoresInterval is the default interval for gossiping store descriptors.
-	StoresInterval = 60 * time.Second
+	// Note that there are additional conditions that trigger reactive store
+	// gossip.
+	StoresInterval = 10 * time.Second
 
 	// StoreTTL is time-to-live for store-related info.
 	StoreTTL = 2 * StoresInterval


### PR DESCRIPTION
In #81669 @kvoli discovered that we often gossip much more frequently
than at a 60s interval. Since we are also adding I/O liveness signals
to the store capacity to use in a solution for #79215, we want to make
this more reactive interval explicit.

This change has the side effect of reducing the minimum allowed value
for `server.time_until_store_dead` to 25s[^1]; this seems reasonable.

[^1]: https://github.com/cockroachdb/cockroach/blob/263fbb7c8fcf001fcf47d7d35894b5824c78dc14/pkg/kv/kvserver/allocator/storepool/store_pool.go#L94-L99

Release note: None
