### PR TITLE
server: don't use the client's RPC context when draining a node

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -69,8 +69,9 @@ var (
 // instructs the process to terminate.
 // This method is part of the serverpb.AdminClient interface.
 func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_DrainServer) error {
-	ctx := stream.Context()
-	ctx = s.server.AnnotateCtx(ctx)
+	// NB: Don't use the client's context since the caller is allowed to bail
+	// after the drain starts.
+	ctx := s.server.AnnotateCtx(context.Background())
 
 	// Which node is this request for?
 	nodeID, local, err := s.server.status.parseNodeID(req.NodeId)


### PR DESCRIPTION
Previously, we were using the client's context when gracefully shutting
a node down. This is incorrect because the client is allowed to bail
after issuing the drain request. This means that the code below this
level was supposed to be able to deal with a cancelled context, which it
was never meant to (since draining a node is a one-way street, the only
way to undrain a node, at the moment, is to restart the process).

This commit makes the drain process use a background context instead.

Fixes https://github.com/cockroachdb/cockroach/issues/83060

Release note: None