### PR TITLE
release-22.1: sql: allow foreign key to reference crdb_region column in REGIONAL BY ROW

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -305,8 +305,8 @@ INSERT INTO fk_using_implicit_columns_against_t VALUES (1, 1, 4)
 statement error Key \(ref_t_pk\)=\(2\) is not present in table "t"
 INSERT INTO fk_using_implicit_columns_against_t VALUES (2, 2, 4)
 
-# Error if we reference the implicit partitioning in the foreign key.
-statement error there is no unique constraint matching given keys for referenced table t
+# We are allowed to reference the implicit partitioning in the foreign key.
+statement ok
 CREATE TABLE fk_including_implicit_columns_against_t (
   pk INT NOT NULL PRIMARY KEY,
   ref_t_a INT,

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1798,3 +1798,53 @@ SELECT pk, a, b, crdb_region_col, crdb_region_col1 FROM regional_by_row_table_as
 1  NULL  NULL  ca-central-1  ca-central-1
 2  NULL  NULL  us-east-1     ca-central-1
 3  NULL  NULL  us-east-1     ca-central-1
+
+# Permit foreign key constraint on full primary index of RBR table (See #74244).
+statement ok
+CREATE TABLE users (
+    id         UUID   PRIMARY KEY DEFAULT gen_random_uuid(),
+    username   STRING NOT NULL
+) LOCALITY REGIONAL BY ROW;
+CREATE TABLE user_settings (
+    id      UUID   PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID   NOT NULL,
+    value   STRING NOT NULL,
+    FOREIGN KEY (user_id, crdb_region) REFERENCES users (id, crdb_region) ON DELETE CASCADE ON UPDATE CASCADE
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO users (crdb_region, id, username) VALUES ('ap-southeast-2', '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'artem')
+
+query error violates foreign key constraint
+INSERT INTO user_settings (crdb_region, id, user_id, value)
+  VALUES ('ca-central-1', DEFAULT, '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'this should work')
+
+statement ok
+INSERT INTO user_settings (crdb_region, id, user_id, value)
+  VALUES ('ap-southeast-2', 'f1867e8b-3414-425c-b3f8-d7e237f848e6', '5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'this should work')
+
+query TTT
+SELECT crdb_region, * FROM users
+----
+ap-southeast-2  5ebfedee-0dcf-41e6-a315-5fa0b51b9882  artem
+
+query TTTT
+SELECT crdb_region, * FROM user_settings
+----
+ap-southeast-2  f1867e8b-3414-425c-b3f8-d7e237f848e6  5ebfedee-0dcf-41e6-a315-5fa0b51b9882  this should work
+
+query error violates foreign key constraint
+UPDATE user_settings SET crdb_region = 'ca-central-1' WHERE id = 'f1867e8b-3414-425c-b3f8-d7e237f848e6';
+
+statement ok
+UPDATE users SET crdb_region = 'ca-central-1' WHERE id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882';
+
+query TTT
+SELECT crdb_region, * FROM users
+----
+ca-central-1  5ebfedee-0dcf-41e6-a315-5fa0b51b9882  artem
+
+query TTTT
+SELECT crdb_region, * FROM user_settings
+----
+ca-central-1  f1867e8b-3414-425c-b3f8-d7e237f848e6  5ebfedee-0dcf-41e6-a315-5fa0b51b9882  this should work

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
@@ -148,3 +148,38 @@ CREATE TABLE public.t_regional_pk_hashed_2 (
                             INDEX t_regional_pk_hashed_2_b_idx (b ASC) USING HASH WITH (bucket_count=16),
                             FAMILY fam_0_b_pk_crdb_region (b, pk, crdb_region)
 ) LOCALITY REGIONAL BY ROW
+
+# Permit foreign key constraint on full primary index of RBR table excluding
+# hash column (See #74244).
+statement ok
+CREATE TABLE users (
+    id         UUID   NOT NULL DEFAULT gen_random_uuid(),
+    username   STRING NOT NULL,
+    PRIMARY KEY (id) USING HASH
+) LOCALITY REGIONAL BY ROW
+
+statement error virtual column "crdb_internal_user_id_shard_16" cannot reference a foreign key
+CREATE TABLE user_settings (
+    id      UUID   PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID   NOT NULL,
+    value   STRING NOT NULL,
+    INDEX (user_id) USING HASH,
+    FOREIGN KEY (crdb_internal_user_id_shard_16, user_id, crdb_region) REFERENCES users (crdb_internal_id_shard_16, id, crdb_region) ON DELETE CASCADE ON UPDATE CASCADE
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE TABLE user_settings (
+    id      UUID   PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID   NOT NULL,
+    value   STRING NOT NULL,
+    INDEX (user_id) USING HASH,
+    FOREIGN KEY (user_id, crdb_region) REFERENCES users (id, crdb_region) ON DELETE CASCADE ON UPDATE CASCADE
+) LOCALITY REGIONAL BY ROW
+
+statement error virtual column "crdb_internal_user_id_shard_16" cannot reference a foreign key
+ALTER TABLE user_settings ADD FOREIGN KEY (crdb_internal_user_id_shard_16, user_id, crdb_region)
+  REFERENCES users (crdb_internal_id_shard_16, id, crdb_region) ON DELETE CASCADE ON UPDATE CASCADE
+
+statement ok
+ALTER TABLE user_settings ADD FOREIGN KEY (user_id, crdb_region)
+  REFERENCES users (id, crdb_region) ON DELETE CASCADE ON UPDATE CASCADE

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -2962,3 +2962,136 @@ vectorized: true
 statement ok
 SET index_recommendations_enabled = false;
 RESET vectorize
+
+subtest foreign_keys
+
+statement ok
+DROP TABLE users;
+CREATE TABLE users (
+    id         UUID   PRIMARY KEY DEFAULT gen_random_uuid(),
+    username   STRING NOT NULL
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE user_settings (
+    id      UUID   PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID   NOT NULL,
+    value   STRING NOT NULL,
+    INDEX(user_id),
+    FOREIGN KEY (user_id, crdb_region) REFERENCES users (id, crdb_region)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE user_settings_cascades (
+    id      UUID   PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID   NOT NULL,
+    value   STRING NOT NULL,
+    INDEX(user_id),
+    FOREIGN KEY (user_id, crdb_region) REFERENCES users (id, crdb_region) ON DELETE CASCADE ON UPDATE CASCADE
+) LOCALITY REGIONAL BY ROW;
+
+# TODO(rytaft): The following query should be able to infer that the join
+# condition
+#   users.id = user_settings.user_id
+# is equivalent to
+#   users.id = user_settings.user_id AND users.crdb_region = user_settings.crdb_region
+# This would allow the optimizer to plan a lookup join between users and user_settings
+# and avoid visiting all regions. See #69617.
+query T
+EXPLAIN SELECT users.crdb_region AS user_region, user_settings.crdb_region AS user_settings_region, *
+  FROM users JOIN user_settings ON users.id = user_settings.user_id AND users.id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882';
+----
+distribution: local
+vectorized: true
+·
+• merge join
+│ equality: (user_id) = (id)
+│ right cols are key
+│
+├── • index join
+│   │ table: user_settings@user_settings_pkey
+│   │
+│   └── • scan
+│         missing stats
+│         table: user_settings@user_settings_user_id_idx
+│         spans: [/'ap-southeast-2'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'ap-southeast-2'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882'] [/'ca-central-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'ca-central-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882'] [/'us-east-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'us-east-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882']
+│
+└── • union all
+    │ limit: 1
+    │
+    ├── • scan
+    │     missing stats
+    │     table: users@users_pkey
+    │     spans: [/'ap-southeast-2'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'ap-southeast-2'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882']
+    │
+    └── • scan
+          missing stats
+          table: users@users_pkey
+          spans: [/'ca-central-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'ca-central-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882'] [/'us-east-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'us-east-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882']
+
+# Ensure that the FK checks and cascades are efficient.
+query T
+EXPLAIN INSERT INTO user_settings (user_id, value) VALUES ('5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'foo')
+----
+distribution: local
+vectorized: true
+·
+• insert fast path
+  into: user_settings(id, user_id, value, crdb_region)
+  auto commit
+  FK check: users@users_pkey
+  size: 5 columns, 1 row
+
+query T
+EXPLAIN INSERT INTO user_settings_cascades (user_id, value) VALUES ('5ebfedee-0dcf-41e6-a315-5fa0b51b9882', 'foo')
+----
+distribution: local
+vectorized: true
+·
+• insert fast path
+  into: user_settings_cascades(id, user_id, value, crdb_region)
+  auto commit
+  FK check: users@users_pkey
+  size: 5 columns, 1 row
+
+query T
+EXPLAIN DELETE FROM users WHERE id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882'
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • delete
+│   │ from: users
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • union all
+│           │ limit: 1
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: users@users_pkey
+│           │     spans: [/'ap-southeast-2'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'ap-southeast-2'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882']
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: users@users_pkey
+│                 spans: [/'ca-central-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'ca-central-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882'] [/'us-east-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882' - /'us-east-1'/'5ebfedee-0dcf-41e6-a315-5fa0b51b9882']
+│
+├── • fk-cascade
+│     fk: user_settings_cascades_user_id_crdb_region_fkey
+│     input: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • lookup join (semi)
+            │ table: user_settings@user_settings_user_id_idx
+            │ equality: (crdb_region, id) = (crdb_region,user_id)
+            │
+            └── • scan buffer
+                  label: buffer 1

--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -83,13 +83,21 @@ func (desc *IndexDescriptor) explicitColumnIDsWithoutShardColumn() ColumnIDs {
 	return colIDs
 }
 
+// implicitColumnIDs returns the implicit column ids of the index.
+func (desc *IndexDescriptor) implicitColumnIDs() ColumnIDs {
+	return desc.KeyColumnIDs[:desc.Partitioning.NumImplicitColumns]
+}
+
 // IsValidReferencedUniqueConstraint  is part of the UniqueConstraint interface.
 // It returns whether the index can serve as a referenced index for a foreign
 // key constraint with the provided set of referencedColumnIDs.
 func (desc *IndexDescriptor) IsValidReferencedUniqueConstraint(referencedColIDs ColumnIDs) bool {
+	explicitColumnIDs := desc.explicitColumnIDsWithoutShardColumn()
+	allColumnIDs := append(explicitColumnIDs, desc.implicitColumnIDs()...)
 	return desc.Unique &&
 		!desc.IsPartial() &&
-		desc.explicitColumnIDsWithoutShardColumn().PermutationOf(referencedColIDs)
+		(explicitColumnIDs.PermutationOf(referencedColIDs) ||
+			allColumnIDs.PermutationOf(referencedColIDs))
 }
 
 // GetName is part of the UniqueConstraint interface.

--- a/pkg/sql/catalog/descpb/structured.go
+++ b/pkg/sql/catalog/descpb/structured.go
@@ -347,7 +347,7 @@ var _ UniqueConstraint = &IndexDescriptor{}
 func (u *UniqueWithoutIndexConstraint) IsValidReferencedUniqueConstraint(
 	referencedColIDs ColumnIDs,
 ) bool {
-	return ColumnIDs(u.ColumnIDs).PermutationOf(referencedColIDs)
+	return !u.IsPartial() && ColumnIDs(u.ColumnIDs).PermutationOf(referencedColIDs)
 }
 
 // GetName is part of the UniqueConstraint interface.

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -464,13 +464,6 @@ func FindFKReferencedUniqueConstraint(
 	uniqueWithoutIndexConstraints := referencedTable.GetUniqueWithoutIndexConstraints()
 	for i := range uniqueWithoutIndexConstraints {
 		c := &uniqueWithoutIndexConstraints[i]
-
-		// A partial unique constraint cannot be a reference constraint for a
-		// FK.
-		if c.IsPartial() {
-			continue
-		}
-
 		if c.IsValidReferencedUniqueConstraint(referencedColIDs) {
 			return c, nil
 		}


### PR DESCRIPTION
Backport 1/1 commits from #83375.

/cc @cockroachdb/release

Release justification: This is a low-risk change that unblocks several multi-region use cases

---

This commit loosens the restrictions on foreign key references to allow
referencing `crdb_region` and other implicit partitioning columns used by
`PARTITION ALL BY` tables. There is no technical reason why such references
should be disallowed, so this commit simply removes the restriction.

Fixes #74244

Release note (sql change): Foreign keys can now reference the `crdb_region`
column in `REGIONAL BY ROW` tables even if `crdb_region` is not explicitly part
of a `UNIQUE` constraint. This is possible since `crdb_region` is implicitly
included in every index on `REGIONAL BY ROW` tables as the partitioning key.
(This applies to whichever column is used as the partitioning column, in
case a different name is used via `REGIONAL BY ROW AS`.)
