### PR TITLE
tree: support row_to_json on VOID type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/void
+++ b/pkg/sql/logictest/testdata/logic_test/void
@@ -6,6 +6,13 @@ SELECT 'this will be ignored'::void
 ----
 ·
 
+# Regression test for #83791. row_to_json on a VOID should produce an
+# empty string, unadorned with single quotes, as in done in postgres.
+query T
+SELECT row_to_json((''::VOID, null))::JSONB AS col_12295
+----
+{"f1": "", "f2": null}
+
 query T
 select row (''::void, 2::int)
 ----

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3696,6 +3696,8 @@ func AsJSON(
 		return json.FromSpatialObject(t.Geometry.SpatialObject(), geo.DefaultGeoJSONDecimalDigits)
 	case *DGeography:
 		return json.FromSpatialObject(t.Geography.SpatialObject(), geo.DefaultGeoJSONDecimalDigits)
+	case *DVoid:
+		return json.FromString(AsStringWithFlags(t, fmtRawStrings)), nil
 	default:
 		if d == DNull {
 			return json.NullJSONValue, nil


### PR DESCRIPTION
Fixes #83791

Previously, the row_to_json function errors out when processing a VOID
literal.

This was inadequate because VOID has a valid string representation, the
empty string, which should be used wherever a VOID literal occurs, as is
done in postgres.

To address this, this patch returns the string representation of a
VOID datum within the `AsJSON` function, if this datum is encountered.

Release note (bug fix): This patch fixes the row_to_json SQL function
so it does not error out with input having the VOID data type.