### PR TITLE
kvstreamer: reuse the truncation helper and introduce a fast path for a single range case

### DIFF
--- a/pkg/kv/kvclient/kvcoord/batch_test.go
+++ b/pkg/kv/kvclient/kvcoord/batch_test.go
@@ -210,9 +210,9 @@ func TestBatchPrevNext(t *testing.T) {
 			}
 			const mustPreserveOrder = false
 			const canReorderRequestsSlice = false
-			ascHelper, err := MakeBatchTruncationHelper(Ascending, ba.Requests, mustPreserveOrder, canReorderRequestsSlice)
+			ascHelper, err := NewBatchTruncationHelper(Ascending, ba.Requests, mustPreserveOrder, canReorderRequestsSlice)
 			require.NoError(t, err)
-			descHelper, err := MakeBatchTruncationHelper(Descending, ba.Requests, mustPreserveOrder, canReorderRequestsSlice)
+			descHelper, err := NewBatchTruncationHelper(Descending, ba.Requests, mustPreserveOrder, canReorderRequestsSlice)
 			require.NoError(t, err)
 			if _, _, next, err := ascHelper.Truncate(
 				roachpb.RSpan{
@@ -396,10 +396,10 @@ func TestTruncate(t *testing.T) {
 						original.Requests[i].MustSetInner(request.GetInner().ShallowCopy())
 					}
 
-					var truncationHelper BatchTruncationHelper
+					var truncationHelper *BatchTruncationHelper
 					if !isLegacy {
 						var err error
-						truncationHelper, err = MakeBatchTruncationHelper(
+						truncationHelper, err = NewBatchTruncationHelper(
 							Ascending, original.Requests, mustPreserveOrder, canReorderRequestsSlice,
 						)
 						if err != nil {
@@ -562,7 +562,7 @@ func TestTruncateLoop(t *testing.T) {
 			for _, mustPreserveOrder := range []bool{false, true} {
 				t.Run(fmt.Sprintf("run=%d/%s/order=%t", numRuns, scanDir, mustPreserveOrder), func(t *testing.T) {
 					const canReorderRequestsSlice = false
-					helper, err := MakeBatchTruncationHelper(
+					helper, err := NewBatchTruncationHelper(
 						scanDir, requests, mustPreserveOrder, canReorderRequestsSlice,
 					)
 					require.NoError(t, err)
@@ -698,7 +698,7 @@ func BenchmarkTruncateLoop(b *testing.B) {
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
 								const canReorderRequestsSlice = false
-								h, err := MakeBatchTruncationHelper(
+								h, err := NewBatchTruncationHelper(
 									scanDir, reqs, mustPreserveOrder, canReorderRequestsSlice,
 								)
 								require.NoError(b, err)

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1339,7 +1339,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 	// TODO(yuzefovich): refactor the DistSender so that the truncation helper
 	// could reorder requests as it pleases.
 	const canReorderRequestsSlice = false
-	truncationHelper, err := MakeBatchTruncationHelper(
+	truncationHelper, err := NewBatchTruncationHelper(
 		scanDir, ba.Requests, mustPreserveOrder, canReorderRequestsSlice,
 	)
 	if err != nil {

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -230,6 +230,12 @@ type Streamer struct {
 
 	waitGroup sync.WaitGroup
 
+	truncationHelper *kvcoord.BatchTruncationHelper
+	// truncationHelperAccountedFor tracks how much space has been consumed from
+	// the budget in order to account for the memory usage of the truncation
+	// helper.
+	truncationHelperAccountedFor int64
+
 	// requestsToServe contains all single-range sub-requests that have yet
 	// to be served.
 	requestsToServe requestsProvider
@@ -504,21 +510,21 @@ func (s *Streamer) Enqueue(ctx context.Context, reqs []roachpb.RequestUnion) (re
 		}
 	}()
 	allRequestsAreWithinSingleRange := !ri.NeedAnother(rs)
-	var truncationHelper kvcoord.BatchTruncationHelper
 	if !allRequestsAreWithinSingleRange {
 		// We only need the truncation helper if the requests span multiple
 		// ranges.
-		//
-		// The streamer can process the responses in an arbitrary order, so we
-		// don't require the helper to preserve the order of requests and allow
-		// it to reorder the reqs slice too.
-		const mustPreserveOrder = false
-		const canReorderRequestsSlice = true
-		// TODO(yuzefovich): reuse truncation helpers between different
-		// Enqueue() calls.
-		truncationHelper, err = kvcoord.MakeBatchTruncationHelper(
-			scanDir, reqs, mustPreserveOrder, canReorderRequestsSlice,
-		)
+		if s.truncationHelper == nil {
+			// The streamer can process the responses in an arbitrary order, so
+			// we don't require the helper to preserve the order of requests and
+			// allow it to reorder the reqs slice too.
+			const mustPreserveOrder = false
+			const canReorderRequestsSlice = true
+			s.truncationHelper, err = kvcoord.NewBatchTruncationHelper(
+				scanDir, reqs, mustPreserveOrder, canReorderRequestsSlice,
+			)
+		} else {
+			err = s.truncationHelper.Init(reqs)
+		}
 		if err != nil {
 			return err
 		}
@@ -544,7 +550,7 @@ func (s *Streamer) Enqueue(ctx context.Context, reqs []roachpb.RequestUnion) (re
 			if err != nil {
 				return err
 			}
-			singleRangeReqs, positions, seekKey, err = truncationHelper.Truncate(singleRangeSpan)
+			singleRangeReqs, positions, seekKey, err = s.truncationHelper.Truncate(singleRangeSpan)
 			if err != nil {
 				return err
 			}
@@ -634,6 +640,11 @@ func (s *Streamer) Enqueue(ctx context.Context, reqs []roachpb.RequestUnion) (re
 	}
 
 	toConsume := totalReqsMemUsage
+	if !allRequestsAreWithinSingleRange {
+		accountedFor := s.truncationHelperAccountedFor
+		s.truncationHelperAccountedFor = s.truncationHelper.MemUsage()
+		toConsume += s.truncationHelperAccountedFor - accountedFor
+	}
 	if newNumRangesPerScanRequestMemoryUsage != 0 && newNumRangesPerScanRequestMemoryUsage != s.numRangesPerScanRequestAccountedFor {
 		toConsume += newNumRangesPerScanRequestMemoryUsage - s.numRangesPerScanRequestAccountedFor
 		s.numRangesPerScanRequestAccountedFor = newNumRangesPerScanRequestMemoryUsage


### PR DESCRIPTION
**kvstreamer: introduce a single range fast path for request truncation**

This commit introduces a fast path to avoid the usage of the batch
truncation helper when all requests are contained within a single range.
Some modifications needed to be made to the `txnKVStreamer` so that it
didn't nil out the requests slice - we now delay that until right before
the next call to `Enqueue`.

```
ame                                  old time/op    new time/op    delta
IndexJoin/Cockroach-24                  6.21ms ± 1%    5.96ms ± 2%  -4.08%  (p=0.000 n=8+10)
IndexJoinColumnFamilies/Cockroach-24    8.97ms ± 4%    8.79ms ± 7%    ~     (p=0.190 n=10+10)

name                                  old alloc/op   new alloc/op   delta
IndexJoin/Cockroach-24                  1.39MB ± 1%    1.27MB ± 1%  -7.97%  (p=0.000 n=10+10)
IndexJoinColumnFamilies/Cockroach-24    1.46MB ± 1%    1.34MB ± 0%  -8.04%  (p=0.000 n=9+7)

name                                  old allocs/op  new allocs/op  delta
IndexJoin/Cockroach-24                   7.20k ± 1%     7.16k ± 1%  -0.61%  (p=0.022 n=10+10)
IndexJoinColumnFamilies/Cockroach-24     12.0k ± 1%     11.9k ± 0%  -0.83%  (p=0.000 n=9+8)
```

Addresses: #82159.

Release note: None

**kvcoord: refactor the truncation helper for reuse**

This commit refactors the batch truncation helper so that it can be
reused for multiple batches of requests. In particular, that ability is
now utilized by the streamer. Additionally, since the streamer now holds
on to the same truncation helper for possibly a long time, this commit
adds the memory accounting for the internal state of the helper.

Addresses: #82160.

Release note: None