### PR TITLE
gc: use randutil.NewTestRand() instead of hardcoded seed

### DIFF
--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "gc_old_test.go",
         "gc_random_test.go",
         "gc_test.go",
+        "main_test.go",
     ],
     embed = [":gc"],
     deps = [

--- a/pkg/kv/kvserver/gc/main_test.go
+++ b/pkg/kv/kvserver/gc/main_test.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package gc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Previously randomized tests used hardcoded seed 1 for testing.
This is giving us fixed coverage which can't find new failure modes.
This commit changes it to use randutil.NewTestRand() which uses
different seed by default, but could be overridden for failure
reproductions.

Release note: None