### PR TITLE
pgwire: fix buffer size limiting behavior for addBatch

### DIFF
--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -194,9 +194,8 @@ func (r *commandResult) SetError(err error) {
 	r.err = err
 }
 
-// addInternal is the skeleton of AddRow and AddBatch implementations.
-// bufferData should update rowsAffected and buffer the data accordingly.
-func (r *commandResult) addInternal(bufferData func()) error {
+// beforeAdd should be called before rows are buffered.
+func (r *commandResult) beforeAdd() error {
 	r.assertNotReleased()
 	if r.err != nil {
 		panic(errors.NewAssertionErrorWithWrappedErrf(r.err, "can't call AddRow after having set error"))
@@ -208,32 +207,25 @@ func (r *commandResult) addInternal(bufferData func()) error {
 	if r.err != nil {
 		panic("can't send row after error")
 	}
-
-	bufferData()
-
-	var err error
-	if r.bufferingDisabled {
-		err = r.conn.Flush(r.pos)
-	} else {
-		_ /* flushed */, err = r.conn.maybeFlush(r.pos)
-	}
-	return err
+	return nil
 }
 
 // AddRow is part of the sql.RestrictedCommandResult interface.
 func (r *commandResult) AddRow(ctx context.Context, row tree.Datums) error {
-	return r.addInternal(func() {
-		r.rowsAffected++
-		r.conn.bufferRow(ctx, row, r.formatCodes, r.conv, r.location, r.types)
-	})
+	if err := r.beforeAdd(); err != nil {
+		return err
+	}
+	r.rowsAffected++
+	return r.conn.bufferRow(ctx, row, r)
 }
 
 // AddBatch is part of the sql.RestrictedCommandResult interface.
 func (r *commandResult) AddBatch(ctx context.Context, batch coldata.Batch) error {
-	return r.addInternal(func() {
-		r.rowsAffected += batch.Length()
-		r.conn.bufferBatch(ctx, batch, r.formatCodes, r.conv, r.location)
-	})
+	if err := r.beforeAdd(); err != nil {
+		return err
+	}
+	r.rowsAffected += batch.Length()
+	return r.conn.bufferBatch(ctx, batch, r)
 }
 
 // SupportsAddBatch is part of the sql.RestrictedCommandResult interface.
@@ -443,10 +435,7 @@ func (r *limitedCommandResult) AddRow(ctx context.Context, row tree.Datums) erro
 
 		return r.moreResultsNeeded(ctx)
 	}
-	if _ /* flushed */, err := r.conn.maybeFlush(r.pos); err != nil {
-		return err
-	}
-	return nil
+	return r.conn.maybeFlush(r.pos, r.bufferingDisabled)
 }
 
 // SupportsAddBatch is part of the sql.RestrictedCommandResult interface.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1316,31 +1316,21 @@ func cookTag(
 	return tag
 }
 
