### PR TITLE
sql: fix lastUpdated for version in system.settings in tenants

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant
@@ -9,6 +9,15 @@ SELECT version = crdb_internal.node_executable_version()
 ----
 true
 
+# Regression test for issue #83928: check that the lastUpdated value is sane.
+query B
+WITH a AS (
+  SELECT extract(YEAR FROM "lastUpdated") AS year
+  FROM system.settings WHERE name = 'version'
+) SELECT year > 2020 AND year < 2100 FROM a
+----
+true
+
 # This file documents operations that are supported when running a SQL tenant
 # server. It's mostly a dumping ground for tests moved from tenant_unsupported.
 

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -310,15 +310,20 @@ func generateTenantClusterSettingKV(
 		return roachpb.KeyValue{}, errors.NewAssertionErrorWithWrappedErrf(err,
 			"failed to encode current cluster version %v", &v)
 	}
+	ts, err := tree.MakeDTimestamp(timeutil.Now(), time.Microsecond)
+	if err != nil {
+		return roachpb.KeyValue{}, errors.NewAssertionErrorWithWrappedErrf(err,
+			"failed to represent the current time")
+	}
 	kvs, err := rowenc.EncodePrimaryIndex(
 		codec,
 		systemschema.SettingsTable,
 		systemschema.SettingsTable.GetPrimaryIndex(),
 		catalog.ColumnIDToOrdinalMap(systemschema.SettingsTable.PublicColumns()),
 		[]tree.Datum{
-			tree.NewDString(clusterversion.KeyVersionSetting),      // name
-			tree.NewDString(string(encoded)),                       // value
-			tree.NewDTimeTZFromTime(timeutil.Now()),                // lastUpdated
+			tree.NewDString(clusterversion.KeyVersionSetting), // name
+			tree.NewDString(string(encoded)),                  // value
+			ts,                                                // lastUpdated
 			tree.NewDString((*settings.VersionSetting)(nil).Typ()), // type
 		},
 		false, /* includeEmpty */


### PR DESCRIPTION
The code was incorrectly encoding a TIMETZ value where a TIMESTAMP
value was expected. This patch fixes it.

Fixes #83928

Release note: None