### PR TITLE
roachprod: fix target path when getting cluster artifacts.

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1846,7 +1846,7 @@ func (c *SyncedCluster) Get(l *logger.Logger, nodes Nodes, src, dest string) err
 			src := src
 			dest := dest
 			if len(nodes) > 1 {
-				base := fmt.Sprintf("%d.%s", nodes, filepath.Base(dest))
+				base := fmt.Sprintf("%d.%s", nodes[i], filepath.Base(dest))
 				dest = filepath.Join(filepath.Dir(dest), base)
 			}
 


### PR DESCRIPTION
A bug was introduced in the computation of the local path where
cluster artifacts are downloaded: instead of prefixing the path with
the node ID, the list of nodes would be used instead. This results
in (other than weird looking paths, such as `[1 2 3 4].logs`) only the
logs for the last node being downloaded.

This commit fixes the issue by using the node ID correctly.

Release note: None.