### PR TITLE
sql: optimize copy to bypass optimizer

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -124,29 +124,10 @@ func (ex *connExecutor) execStmt(
 		ev, payload = ex.execStmtInNoTxnState(ctx, ast)
 
 	case stateOpen:
-		if ex.server.cfg.Settings.CPUProfileType() == cluster.CPUProfileWithLabels {
-			remoteAddr := "internal"
-			if rAddr := ex.sessionData().RemoteAddr; rAddr != nil {
-				remoteAddr = rAddr.String()
-			}
-			var stmtNoConstants string
-			if prepared != nil {
-				stmtNoConstants = prepared.StatementNoConstants
-			} else {
-				stmtNoConstants = formatStatementHideConstants(ast)
-			}
-			labels := pprof.Labels(
-				"appname", ex.sessionData().ApplicationName,
-				"addr", remoteAddr,
-				"stmt.tag", ast.StatementTag(),
-				"stmt.no.constants", stmtNoConstants,
-			)
-			pprof.Do(ctx, labels, func(ctx context.Context) {
-				ev, payload, err = ex.execStmtInOpenState(ctx, parserStmt, prepared, pinfo, res, canAutoCommit)
-			})
-		} else {
+		err = ex.execWithProfiling(ctx, ast, prepared, func(ctx context.Context) error {
 			ev, payload, err = ex.execStmtInOpenState(ctx, parserStmt, prepared, pinfo, res, canAutoCommit)
-		}
+			return err
+		})
 		switch ev.(type) {
 		case eventNonRetriableErr:
 			ex.recordFailure()
@@ -2335,4 +2316,37 @@ func logTraceAboveThreshold(
 	// Note that log lines larger than 65k are truncated in the debug zip (see
 	// #50166).
 	log.Infof(ctx, "%s took %s, exceeding threshold of %s:\n%s", opName, elapsed, threshold, dump)
+}
+
+func (ex *connExecutor) execWithProfiling(
+	ctx context.Context,
+	ast tree.Statement,
+	prepared *PreparedStatement,
+	op func(context.Context) error,
+) error {
+	var err error
+	if ex.server.cfg.Settings.CPUProfileType() == cluster.CPUProfileWithLabels {
+		remoteAddr := "internal"
+		if rAddr := ex.sessionData().RemoteAddr; rAddr != nil {
+			remoteAddr = rAddr.String()
+		}
+		var stmtNoConstants string
+		if prepared != nil {
+			stmtNoConstants = prepared.StatementNoConstants
+		} else {
+			stmtNoConstants = formatStatementHideConstants(ast)
+		}
+		labels := pprof.Labels(
+			"appname", ex.sessionData().ApplicationName,
+			"addr", remoteAddr,
+			"stmt.tag", ast.StatementTag(),
+			"stmt.no.constants", stmtNoConstants,
+		)
+		pprof.Do(ctx, labels, func(ctx context.Context) {
+			err = op(ctx)
+		})
+	} else {
+		err = op(ctx)
+	}
+	return err
 }

--- a/pkg/sql/copy_from_test.go
+++ b/pkg/sql/copy_from_test.go
@@ -98,7 +98,7 @@ func BenchmarkCopyFrom(b *testing.B) {
 	r.Exec(b, lineitemSchema)
 
 	// send data in 5 batches of 10k rows
-	ROWS := 50000
+	const ROWS = sql.CopyBatchRowSizeDefault * 4
 	datalen := 0
 	var rows []string
 	for i := 0; i < ROWS; i++ {
@@ -106,15 +106,24 @@ func BenchmarkCopyFrom(b *testing.B) {
 		rows = append(rows, row)
 		datalen += len(row)
 	}
-	start := timeutil.Now()
-	pprof.Do(ctx, pprof.Labels("run", "copy"), func(ctx context.Context) {
-		rows, err := sql.RunCopyFrom(ctx, s, "c", nil, "COPY lineitem FROM STDIN WITH CSV DELIMITER '|';", rows)
-		require.NoError(b, err)
-		require.Equal(b, ROWS, rows)
-	})
-	duration := timeutil.Since(start)
-	b.ReportMetric(float64(datalen)/(1024*1024)/duration.Seconds(), "mb/s")
-	b.ReportMetric(float64(ROWS)/duration.Seconds(), "rows/s")
+	rowsize := datalen / ROWS
+	for _, batchSizeFactor := range []float64{.5, 1, 2, 4} {
+		batchSize := int(batchSizeFactor * sql.CopyBatchRowSizeDefault)
+		b.Run(fmt.Sprintf("%d", batchSize), func(b *testing.B) {
+			actualRows := rows[:batchSize]
+			for i := 0; i < b.N; i++ {
+				pprof.Do(ctx, pprof.Labels("run", "copy"), func(ctx context.Context) {
+					rowcount, err := sql.RunCopyFrom(ctx, s, "c", nil, "COPY lineitem FROM STDIN WITH CSV DELIMITER '|';", actualRows)
+					require.NoError(b, err)
+					require.Equal(b, len(actualRows), rowcount)
+				})
+				b.StopTimer()
+				r.Exec(b, "TRUNCATE TABLE c.lineitem")
+				b.StartTimer()
+			}
+			b.SetBytes(int64(len(actualRows) * rowsize))
+		})
+	}
 }
 
 func BenchmarkParallelCopyFrom(b *testing.B) {
@@ -129,9 +138,9 @@ func BenchmarkParallelCopyFrom(b *testing.B) {
 
 	r := sqlutils.MakeSQLRunner(conn)
 	r.Exec(b, lineitemSchema)
-	ROWS := 50000
+	const ROWS = 50000
 	datalen := 0
-	THREADS := 10
+	const THREADS = 10
 	var allrows [][]string
 
 	chunk := ROWS / THREADS

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1216,3 +1216,9 @@ func (e *distSQLSpecExecFactory) constructHashOrMergeJoin(
 	p.ResultColumns = resultColumns
 	return makePlanMaybePhysical(p, append(leftPlan.physPlan.planNodesToClose, rightPlan.physPlan.planNodesToClose...)), nil
 }
+
+func (e *distSQLSpecExecFactory) ConstructLiteralValues(
+	rows tree.ExprContainer, cols colinfo.ResultColumns,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: literal values")
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3328,6 +3328,10 @@ func (m *sessionDataMutator) SetTroubleshootingModeEnabled(val bool) {
 	m.data.TroubleshootingMode = val
 }
 
+func (m *sessionDataMutator) SetCopyFastPathEnabled(val bool) {
+	m.data.CopyFastPathEnabled = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -237,12 +237,13 @@ import (
 //  - copy,copy-error
 //    Runs a COPY FROM STDIN statement, because of the separate data chunk it requires
 //    special logictest support. Format is:
-//    copy
-//    COPY <table> FROM STDIN;
-//    <blankline>
-//    COPY DATA
-//    ----
-//    <NUMROWS>
+//      copy
+//      COPY <table> FROM STDIN;
+//      <blankline>
+//      COPY DATA
+//      ----
+//      <NUMROWS>
+//
 //    copy-error is just like copy but an error is expected and results should be error
 //    string.
 //
@@ -2298,11 +2299,14 @@ func (t *logicTest) processSubtest(
 			if !sep {
 				return errors.Errorf("%s: expected ---- separator at end of copy data", query.pos)
 			}
-			// TODO: This is broken, t.cluster.Server(0) may not be the same tenant as t.db points to, for now
-			// the copy tests disable the 3node-tenant config but we should fix this. Also RunCopyFrom does an
-			// end run around the t.db connection entirely and runs copies w/o using the client protocol at all,
-			// not ideal but the go sql.DB interface doesn't support COPY so fixing it the right way that would
-			// require major surgery (ie making logictest use libpq or something low level like that).
+			// TODO(cucaroach): This is broken, t.cluster.Server(0) may not be
+			// the same tenant as t.db points to, for now the copy tests disable
+			// the 3node-tenant config but we should fix this. Also RunCopyFrom
+			// does an end run around the t.db connection entirely and runs
+			// copies w/o using the client protocol at all, not ideal but the go
+			// sql.DB interface doesn't support COPY so fixing it the right way
+			// that would require major surgery (ie making logictest use libpq
+			// or something low level like that).
 			rows, err := sql.RunCopyFrom(context.Background(), t.cluster.Server(0), "test", nil, query.sql, []string{data.String()})
 			result := fmt.Sprintf("%d", rows)
 			if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/copyfrom
+++ b/pkg/sql/logictest/testdata/logic_test/copyfrom
@@ -52,12 +52,10 @@ COPY t2 FROM STDIN
 ----
 1
 
-query I rowsort
-SELECT * FROM t
+query IT rowsort
+SELECT i,dec FROM t2
 ----
-1
-1
-2
+1  12.123
 
 copy-error
 COPY t2 FROM STDIN
@@ -173,6 +171,7 @@ COPY t4 FROM STDIN
 1
 ----
 duplicate key value violates unique constraint "t4_i_key"
+
 subtest defaults
 # Default column values tests
 

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4663,7 +4663,8 @@ WHERE
       'vectorize',
       'experimental_distsql_planning',
       'use_declarative_schema_changer',
-      'distsql_workmem'
+      'distsql_workmem',
+      'copy_fast_path_enabled'
     );
 ----
 variable                                              value

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4150,7 +4150,7 @@ SELECT
 FROM
   pg_catalog.pg_settings
 WHERE
-  name NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem')
+  name NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem', 'copy_fast_path_enabled')
 ----
 name                                                  setting             category  short_desc  extra_desc  vartype
 alter_primary_region_super_region_override            off                 NULL      NULL        NULL        string
@@ -4276,7 +4276,7 @@ SELECT
 FROM
   pg_catalog.pg_settings
 WHERE
-  name NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem')
+  name NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem', 'copy_fast_path_enabled')
 ----
 name                                                  setting             unit  context  enumvals  boot_val            reset_val
 alter_primary_region_super_region_override            off                 NULL  user     NULL      off                 off
@@ -4407,6 +4407,7 @@ bytea_output                                          NULL    NULL     NULL     
 check_function_bodies                                 NULL    NULL     NULL     NULL        NULL
 client_encoding                                       NULL    NULL     NULL     NULL        NULL
 client_min_messages                                   NULL    NULL     NULL     NULL        NULL
+copy_fast_path_enabled                                NULL    NULL     NULL     NULL        NULL
 cost_scans_with_default_col_size                      NULL    NULL     NULL     NULL        NULL
 crdb_version                                          NULL    NULL     NULL     NULL        NULL
 database                                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -23,7 +23,7 @@ UTF8                1
 query TT colnames
 SELECT *
 FROM [SHOW ALL]
-WHERE variable NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem')
+WHERE variable NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem', 'copy_fast_path_enabled')
 ----
 variable                                              value
 alter_primary_region_super_region_override            off

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "schema_dependencies.go",
         "table_meta.go",
         "telemetry.go",
+        "values.go",
         ":gen-operator",  # keep
         ":gen-rulenames",  # keep
         ":gen-rulenames-stringer",  # keep

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -194,6 +194,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.ValuesExpr:
 		ep, err = b.buildValues(t)
 
+	case *memo.LiteralValuesExpr:
+		ep, err = b.buildLiteralValues(t)
+
 	case *memo.ScanExpr:
 		ep, err = b.buildScan(t)
 
@@ -473,6 +476,26 @@ func (b *Builder) constructValues(rows [][]tree.TypedExpr, cols opt.ColList) (ex
 	}
 	ep := execPlan{root: node}
 	for i, col := range cols {
+		ep.outputCols.Set(int(col), i)
+	}
+
+	return ep, nil
+}
+
+func (b *Builder) buildLiteralValues(values *memo.LiteralValuesExpr) (execPlan, error) {
+	md := b.mem.Metadata()
+	resultCols := make(colinfo.ResultColumns, len(values.ColList()))
+	for i, col := range values.ColList() {
+		colMeta := md.ColumnMeta(col)
+		resultCols[i].Name = colMeta.Alias
+		resultCols[i].Typ = colMeta.Type
+	}
+	node, err := b.factory.ConstructLiteralValues(values.Rows.Rows, resultCols)
+	if err != nil {
+		return execPlan{}, err
+	}
+	ep := execPlan{root: node}
+	for i, col := range values.ColList() {
 		ep.outputCols.Set(int(col), i)
 	}
 

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -546,7 +546,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		a := n.args.(*valuesArgs)
 		// Don't emit anything for the "norows" and "emptyrow" cases.
 		if len(a.Rows) > 0 && (len(a.Rows) > 1 || len(a.Columns) > 0) {
-			e.emitTuples(a.Rows, len(a.Columns))
+			e.emitTuples(tree.RawRows(a.Rows), len(a.Columns))
 		}
 
 	case filterOp:
@@ -807,7 +807,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 			)
 		}
 		if len(a.Rows) > 0 {
-			e.emitTuples(a.Rows, len(a.Rows[0]))
+			e.emitTuples(tree.RawRows(a.Rows), len(a.Rows[0]))
 		}
 
 	case upsertOp:
@@ -1003,15 +1003,16 @@ func (e *emitter) emitLockingPolicyWithPrefix(keyPrefix string, locking opt.Lock
 	}
 }
 
-func (e *emitter) emitTuples(rows [][]tree.TypedExpr, numColumns int) {
+func (e *emitter) emitTuples(rows tree.ExprContainer, numColumns int) {
 	e.ob.Attrf(
 		"size", "%d column%s, %d row%s",
 		numColumns, util.Pluralize(int64(numColumns)),
-		len(rows), util.Pluralize(int64(len(rows))),
+		rows.NumRows(), util.Pluralize(int64(rows.NumRows())),
 	)
 	if e.ob.flags.Verbose {
-		for i := range rows {
-			for j, expr := range rows[i] {
+		for i := 0; i < rows.NumRows(); i++ {
+			for j := 0; j < rows.NumCols(); j++ {
+				expr := rows.Get(i, j).(tree.TypedExpr)
 				e.ob.Expr(fmt.Sprintf("row %d, expr %d", i, j), expr, nil /* varColumns */)
 			}
 		}

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	if numOperators != 59 {
+	if numOperators != 60 {
 		// This error occurs when an operator has been added or removed in
 		// pkg/sql/opt/exec/explain/factory.opt. If an operator is added at the
 		// end of factory.opt, simply adjust the hardcoded value above. If an

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -759,3 +759,10 @@ define CreateFunction {
     Deps opt.SchemaDeps
     TypeDeps opt.SchemaTypeDeps
 }
+
+# LiteralValues allows datums to be planned directly that are type checked
+# and evaluated (i.e. literals).
+define LiteralValues {
+    Rows tree.ExprContainer
+    Columns colinfo.ResultColumns
+}

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -334,6 +334,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	case *ValuesExpr:
 		colList = t.Cols
 
+	case *LiteralValuesExpr:
+		colList = t.Cols
+
 	case *UnionExpr, *IntersectExpr, *ExceptExpr,
 		*UnionAllExpr, *IntersectAllExpr, *ExceptAllExpr, *LocalityOptimizedSearchExpr:
 		colList = e.Private().(*SetPrivate).OutCols

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -758,6 +758,10 @@ func (h *hasher) HashVolatility(val volatility.V) {
 	h.HashInt(int(val))
 }
 
+func (h *hasher) HashLiteralRows(val *opt.LiteralRows) {
+	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
+}
+
 // ----------------------------------------------------------------------
 //
 // Equality functions
@@ -1217,6 +1221,10 @@ func (h *hasher) IsPersistenceEqual(l, r tree.Persistence) bool {
 }
 
 func (h *hasher) IsVolatilityEqual(l, r volatility.V) bool {
+	return l == r
+}
+
+func (h *hasher) IsLiteralRowsEqual(l, r *opt.LiteralRows) bool {
 	return l == r
 }
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -807,33 +807,35 @@ func (b *logicalPropsBuilder) buildSetProps(setNode RelExpr, rel *props.Relation
 	}
 }
 
-func (b *logicalPropsBuilder) buildValuesProps(values *ValuesExpr, rel *props.Relational) {
+func (b *logicalPropsBuilder) buildValuesProps(values ValuesContainer, rel *props.Relational) {
 	BuildSharedProps(values, &rel.Shared, b.evalCtx)
 
-	card := uint32(len(values.Rows))
+	card := uint32(values.Len())
 
 	// Output Columns
 	// --------------
 	// Use output columns that are attached to the values op.
-	rel.OutputCols = values.Cols.ToSet()
+	rel.OutputCols = values.ColList().ToSet()
 
 	// Not Null Columns
 	// ----------------
 	// All columns are assumed to be nullable, unless they contain only constant
 	// non-null values.
 
-	for colIdx, col := range values.Cols {
-		notNull := true
-		for rowIdx := range values.Rows {
-			val := values.Rows[rowIdx].(*TupleExpr).Elems[colIdx]
-			if !opt.IsConstValueOp(val) || val.Op() == opt.NullOp {
-				// Null or not a constant.
-				notNull = false
-				break
+	if v, ok := values.(*ValuesExpr); ok {
+		for colIdx, col := range v.ColList() {
+			notNull := true
+			for rowIdx := range v.Rows {
+				val := v.Rows[rowIdx].(*TupleExpr).Elems[colIdx]
+				if !opt.IsConstValueOp(val) || val.Op() == opt.NullOp {
+					// Null or not a constant.
+					notNull = false
+					break
+				}
 			}
-		}
-		if notNull {
-			rel.NotNullCols.Add(col)
+			if notNull {
+				rel.NotNullCols.Add(col)
+			}
 		}
 	}
 
@@ -857,6 +859,12 @@ func (b *logicalPropsBuilder) buildValuesProps(values *ValuesExpr, rel *props.Re
 	if !b.disableStats {
 		b.sb.buildValues(values, rel)
 	}
+}
+
+func (b *logicalPropsBuilder) buildLiteralValuesProps(
+	values ValuesContainer, rel *props.Relational,
+) {
+	b.buildValuesProps(values, rel)
 }
 
 func (b *logicalPropsBuilder) buildBasicProps(e opt.Expr, cols opt.ColList, rel *props.Relational) {

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -495,3 +495,34 @@ func (m *Memo) Detach() {
 func (m *Memo) DisableCheckExpr() {
 	m.disableCheckExpr = true
 }
+
+// ValuesContainer lets ValuesExpr and LiteralValuesExpr share code.
+type ValuesContainer interface {
+	RelExpr
+
+	Len() int
+	ColList() opt.ColList
+}
+
+var _ ValuesContainer = &ValuesExpr{}
+var _ ValuesContainer = &LiteralValuesExpr{}
+
+// ColList implements the ValuesContainer interface.
+func (v *ValuesExpr) ColList() opt.ColList {
+	return v.Cols
+}
+
+// Len implements the ValuesContainer interface.
+func (v *ValuesExpr) Len() int {
+	return len(v.Rows)
+}
+
+// ColList implements the ValuesContainer interface.
+func (l *LiteralValuesExpr) ColList() opt.ColList {
+	return l.Cols
+}
+
+// Len implements the ValuesContainer interface.
+func (l *LiteralValuesExpr) Len() int {
+	return l.Rows.Rows.NumRows()
+}

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -161,6 +161,14 @@ define ValuesPrivate {
     ID UniqueID
 }
 
+# LiteralValues is a version of values where the exprs have already been type checked
+# and are real Datums that don't need evaluation.
+[Relational]
+define LiteralValues {
+    Rows LiteralRows
+    Cols ColList
+}
+
 # Select filters rows from its input result set, based on the boolean filter
 # predicate expression. Rows which do not match the filter are discarded. While
 # the Filter operand can be any boolean expression, normalization rules will

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -849,6 +849,9 @@ func (b *Builder) buildSelectStmt(
 ) (outScope *scope) {
 	// NB: The case statements are sorted lexicographically.
 	switch stmt := stmt.(type) {
+	case *tree.LiteralValuesClause:
+		return b.buildLiteralValuesClause(stmt, desiredTypes, inScope)
+
 	case *tree.ParenSelect:
 		return b.buildSelect(stmt.Select, locking, desiredTypes, inScope)
 
@@ -938,6 +941,10 @@ func (b *Builder) buildSelectStmtWithoutParens(
 ) (outScope *scope) {
 	// NB: The case statements are sorted lexicographically.
 	switch t := wrapped.(type) {
+	case *tree.LiteralValuesClause:
+		b.rejectIfLocking(locking, "VALUES")
+		outScope = b.buildLiteralValuesClause(t, desiredTypes, inScope)
+
 	case *tree.ParenSelect:
 		panic(errors.AssertionFailedf(
 			"%T in buildSelectStmtWithoutParens", wrapped))

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -13,6 +13,7 @@ package optbuilder
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -171,4 +172,19 @@ func rightHasMoreSpecificTuple(left, right *types.T) (isMoreSpecific bool, isEqu
 	}
 	// At this point, both left and right are neither tuples nor arrays.
 	return false, left.Equivalent(right)
+}
+
+func (b *Builder) buildLiteralValuesClause(
+	values *tree.LiteralValuesClause, desiredTypes []*types.T, inScope *scope,
+) *scope {
+	outScope := inScope.push()
+	for colIdx := 0; colIdx < len(desiredTypes); colIdx++ {
+		// The column names for VALUES are column1, column2, etc.
+		colName := scopeColName(tree.Name(fmt.Sprintf("column%d", colIdx+1)))
+		b.synthesizeColumn(outScope, colName, desiredTypes[colIdx], nil, nil /* scalar */)
+	}
+
+	colList := colsToColList(outScope.cols)
+	outScope.expr = b.factory.ConstructLiteralValues(&opt.LiteralRows{Rows: values.Rows}, colList)
+	return outScope
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -251,6 +251,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"Persistence":         {fullName: "tree.Persistence", passByVal: true},
 		"PreFiltererState":    {fullName: "invertedexpr.PreFiltererStateForInvertedFilterer", isPointer: true, usePointerIntern: true},
 		"Volatility":          {fullName: "volatility.V", passByVal: true},
+		"LiteralRows":         {fullName: "opt.LiteralRows", isExpr: true, isPointer: true},
 	}
 
 	// Add types of generated op and private structs.

--- a/pkg/sql/opt/values.go
+++ b/pkg/sql/opt/values.go
@@ -1,0 +1,62 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package opt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// LiteralRows is a container for literal values (i.e. Datums).
+type LiteralRows struct {
+	Rows tree.ExprContainer
+}
+
+var _ ScalarExpr = &LiteralRows{}
+
+// Op returns the operator type of the expression.
+func (t LiteralRows) Op() Operator {
+	return AnyScalarOp
+}
+
+// ChildCount returns the number of children of the expression.
+func (t LiteralRows) ChildCount() int {
+	return 0
+}
+
+// Child returns the nth child of the expression.
+func (t LiteralRows) Child(nth int) Expr {
+	return nil
+}
+
+// Private returns operator-specific data. Callers are expected to know the
+// type and format of the data, which will differ from operator to operator.
+// For example, an operator may choose to return one of its fields, or perhaps
+// a pointer to itself, or nil if there is nothing useful to return.
+func (t LiteralRows) Private() interface{} {
+	return nil
+}
+
+// String returns a human-readable string representation for the expression
+// that can be used for debugging and testing.
+func (t LiteralRows) String() string {
+	return ""
+}
+
+// Rank is part of ScalarExpr interface
+func (t LiteralRows) Rank() ScalarRank {
+	return 0
+}
+
+// DataType is part of ScalarExpr interface
+func (t LiteralRows) DataType() *types.T {
+	return nil
+}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -74,6 +75,24 @@ func (ef *execFactory) ConstructValues(
 		columns:          cols,
 		tuples:           rows,
 		specifiedInQuery: true,
+	}, nil
+}
+
+// ConstructLiteralValues is part of the exec.Factory interface.
+func (ef *execFactory) ConstructLiteralValues(
+	rows tree.ExprContainer, cols colinfo.ResultColumns,
+) (exec.Node, error) {
+	if len(cols) == 0 && rows.NumRows() == 1 {
+		return &unaryNode{}, nil
+	}
+	if rows.NumRows() == 0 {
+		return &zeroNode{columns: cols}, nil
+	}
+	return &valuesNode{
+		columns:                  cols,
+		specifiedInQuery:         true,
+		externallyOwnedContainer: true,
+		valuesRun:                valuesRun{rows: rows.(*rowcontainer.RowContainer)},
 	}, nil
 }
 

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -990,3 +990,13 @@ func (ir IndexedRow) GetDatums(startColIdx, endColIdx int) (tree.Datums, error) 
 	}
 	return datums, nil
 }
+
+// Get implements tree.ExprContainer interface.
+func (r *RowContainer) Get(i, j int) tree.Expr {
+	return r.At(i)[j]
+}
+
+// NumRows implements tree.ExprContainer interface.
+func (r *RowContainer) NumRows() int {
+	return r.Len()
+}

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -36,10 +36,11 @@ type SelectStatement interface {
 	selectStatement()
 }
 
-func (*ParenSelect) selectStatement()  {}
-func (*SelectClause) selectStatement() {}
-func (*UnionClause) selectStatement()  {}
-func (*ValuesClause) selectStatement() {}
+func (*ParenSelect) selectStatement()         {}
+func (*SelectClause) selectStatement()        {}
+func (*UnionClause) selectStatement()         {}
+func (*ValuesClause) selectStatement()        {}
+func (*LiteralValuesClause) selectStatement() {}
 
 // Select represents a SelectStatement with an ORDER and/or LIMIT.
 type Select struct {

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1042,6 +1042,15 @@ func (*Import) StatementTag() string { return "IMPORT" }
 func (*Import) cclOnlyStatement() {}
 
 // StatementReturnType implements the Statement interface.
+func (*LiteralValuesClause) StatementReturnType() StatementReturnType { return Rows }
+
+// StatementType implements the Statement interface.
+func (*LiteralValuesClause) StatementType() StatementType { return TypeDML }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*LiteralValuesClause) StatementTag() string { return "VALUES" }
+
+// StatementReturnType implements the Statement interface.
 func (*ParenSelect) StatementReturnType() StatementReturnType { return Rows }
 
 // StatementType implements the Statement interface.
@@ -2046,6 +2055,7 @@ func (n *GrantRole) String() string                           { return AsString(
 func (n *MoveCursor) String() string                          { return AsString(n) }
 func (n *Insert) String() string                              { return AsString(n) }
 func (n *Import) String() string                              { return AsString(n) }
+func (n *LiteralValuesClause) String() string                 { return AsString(n) }
 func (n *ParenSelect) String() string                         { return AsString(n) }
 func (n *Prepare) String() string                             { return AsString(n) }
 func (n *ReassignOwnedBy) String() string                     { return AsString(n) }

--- a/pkg/sql/sem/tree/values.go
+++ b/pkg/sql/sem/tree/values.go
@@ -24,6 +24,42 @@ type ValuesClause struct {
 	Rows []Exprs
 }
 
+// ExprContainer represents an abstract container of Exprs
+type ExprContainer interface {
+	// NumRows returns number of rows.
+	NumRows() int
+	// NumCols returns number of columns.
+	NumCols() int
+	// Get returns the Expr at row i column j.
+	Get(i, j int) Expr
+}
+
+// RawRows exposes a [][]TypedExpr as an ExprContainer.
+type RawRows [][]TypedExpr
+
+var _ ExprContainer = RawRows{}
+
+// NumRows implements the ExprContainer interface.
+func (r RawRows) NumRows() int {
+	return len(r)
+}
+
+// NumCols implements the ExprContainer interface.
+func (r RawRows) NumCols() int {
+	return len(r[0])
+}
+
+// Get implements the ExprContainer interface.
+func (r RawRows) Get(i, j int) Expr {
+	return r[i][j]
+}
+
+// LiteralValuesClause is like ValuesClause but values have been typed checked
+// and evaluated and are assumed to be ready to use Datums.
+type LiteralValuesClause struct {
+	Rows ExprContainer
+}
+
 // Format implements the NodeFormatter interface.
 func (node *ValuesClause) Format(ctx *FmtCtx) {
 	ctx.WriteString("VALUES ")
@@ -32,6 +68,24 @@ func (node *ValuesClause) Format(ctx *FmtCtx) {
 		ctx.WriteString(comma)
 		ctx.WriteByte('(')
 		ctx.FormatNode(&node.Rows[i])
+		ctx.WriteByte(')')
+		comma = ", "
+	}
+}
+
+// Format implements the NodeFormatter interface.
+func (node *LiteralValuesClause) Format(ctx *FmtCtx) {
+	ctx.WriteString("VALUES ")
+	comma := ""
+	for i := 0; i < node.Rows.NumRows(); i++ {
+		ctx.WriteString(comma)
+		ctx.WriteByte('(')
+		comma2 := ""
+		for j := 0; j < node.Rows.NumCols(); j++ {
+			ctx.WriteString(comma2)
+			ctx.FormatNode(node.Rows.Get(i, j))
+			comma2 = ", "
+		}
 		ctx.WriteByte(')')
 		comma = ", "
 	}

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -274,6 +274,8 @@ message LocalOnlySessionData {
   // OptimizerUseNotVisibleIndexes indicates whether the optimizer can still
   // choose to use visible indexes for query plans.
   bool optimizer_use_not_visible_indexes = 74;
+  // CopyFastPathEnabled controls whether the optimized copy mode is enabled.
+  bool copy_fast_path_enabled = 75;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -30,6 +30,10 @@ type valuesNode struct {
 	// a vtable value generator. This changes distsql physical planning.
 	specifiedInQuery bool
 
+	// externallyOwnedContainer allows an external entity to control its
+	// lifetime so we don't call Close.  Used by copy to reuse the container.
+	externallyOwnedContainer bool
+
 	valuesRun
 }
 
@@ -99,7 +103,7 @@ func (n *valuesNode) Values() tree.Datums {
 }
 
 func (n *valuesNode) Close(ctx context.Context) {
-	if n.rows != nil {
+	if n.rows != nil && !n.externallyOwnedContainer {
 		n.rows.Close(ctx)
 		n.rows = nil
 	}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -2139,7 +2140,29 @@ var varGen = map[string]sessionVar{
 			return formatFloatAsPostgresSetting(0)
 		},
 	},
+
+	// CockroachDB extension.
+	`copy_fast_path_enabled`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`copy_fast_path_enabled`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("copy_fast_path_enabled", s)
+			if err != nil {
+				return err
+			}
+			m.SetCopyFastPathEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().CopyFastPathEnabled), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(copyFastPathDefault)
+		},
+	},
 }
+
+// We want test coverage for this on and off so make it metamorphic.
+var copyFastPathDefault bool = util.ConstantWithMetamorphicTestBool("copy-fast-path-enabled-default", true)
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."
 


### PR DESCRIPTION
COPY FROM currently does type checking twice, once when reading the
tuples using ParseAndRequireString and again in the optimizer using
the expensive buildValues machinery. Instead of converting the already
typed tuples into opt expressions just leave them as Datums and
pass them through the optimizer untouched. Exploit existing pseudo
table machinery that uses RowContainer to pre-populate the valuesNode
with Datums. Also use a scratch buffer to populate the RowContainer
instead of allocating new Datums for every row.

benchstat output:

name         old time/op    new time/op    delta
CopyFrom-32     7.78s ± 3%     6.93s ± 4%  -10.89%  (p=0.000 n=10+9)

name         old mb/s       new mb/s       delta
CopyFrom-32      0.82 ± 1%      0.94 ± 3%  +15.18%  (p=0.000 n=10+10)

name         old rows/s     new rows/s     delta
CopyFrom-32     6.76k ± 1%     7.79k ± 3%  +15.17%  (p=0.000 n=10+10)

name         old alloc/op   new alloc/op   delta
CopyFrom-32    3.29GB ± 2%    3.19GB ± 1%   -3.11%  (p=0.000 n=10+9)

name         old allocs/op  new allocs/op  delta
CopyFrom-32     11.6M ± 0%      8.3M ± 0%  -28.93%  (p=0.000 n=9+8)

Release note (performance improvement): Optimize the execution of COPY
FROM.

Release justification: low risk high benefit changes to existing
    functionality