### PR TITLE
kvserver/batcheval: restore lease if transfer fails 

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_lease.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease.go
@@ -41,10 +41,6 @@ func newFailedLeaseTrigger(isTransfer bool) result.Result {
 // The new lease might be a lease for a range that didn't previously have an
 // active lease, might be an extension or a lease transfer.
 //
-// isExtension should be set if the lease holder does not change with this
-// lease. If it doesn't change, we don't need the application of this lease to
-// block reads.
-//
 // TODO(tschottdorf): refactoring what's returned from the trigger here makes
 // sense to minimize the amount of code intolerant of rolling updates.
 func evalNewLease(
@@ -55,7 +51,6 @@ func evalNewLease(
 	lease roachpb.Lease,
 	prevLease roachpb.Lease,
 	priorReadSum *rspb.ReadSummary,
-	isExtension bool,
 	isTransfer bool,
 ) (result.Result, error) {
 	// When returning an error from this method, must always return

--- a/pkg/kv/kvserver/batcheval/cmd_lease_request.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_request.go
@@ -158,5 +158,5 @@ func RequestLease(
 	}
 
 	return evalNewLease(ctx, cArgs.EvalCtx, readWriter, cArgs.Stats,
-		newLease, prevLease, priorReadSum, isExtension, false /* isTransfer */)
+		newLease, prevLease, priorReadSum, false /* isTransfer */)
 }

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -130,5 +130,5 @@ func TransferLease(
 
 	log.VEventf(ctx, 2, "lease transfer: prev lease: %+v, new lease: %+v", prevLease, newLease)
 	return evalNewLease(ctx, cArgs.EvalCtx, readWriter, cArgs.Stats,
-		newLease, prevLease, &priorReadSum, false /* isExtension */, true /* isTransfer */)
+		newLease, prevLease, &priorReadSum, true /* isTransfer */)
 }

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -249,8 +249,10 @@ func (rec *SpanSetReplicaEvalContext) GetExternalStorageFromURI(
 }
 
 // RevokeLease stops the replica from using its current lease.
-func (rec *SpanSetReplicaEvalContext) RevokeLease(ctx context.Context, seq roachpb.LeaseSequence) {
-	rec.i.RevokeLease(ctx, seq)
+func (rec *SpanSetReplicaEvalContext) RevokeLease(
+	ctx context.Context, seq roachpb.LeaseSequence,
+) func() {
+	return rec.i.RevokeLease(ctx, seq)
 }
 
 // WatchForMerge arranges to block all requests until the in-progress merge


### PR DESCRIPTION
Before evaluating a TransferLeaseRequest, we revoke the existing lease.
This is needed so that further reads are not permitted before the new
lease takes effect without being captured in the timestamp cache summary
carried by the transfer.

This patch makes it so that we restore the original lease if the
evaluation of the transfer fails(*), as there doesn't seem to be any
reason to force the replica to acquire a new lease in that case. This
patch is strictly about evaluation failing, and not about failures or
ambiguity during application of the lease transfer Raft command.

(*) It's not common for the evaluation of a transfer to fail. We see
something going wrong with a transfer (either with the evaluation or
with the proposal) in https://github.com/cockroachdb/cockroach/issues/83687. Evaluation fails on inconsistent next
leases, which I think can happen under transfer races.

Release note: None