### PR TITLE
sql: add identifiers to sampled query

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2459,6 +2459,10 @@ contains common SQL event/execution details.
 | `CostEstimate` | Cost of the query as estimated by the optimizer. | no |
 | `Distribution` | The distribution of the DistSQL query plan (local, full, or partial). | no |
 | `PlanGist` | The query's plan gist bytes as a base64 encoded string. | no |
+| `SessionID` | SessionID is the ID of the session that initiated the query. | no |
+| `Database` | Name of the database that initiated the query. | no |
+| `StatementID` | Statement ID of the query. | no |
+| `TransactionID` | Transaction ID of the query. | no |
 
 
 #### Common fields

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -390,6 +390,10 @@ func (p *planner) maybeLogStatementInternal(
 				CostEstimate:         p.curPlan.instrumentation.costEstimate,
 				Distribution:         p.curPlan.instrumentation.distribution.String(),
 				PlanGist:             p.curPlan.instrumentation.planGist.String(),
+				SessionID:            p.extendedEvalCtx.SessionID.String(),
+				Database:             p.CurrentDatabase(),
+				StatementID:          p.stmt.QueryID.String(),
+				TransactionID:        p.txn.ID().String(),
 			}})
 		} else {
 			telemetryMetrics.incSkippedQueryCount()

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3295,6 +3295,46 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, '"')
 	}
 
+	if m.SessionID != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SessionID\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SessionID)))
+		b = append(b, '"')
+	}
+
+	if m.Database != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Database\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Database)))
+		b = append(b, '"')
+	}
+
+	if m.StatementID != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementID\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.StatementID)))
+		b = append(b, '"')
+	}
+
+	if m.TransactionID != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TransactionID\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TransactionID)))
+		b = append(b, '"')
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -46,6 +46,18 @@ message SampledQuery {
 
   // The query's plan gist bytes as a base64 encoded string.
   string plan_gist = 7 [(gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // SessionID is the ID of the session that initiated the query.
+  string session_id = 8 [(gogoproto.customname) = "SessionID", (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Name of the database that initiated the query.
+  string database = 9 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Statement ID of the query.
+  string statement_id = 10 [(gogoproto.customname) = "StatementID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Transaction ID of the query.
+  string transaction_id = 11 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
Partially addresses: #71328

This change introduces identifiers into the sampled query log, namely:
- Database name
- Session ID
- Transaction ID
- Statement ID

Adding transaction ID incurs an additional lock access, the difference in performance is negligible. Results after running `kv95` on a 3 node GCE cluster using roachprod:
```
setup:

./workload init kv --splits 1000 --read-percent 95
./workload run kv --read-percent 95 --concurrency 64 --sequential --duration 30m
```

```
master:

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__total
 1800.0s        0       29725479        16514.2      3.4      2.8      8.9     16.8    104.9  read

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__total
 1800.0s        0        1564158          869.0      8.5      8.1     15.7     26.2    100.7  write

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
 1800.0s        0       31289637        17383.1      3.7      2.9     10.0     17.8    104.9
```

```
enrich_telemetry_add_identifiers

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__total
 1800.0s        0       29635045        16463.9      3.4      2.8      8.9     16.8    117.4  read

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__total
 1800.0s        0        1561022          867.2      8.5      7.9     15.7     26.2    113.2  write

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)__result
 1800.0s        0       31196067        17331.1      3.7      2.9     10.0     17.8    117.4
```


Release note (sql change): Sampled query telemetry log now includes
session/transaction/statement IDs, and database name of the query.