### PR TITLE
sql/catalog/lease: check for cancelled ctx when draining lease Manager

### DIFF
--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -201,7 +201,7 @@ func (s storage) release(ctx context.Context, stopper *stop.Stopper, lease *stor
 	firstAttempt := true
 	// This transaction is idempotent; the retry was put in place because of
 	// NodeUnavailableErrors.
-	for r := retry.Start(retryOptions); r.Next(); {
+	for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
 		log.VEventf(ctx, 2, "storage releasing lease %+v", lease)
 		instanceID := s.nodeIDContainer.SQLInstanceID()
 		if instanceID == 0 {


### PR DESCRIPTION
Previously, we'd retry indefinitely when `leaseMgr.SetDraining` was
called with a cancelled context. This showed up in #83060 as one of the
reasons a graceful node shutdown could stall forever.

See https://github.com/cockroachdb/cockroach/issues/83060#issuecomment-1174653377 for more details.
Relates to https://github.com/cockroachdb/cockroach/issues/83060

Release note (bug fix): A bug causing a graceful node shutdown to stall
forever has been fixed.