### PR TITLE
asim: update range size split threshold, more keys

### DIFF
--- a/pkg/kv/kvserver/asim/settings.go
+++ b/pkg/kv/kvserver/asim/settings.go
@@ -16,7 +16,7 @@ const (
 	defaultReplicaChangeBaseDelay  = 100 * time.Millisecond
 	defaultReplicaAddDelayFactor   = 16
 	defaultSplitQueueDelay         = 100 * time.Millisecond
-	defaultRangeSizeSplitThreshold = 512
+	defaultRangeSizeSplitThreshold = 512 * 1024 * 1024 // 512mb
 	defaultRangeRebalanceThreshold = 0.05
 	defaultPacerLoopInterval       = 10 * time.Minute
 	defaultPacerMinIterInterval    = 10 * time.Millisecond

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -83,20 +83,20 @@ func (r *rng) Less(than btree.Item) bool {
 }
 
 // initFirstRange initializes the first range within the rangemap, with
-// [minKey, maxKey) start and end key. All other ranges are split from this.
+// [MinKey, MaxKey) start and end key. All other ranges are split from this.
 func (rm *rmap) initFirstRange() {
 	rm.rangeSeqGen++
 	rangeID := rm.rangeSeqGen
 	desc := roachpb.RangeDescriptor{
 		RangeID:       roachpb.RangeID(rangeID),
-		StartKey:      minKey.ToRKey(),
-		EndKey:        maxKey.ToRKey(),
+		StartKey:      MinKey.ToRKey(),
+		EndKey:        MaxKey.ToRKey(),
 		NextReplicaID: 1,
 	}
 	rng := &rng{
 		rangeID:     rangeID,
-		startKey:    minKey,
-		endKey:      maxKey,
+		startKey:    MinKey,
+		endKey:      MaxKey,
 		desc:        desc,
 		config:      defaultSpanConfig,
 		replicas:    make(map[StoreID]*replica),
@@ -116,7 +116,7 @@ func (s *state) String() string {
 	s.ranges.rangeTree.Ascend(func(i btree.Item) bool {
 		r := i.(*rng)
 		orderedRanges = append(orderedRanges, r)
-		return !r.desc.EndKey.Equal(maxKey.ToRKey())
+		return !r.desc.EndKey.Equal(MaxKey.ToRKey())
 	})
 
 	nStores := len(s.stores)

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -239,11 +239,11 @@ func (m *ManualSimClock) Set(tsNanos int64) {
 // Key is a single slot in the keyspace.
 type Key int64
 
-// minKey is the minimum key in the keyspace.
-const minKey Key = -1
+// MinKey is the minimum key in the keyspace.
+const MinKey Key = -1
 
-// maxKey is the maximum key in the keyspace.
-const maxKey Key = 9999999999
+// MaxKey is the maximum key in the keyspace.
+const MaxKey Key = 9999999999
 
 // InvalidKey is a placeholder key that does not exist in the keyspace.
 const InvalidKey Key = -2

--- a/pkg/kv/kvserver/asim/state/state_test.go
+++ b/pkg/kv/kvserver/asim/state/state_test.go
@@ -31,7 +31,7 @@ func TestStateUpdates(t *testing.T) {
 // the post-split keys are correct.
 func TestRangeSplit(t *testing.T) {
 	s := newState()
-	k1 := minKey
+	k1 := MinKey
 	r1 := s.rangeFor(k1)
 
 	n1 := s.AddNode()
@@ -64,10 +64,10 @@ func TestRangeMap(t *testing.T) {
 	require.Len(t, s.ranges.rangeMap, 1)
 	require.Equal(t, s.ranges.rangeTree.Max(), s.ranges.rangeTree.Min())
 	firstRange := s.ranges.rangeMap[1]
-	require.Equal(t, s.rangeFor(minKey), firstRange)
-	require.Equal(t, firstRange.startKey, minKey)
-	require.Equal(t, firstRange.desc.StartKey, minKey.ToRKey())
-	require.Equal(t, firstRange.desc.EndKey, maxKey.ToRKey())
+	require.Equal(t, s.rangeFor(MinKey), firstRange)
+	require.Equal(t, firstRange.startKey, MinKey)
+	require.Equal(t, firstRange.desc.StartKey, MinKey.ToRKey())
+	require.Equal(t, firstRange.desc.EndKey, MaxKey.ToRKey())
 	require.Equal(t, defaultSpanConfig, firstRange.SpanConfig())
 
 	k2 := Key(1)
@@ -81,7 +81,7 @@ func TestRangeMap(t *testing.T) {
 	_, r4, ok := s.SplitRange(k4)
 	require.True(t, ok)
 
-	// Assert that the range is segmented into [minKey, EndKey) intervals.
+	// Assert that the range is segmented into [MinKey, EndKey) intervals.
 	require.Equal(t, k2.ToRKey(), r1.Descriptor().EndKey)
 	require.Equal(t, k3.ToRKey(), r2.Descriptor().EndKey)
 	require.Equal(t, k4.ToRKey(), r3.Descriptor().EndKey)


### PR DESCRIPTION
This patch updates the range size split threshold to 512mb by default.
Additionally it adds support for initializing a testing replica
distribution, where the ranges contain an equal span of the keyspace.

Release note: None