### PR TITLE
sql: add access control checks to multi-region related builtins

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1854,3 +1854,14 @@ SELECT table_id FROM crdb_internal.tables WHERE schema_name = 'public' AND name 
 # Validate that builtin errors if called on a table id
 query error pq: crdb_internal\.reset_multi_region_zone_configs_for_database\(\): database "\[3\]" does not exist
 SELECT crdb_internal.reset_multi_region_zone_configs_for_database($descriptor_table_id)
+
+user testuser
+
+query error user testuser must be owner of rebuild_zc_db or have CREATE privilege on database rebuild_zc_db
+SELECT crdb_internal.reset_multi_region_zone_configs_for_database($rebuild_db_id)
+
+query error user testuser must be owner of tbl11 or have CREATE privilege on relation tbl11
+SELECT crdb_internal.reset_multi_region_zone_configs_for_table($tbl11_id)
+
+query error user testuser must be owner of test or have CREATE privilege on database test
+SELECT crdb_internal.validate_multi_region_zone_configs()

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1053,6 +1053,11 @@ func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context
 	if err != nil {
 		return err
 	}
+
+	if err := p.checkPrivilegesForMultiRegionOp(ctx, dbDesc); err != nil {
+		return err
+	}
+
 	if !dbDesc.IsMultiRegion() {
 		return nil
 	}
@@ -1085,6 +1090,11 @@ func (p *planner) ResetMultiRegionZoneConfigsForTable(ctx context.Context, id in
 	if err != nil {
 		return errors.Wrapf(err, "error resolving referenced table ID %d", id)
 	}
+
+	if err := p.checkPrivilegesForMultiRegionOp(ctx, desc); err != nil {
+		return err
+	}
+
 	// If the table is not a multi-region table, there's no work to be done
 	// here.
 	if desc.LocalityConfig == nil {
@@ -1121,6 +1131,11 @@ func (p *planner) ResetMultiRegionZoneConfigsForDatabase(ctx context.Context, id
 	if err != nil {
 		return err
 	}
+
+	if err := p.checkPrivilegesForMultiRegionOp(ctx, dbDesc); err != nil {
+		return err
+	}
+
 	if !dbDesc.IsMultiRegion() {
 		// Nothing to do.
 		return nil


### PR DESCRIPTION
This adds access checks to the functions that power the following
builtins:

 - crdb_internal.reset_multi_region_zone_configs_for_database
 - crdb_internal.reset_multi_region_zone_configs_for_table
 - crdb_internal.validate_multi_region_zone_configs

Fixes #83912

Release note (security update): Multi-region related builtin functions
now have access control checks.