### PR TITLE
parser: require single-quotes when setting password

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2995,7 +2995,7 @@ backup_kms ::=
 	'NEW_KMS' '=' string_or_placeholder_opt_list 'WITH' 'OLD_KMS' '=' string_or_placeholder_opt_list
 
 password_clause ::=
-	'PASSWORD' string_or_placeholder
+	'PASSWORD' sconst_or_placeholder
 	| 'PASSWORD' 'NULL'
 
 valid_until_clause ::=

--- a/pkg/acceptance/compose/gss/psql/start.sh
+++ b/pkg/acceptance/compose/gss/psql/start.sh
@@ -15,7 +15,7 @@ echo "Preparing SQL user ahead of test"
 env \
     PGSSLKEY=/certs/client.root.key \
     PGSSLCERT=/certs/client.root.crt \
-    psql -U root -c "ALTER USER root WITH PASSWORD rootpw"
+    psql -U root -c "ALTER USER root WITH PASSWORD 'rootpw'"
 
 echo "Running test"
 ./gss.test

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -456,7 +456,7 @@ func TestProxyModifyRequestParams(t *testing.T) {
 	defer sql.Stopper().Stop(ctx)
 
 	// Create some user with password authn.
-	_, err := sqlDB.Exec("CREATE USER testuser WITH PASSWORD foo123")
+	_, err := sqlDB.Exec("CREATE USER testuser WITH PASSWORD 'foo123'")
 	require.NoError(t, err)
 
 	outgoingTLSConfig, err := sql.RPCContext().GetClientTLSConfig()
@@ -639,7 +639,7 @@ func TestDenylistUpdate(t *testing.T) {
 	defer sql.Stopper().Stop(ctx)
 
 	// Create some user with password authn.
-	_, err = sqlDB.Exec("CREATE USER testuser WITH PASSWORD foo123")
+	_, err = sqlDB.Exec("CREATE USER testuser WITH PASSWORD 'foo123'")
 	require.NoError(t, err)
 
 	outgoingTLSConfig, err := sql.RPCContext().GetClientTLSConfig()

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -438,7 +438,7 @@ func (c *transientCluster) Start(
 					// Set up the demo username and password on each tenant.
 					ie := ts.DistSQLServer().(*distsql.ServerImpl).ServerConfig.Executor
 					_, err = ie.Exec(ctx, "tenant-password", nil,
-						fmt.Sprintf("CREATE USER %s WITH PASSWORD %s", demoUsername, demoPassword))
+						fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s'", demoUsername, demoPassword))
 					if err != nil {
 						return err
 					}

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -301,7 +301,7 @@ func TestTransientClusterMultitenant(t *testing.T) {
 	require.NoError(t, c.Start(ctx, func(ctx context.Context, s *server.Server, _ bool, adminUser, adminPassword string) error {
 		return s.RunLocalSQL(ctx,
 			func(ctx context.Context, ie *sql.InternalExecutor) error {
-				_, err := ie.Exec(ctx, "admin-user", nil, fmt.Sprintf("CREATE USER %s WITH PASSWORD %s", adminUser,
+				_, err := ie.Exec(ctx, "admin-user", nil, fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s'", adminUser,
 					adminPassword))
 				return err
 			})

--- a/pkg/server/api_v2_sql_schema_test.go
+++ b/pkg/server/api_v2_sql_schema_test.go
@@ -74,7 +74,7 @@ func TestDatabasesTablesV2(t *testing.T) {
 	require.NoError(t, err)
 	_, err = conn.Exec("CREATE TABLE testdb.testtable (id INTEGER PRIMARY KEY, value STRING);")
 	require.NoError(t, err)
-	_, err = conn.Exec("CREATE USER testuser WITH PASSWORD testpassword;")
+	_, err = conn.Exec("CREATE USER testuser WITH PASSWORD 'testpassword';")
 	require.NoError(t, err)
 	_, err = conn.Exec("GRANT ALL ON DATABASE testdb TO testuser;")
 	require.NoError(t, err)

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -78,7 +78,7 @@ PREPARE pcu AS CREATE USER foo WITH PASSWORD $1;
   EXECUTE pcu('bar')
 
 statement ok
-ALTER USER foo WITH PASSWORD somepass
+ALTER USER foo WITH PASSWORD 'somepass'
 
 statement ok
 PREPARE chpw AS ALTER USER foo WITH PASSWORD $1;

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -8228,13 +8228,13 @@ truncate_stmt:
 | TRUNCATE error // SHOW HELP: TRUNCATE
 
 password_clause:
-  ENCRYPTED PASSWORD string_or_placeholder
+  ENCRYPTED PASSWORD sconst_or_placeholder
   {
     /* SKIP DOC */
     // This is a legacy postgres syntax.
     $$.val = tree.KVOption{Key: tree.Name($2), Value: $3.expr()}
   }
-| PASSWORD string_or_placeholder
+| PASSWORD sconst_or_placeholder
   {
     $$.val = tree.KVOption{Key: tree.Name($1), Value: $2.expr()}
   }

--- a/pkg/sql/parser/testdata/alter_user
+++ b/pkg/sql/parser/testdata/alter_user
@@ -1,14 +1,14 @@
-parse
+error
 ALTER USER foo PASSWORD bar
 ----
-ALTER USER foo WITH PASSWORD '*****' -- normalized!
-ALTER USER foo WITH PASSWORD '*****' -- fully parenthesized
-ALTER USER foo WITH PASSWORD '*****' -- literals removed
-ALTER USER _ WITH PASSWORD '*****' -- identifiers removed
-ALTER USER foo WITH PASSWORD 'bar' -- passwords exposed
+at or near "bar": syntax error
+DETAIL: source SQL:
+ALTER USER foo PASSWORD bar
+                        ^
+HINT: try \h ALTER ROLE
 
 parse
-ALTER USER foo WITH PASSWORD bar
+ALTER USER foo PASSWORD 'bar'
 ----
 ALTER USER foo WITH PASSWORD '*****' -- normalized!
 ALTER USER foo WITH PASSWORD '*****' -- fully parenthesized
@@ -16,8 +16,35 @@ ALTER USER foo WITH PASSWORD '*****' -- literals removed
 ALTER USER _ WITH PASSWORD '*****' -- identifiers removed
 ALTER USER foo WITH PASSWORD 'bar' -- passwords exposed
 
+error
+ALTER USER foo WITH PASSWORD bar
+----
+at or near "bar": syntax error
+DETAIL: source SQL:
+ALTER USER foo WITH PASSWORD bar
+                             ^
+HINT: try \h ALTER ROLE
+
 parse
+ALTER USER foo WITH PASSWORD 'bar'
+----
+ALTER USER foo WITH PASSWORD '*****' -- normalized!
+ALTER USER foo WITH PASSWORD '*****' -- fully parenthesized
+ALTER USER foo WITH PASSWORD '*****' -- literals removed
+ALTER USER _ WITH PASSWORD '*****' -- identifiers removed
+ALTER USER foo WITH PASSWORD 'bar' -- passwords exposed
+
+error
 ALTER USER foo WITH ENCRYPTED PASSWORD bar
+----
+at or near "bar": syntax error
+DETAIL: source SQL:
+ALTER USER foo WITH ENCRYPTED PASSWORD bar
+                                       ^
+HINT: try \h ALTER ROLE
+
+parse
+ALTER USER foo WITH ENCRYPTED PASSWORD 'bar'
 ----
 ALTER USER foo WITH PASSWORD '*****' -- normalized!
 ALTER USER foo WITH PASSWORD '*****' -- fully parenthesized

--- a/pkg/sql/parser/testdata/create_user
+++ b/pkg/sql/parser/testdata/create_user
@@ -95,8 +95,17 @@ CREATE ROLE IF NOT EXISTS foo WITH CREATEROLE -- fully parenthesized
 CREATE ROLE IF NOT EXISTS foo WITH CREATEROLE -- literals removed
 CREATE ROLE IF NOT EXISTS _ WITH CREATEROLE -- identifiers removed
 
-parse
+error
 CREATE USER foo PASSWORD bar
+----
+at or near "bar": syntax error
+DETAIL: source SQL:
+CREATE USER foo PASSWORD bar
+                         ^
+HINT: try \h CREATE ROLE
+
+parse
+CREATE USER foo PASSWORD 'bar'
 ----
 CREATE USER foo WITH PASSWORD '*****' -- normalized!
 CREATE USER foo WITH PASSWORD '*****' -- fully parenthesized
@@ -104,8 +113,17 @@ CREATE USER foo WITH PASSWORD '*****' -- literals removed
 CREATE USER _ WITH PASSWORD '*****' -- identifiers removed
 CREATE USER foo WITH PASSWORD 'bar' -- passwords exposed
 
-parse
+error
 CREATE USER foo ENCRYPTED PASSWORD bar
+----
+at or near "bar": syntax error
+DETAIL: source SQL:
+CREATE USER foo ENCRYPTED PASSWORD bar
+                                   ^
+HINT: try \h CREATE ROLE
+
+parse
+CREATE USER foo ENCRYPTED PASSWORD 'bar'
 ----
 CREATE USER foo WITH PASSWORD '*****' -- normalized!
 CREATE USER foo WITH PASSWORD '*****' -- fully parenthesized
@@ -122,8 +140,17 @@ CREATE USER foo WITH PASSWORD '*****' -- literals removed
 CREATE USER _ WITH PASSWORD '*****' -- identifiers removed
 CREATE USER foo WITH PASSWORD NULL -- passwords exposed
 
-parse
+error
 CREATE USER foo WITH ENCRYPTED PASSWORD bar
+----
+at or near "bar": syntax error
+DETAIL: source SQL:
+CREATE USER foo WITH ENCRYPTED PASSWORD bar
+                                        ^
+HINT: try \h CREATE ROLE
+
+parse
+CREATE USER foo WITH ENCRYPTED PASSWORD 'bar'
 ----
 CREATE USER foo WITH PASSWORD '*****' -- normalized!
 CREATE USER foo WITH PASSWORD '*****' -- fully parenthesized


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/83699

This matches the Postgres behavior, but more importantly, it fixes a
UX issue that could lead to a security flaw.

Release note (bug fix, backwards-incompatible change): The PASSWORD
option of the CREATE/ALTER ROLE commands now require the password to be
surrounded with single quotes. This fixes confusion that could arise
when a mixed-case string is used, since previously that would cause the
password to be normalized to lower-case.