### PR TITLE
workload/schemachanger: stabilize schema changer workload

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -727,7 +727,7 @@ WITH tab_json AS (
 GROUP BY name;
 		`, tableName.String())
 		if err != nil {
-			return false, nil, nil, err
+			return false, nil, nil, og.checkAndAdjustForUnknownSchemaErrors(err)
 		}
 
 		for _, constraint := range constraints {

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -246,7 +246,7 @@ var opWeights = []int{
 	dropTable:               1,
 	dropView:                1,
 	dropSchema:              1,
-	primaryRegion:           1,
+	primaryRegion:           0, // Disabled and tracked with #83831
 	renameColumn:            1,
 	renameIndex:             1,
 	renameSequence:          1,
@@ -254,8 +254,8 @@ var opWeights = []int{
 	renameView:              1,
 	setColumnDefault:        1,
 	setColumnNotNull:        1,
-	setColumnType:           0, // Disabled and tracked with #66662.
-	survive:                 1,
+	setColumnType:           0,  // Disabled and tracked with #66662.
+	survive:                 0,  // Disabled and tracked with #83831
 	insertRow:               10, // Temporarily reduced because of #80820
 	validate:                2,  // validate twice more often
 }


### PR DESCRIPTION
This pull request will do the following, to help stabilize the workload under CI:

1) Temporarily disable survive/primary region-related database alters to avoid (https://github.com/cockroachdb/cockroach/issues/83831)
2) Add retry logic for unknown schema errors which are due to (https://github.com/cockroachdb/cockroach/issues/64673)