### PR TITLE
ui: add connected component for jobs pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/jobsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/jobsApi.ts
@@ -9,9 +9,42 @@
 // licenses/APL.txt.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { fetchData } from "./fetchData";
+import { propsToQueryString } from "../util";
+
+const JOBS_PATH = "/_admin/v1/jobs";
 
 export type JobsRequest = cockroach.server.serverpb.JobsRequest;
 export type JobsResponse = cockroach.server.serverpb.JobsResponse;
 
 export type JobRequest = cockroach.server.serverpb.JobRequest;
 export type JobResponse = cockroach.server.serverpb.JobResponse;
+
+export const getJobs = (
+  req: JobsRequest,
+): Promise<cockroach.server.serverpb.JobsResponse> => {
+  const queryStr = propsToQueryString({
+    status: req.status,
+    type: req.type.toString(),
+    limit: req.limit,
+  });
+  return fetchData(
+    cockroach.server.serverpb.JobsResponse,
+    `${JOBS_PATH}?${queryStr}`,
+    null,
+    null,
+    "30M",
+  );
+};
+
+export const getJob = (
+  req: JobRequest,
+): Promise<cockroach.server.serverpb.JobResponse> => {
+  return fetchData(
+    cockroach.server.serverpb.JobResponse,
+    `${JOBS_PATH}/${req.job_id}`,
+    null,
+    null,
+    "30M",
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/index.ts
@@ -9,3 +9,4 @@
 // licenses/APL.txt.
 
 export * from "./jobDetails";
+export * from "./jobDetailsConnected";

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
@@ -1,0 +1,45 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+
+import { AppState } from "src/store";
+import { selectJobState } from "../../store/jobDetails/job.selectors";
+import {
+  JobDetailsStateProps,
+  JobDetailsDispatchProps,
+  JobDetails,
+} from "./jobDetails";
+import { JobRequest } from "src/api/jobsApi";
+import { actions as jobActions } from "src/store/jobDetails";
+
+const mapStateToProps = (state: AppState): JobDetailsStateProps => {
+  const jobState = selectJobState(state);
+  const job = jobState ? jobState.data : null;
+  const jobLoading = jobState ? jobState.inFlight : false;
+  const jobError = jobState ? jobState.lastError : null;
+  return {
+    job,
+    jobLoading,
+    jobError,
+  };
+};
+
+const mapDispatchToProps = {
+  refreshJob: (req: JobRequest) => jobActions.refresh(req),
+};
+
+export const JobDetailsPageConnected = withRouter(
+  connect<JobDetailsStateProps, JobDetailsDispatchProps, RouteComponentProps>(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(JobDetails),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobTable.tsx
@@ -10,7 +10,7 @@
 import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { isEqual, map } from "lodash";
-import React, { MouseEvent } from "react";
+import React from "react";
 import { Anchor } from "src/anchor";
 import { JobsResponse } from "src/api/jobsApi";
 import emptyTableResultsIcon from "src/assets/emptyState/empty-table-results.svg";
@@ -28,9 +28,8 @@ import {
 } from "src/util/docs";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
 
-import { HighwaterTimestamp } from "../util/highwaterTimestamp";
+import { HighwaterTimestamp, JobStatusCell } from "../util";
 import { JobDescriptionCell } from "./jobDescriptionCell";
-import { JobStatusCell } from "../util/jobStatusCell";
 
 import styles from "../jobs.module.scss";
 import classNames from "classnames/bind";
@@ -125,7 +124,7 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
         style="tableTitle"
         content={<p>User that created the job.</p>}
       >
-        {"User"}
+        {"User Name"}
       </Tooltip>
     ),
     cell: job => job.username,
@@ -179,7 +178,13 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
       <Tooltip
         placement="bottom"
         style="tableTitle"
-        content={<p>Date and time the job was last executed.</p>}
+        content={
+          <p>
+            The high-water mark acts as a checkpoint for the changefeed’s job
+            progress, and guarantees that all changes before (or at) the
+            timestamp have been emitted.
+          </p>
+        }
       >
         {"High-water Timestamp"}
       </Tooltip>

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.spec.tsx
@@ -8,18 +8,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { assert, expect } from "chai";
+import { assert } from "chai";
 import moment from "moment";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { JobsPage, JobsPageProps } from "./jobsPage";
 import { formatDuration } from "../util/duration";
-import {
-  allJobsFixture,
-  retryRunningJobFixture,
-  earliestRetainedTime,
-} from "./jobsPage.fixture";
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { allJobsFixture, earliestRetainedTime } from "./jobsPage.fixture";
+import { render } from "@testing-library/react";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import * as H from "history";
@@ -78,7 +73,7 @@ describe("Jobs", () => {
       "Description",
       "Status",
       "Job ID",
-      "User",
+      "User Name",
       "Creation Time (UTC)",
       "Last Execution Time (UTC)",
       "Execution Count",

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPageConnected.tsx
@@ -1,0 +1,99 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+
+import { AppState } from "src/store";
+import {
+  selectJobsState,
+  selectShowSetting,
+  selectSortSetting,
+  selectTypeSetting,
+  selectStatusSetting,
+} from "../../store/jobs/jobs.selectors";
+import {
+  JobsPageStateProps,
+  JobsPageDispatchProps,
+  JobsPage,
+} from "./jobsPage";
+import { JobsRequest } from "src/api/jobsApi";
+import { actions as jobsActions } from "src/store/jobs";
+import { actions as localStorageActions } from "../../store/localStorage";
+import { Dispatch } from "redux";
+import { SortSetting } from "../../sortedtable";
+
+const mapStateToProps = (
+  state: AppState,
+  _: RouteComponentProps,
+): JobsPageStateProps => {
+  const sort = selectSortSetting(state);
+  const status = selectStatusSetting(state);
+  const show = selectShowSetting(state);
+  const type = selectTypeSetting(state);
+  const jobsState = selectJobsState(state);
+  const jobs = jobsState ? jobsState.data : null;
+  const jobsLoading = jobsState ? jobsState.inFlight : false;
+  const jobsError = jobsState ? jobsState.lastError : null;
+  return {
+    sort,
+    status,
+    show,
+    type,
+    jobs,
+    jobsLoading,
+    jobsError,
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch): JobsPageDispatchProps => ({
+  setShow: (showValue: string) => {
+    dispatch(
+      localStorageActions.update({
+        key: "showSetting/JobsPage",
+        value: showValue,
+      }),
+    );
+  },
+  setSort: (ss: SortSetting) => {
+    dispatch(
+      localStorageActions.update({
+        key: "sortSetting/JobsPage",
+        value: ss,
+      }),
+    );
+  },
+  setStatus: (statusValue: string) => {
+    dispatch(
+      localStorageActions.update({
+        key: "statusSetting/JobsPage",
+        value: statusValue,
+      }),
+    );
+  },
+  setType: (jobValue: number) => {
+    dispatch(
+      localStorageActions.update({
+        key: "typeSetting/JobsPage",
+        value: jobValue,
+      }),
+    );
+  },
+  refreshJobs: (req: JobsRequest) => dispatch(jobsActions.refresh(req)),
+  onFilterChange: (req: JobsRequest) =>
+    dispatch(jobsActions.updateFilteredJobs(req)),
+});
+
+export const JobsPageConnected = withRouter(
+  connect<JobsPageStateProps, JobsPageDispatchProps, RouteComponentProps>(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(JobsPage),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
@@ -26,20 +26,11 @@ import {
 import { Dispatch } from "redux";
 import { Filters } from "../queryFilter";
 import { sqlStatsSelector } from "../store/sqlStats/sqlStats.selector";
+import { localStorageSelector } from "../store/utils/selectors";
 
 export const selectSessionsData = createSelector(
   sqlStatsSelector,
   sessionsState => (sessionsState.valid ? sessionsState.data : null),
-);
-
-export const adminUISelector = createSelector(
-  (state: AppState) => state.adminUI,
-  adminUiState => adminUiState,
-);
-
-export const localStorageSelector = createSelector(
-  adminUISelector,
-  adminUiState => adminUiState.localStorage,
 );
 
 export const selectSessions = createSelector(

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
@@ -10,7 +10,7 @@
 
 import { createSelector } from "reselect";
 import { getActiveStatementsFromSessions } from "../activeExecutions/activeStatementUtils";
-import { localStorageSelector } from "./statementsPage.selectors";
+import { localStorageSelector } from "../store/utils/selectors";
 import {
   ActiveStatementFilters,
   ActiveStatementsViewDispatchProps,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -30,6 +30,7 @@ import { selectDiagnosticsReportsPerStatement } from "../store/statementDiagnost
 import { AggregateStatistics } from "../statementsTable";
 import { sqlStatsSelector } from "../store/sqlStats/sqlStats.selector";
 import { SQLStatsState } from "../store/sqlStats";
+import { localStorageSelector } from "../store/utils/selectors";
 
 type ICollectedStatementStatistics =
   cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
@@ -44,16 +45,6 @@ export interface StatementsSummaryData {
   database: string;
   stats: StatementStatistics[];
 }
-
-export const adminUISelector = createSelector(
-  (state: AppState) => state.adminUI,
-  adminUiState => adminUiState,
-);
-
-export const localStorageSelector = createSelector(
-  adminUISelector,
-  adminUiState => adminUiState.localStorage,
-);
 
 // selectApps returns the array of all apps with statement statistics present
 // in the data.

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/index.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./jobDescriptionCell";
-export * from "./jobsPage";
-export * from "./jobTable";
-export * from "./jobsPageConnected";
+export * from "./job.reducer";
+export * from "./job.sagas";
+export * from "./job.selectors";

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/job.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/job.reducer.ts
@@ -1,0 +1,52 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { JobRequest, JobResponse } from "src/api/jobsApi";
+import { DOMAIN_NAME } from "../utils";
+
+export type JobState = {
+  data: JobResponse;
+  lastError: Error;
+  valid: boolean;
+  inFlight: boolean;
+};
+
+const initialState: JobState = {
+  data: null,
+  lastError: null,
+  valid: true,
+  inFlight: false,
+};
+
+const JobSlice = createSlice({
+  name: `${DOMAIN_NAME}/job`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<JobResponse>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+      state.inFlight = false;
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    invalidated: state => {
+      state.valid = false;
+    },
+    refresh: (_, action: PayloadAction<JobRequest>) => {},
+    request: (_, action: PayloadAction<JobRequest>) => {},
+    reset: (_, action: PayloadAction<JobRequest>) => {},
+  },
+});
+
+export const { reducer, actions } = JobSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/job.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/job.sagas.spec.ts
@@ -1,0 +1,99 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { expectSaga } from "redux-saga-test-plan";
+import {
+  EffectProviders,
+  StaticProvider,
+  throwError,
+} from "redux-saga-test-plan/providers";
+import * as matchers from "redux-saga-test-plan/matchers";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { getJob } from "src/api/jobsApi";
+import { refreshJobSaga, requestJobSaga, receivedJobSaga } from "./job.sagas";
+import { actions, reducer, JobState } from "./job.reducer";
+import { succeededJobFixture } from "../../jobs/jobsPage/jobsPage.fixture";
+import Long from "long";
+
+describe("job sagas", () => {
+  const payload = new cockroach.server.serverpb.JobRequest({
+    job_id: new Long(8136728577, 70289336),
+  });
+  const jobResponse = new cockroach.server.serverpb.JobResponse(
+    succeededJobFixture,
+  );
+
+  const jobAPIProvider: (EffectProviders | StaticProvider)[] = [
+    [matchers.call.fn(getJob), jobResponse],
+  ];
+
+  describe("refreshJobSaga", () => {
+    it("dispatches refresh job action", () => {
+      return expectSaga(refreshJobSaga, actions.request(payload))
+        .provide(jobAPIProvider)
+        .put(actions.request(payload))
+        .run();
+    });
+  });
+
+  describe("requestJobSaga", () => {
+    it("successfully requests job", () => {
+      return expectSaga(requestJobSaga, actions.request(payload))
+        .provide(jobAPIProvider)
+        .put(actions.received(jobResponse))
+        .withReducer(reducer)
+        .hasFinalState<JobState>({
+          data: jobResponse,
+          lastError: null,
+          valid: true,
+          inFlight: false,
+        })
+        .run();
+    });
+
+    it("returns error on failed request", () => {
+      const error = new Error("Failed request");
+      return expectSaga(requestJobSaga, actions.request(payload))
+        .provide([[matchers.call.fn(getJob), throwError(error)]])
+        .put(actions.failed(error))
+        .withReducer(reducer)
+        .hasFinalState<JobState>({
+          data: null,
+          lastError: error,
+          valid: false,
+          inFlight: false,
+        })
+        .run();
+    });
+  });
+
+  describe("receivedJobSaga", () => {
+    it("sets valid status to false after specified period of time", () => {
+      const timeout = 500;
+      return expectSaga(receivedJobSaga, timeout)
+        .delay(timeout)
+        .put(actions.invalidated())
+        .withReducer(reducer, {
+          data: jobResponse,
+          lastError: null,
+          valid: true,
+          inFlight: false,
+        })
+        .hasFinalState<JobState>({
+          data: jobResponse,
+          lastError: null,
+          valid: false,
+          inFlight: false,
+        })
+        .run(1000);
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/job.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/job.sagas.ts
@@ -1,0 +1,50 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, delay, put, takeLatest } from "redux-saga/effects";
+
+import { actions } from "./job.reducer";
+import { getJob, JobRequest } from "src/api/jobsApi";
+import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
+import { rootActions } from "../reducers";
+import { PayloadAction } from "@reduxjs/toolkit";
+
+export function* refreshJobSaga(action: PayloadAction<JobRequest>) {
+  yield put(actions.request(action.payload));
+}
+
+export function* requestJobSaga(action: PayloadAction<JobRequest>): any {
+  try {
+    const result = yield call(getJob, action.payload);
+    yield put(actions.received(result));
+  } catch (e) {
+    yield put(actions.failed(e));
+  }
+}
+
+export function* receivedJobSaga(delayMs: number) {
+  yield delay(delayMs);
+  yield put(actions.invalidated());
+}
+
+export function* jobSaga(
+  cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
+) {
+  yield all([
+    throttleWithReset(
+      cacheInvalidationPeriod,
+      actions.refresh,
+      [actions.invalidated, rootActions.resetState],
+      refreshJobSaga,
+    ),
+    takeLatest(actions.request, requestJobSaga),
+    takeLatest(actions.received, receivedJobSaga, cacheInvalidationPeriod),
+  ]);
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/job.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobDetails/job.selectors.ts
@@ -8,7 +8,10 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./jobDescriptionCell";
-export * from "./jobsPage";
-export * from "./jobTable";
-export * from "./jobsPageConnected";
+import { createSelector } from "reselect";
+import { adminUISelector } from "../utils/selectors";
+
+export const selectJobState = createSelector(
+  adminUISelector,
+  adminUiState => adminUiState.job,
+);

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/index.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./jobDescriptionCell";
-export * from "./jobsPage";
-export * from "./jobTable";
-export * from "./jobsPageConnected";
+export * from "./jobs.reducer";
+export * from "./jobs.sagas";
+export * from "./jobs.selectors";

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.reducer.ts
@@ -1,0 +1,53 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { JobsRequest, JobsResponse } from "src/api/jobsApi";
+import { DOMAIN_NAME } from "../utils";
+
+export type JobsState = {
+  data: JobsResponse;
+  lastError: Error;
+  valid: boolean;
+  inFlight: boolean;
+};
+
+const initialState: JobsState = {
+  data: null,
+  lastError: null,
+  valid: true,
+  inFlight: false,
+};
+
+const JobsSlice = createSlice({
+  name: `${DOMAIN_NAME}/jobs`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<JobsResponse>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+      state.inFlight = false;
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    invalidated: state => {
+      state.valid = false;
+    },
+    refresh: (_, action: PayloadAction<JobsRequest>) => {},
+    request: (_, action: PayloadAction<JobsRequest>) => {},
+    reset: (_, action: PayloadAction<JobsRequest>) => {},
+    updateFilteredJobs: (_, action: PayloadAction<JobsRequest>) => {},
+  },
+});
+
+export const { reducer, actions } = JobsSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.sagas.spec.ts
@@ -1,0 +1,108 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { expectSaga } from "redux-saga-test-plan";
+import {
+  EffectProviders,
+  StaticProvider,
+  throwError,
+} from "redux-saga-test-plan/providers";
+import * as matchers from "redux-saga-test-plan/matchers";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { getJobs } from "src/api/jobsApi";
+import {
+  refreshJobsSaga,
+  requestJobsSaga,
+  receivedJobsSaga,
+} from "./jobs.sagas";
+import { actions, reducer, JobsState } from "./jobs.reducer";
+import {
+  allJobsFixture,
+  earliestRetainedTime,
+} from "../../jobs/jobsPage/jobsPage.fixture";
+
+describe("jobs sagas", () => {
+  const payload = new cockroach.server.serverpb.JobsRequest({
+    limit: 0,
+    type: 0,
+    status: "",
+  });
+  const jobsResponse = new cockroach.server.serverpb.JobsResponse({
+    jobs: allJobsFixture,
+    earliest_retained_time: earliestRetainedTime,
+  });
+
+  const jobsAPIProvider: (EffectProviders | StaticProvider)[] = [
+    [matchers.call.fn(getJobs), jobsResponse],
+  ];
+
+  describe("refreshJobsSaga", () => {
+    it("dispatches refresh jobs action", () => {
+      return expectSaga(refreshJobsSaga, actions.request(payload))
+        .provide(jobsAPIProvider)
+        .put(actions.request(payload))
+        .run();
+    });
+  });
+
+  describe("requestJobsSaga", () => {
+    it("successfully requests jobs", () => {
+      return expectSaga(requestJobsSaga, actions.request(payload))
+        .provide(jobsAPIProvider)
+        .put(actions.received(jobsResponse))
+        .withReducer(reducer)
+        .hasFinalState<JobsState>({
+          data: jobsResponse,
+          lastError: null,
+          valid: true,
+          inFlight: false,
+        })
+        .run();
+    });
+
+    it("returns error on failed request", () => {
+      const error = new Error("Failed request");
+      return expectSaga(requestJobsSaga, actions.request(payload))
+        .provide([[matchers.call.fn(getJobs), throwError(error)]])
+        .put(actions.failed(error))
+        .withReducer(reducer)
+        .hasFinalState<JobsState>({
+          data: null,
+          lastError: error,
+          valid: false,
+          inFlight: false,
+        })
+        .run();
+    });
+  });
+
+  describe("receivedJobsSaga", () => {
+    it("sets valid status to false after specified period of time", () => {
+      const timeout = 500;
+      return expectSaga(receivedJobsSaga, timeout)
+        .delay(timeout)
+        .put(actions.invalidated())
+        .withReducer(reducer, {
+          data: jobsResponse,
+          lastError: null,
+          valid: true,
+          inFlight: false,
+        })
+        .hasFinalState<JobsState>({
+          data: jobsResponse,
+          lastError: null,
+          valid: false,
+          inFlight: false,
+        })
+        .run(1000);
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.sagas.ts
@@ -1,0 +1,58 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, delay, put, takeLatest } from "redux-saga/effects";
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { actions } from "./jobs.reducer";
+import { getJobs, JobsRequest } from "src/api/jobsApi";
+import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
+import { PayloadAction } from "@reduxjs/toolkit";
+import { rootActions } from "../reducers";
+
+export function* refreshJobsSaga(action: PayloadAction<JobsRequest>) {
+  yield put(actions.request(action.payload));
+}
+
+export function* requestJobsSaga(action: PayloadAction<JobsRequest>): any {
+  try {
+    const result = yield call(getJobs, action.payload);
+    yield put(actions.received(result));
+  } catch (e) {
+    yield put(actions.failed(e));
+  }
+}
+
+export function* receivedJobsSaga(delayMs: number) {
+  yield delay(delayMs);
+  yield put(actions.invalidated());
+}
+
+export function* updateFilteredJobsSaga(action: PayloadAction<JobsRequest>) {
+  yield put(actions.invalidated());
+  const req = new cockroach.server.serverpb.JobsRequest(action.payload);
+  yield put(actions.refresh(req));
+}
+
+export function* jobsSaga(
+  cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
+) {
+  yield all([
+    throttleWithReset(
+      cacheInvalidationPeriod,
+      actions.refresh,
+      [actions.invalidated, rootActions.resetState],
+      refreshJobsSaga,
+    ),
+    takeLatest(actions.request, requestJobsSaga),
+    takeLatest(actions.received, receivedJobsSaga, cacheInvalidationPeriod),
+    takeLatest(actions.updateFilteredJobs, updateFilteredJobsSaga),
+  ]);
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.selectors.ts
@@ -1,0 +1,38 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+import { localStorageSelector } from "../utils/selectors";
+import { adminUISelector } from "../utils/selectors";
+
+export const selectJobsState = createSelector(
+  adminUISelector,
+  adminUiState => adminUiState.jobs,
+);
+
+export const selectSortSetting = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["sortSetting/JobsPage"],
+);
+
+export const selectShowSetting = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["showSetting/JobsPage"],
+);
+
+export const selectTypeSetting = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["typeSetting/JobsPage"],
+);
+
+export const selectStatusSetting = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["statusSetting/JobsPage"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import moment from "moment";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "../utils";
 import { defaultFilters, Filters } from "../../queryFilter";
@@ -32,6 +31,7 @@ export type LocalStorageState = {
   "sortSetting/StatementsPage": SortSetting;
   "sortSetting/TransactionsPage": SortSetting;
   "sortSetting/SessionsPage": SortSetting;
+  "sortSetting/JobsPage": SortSetting;
   "filters/ActiveStatementsPage": Filters;
   "filters/ActiveTransactionsPage": Filters;
   "filters/StatementsPage": Filters;
@@ -39,6 +39,9 @@ export type LocalStorageState = {
   "filters/SessionsPage": Filters;
   "search/StatementsPage": string;
   "search/TransactionsPage": string;
+  "typeSetting/JobsPage": number;
+  "statusSetting/JobsPage": string;
+  "showSetting/JobsPage": string;
 };
 
 type Payload = {
@@ -65,6 +68,17 @@ const defaultSessionsSortSetting: SortSetting = {
   columnTitle: "statementAge",
 };
 
+const defaultJobsSortSetting: SortSetting = {
+  ascending: false,
+  columnTitle: "lastExecutionTime",
+};
+
+const defaultJobStatusSetting = "";
+
+const defaultJobShowSetting = "0";
+
+const defaultJobTypeSetting = 0;
+
 // TODO (koorosh): initial state should be restored from preserved keys in LocalStorage
 const initialState: LocalStorageState = {
   "adminUi/showDiagnosticsModal":
@@ -82,6 +96,9 @@ const initialState: LocalStorageState = {
     JSON.parse(localStorage.getItem("showColumns/TransactionPage")) || null,
   "showColumns/SessionsPage":
     JSON.parse(localStorage.getItem("showColumns/SessionsPage")) || null,
+  "showSetting/JobsPage":
+    JSON.parse(localStorage.getItem("showSetting/JobsPage")) ||
+    defaultJobShowSetting,
   "timeScale/SQLActivity":
     JSON.parse(localStorage.getItem("timeScale/SQLActivity")) ||
     defaultTimeScaleSelected,
@@ -91,6 +108,9 @@ const initialState: LocalStorageState = {
   "sortSetting/ActiveTransactionsPage":
     JSON.parse(localStorage.getItem("sortSetting/ActiveTransactionsPage")) ||
     defaultSortSettingActiveExecutions,
+  "sortSetting/JobsPage":
+    JSON.parse(localStorage.getItem("sortSetting/JobsPage")) ||
+    defaultJobsSortSetting,
   "sortSetting/StatementsPage":
     JSON.parse(localStorage.getItem("sortSetting/StatementsPage")) ||
     defaultSortSetting,
@@ -118,6 +138,12 @@ const initialState: LocalStorageState = {
     JSON.parse(localStorage.getItem("search/StatementsPage")) || null,
   "search/TransactionsPage":
     JSON.parse(localStorage.getItem("search/TransactionsPage")) || null,
+  "typeSetting/JobsPage":
+    JSON.parse(localStorage.getItem("typeSetting/JobsPage")) ||
+    defaultJobTypeSetting,
+  "statusSetting/JobsPage":
+    JSON.parse(localStorage.getItem("statusSetting/JobsPage")) ||
+    defaultJobStatusSetting,
 };
 
 const localStorageSlice = createSlice({

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -33,6 +33,8 @@ import {
   IndexStatsReducerState,
   reducer as indexStats,
 } from "./indexStats/indexStats.reducer";
+import { JobsState, reducer as jobs } from "./jobs";
+import { JobState, reducer as job } from "./jobDetails";
 
 export type AdminUiState = {
   statementDiagnostics: StatementDiagnosticsState;
@@ -45,6 +47,8 @@ export type AdminUiState = {
   sqlStats: SQLStatsState;
   sqlDetailsStats: SQLDetailsStatsReducerState;
   indexStats: IndexStatsReducerState;
+  jobs: JobsState;
+  job: JobState;
 };
 
 export type AppState = {
@@ -62,6 +66,8 @@ export const reducers = combineReducers<AdminUiState>({
   sqlStats,
   sqlDetailsStats,
   indexStats,
+  jobs,
+  job,
 });
 
 export const rootActions = {

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -14,6 +14,8 @@ import { all, fork } from "redux-saga/effects";
 import { localStorageSaga } from "./localStorage";
 import { statementsDiagnosticsSagas } from "./statementDiagnostics";
 import { nodesSaga } from "./nodes";
+import { jobsSaga } from "./jobs";
+import { jobSaga } from "./jobDetails";
 import { livenessSaga } from "./liveness";
 import { sessionsSaga } from "./sessions";
 import { terminateSaga } from "./terminateQuery";
@@ -28,6 +30,8 @@ export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
     fork(statementsDiagnosticsSagas, cacheInvalidationPeriod),
     fork(nodesSaga, cacheInvalidationPeriod),
     fork(livenessSaga, cacheInvalidationPeriod),
+    fork(jobsSaga),
+    fork(jobSaga),
     fork(sessionsSaga),
     fork(terminateSaga),
     fork(notifificationsSaga),

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.selector.ts
@@ -9,12 +9,7 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
-import { AppState } from "../reducers";
-
-const adminUISelector = createSelector(
-  (state: AppState) => state.adminUI,
-  adminUiState => adminUiState,
-);
+import { adminUISelector } from "../utils/selectors";
 
 export const sqlStatsSelector = createSelector(
   adminUISelector,

--- a/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
@@ -8,7 +8,15 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./jobDescriptionCell";
-export * from "./jobsPage";
-export * from "./jobTable";
-export * from "./jobsPageConnected";
+import { createSelector } from "reselect";
+import { AppState } from "../reducers";
+
+export const adminUISelector = createSelector(
+  (state: AppState) => state.adminUI,
+  adminUiState => adminUiState,
+);
+
+export const localStorageSelector = createSelector(
+  adminUISelector,
+  adminUiState => adminUiState.localStorage,
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
@@ -10,8 +10,8 @@
 
 import { createSelector } from "reselect";
 import { getActiveTransactionsFromSessions } from "../activeExecutions/activeStatementUtils";
-import { localStorageSelector } from "src/statementsPage/statementsPage.selectors";
 import { selectAppName } from "src/statementsPage/activeStatementsPage.selectors";
+import { localStorageSelector } from "../store/utils/selectors";
 import {
   ActiveTransactionFilters,
   ActiveTransactionsViewDispatchProps,

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.selectors.ts
@@ -10,7 +10,7 @@
 
 import { createSelector } from "reselect";
 
-import { localStorageSelector } from "../statementsPage/statementsPage.selectors";
+import { localStorageSelector } from "../store/utils/selectors";
 import { sqlStatsSelector } from "../store/sqlStats/sqlStats.selector";
 
 export const selectTransactionsData = createSelector(


### PR DESCRIPTION
This PR adds "connected" components for the jobs pages. These components can be imported from the `cluster-ui` package into the `managed-service` repo and used on the CC console **for Dedicated clusters** (serverless clusters do not support the admin server that handles job requests).

Related to https://github.com/cockroachdb/cockroach/issues/71324.

Release note: None