### PR TITLE
ui: fix copy in DB console jobs table

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/jobs/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/index.spec.tsx
@@ -81,7 +81,7 @@ describe("Jobs", () => {
       "Description",
       "Status",
       "Job ID",
-      "User",
+      "User Name",
       "Creation Time (UTC)",
       "Last Execution Time (UTC)",
       "Execution Count",

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobTable.tsx
@@ -124,7 +124,7 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
         style="tableTitle"
         content={<p>User that created the job.</p>}
       >
-        {"User"}
+        {"User Name"}
       </Tooltip>
     ),
     cell: job => job.username,
@@ -166,7 +166,13 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
       <Tooltip
         placement="bottom"
         style="tableTitle"
-        content={<p>Date and time the job was last executed.</p>}
+        content={
+          <p>
+            The high-water mark acts as a checkpoint for the changefeed’s job
+            progress, and guarantees that all changes before (or at) the
+            timestamp have been emitted.
+          </p>
+        }
       >
         {"High-water Timestamp"}
       </Tooltip>


### PR DESCRIPTION
This commit makes a minor change to the Jobs table in the DB
console.

These changes are also present in https://github.com/cockroachdb/cockroach/pull/83901.

Fixes #83872.

Release note (ui change): Updated `User` column name to `User Name` and fixed `High-water Timestamp` column tooltip on the Jobs page.