### PR TITLE
sql: add builtins to construct and scan spans

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1220,6 +1220,10 @@ the locality flag on node startup. Returns an error if no region is set.</p>
 <tbody>
 <tr><td><a name="aclexplode"></a><code>aclexplode(aclitems: <a href="string.html">string</a>[]) &rarr; tuple{oid AS grantor, oid AS grantee, string AS privilege_type, bool AS is_grantable}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing aclitem stuff (returns no rows as this feature is unsupported in CockroachDB)</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="crdb_internal.scan"></a><code>crdb_internal.scan(span: <a href="bytes.html">bytes</a>[]) &rarr; tuple{bytes AS key, bytes AS value}</code></td><td><span class="funcdesc"><p>Returns the raw keys and values from the specified span</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="crdb_internal.scan"></a><code>crdb_internal.scan(start_key: <a href="bytes.html">bytes</a>, end_key: <a href="bytes.html">bytes</a>) &rarr; tuple{bytes AS key, bytes AS value}</code></td><td><span class="funcdesc"><p>Returns the raw keys and values from the specified span</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="crdb_internal.testing_callback"></a><code>crdb_internal.testing_callback(name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>For internal CRDB testing only. The function calls a callback identified by <code>name</code> registered with the server by the test.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.unary_table"></a><code>crdb_internal.unary_table() &rarr; tuple</code></td><td><span class="funcdesc"><p>Produces a virtual table containing a single row with no values.</p>
@@ -3041,6 +3045,8 @@ SELECT * FROM crdb_internal.check_consistency(true, ‘\x02’, ‘\x04’)</p>
 <tr><td><a name="crdb_internal.get_zone_config"></a><code>crdb_internal.get_zone_config(namespace_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td></td><td>Stable</td></tr>
 <tr><td><a name="crdb_internal.has_role_option"></a><code>crdb_internal.has_role_option(option: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the current user has the specified role option</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="crdb_internal.index_span"></a><code>crdb_internal.index_span(table_id: <a href="int.html">int</a>, index_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>This function returns the span that contains the keys for the given index.</p>
+</span></td><td>Leakproof</td></tr>
 <tr><td><a name="crdb_internal.is_admin"></a><code>crdb_internal.is_admin() &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Retrieves the current user’s admin status.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="crdb_internal.is_at_least_version"></a><code>crdb_internal.is_at_least_version(version: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if the cluster version is not older than the argument.</p>
@@ -3120,8 +3126,16 @@ table. Returns an error if validation fails.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.set_vmodule"></a><code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the equivalent of the <code>--vmodule</code> flag on the gateway node processing this request; it affords control over the logging verbosity of different files. Example syntax: <code>crdb_internal.set_vmodule('recordio=2,file=1,gfs*=3')</code>. Reset with: <code>crdb_internal.set_vmodule('')</code>. Raising the verbosity can severely affect performance.</p>
 </span></td><td>Volatile</td></tr>
+<tr><td><a name="crdb_internal.table_span"></a><code>crdb_internal.table_span(table_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>This function returns the span that contains the keys for the given table.</p>
+</span></td><td>Leakproof</td></tr>
+<tr><td><a name="crdb_internal.tenant_span"></a><code>crdb_internal.tenant_span(tenant_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>This function returns the span that contains the keys for the given tenant.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="crdb_internal.trace_id"></a><code>crdb_internal.trace_id() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the current trace ID or an error if no trace is open.</p>
 </span></td><td>Volatile</td></tr>
+<tr><td><a name="crdb_internal.trim_tenant_prefix"></a><code>crdb_internal.trim_tenant_prefix(key: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>This function assumes the given bytes are a CockroachDB key and trims any tenant prefix from the key.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="crdb_internal.trim_tenant_prefix"></a><code>crdb_internal.trim_tenant_prefix(keys: <a href="bytes.html">bytes</a>[]) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>This function assumes the given bytes are a CockroachDB key and trims any tenant prefix from the key.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="crdb_internal.validate_session_revival_token"></a><code>crdb_internal.validate_session_revival_token(token: <a href="bytes.html">bytes</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Validate a token that was created by create_session_revival_token. Intended for testing.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.validate_ttl_scheduled_jobs"></a><code>crdb_internal.validate_ttl_scheduled_jobs() &rarr; void</code></td><td><span class="funcdesc"><p>Validate all TTL tables have a valid scheduled job attached.</p>

--- a/pkg/sql/logictest/testdata/logic_test/span_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/span_builtins
@@ -1,0 +1,16 @@
+## Tests for span construction/manipulation builtins
+
+query T
+select crdb_internal.trim_tenant_prefix(crdb_internal.table_span(1))
+----
+{"\\x89","\\x8a"}
+
+query T
+select crdb_internal.trim_tenant_prefix(crdb_internal.index_span(1, 1))
+----
+{"\\x8989","\\x898a"}
+
+query T
+select crdb_internal.tenant_span(2)
+----
+{"\\xfe8a","\\xfe8b"}

--- a/pkg/sql/logictest/testdata/logic_test/sql_keys
+++ b/pkg/sql/logictest/testdata/logic_test/sql_keys
@@ -12,6 +12,9 @@ ALTER TABLE t SPLIT AT VALUES (0)
 let $rangeid
 SELECT range_id FROM crdb_internal.ranges WHERE table_name = 't'
 
+let $tableid
+SELECT id FROM system.namespace WHERE name = 't'
+
 # Without any data in the table, there shouldn't be any keys in the range.
 query T
 SELECT key FROM crdb_internal.list_sql_keys_in_range($rangeid)
@@ -29,6 +32,14 @@ SELECT key FROM crdb_internal.list_sql_keys_in_range($rangeid)
 /Table/106/1/1/0
 /Table/106/1/2/0
 
+# List out all of the keys in this range. The values themselves are
+# different on each run of the test due to metadata stored in the value.
+query T
+SELECT crdb_internal.pretty_key(key, 0) FROM crdb_internal.scan(crdb_internal.table_span($tableid))
+----
+/106/1/1/0
+/106/1/2/0
+
 # An error should be returned when an invalid range ID is specified.
 statement error pq: range with ID 1000000 not found
 SELECT key FROM crdb_internal.list_sql_keys_in_range(1000000)
@@ -37,13 +48,21 @@ SELECT key FROM crdb_internal.list_sql_keys_in_range(1000000)
 # Create a new table with a multiple of rangeKeyIteratorChunkSize (currently 256).
 statement ok
 CREATE TABLE t2 (x INT PRIMARY KEY);
-INSERT INTO t2 (SELECT * FROM generate_series(1, 1024));
+INSERT INTO t2 (SELECT * FROM generate_series(1, 4096));
 ALTER TABLE t2 SPLIT AT VALUES (0)
 
 let $rangeid
 SELECT range_id FROM crdb_internal.ranges WHERE table_name = 't2'
 
+let $tableid
+SELECT id FROM system.namespace WHERE name = 't2'
+
 query II
 SELECT count(key), count(DISTINCT key) FROM crdb_internal.list_sql_keys_in_range($rangeid)
 ----
-1024 1024
+4096 4096
+
+query II
+SELECT count(key), count(DISTINCT key) FROM crdb_internal.scan(crdb_internal.table_span($tableid))
+----
+4096 4096

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5228,6 +5228,147 @@ value if you rely on the HLC for accuracy.`,
 		},
 	),
 
+	"crdb_internal.trim_tenant_prefix": makeBuiltin(
+		tree.FunctionProperties{
+			Category: builtinconstants.CategorySystemInfo,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"key", types.Bytes},
+			},
+			ReturnType: tree.FixedReturnType(types.Bytes),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				key := tree.MustBeDBytes(args[0])
+				remainder, _, err := keys.DecodeTenantPrefix([]byte(key))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDBytes(tree.DBytes(remainder)), nil
+			},
+			Info:       "This function assumes the given bytes are a CockroachDB key and trims any tenant prefix from the key.",
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"keys", types.BytesArray},
+			},
+			ReturnType: tree.FixedReturnType(types.BytesArray),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				arr := tree.MustBeDArray(args[0])
+				result := tree.NewDArray(types.Bytes)
+				for _, datum := range arr.Array {
+					key := tree.MustBeDBytes(datum)
+					remainder, _, err := keys.DecodeTenantPrefix([]byte(key))
+					if err != nil {
+						return nil, err
+					}
+					if err := result.Append(tree.NewDBytes(tree.DBytes(remainder))); err != nil {
+						return nil, err
+					}
+
+				}
+				return result, nil
+			},
+			Info:       "This function assumes the given bytes are a CockroachDB key and trims any tenant prefix from the key.",
+			Volatility: volatility.Immutable,
+		},
+	),
+	"crdb_internal.tenant_span": makeBuiltin(
+		tree.FunctionProperties{
+			Category: builtinconstants.CategorySystemInfo,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"tenant_id", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.BytesArray),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				sTenID, err := mustBeDIntInTenantRange(args[0])
+				if err != nil {
+					return nil, err
+				}
+				start := keys.MakeTenantPrefix(roachpb.MakeTenantID(uint64(sTenID)))
+				end := start.PrefixEnd()
+
+				result := tree.NewDArray(types.Bytes)
+				if err := result.Append(tree.NewDBytes(tree.DBytes(start))); err != nil {
+					return nil, err
+				}
+
+				if err := result.Append(tree.NewDBytes(tree.DBytes(end))); err != nil {
+					return nil, err
+				}
+
+				return result, nil
+			},
+			Info:       "This function returns the span that contains the keys for the given tenant.",
+			Volatility: volatility.Immutable,
+		},
+	),
+	"crdb_internal.table_span": makeBuiltin(
+		tree.FunctionProperties{
+			Category: builtinconstants.CategorySystemInfo,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"table_id", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.BytesArray),
+			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				tabID := uint32(tree.MustBeDInt(args[0]))
+
+				start := evalCtx.Codec.TablePrefix(tabID)
+				end := start.PrefixEnd()
+
+				result := tree.NewDArray(types.Bytes)
+				if err := result.Append(tree.NewDBytes(tree.DBytes(start))); err != nil {
+					return nil, err
+				}
+
+				if err := result.Append(tree.NewDBytes(tree.DBytes(end))); err != nil {
+					return nil, err
+				}
+
+				return result, nil
+			},
+			Info:       "This function returns the span that contains the keys for the given table.",
+			Volatility: volatility.Leakproof,
+		},
+	),
+	"crdb_internal.index_span": makeBuiltin(
+		tree.FunctionProperties{
+			Category: builtinconstants.CategorySystemInfo,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"table_id", types.Int},
+				{"index_id", types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.BytesArray),
+			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				tabID := uint32(tree.MustBeDInt(args[0]))
+				indexID := uint32(tree.MustBeDInt(args[1]))
+
+				start := roachpb.Key(rowenc.MakeIndexKeyPrefix(evalCtx.Codec,
+					catid.DescID(tabID),
+					catid.IndexID(indexID)))
+				end := start.PrefixEnd()
+
+				result := tree.NewDArray(types.Bytes)
+				if err := result.Append(tree.NewDBytes(tree.DBytes(start))); err != nil {
+					return nil, err
+				}
+
+				if err := result.Append(tree.NewDBytes(tree.DBytes(end))); err != nil {
+					return nil, err
+				}
+
+				return result, nil
+			},
+			Info:       "This function returns the span that contains the keys for the given index.",
+			Volatility: volatility.Leakproof,
+		},
+	),
 	// Return a pretty key for a given raw key, skipping the specified number of
 	// fields.
 	"crdb_internal.pretty_key": makeBuiltin(


### PR DESCRIPTION
This adds crdb_internal.scan, a generating functions that returns the
raw keys and values contained in a span.

Additionally, it adds the following utility functions:

- crdb_internal.tenant_span
- crdb_internal.table_span
- crdb_internal.index_span
- crdb_internal.trim_tenant_prefix

These can be combined to create basic "tenant fingerprinting" queries:

    SELECT xor_agg(fnv64(key, value)) AS fingerprint
    FROM crdb_internal.scan(crdb_internal.tenant_span(2))

The current implementation of crdb_internal.scan is naive. It is a
small wrapper around txn.Scan. However, it still seems like a useful
first step and is likely good enough for use in medium scale tests and
it has already found a few small bugs.

Possible future work includes:

    - using ExportRequest instead of scan so we can also get all keys
      for some time range.

    - plumbing this further into the sql table reader or some new
      processor such that it can easily be distributed.

Release note: None