### PR TITLE
tree: fix vectorized COALESCE and NULLIF type checking with VOID

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/void
+++ b/pkg/sql/logictest/testdata/logic_test/void
@@ -40,3 +40,110 @@ query T
 SELECT crdb_internal.void_func()
 ----
 ·
+
+# Regression test for #83754. Postgres does not error out, but is inconsistent
+# in evaluation. For example, `SELECT ''::VOID IS DISTINCT FROM NULL::UNKNOWN;`
+# errors out, but `SELECT ''::VOID IS DISTINCT FROM NULL;` does not.
+# This is due to normalization into an IS NOT NULL op when one operand is NULL.
+# The NULL with type cast is not recognized as NULL.
+# We will stay consistent and have both cases error out to avoid different
+# behavior between normalized and unnormalized expressions.
+statement error pq: unsupported comparison operator: <void> IS DISTINCT FROM <unknown>
+SELECT ''::VOID IS DISTINCT FROM NULL
+
+statement ok
+SET vectorize=on
+
+# Regression test for #83754. Vectorized execution should not error out.
+query T
+SELECT
+  COALESCE(tab_115318.col_199168, NULL) AS col_199169
+FROM
+  (VALUES (''::VOID), (NULL), (NULL), (''::VOID)) AS tab_115318 (col_199168)
+ORDER BY
+  tab_115318.col_199168
+----
+NULL
+NULL
+·
+·
+
+# Regression test for #83754. Illegal type comparison should be caught in the
+# parser.
+statement error pq: incompatible NULLIF expressions: unsupported comparison operator: <void> = <unknown>
+SELECT NULLIF(tab_115318.a, tab_115318.b) AS col_199169
+FROM
+  (VALUES (''::VOID, NULL), (NULL, NULL)) AS tab_115318 (a, b)
+ORDER BY
+  tab_115318.a;
+
+statement error pq: incompatible NULLIF expressions: unsupported comparison operator: <void> = <void>
+SELECT NULLIF(tab_115318.a, tab_115318.b) AS col_199169
+FROM
+  (VALUES (''::VOID, ''::VOID), (NULL, NULL)) AS tab_115318 (a, b)
+ORDER BY
+  tab_115318.col_199168;
+
+# Regression test for #83754. Tuple type should be handled properly.
+query T
+SELECT
+  COALESCE(tab_115318.col_199168, NULL) AS col_199169
+FROM
+  (VALUES ((NULL, 1)), (NULL)) AS tab_115318 (col_199168)
+ORDER BY
+  tab_115318.col_199168
+----
+NULL
+(,1)
+
+statement ok
+SET vectorize=off
+
+# Regression test for #83754.
+# Non-vectorized and vectorized results should match.
+query T
+SELECT
+  COALESCE(tab_115318.col_199168, NULL) AS col_199169
+FROM
+  (VALUES (''::VOID), (NULL), (NULL), (''::VOID)) AS tab_115318 (col_199168)
+ORDER BY
+  tab_115318.col_199168
+----
+NULL
+NULL
+·
+·
+
+# Regression test for #83754.
+# Non-vectorized and vectorized results should match.
+statement error pq: incompatible NULLIF expressions: unsupported comparison operator: <void> = <unknown>
+SELECT NULLIF(tab_115318.a, tab_115318.b) AS col_199169
+FROM
+  (VALUES (''::VOID, NULL), (NULL, NULL)) AS tab_115318 (a, b)
+ORDER BY
+  tab_115318.a;
+
+# Regression test for #83754.
+# Non-vectorized and vectorized results should match.
+statement error pq: incompatible NULLIF expressions: unsupported comparison operator: <void> = <void>
+SELECT NULLIF(tab_115318.a, tab_115318.b) AS col_199169
+FROM
+  (VALUES (''::VOID, ''::VOID), (NULL, NULL)) AS tab_115318 (a, b)
+ORDER BY
+  tab_115318.col_199168;
+
+# Regression test for #83754.
+# Non-vectorized and vectorized results should match.
+query T
+SELECT
+  COALESCE(tab_115318.col_199168, NULL) AS col_199169
+FROM
+  (VALUES ((NULL, 1)), (NULL)) AS tab_115318 (col_199168)
+ORDER BY
+  tab_115318.col_199168
+----
+NULL
+(,1)
+
+statement ok
+RESET vectorize

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1346,6 +1346,16 @@ func (expr *NullIfExpr) TypeCheck(
 	if err != nil {
 		return nil, decorateTypeCheckError(err, "incompatible NULLIF expressions")
 	}
+	leftType := typedSubExprs[0].ResolvedType()
+	rightType := typedSubExprs[1].ResolvedType()
+	_, ok := CmpOps[treecmp.EQ].LookupImpl(leftType, rightType)
+	if !ok {
+		op := treecmp.ComparisonOperator{Symbol: treecmp.EQ}
+		err = pgerror.Newf(
+			pgcode.UndefinedFunction, "unsupported comparison operator: <%s> %s <%s>",
+			leftType, op, rightType)
+		return nil, decorateTypeCheckError(err, "incompatible NULLIF expressions")
+	}
 
 	expr.Expr1, expr.Expr2 = typedSubExprs[0], typedSubExprs[1]
 	expr.typ = retType


### PR DESCRIPTION
Fixes #83754

Previously, the COALESCE and NULLIF operators could error out in
vectorized execution when comparing a VOID datum with NULL.

This occurred due to the unique property of a VOID, that it
can't be compared with another VOID using any of the normal operators
such as `=`, `<`, `>`..., or even IS [NOT] [DISTINCT FROM], for example:
```
SELECT ''::VOID IS DISTINCT FROM ''::VOID;
ERROR: unsupported comparison operator: <void> IS DISTINCT FROM <void>
SQLSTATE: 22023
```
Processing of COALESCE in the columnar execution engine for an
expression like `COALESCE(void_col, NULL)` builds an IS DISTINCT FROM
operation between the VOID column and NULL here:
https://github.com/cockroachdb/cockroach/blob/ea559dfe0ba57259ca71d3c8ca1de6388954ea73/pkg/sql/colexec/colbuilder/execplan.go#L2122-L2129

This comparison is assumed to be OK, but fails with an internal error
because comparison with `UnknownType` is only implicitly supported if
the type can be compared with itself.

To address this, this patch modifies vectorized COALESCE to use the
IS NOT NULL operator internally instead of IS DISTINCT FROM whenever    
the latter is not a valid comparison.
A similar problem with NULLIF, which internally uses `=`, is fixed.
Type checking of NULLIF is enhanced in the parser so incompatible
comparisons can be caught prior to execution time.

Release note (bug fix): This patch fixes vectorized evaluation of
COALESCE involving expressions of type VOID and enhances type checking
of NULLIF expressions with VOID, so incompatible comparisons can
be caught during query compilation instead of during query execution.