### PR TITLE
bazel: in `check.sh`, restrict `grep` to `pkg`

### DIFF
--- a/build/bazelutil/check.sh
+++ b/build/bazelutil/check.sh
@@ -79,7 +79,7 @@ fi
 # We exclude stringer and add-leaktest.sh -- the former is already all
 # Bazelfied, and the latter can be safely ignored since we have a lint to check
 # the same thing: https://github.com/cockroachdb/cockroach/issues/64440
-git grep '//go:generate' -- './*.go' | grep -v stringer | grep -v 'add-leaktest\.sh' | while read LINE; do
+git grep '//go:generate' 'pkg/**/*.go' | grep -v stringer | grep -v 'add-leaktest\.sh' | while read LINE; do
     if [[ "$EXISTING_GO_GENERATE_COMMENTS" == *"$LINE"* ]]; then
 	# Grandfathered.
 	continue


### PR DESCRIPTION
You can optionally configure `git grep` to recurse into submodules, in
which case this check returns false positives. Here we restrict the
search to the `pkg` directory which is all we care about.

Release note: None