### PR TITLE
ui: persist stmt view  selection in sql activity page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sqlActivity/sqlActivityPage.tsx
@@ -11,7 +11,7 @@
 // All changes made on this file, should also be done on the equivalent
 // file on managed-service repo.
 
-import React from "react";
+import React, { useState } from "react";
 import Helmet from "react-helmet";
 import { Tabs } from "antd";
 import "antd/lib/tabs/style";
@@ -20,7 +20,7 @@ import TransactionsPageConnected from "src/views/transactions/transactionsPage";
 import StatementsPageConnected from "src/views/statements/statementsPage";
 import { commonStyles, util } from "@cockroachlabs/cluster-ui";
 import { RouteComponentProps } from "react-router-dom";
-import { tabAttr } from "src/util/constants";
+import { tabAttr, viewAttr } from "src/util/constants";
 
 const { TabPane } = Tabs;
 
@@ -36,10 +36,23 @@ export const SQL_ACTIVITY_DEFAULT_TAB: SQLActivityTabType =
 const SQLActivityPage = (props: RouteComponentProps) => {
   const currentTab =
     util.queryByName(props.location, tabAttr) || SQLActivityTabType.Statements;
+  const currentView = util.queryByName(props.location, viewAttr);
+  const [restoreStmtsViewParam, setRestoreStmtsViewParam] = useState<
+    string | null
+  >(currentView);
 
   const onTabChange = (tabId: string): void => {
+    const params = new URLSearchParams({ tab: tabId });
+    if (tabId === "Sessions") {
+      setRestoreStmtsViewParam(currentView);
+    } else if (currentView || restoreStmtsViewParam) {
+      // We want to persist the view (fingerprints or active executions)
+      // for statement and transactions pages, and also restore the value
+      // when coming from sessions tab.
+      params.set("view", currentView ?? restoreStmtsViewParam ?? "");
+    }
     props.history.push({
-      search: new URLSearchParams({ tab: tabId }).toString(),
+      search: params.toString(),
     });
   };
 


### PR DESCRIPTION
Previously, the selection of viewing historical or active
executions for statements and transactions tabs in the SQL
activity page did not persist on tab change. This commit
persists the selection between tab changes in the SQL
activity page.

Release note (ui change): In the SQL Activity Page, the
selection to view historical or active executions will
persist between tabs.


https://www.loom.com/share/6990f8e273f64ddcaf971e85f0a8ef89