-// bufferRow serializes a row and adds it to the buffer.
-//
-// formatCodes describes the desired encoding for each column. It can be nil, in
-// which case all columns are encoded using the text encoding. Otherwise, it
-// needs to contain an entry for every column.
-func (c *conn) bufferRow(
-	ctx context.Context,
-	row tree.Datums,
-	formatCodes []pgwirebase.FormatCode,
-	conv sessiondatapb.DataConversionConfig,
-	sessionLoc *time.Location,
-	types []*types.T,
-) {
+// bufferRow serializes a row and adds it to the buffer. Depending on the buffer
+// size limit, bufferRow may flush the buffered data to the connection.
+func (c *conn) bufferRow(ctx context.Context, row tree.Datums, r *commandResult) error {
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgDataRow)
 	c.msgBuilder.putInt16(int16(len(row)))
 	for i, col := range row {
 		fmtCode := pgwirebase.FormatText
-		if formatCodes != nil {
-			fmtCode = formatCodes[i]
+		if r.formatCodes != nil {
+			fmtCode = r.formatCodes[i]
 		}
 		switch fmtCode {
 		case pgwirebase.FormatText:
-			c.msgBuilder.writeTextDatum(ctx, col, conv, sessionLoc, types[i])
+			c.msgBuilder.writeTextDatum(ctx, col, r.conv, r.location, r.types[i])
 		case pgwirebase.FormatBinary:
-			c.msgBuilder.writeBinaryDatum(ctx, col, sessionLoc, types[i])
+			c.msgBuilder.writeBinaryDatum(ctx, col, r.location, r.types[i])
 		default:
 			c.msgBuilder.setError(errors.Errorf("unsupported format code %s", fmtCode))
 		}
@@ -1348,21 +1338,13 @@ func (c *conn) bufferRow(
 	if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
 		panic(errors.NewAssertionErrorWithWrappedErrf(err, "unexpected err from buffer"))
 	}
+	return c.maybeFlush(r.pos, r.bufferingDisabled)
 }
 
 // bufferBatch serializes a batch and adds all the rows from it to the buffer.
-// It is a noop for zero-length batch.
-//
-// formatCodes describes the desired encoding for each column. It can be nil, in
-// which case all columns are encoded using the text encoding. Otherwise, it
-// needs to contain an entry for every column.
-func (c *conn) bufferBatch(
-	ctx context.Context,
-	batch coldata.Batch,
-	formatCodes []pgwirebase.FormatCode,
-	conv sessiondatapb.DataConversionConfig,
-	sessionLoc *time.Location,
-) {
+// It is a noop for zero-length batch. Depending on the buffer size limit,
+// bufferBatch may flush the buffered data to the connection.
+func (c *conn) bufferBatch(ctx context.Context, batch coldata.Batch, r *commandResult) error {
 	sel := batch.Selection()
 	n := batch.Length()
 	if n > 0 {
@@ -1379,14 +1361,14 @@ func (c *conn) bufferBatch(
 			c.msgBuilder.putInt16(width)
 			for vecIdx := 0; vecIdx < len(c.vecsScratch.Vecs); vecIdx++ {
 				fmtCode := pgwirebase.FormatText
-				if formatCodes != nil {
-					fmtCode = formatCodes[vecIdx]
+				if r.formatCodes != nil {
+					fmtCode = r.formatCodes[vecIdx]
 				}
 				switch fmtCode {
 				case pgwirebase.FormatText:
-					c.msgBuilder.writeTextColumnarElement(ctx, &c.vecsScratch, vecIdx, rowIdx, conv, sessionLoc)
+					c.msgBuilder.writeTextColumnarElement(ctx, &c.vecsScratch, vecIdx, rowIdx, r.conv, r.location)
 				case pgwirebase.FormatBinary:
-					c.msgBuilder.writeBinaryColumnarElement(ctx, &c.vecsScratch, vecIdx, rowIdx, sessionLoc)
+					c.msgBuilder.writeBinaryColumnarElement(ctx, &c.vecsScratch, vecIdx, rowIdx, r.location)
 				default:
 					c.msgBuilder.setError(errors.Errorf("unsupported format code %s", fmtCode))
 				}
@@ -1394,8 +1376,12 @@ func (c *conn) bufferBatch(
 			if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
 				panic(fmt.Sprintf("unexpected err from buffer: %s", err))
 			}
+			if err := c.maybeFlush(r.pos, r.bufferingDisabled); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 func (c *conn) bufferReadyForQuery(txnStatus byte) {
@@ -1601,12 +1587,12 @@ func (c *conn) Flush(pos sql.CmdPos) error {
 }
 
 // maybeFlush flushes the buffer to the network connection if it exceeded
-// sessionArgs.ConnResultsBufferSize.
-func (c *conn) maybeFlush(pos sql.CmdPos) (bool, error) {
-	if int64(c.writerState.buf.Len()) <= c.sessionArgs.ConnResultsBufferSize {
-		return false, nil
+// sessionArgs.ConnResultsBufferSize or if buffering is disabled.
+func (c *conn) maybeFlush(pos sql.CmdPos, bufferingDisabled bool) error {
+	if !bufferingDisabled && int64(c.writerState.buf.Len()) <= c.sessionArgs.ConnResultsBufferSize {
+		return nil
 	}
-	return true, c.Flush(pos)
+	return c.Flush(pos)
 }
 
 // LockCommunication is part of the ClientComm interface.


### PR DESCRIPTION
Previously, the size of the buffer used to store results before sending them
to the client was checked after buffering each batch entirely. This could
result in significantly exceeding the buffer memory limit when a batch had wide
rows on average.

This patch modifies the pwire logic to ensure that `maybeFlush` is called each
time a row is buffered. This ensures that the pre-21.2 behavior is preserved.

Fixes #83837

Release note (bug fix): Fixed a bug that was introduced in release 21.2 that
could cause increased memory usage when scanning a table with wide rows.