### PR TITLE
ui/cluster-ui: filter out closed sessions from active exec pages 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
@@ -13,6 +13,7 @@ import {
   SessionsResponse,
   ActiveTransaction,
   ActiveStatement,
+  SessionStatusType,
 } from "./types";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import moment from "moment";
@@ -185,6 +186,14 @@ describe("test activeStatementUtils", () => {
           client_address: "clientAddress2",
           active_queries: activeQueries,
         },
+        {
+          id: new Uint8Array(),
+          username: "foo",
+          status: SessionStatusType.CLOSED,
+          application_name: "application2",
+          client_address: "clientAddress2",
+          active_queries: activeQueries,
+        },
       ],
       errors: [],
       internal_app_name_prefix: "",
@@ -270,6 +279,15 @@ describe("test activeStatementUtils", () => {
           active_queries: [makeActiveQuery()],
           active_txn: txns[1],
         },
+        {
+          id: new Uint8Array(),
+          username: "foo",
+          status: SessionStatusType.CLOSED,
+          application_name: "closed_application",
+          client_address: "clientAddress2",
+          active_queries: [makeActiveQuery()],
+          active_txn: txns[1],
+        },
       ],
       errors: [],
       internal_app_name_prefix: "",
@@ -280,6 +298,9 @@ describe("test activeStatementUtils", () => {
       sessionsResponse,
       LAST_UPDATED,
     );
+
+    // Should filter out the txn from closed  session.
+    expect(activeTransactions.length).toBe(2);
 
     expect(activeTransactions.length).toBe(txns.length);
 

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -17,6 +17,7 @@ import {
   ActiveStatementPhase,
   ExecutionStatus,
   ActiveTransactionFilters,
+  SessionStatusType,
 } from "./types";
 import { ActiveStatement, ActiveStatementFilters } from "./types";
 
@@ -54,6 +55,7 @@ export function getActiveStatementsFromSessions(
   const time = lastUpdated || moment.utc();
 
   sessionsResponse.sessions.forEach(session => {
+    if (session.status === SessionStatusType.CLOSED) return;
     session.active_queries.forEach(query => {
       activeQueries.push({
         executionID: query.id,
@@ -140,7 +142,10 @@ export function getActiveTransactionsFromSessions(
   });
 
   return sessionsResponse.sessions
-    .filter(session => session.active_txn)
+    .filter(
+      session =>
+        session.status !== SessionStatusType.CLOSED && session.active_txn,
+    )
     .map(session => {
       const activeTxn = session.active_txn;
 

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
@@ -17,8 +17,11 @@ export type SessionsResponse =
 export type ActiveStatementResponse =
   protos.cockroach.server.serverpb.ActiveQuery;
 export type ExecutionStatus = "Waiting" | "Executing" | "Preparing";
+
 export const ActiveStatementPhase =
   protos.cockroach.server.serverpb.ActiveQuery.Phase;
+export const SessionStatusType =
+  protos.cockroach.server.serverpb.Session.Status;
 
 export type ActiveStatement = {
   executionID: string;


### PR DESCRIPTION
Previously, it was possible for the active transactions page
to show txns from closed sessions. The sessions API was
recently updated to return closed sessions, and it is
possible for the active_txn field in a closed session to be
populated. This commit filters  out the closed sessions when
retrieving active transactions.

Release note (bug fix): active transactions page no longer
shows transactions from closed sessions