### PR TITLE
outliers: extract a Registry interface.

### DIFF
--- a/pkg/sql/sqlstats/outliers/BUILD.bazel
+++ b/pkg/sql/sqlstats/outliers/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     srcs = [
         "detector.go",
         "outliers.go",
+        "registry.go",
     ],
     embed = [":outliers_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/outliers",

--- a/pkg/sql/sqlstats/outliers/outliers.go
+++ b/pkg/sql/sqlstats/outliers/outliers.go
@@ -18,10 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
-	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	prometheus "github.com/prometheus/client_model/go"
 )
@@ -121,114 +118,31 @@ func NewMetrics() Metrics {
 	}
 }
 
-// maxCacheSize is the number of detected outliers we will retain in memory.
-// We choose a small value for the time being to allow us to iterate without
-// worrying about memory usage. See #79450.
-const (
-	maxCacheSize = 10
-)
+// Reader offers read-only access to the currently retained set of outliers.
+type Reader interface {
+	// IterateOutliers calls visitor with each of the currently retained set of outliers.
+	IterateOutliers(context.Context, func(context.Context, *Outlier))
+}
 
 // Registry is the central object in the outliers subsystem. It observes
 // statement execution to determine which statements are outliers and
 // exposes the set of currently retained outliers.
-type Registry struct {
-	detector detector
+type Registry interface {
+	// ObserveStatement notifies the registry of a statement execution.
+	ObserveStatement(
+		sessionID clusterunique.ID,
+		statementID clusterunique.ID,
+		statementFingerprintID roachpb.StmtFingerprintID,
+		latencyInSeconds float64,
+	)
 
-	// Note that this single mutex places unnecessary constraints on outlier
-	// detection and reporting. We will develop a higher-throughput system
-	// before enabling the outliers subsystem by default.
-	mu struct {
-		syncutil.RWMutex
-		statements map[clusterunique.ID][]*Outlier_Statement
-		outliers   *cache.UnorderedCache
-	}
+	// ObserveTransaction notifies the registry of the end of a transaction.
+	ObserveTransaction(sessionID clusterunique.ID, txnID uuid.UUID)
+
+	Reader
 }
 
 // New builds a new Registry.
-func New(st *cluster.Settings, metrics Metrics) *Registry {
-	config := cache.Config{
-		Policy: cache.CacheFIFO,
-		ShouldEvict: func(size int, key, value interface{}) bool {
-			return size > maxCacheSize
-		},
-	}
-	r := &Registry{
-		detector: anyDetector{detectors: []detector{
-			latencyThresholdDetector{st: st},
-			newLatencyQuantileDetector(st, metrics),
-		}}}
-	r.mu.statements = make(map[clusterunique.ID][]*Outlier_Statement)
-	r.mu.outliers = cache.NewUnorderedCache(config)
-	return r
-}
-
-// ObserveStatement notifies the registry of a statement execution.
-func (r *Registry) ObserveStatement(
-	sessionID clusterunique.ID,
-	statementID clusterunique.ID,
-	statementFingerprintID roachpb.StmtFingerprintID,
-	latencyInSeconds float64,
-) {
-	if !r.enabled() {
-		return
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.mu.statements[sessionID] = append(r.mu.statements[sessionID], &Outlier_Statement{
-		ID:               statementID.GetBytes(),
-		FingerprintID:    statementFingerprintID,
-		LatencyInSeconds: latencyInSeconds,
-	})
-}
-
-// ObserveTransaction notifies the registry of the end of a transaction.
-func (r *Registry) ObserveTransaction(sessionID clusterunique.ID, txnID uuid.UUID) {
-	if !r.enabled() {
-		return
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	statements := r.mu.statements[sessionID]
-	delete(r.mu.statements, sessionID)
-
-	hasOutlier := false
-	for _, s := range statements {
-		if r.detector.isOutlier(s) {
-			hasOutlier = true
-		}
-	}
-
-	if hasOutlier {
-		for _, s := range statements {
-			r.mu.outliers.Add(uint128.FromBytes(s.ID), &Outlier{
-				Session:     &Outlier_Session{ID: sessionID.GetBytes()},
-				Transaction: &Outlier_Transaction{ID: &txnID},
-				Statement:   s,
-			})
-		}
-	}
-}
-
-// TODO(todd):
-//   Once we can handle sufficient throughput to live on the hot
-//   execution path in #81021, we can probably get rid of this external
-//   concept of "enabled" and let the detectors just decide for themselves
-//   internally.
-func (r *Registry) enabled() bool {
-	return r.detector.enabled()
-}
-
-// Reader offers read-only access to the currently retained set of outliers.
-type Reader interface {
-	IterateOutliers(context.Context, func(context.Context, *Outlier))
-}
-
-// IterateOutliers calls visitor with each of the currently retained set of
-// outliers.
-func (r *Registry) IterateOutliers(ctx context.Context, visitor func(context.Context, *Outlier)) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	r.mu.outliers.Do(func(e *cache.Entry) {
-		visitor(ctx, e.Value.(*Outlier))
-	})
+func New(st *cluster.Settings, metrics Metrics) Registry {
+	return newRegistry(st, metrics)
 }

--- a/pkg/sql/sqlstats/outliers/registry.go
+++ b/pkg/sql/sqlstats/outliers/registry.go
@@ -1,0 +1,127 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package outliers
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// maxCacheSize is the number of detected outliers we will retain in memory.
+// We choose a small value for the time being to allow us to iterate without
+// worrying about memory usage. See #79450.
+const (
+	maxCacheSize = 10
+)
+
+// registry is the central object in the outliers subsystem. It observes
+// statement execution to determine which statements are outliers and
+// exposes the set of currently retained outliers.
+type registry struct {
+	detector detector
+
+	// Note that this single mutex places unnecessary constraints on outlier
+	// detection and reporting. We will develop a higher-throughput system
+	// before enabling the outliers subsystem by default.
+	mu struct {
+		syncutil.RWMutex
+		statements map[clusterunique.ID][]*Outlier_Statement
+		outliers   *cache.UnorderedCache
+	}
+}
+
+var _ Registry = &registry{}
+
+func newRegistry(st *cluster.Settings, metrics Metrics) Registry {
+	config := cache.Config{
+		Policy: cache.CacheFIFO,
+		ShouldEvict: func(size int, key, value interface{}) bool {
+			return size > maxCacheSize
+		},
+	}
+	r := &registry{
+		detector: anyDetector{detectors: []detector{
+			latencyThresholdDetector{st: st},
+			newLatencyQuantileDetector(st, metrics),
+		}}}
+	r.mu.statements = make(map[clusterunique.ID][]*Outlier_Statement)
+	r.mu.outliers = cache.NewUnorderedCache(config)
+	return r
+}
+
+func (r *registry) ObserveStatement(
+	sessionID clusterunique.ID,
+	statementID clusterunique.ID,
+	statementFingerprintID roachpb.StmtFingerprintID,
+	latencyInSeconds float64,
+) {
+	if !r.enabled() {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.mu.statements[sessionID] = append(r.mu.statements[sessionID], &Outlier_Statement{
+		ID:               statementID.GetBytes(),
+		FingerprintID:    statementFingerprintID,
+		LatencyInSeconds: latencyInSeconds,
+	})
+}
+
+func (r *registry) ObserveTransaction(sessionID clusterunique.ID, txnID uuid.UUID) {
+	if !r.enabled() {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	statements := r.mu.statements[sessionID]
+	delete(r.mu.statements, sessionID)
+
+	hasOutlier := false
+	for _, s := range statements {
+		if r.detector.isOutlier(s) {
+			hasOutlier = true
+		}
+	}
+
+	if hasOutlier {
+		for _, s := range statements {
+			r.mu.outliers.Add(uint128.FromBytes(s.ID), &Outlier{
+				Session:     &Outlier_Session{ID: sessionID.GetBytes()},
+				Transaction: &Outlier_Transaction{ID: &txnID},
+				Statement:   s,
+			})
+		}
+	}
+}
+
+func (r *registry) IterateOutliers(ctx context.Context, visitor func(context.Context, *Outlier)) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	r.mu.outliers.Do(func(e *cache.Entry) {
+		visitor(ctx, e.Value.(*Outlier))
+	})
+}
+
+// TODO(todd):
+//   Once we can handle sufficient throughput to live on the hot
+//   execution path in #81021, we can probably get rid of this external
+//   concept of "enabled" and let the detectors just decide for themselves
+//   internally.
+func (r *registry) enabled() bool {
+	return r.detector.enabled()
+}

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -67,7 +67,7 @@ type SQLStats struct {
 
 	knobs *sqlstats.TestingKnobs
 
-	outliers *outliers.Registry
+	outliers outliers.Registry
 }
 
 func newSQLStats(

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -120,7 +120,7 @@ type Container struct {
 	mon       *mon.BytesMonitor
 
 	knobs            *sqlstats.TestingKnobs
-	outliersRegistry *outliers.Registry
+	outliersRegistry outliers.Registry
 }
 
 var _ sqlstats.ApplicationStats = &Container{}
@@ -135,7 +135,7 @@ func New(
 	mon *mon.BytesMonitor,
 	appName string,
 	knobs *sqlstats.TestingKnobs,
-	outliersRegistry *outliers.Registry,
+	outliersRegistry outliers.Registry,
 ) *Container {
 	s := &Container{
 		st:                         st,


### PR DESCRIPTION
This is a pure mechanical refactoring, preparing us for #81021, where
we'll move outlier processing off of the hot execution path. The idea is
that the outside world will continue to talk to us as a Registry, but
we'll now have a seam into which we can insert some asynchrony.

Release note: None