### PR TITLE
release-22.1: kvserver: fix merge skew from previous patch

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -643,9 +643,8 @@ func TestReplicateQueueDecommissionPurgatoryError(t *testing.T) {
 	store := tc.GetFirstStoreFromServer(t, 0)
 	repl, err := store.GetReplica(tc.LookupRangeOrFatal(t, scratchKey).RangeID)
 	require.NoError(t, err)
-	_, processErr, enqueueErr := tc.GetFirstStoreFromServer(t, 0).ManuallyEnqueue(
-		ctx, "replicate", repl, true, /* skipShouldQueue */
-	)
+	_, processErr, enqueueErr := tc.GetFirstStoreFromServer(t, 0).Enqueue(
+		ctx, "replicate", repl, true /* skipShouldQueue */, false /* async */)
 	require.NoError(t, enqueueErr)
 	_, isPurgErr := kvserver.IsPurgatoryError(processErr)
 	if !isPurgErr {


### PR DESCRIPTION
This patch fixes a merge skew introduced by #82680 and #82800

Release justification: Fixes merge skew
Release note: None