### PR TITLE
kvserver,admission: kvserver changes to plumb write bytes to admissio…

### DIFF
--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -13,6 +13,7 @@ package kvserver
 import (
 	"context"
 	"fmt"
+	"sync"
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -179,20 +181,47 @@ func (ls *Stores) GetReplicaForRangeID(
 func (ls *Stores) Send(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
+	br, _, pErr := ls.SendWithWriteBytes(ctx, ba)
+	return br, pErr
+}
+
+// StoreWriteBytes aliases admission.StoreWorkDoneInfo, since the notion of
+// "work is done" is specific to admission control and doesn't need to leak
+// everywhere.
+type StoreWriteBytes admission.StoreWorkDoneInfo
+
+var storeWriteBytesPool = sync.Pool{
+	New: func() interface{} { return &StoreWriteBytes{} },
+}
+
+func newStoreWriteBytes() *StoreWriteBytes {
+	return storeWriteBytesPool.Get().(*StoreWriteBytes)
+}
+
+// Release returns the *StoreWriteBytes to the pool.
+func (wb *StoreWriteBytes) Release() {
+	storeWriteBytesPool.Put(wb)
+}
+
+// SendWithWriteBytes is the implementation of Send with an additional
+// *StoreWriteBytes return value.
+func (ls *Stores) SendWithWriteBytes(
+	ctx context.Context, ba roachpb.BatchRequest,
+) (*roachpb.BatchResponse, *StoreWriteBytes, *roachpb.Error) {
 	if err := ba.ValidateForEvaluation(); err != nil {
 		log.Fatalf(ctx, "invalid batch (%s): %s", ba, err)
 	}
 
 	store, err := ls.GetStore(ba.Replica.StoreID)
 	if err != nil {
-		return nil, roachpb.NewError(err)
+		return nil, nil, roachpb.NewError(err)
 	}
 
-	br, pErr := store.Send(ctx, ba)
+	br, writeBytes, pErr := store.SendWithWriteBytes(ctx, ba)
 	if br != nil && br.Error != nil {
 		panic(roachpb.ErrorUnexpectedlySet(store, br))
 	}
-	return br, pErr
+	return br, writeBytes, pErr
 }
 
 // RangeFeed registers a rangefeed over the specified span. It sends updates to

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1015,7 +1015,12 @@ func (n *Node) batchInternal(
 		return nil, err
 	}
 	var pErr *roachpb.Error
-	br, pErr = n.stores.Send(ctx, *args)
+	// TODO(sumeer): plumb *StoreWriteBytes to admission control.
+	var writeBytes *kvserver.StoreWriteBytes
+	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, *args)
+	if writeBytes != nil {
+		writeBytes.Release()
+	}
 	if pErr != nil {
 		br = &roachpb.BatchResponse{}
 		log.VErrEventf(ctx, 3, "error from stores.Send: %s", pErr)


### PR DESCRIPTION
…n control

We introduced changes to StoreWorkQueue, for kvserver to provide actual
byte size values for sstable ingestion and how many bytes were ingested
into L0. But did not make the corresponding changes in kvserver to provide
these.

Since then, we've noticed tiny writes (like TruncateLog) consume a
disproportionate number of write tokens (in #82536). The current StoreWorkQueue
interface does not have the ability to do anything reasonable for such
non-ingest requests. Additionally, providing the information of how many
bytes were ingested into L0 requires plumbing through raft replication and
state machine application (which we wish to avoid).

In the context of the WIP PR for disk bandwidth as a bottleneck resource,
an alternative scheme suggested itself. This PR has the kvserver plumbing
changes for this alternative scheme, so that the palatability of this can
be confirmed before making the changes in admission control.

This scheme can be summarized as:
- No byte information is provided at admission time. Admission control
  uses estimates based on past behavior. So tiny writes that are not the
  norm (like TruncateLog) may consume more tokens than needed, and sstable
  ingestion may consume less tokens.
- When the admitted work is done, the size of the batch (for regular writes)
  and sstable size (for ingest) is provided to admission control to fix
  what was consumed earlier. Note that we could have provided the sstable
  information earlier (at admission time), but this keeps everything in
  one place.
- How much was ingested into L0 is never specified on a per admission basis,
  since we avoid plumbing through replication and application. Instead,
  estimates based on the past will be consistently used for this.

Release note: None