### PR TITLE
outliers: protocol buffer adjustments

### DIFF
--- a/pkg/sql/clusterunique/BUILD.bazel
+++ b/pkg/sql/clusterunique/BUILD.bazel
@@ -9,5 +9,6 @@ go_library(
         "//pkg/base",
         "//pkg/util/hlc",
         "//pkg/util/uint128",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/clusterunique/id.go
+++ b/pkg/sql/clusterunique/id.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
+	"github.com/cockroachdb/errors"
 )
 
 // ID represents an identifier that is guaranteed to be unique across
@@ -52,4 +53,23 @@ func IDFromBytes(b []byte) ID {
 // GetNodeID extracts the node ID from a ID.
 func (id ID) GetNodeID() int32 {
 	return int32(0xFFFFFFFF & id.Lo)
+}
+
+// Size returns the marshalled size of id in bytes.
+func (id ID) Size() int {
+	return len(id.GetBytes())
+}
+
+// MarshalTo marshals id to data.
+func (id ID) MarshalTo(data []byte) (int, error) {
+	return copy(data, id.GetBytes()), nil
+}
+
+// Unmarshal unmarshals data to id.
+func (id *ID) Unmarshal(data []byte) error {
+	if len(data) != 16 {
+		return errors.Errorf("input data %s for uint128 must be 16 bytes", data)
+	}
+	id.Uint128 = uint128.FromBytes(data)
+	return nil
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6204,7 +6204,7 @@ CREATE TABLE crdb_internal.node_execution_outliers (
 		) {
 			err = errors.CombineErrors(err, addRow(
 				tree.NewDString(hex.EncodeToString(o.Session.ID.GetBytes())),
-				tree.NewDUuid(tree.DUuid{UUID: *o.Transaction.ID}),
+				tree.NewDUuid(tree.DUuid{UUID: o.Transaction.ID}),
 				tree.NewDString(hex.EncodeToString(o.Statement.ID.GetBytes())),
 				tree.NewDBytes(tree.DBytes(sqlstatsutil.EncodeUint64ToBytes(uint64(o.Statement.FingerprintID)))),
 			))

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6205,7 +6205,7 @@ CREATE TABLE crdb_internal.node_execution_outliers (
 			err = errors.CombineErrors(err, addRow(
 				tree.NewDString(hex.EncodeToString(o.Session.ID.GetBytes())),
 				tree.NewDUuid(tree.DUuid{UUID: *o.Transaction.ID}),
-				tree.NewDString(hex.EncodeToString(o.Statement.ID)),
+				tree.NewDString(hex.EncodeToString(o.Statement.ID.GetBytes())),
 				tree.NewDBytes(tree.DBytes(sqlstatsutil.EncodeUint64ToBytes(uint64(o.Statement.FingerprintID)))),
 			))
 		})

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6203,7 +6203,7 @@ CREATE TABLE crdb_internal.node_execution_outliers (
 			ctx context.Context, o *outliers.Outlier,
 		) {
 			err = errors.CombineErrors(err, addRow(
-				tree.NewDString(hex.EncodeToString(o.Session.ID)),
+				tree.NewDString(hex.EncodeToString(o.Session.ID.GetBytes())),
 				tree.NewDUuid(tree.DUuid{UUID: *o.Transaction.ID}),
 				tree.NewDString(hex.EncodeToString(o.Statement.ID)),
 				tree.NewDBytes(tree.DBytes(sqlstatsutil.EncodeUint64ToBytes(uint64(o.Statement.FingerprintID)))),

--- a/pkg/sql/sqlstats/outliers/BUILD.bazel
+++ b/pkg/sql/sqlstats/outliers/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//pkg/util/quantile",
         "//pkg/util/syncutil",
         "//pkg/util/uint128",
-        "//pkg/util/uuid",
         "@com_github_prometheus_client_model//go",
     ],
 )
@@ -57,5 +56,8 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/outliers",
     proto = ":outliers_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto"],
+    deps = [
+        "//pkg/util/uuid",  # keep
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
 )

--- a/pkg/sql/sqlstats/outliers/BUILD.bazel
+++ b/pkg/sql/sqlstats/outliers/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/quantile",
         "//pkg/util/syncutil",
-        "//pkg/util/uint128",
         "@com_github_prometheus_client_model//go",
     ],
 )

--- a/pkg/sql/sqlstats/outliers/detector.go
+++ b/pkg/sql/sqlstats/outliers/detector.go
@@ -20,7 +20,7 @@ import (
 
 type detector interface {
 	enabled() bool
-	isOutlier(*Outlier_Statement) bool
+	isOutlier(*Statement) bool
 }
 
 var _ detector = &anyDetector{}
@@ -40,7 +40,7 @@ func (a anyDetector) enabled() bool {
 	return false
 }
 
-func (a anyDetector) isOutlier(statement *Outlier_Statement) bool {
+func (a anyDetector) isOutlier(statement *Statement) bool {
 	// Because some detectors may need to observe all statements to build up
 	// their baseline sense of what "normal" is, we avoid short-circuiting.
 	result := false
@@ -68,7 +68,7 @@ func (d latencyQuantileDetector) enabled() bool {
 	return LatencyQuantileDetectorEnabled.Get(&d.settings.SV)
 }
 
-func (d *latencyQuantileDetector) isOutlier(stmt *Outlier_Statement) (decision bool) {
+func (d *latencyQuantileDetector) isOutlier(stmt *Statement) (decision bool) {
 	if !d.enabled() {
 		return false
 	}
@@ -86,7 +86,7 @@ func (d *latencyQuantileDetector) isOutlier(stmt *Outlier_Statement) (decision b
 }
 
 func (d *latencyQuantileDetector) withFingerprintLatencySummary(
-	stmt *Outlier_Statement, consumer func(latencySummary *quantile.Stream),
+	stmt *Statement, consumer func(latencySummary *quantile.Stream),
 ) {
 	var latencySummary *quantile.Stream
 
@@ -138,6 +138,6 @@ func (l latencyThresholdDetector) enabled() bool {
 	return LatencyThreshold.Get(&l.st.SV) > 0
 }
 
-func (l latencyThresholdDetector) isOutlier(s *Outlier_Statement) bool {
+func (l latencyThresholdDetector) isOutlier(s *Statement) bool {
 	return l.enabled() && s.LatencyInSeconds >= LatencyThreshold.Get(&l.st.SV).Seconds()
 }

--- a/pkg/sql/sqlstats/outliers/outliers.go
+++ b/pkg/sql/sqlstats/outliers/outliers.go
@@ -14,12 +14,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	prometheus "github.com/prometheus/client_model/go"
 )
 
@@ -129,15 +127,10 @@ type Reader interface {
 // exposes the set of currently retained outliers.
 type Registry interface {
 	// ObserveStatement notifies the registry of a statement execution.
-	ObserveStatement(
-		sessionID clusterunique.ID,
-		statementID clusterunique.ID,
-		statementFingerprintID roachpb.StmtFingerprintID,
-		latencyInSeconds float64,
-	)
+	ObserveStatement(sessionID clusterunique.ID, statement *Statement)
 
 	// ObserveTransaction notifies the registry of the end of a transaction.
-	ObserveTransaction(sessionID clusterunique.ID, txnID uuid.UUID)
+	ObserveTransaction(sessionID clusterunique.ID, transaction *Transaction)
 
 	Reader
 }

--- a/pkg/sql/sqlstats/outliers/outliers.proto
+++ b/pkg/sql/sqlstats/outliers/outliers.proto
@@ -16,17 +16,20 @@ import "gogoproto/gogo.proto";
 
 message Session {
   bytes id = 1 [(gogoproto.customname) = "ID",
-    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/clusterunique.ID"];
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/clusterunique.ID",
+    (gogoproto.nullable) = false];
 }
 
 message Transaction {
   bytes id = 1 [(gogoproto.customname) = "ID",
-    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
+    (gogoproto.nullable) = false];
 }
 
 message Statement {
   bytes id = 1 [(gogoproto.customname) = "ID",
-    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/clusterunique.ID"];
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/clusterunique.ID",
+    (gogoproto.nullable) = false];
   uint64 fingerprint_id = 2 [(gogoproto.customname) = "FingerprintID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StmtFingerprintID"];
   double latency_in_seconds = 3;

--- a/pkg/sql/sqlstats/outliers/outliers.proto
+++ b/pkg/sql/sqlstats/outliers/outliers.proto
@@ -14,23 +14,23 @@ option go_package = "outliers";
 
 import "gogoproto/gogo.proto";
 
+message Session {
+  bytes id = 1 [(gogoproto.customname) = "ID"];
+}
+
+message Transaction {
+  bytes id = 1 [(gogoproto.customname) = "ID",
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
+}
+
+message Statement {
+  bytes id = 1 [(gogoproto.customname) = "ID"];
+  uint64 fingerprint_id = 2 [(gogoproto.customname) = "FingerprintID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StmtFingerprintID"];
+  double latency_in_seconds = 3;
+}
+
 message Outlier {
-  message Session {
-    bytes id = 1 [(gogoproto.customname) = "ID"];
-  }
-
-  message Transaction {
-    bytes id = 1 [(gogoproto.customname) = "ID",
-      (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
-  }
-
-  message Statement {
-    bytes id = 1 [(gogoproto.customname) = "ID"];
-    uint64 fingerprint_id = 2 [(gogoproto.customname) = "FingerprintID",
-      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StmtFingerprintID"];
-    double latency_in_seconds = 3;
-  }
-
   Session session = 1;
   Transaction transaction = 2;
   Statement statement = 3;

--- a/pkg/sql/sqlstats/outliers/outliers.proto
+++ b/pkg/sql/sqlstats/outliers/outliers.proto
@@ -25,7 +25,8 @@ message Transaction {
 }
 
 message Statement {
-  bytes id = 1 [(gogoproto.customname) = "ID"];
+  bytes id = 1 [(gogoproto.customname) = "ID",
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/clusterunique.ID"];
   uint64 fingerprint_id = 2 [(gogoproto.customname) = "FingerprintID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StmtFingerprintID"];
   double latency_in_seconds = 3;

--- a/pkg/sql/sqlstats/outliers/outliers.proto
+++ b/pkg/sql/sqlstats/outliers/outliers.proto
@@ -15,7 +15,8 @@ option go_package = "outliers";
 import "gogoproto/gogo.proto";
 
 message Session {
-  bytes id = 1 [(gogoproto.customname) = "ID"];
+  bytes id = 1 [(gogoproto.customname) = "ID",
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/clusterunique.ID"];
 }
 
 message Transaction {

--- a/pkg/sql/sqlstats/outliers/outliers_test.go
+++ b/pkg/sql/sqlstats/outliers/outliers_test.go
@@ -41,13 +41,13 @@ func TestOutliers(t *testing.T) {
 		registry.ObserveTransaction(sessionID, txnID)
 
 		expected := []*outliers.Outlier{{
-			Session: &outliers.Outlier_Session{
+			Session: &outliers.Session{
 				ID: sessionID.GetBytes(),
 			},
-			Transaction: &outliers.Outlier_Transaction{
+			Transaction: &outliers.Transaction{
 				ID: &txnID,
 			},
-			Statement: &outliers.Outlier_Statement{
+			Statement: &outliers.Statement{
 				ID:               stmtID.GetBytes(),
 				FingerprintID:    stmtFptID,
 				LatencyInSeconds: 2,
@@ -114,25 +114,25 @@ func TestOutliers(t *testing.T) {
 		registry.ObserveTransaction(otherSessionID, otherTxnID)
 
 		expected := []*outliers.Outlier{{
-			Session: &outliers.Outlier_Session{
+			Session: &outliers.Session{
 				ID: sessionID.GetBytes(),
 			},
-			Transaction: &outliers.Outlier_Transaction{
+			Transaction: &outliers.Transaction{
 				ID: &txnID,
 			},
-			Statement: &outliers.Outlier_Statement{
+			Statement: &outliers.Statement{
 				ID:               stmtID.GetBytes(),
 				FingerprintID:    stmtFptID,
 				LatencyInSeconds: 2,
 			},
 		}, {
-			Session: &outliers.Outlier_Session{
+			Session: &outliers.Session{
 				ID: otherSessionID.GetBytes(),
 			},
-			Transaction: &outliers.Outlier_Transaction{
+			Transaction: &outliers.Transaction{
 				ID: &otherTxnID,
 			},
-			Statement: &outliers.Outlier_Statement{
+			Statement: &outliers.Statement{
 				ID:               otherStmtID.GetBytes(),
 				FingerprintID:    otherStmtFptID,
 				LatencyInSeconds: 3,

--- a/pkg/sql/sqlstats/outliers/outliers_test.go
+++ b/pkg/sql/sqlstats/outliers/outliers_test.go
@@ -29,7 +29,7 @@ func TestOutliers(t *testing.T) {
 	ctx := context.Background()
 
 	sessionID := clusterunique.IDFromBytes([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
-	session := &outliers.Session{ID: sessionID.GetBytes()}
+	session := &outliers.Session{ID: &sessionID}
 	txnID := uuid.FastMakeV4()
 	transaction := &outliers.Transaction{ID: &txnID}
 	statement := &outliers.Statement{
@@ -103,9 +103,7 @@ func TestOutliers(t *testing.T) {
 
 	t.Run("buffering statements per session", func(t *testing.T) {
 		otherSessionID := clusterunique.IDFromBytes([]byte("cccccccccccccccccccccccccccccccc"))
-		otherSession := &outliers.Session{
-			ID: otherSessionID.GetBytes(),
-		}
+		otherSession := &outliers.Session{ID: &otherSessionID}
 		otherTxnID := uuid.FastMakeV4()
 		otherTransaction := &outliers.Transaction{ID: &otherTxnID}
 		otherStatement := &outliers.Statement{
@@ -141,7 +139,7 @@ func TestOutliers(t *testing.T) {
 
 		// IterateOutliers doesn't specify its iteration order, so we sort here for a stable test.
 		sort.Slice(actual, func(i, j int) bool {
-			return bytes.Compare(actual[i].Session.ID, actual[j].Session.ID) < 0
+			return bytes.Compare(actual[i].Session.ID.GetBytes(), actual[j].Session.ID.GetBytes()) < 0
 		})
 
 		require.Equal(t, expected, actual)

--- a/pkg/sql/sqlstats/outliers/outliers_test.go
+++ b/pkg/sql/sqlstats/outliers/outliers_test.go
@@ -32,8 +32,9 @@ func TestOutliers(t *testing.T) {
 	session := &outliers.Session{ID: &sessionID}
 	txnID := uuid.FastMakeV4()
 	transaction := &outliers.Transaction{ID: &txnID}
+	statementID := clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
 	statement := &outliers.Statement{
-		ID:               []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		ID:               &statementID,
 		FingerprintID:    roachpb.StmtFingerprintID(100),
 		LatencyInSeconds: 2,
 	}
@@ -82,8 +83,9 @@ func TestOutliers(t *testing.T) {
 	t.Run("too fast", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		outliers.LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
+		statement2ID := clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
 		statement2 := &outliers.Statement{
-			ID:               []byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+			ID:               &statement2ID,
 			FingerprintID:    roachpb.StmtFingerprintID(100),
 			LatencyInSeconds: 0.5,
 		}
@@ -106,8 +108,9 @@ func TestOutliers(t *testing.T) {
 		otherSession := &outliers.Session{ID: &otherSessionID}
 		otherTxnID := uuid.FastMakeV4()
 		otherTransaction := &outliers.Transaction{ID: &otherTxnID}
+		otherStatementID := clusterunique.IDFromBytes([]byte("dddddddddddddddddddddddddddddddd"))
 		otherStatement := &outliers.Statement{
-			ID:               []byte("dddddddddddddddddddddddddddddddd"),
+			ID:               &otherStatementID,
 			FingerprintID:    roachpb.StmtFingerprintID(101),
 			LatencyInSeconds: 3,
 		}

--- a/pkg/sql/sqlstats/outliers/registry.go
+++ b/pkg/sql/sqlstats/outliers/registry.go
@@ -89,7 +89,7 @@ func (r *registry) ObserveTransaction(sessionID clusterunique.ID, transaction *T
 	if hasOutlier {
 		for _, s := range statements {
 			r.mu.outliers.Add(s.ID, &Outlier{
-				Session:     &Session{ID: &sessionID},
+				Session:     &Session{ID: sessionID},
 				Transaction: transaction,
 				Statement:   s,
 			})

--- a/pkg/sql/sqlstats/outliers/registry.go
+++ b/pkg/sql/sqlstats/outliers/registry.go
@@ -40,7 +40,7 @@ type registry struct {
 	// before enabling the outliers subsystem by default.
 	mu struct {
 		syncutil.RWMutex
-		statements map[clusterunique.ID][]*Outlier_Statement
+		statements map[clusterunique.ID][]*Statement
 		outliers   *cache.UnorderedCache
 	}
 }
@@ -59,7 +59,7 @@ func newRegistry(st *cluster.Settings, metrics Metrics) Registry {
 			latencyThresholdDetector{st: st},
 			newLatencyQuantileDetector(st, metrics),
 		}}}
-	r.mu.statements = make(map[clusterunique.ID][]*Outlier_Statement)
+	r.mu.statements = make(map[clusterunique.ID][]*Statement)
 	r.mu.outliers = cache.NewUnorderedCache(config)
 	return r
 }
@@ -75,7 +75,7 @@ func (r *registry) ObserveStatement(
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.mu.statements[sessionID] = append(r.mu.statements[sessionID], &Outlier_Statement{
+	r.mu.statements[sessionID] = append(r.mu.statements[sessionID], &Statement{
 		ID:               statementID.GetBytes(),
 		FingerprintID:    statementFingerprintID,
 		LatencyInSeconds: latencyInSeconds,
@@ -101,8 +101,8 @@ func (r *registry) ObserveTransaction(sessionID clusterunique.ID, txnID uuid.UUI
 	if hasOutlier {
 		for _, s := range statements {
 			r.mu.outliers.Add(uint128.FromBytes(s.ID), &Outlier{
-				Session:     &Outlier_Session{ID: sessionID.GetBytes()},
-				Transaction: &Outlier_Transaction{ID: &txnID},
+				Session:     &Session{ID: sessionID.GetBytes()},
+				Transaction: &Transaction{ID: &txnID},
 				Statement:   s,
 			})
 		}

--- a/pkg/sql/sqlstats/outliers/registry.go
+++ b/pkg/sql/sqlstats/outliers/registry.go
@@ -90,7 +90,7 @@ func (r *registry) ObserveTransaction(sessionID clusterunique.ID, transaction *T
 	if hasOutlier {
 		for _, s := range statements {
 			r.mu.outliers.Add(uint128.FromBytes(s.ID), &Outlier{
-				Session:     &Session{ID: sessionID.GetBytes()},
+				Session:     &Session{ID: &sessionID},
 				Transaction: transaction,
 				Statement:   s,
 			})

--- a/pkg/sql/sqlstats/outliers/registry.go
+++ b/pkg/sql/sqlstats/outliers/registry.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 )
 
 // maxCacheSize is the number of detected outliers we will retain in memory.
@@ -89,7 +88,7 @@ func (r *registry) ObserveTransaction(sessionID clusterunique.ID, transaction *T
 
 	if hasOutlier {
 		for _, s := range statements {
-			r.mu.outliers.Add(uint128.FromBytes(s.ID), &Outlier{
+			r.mu.outliers.Add(s.ID, &Outlier{
 				Session:     &Session{ID: &sessionID},
 				Transaction: transaction,
 				Statement:   s,

--- a/pkg/sql/sqlstats/outliers/registry.go
+++ b/pkg/sql/sqlstats/outliers/registry.go
@@ -13,13 +13,11 @@ package outliers
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // maxCacheSize is the number of detected outliers we will retain in memory.
@@ -64,25 +62,16 @@ func newRegistry(st *cluster.Settings, metrics Metrics) Registry {
 	return r
 }
 
-func (r *registry) ObserveStatement(
-	sessionID clusterunique.ID,
-	statementID clusterunique.ID,
-	statementFingerprintID roachpb.StmtFingerprintID,
-	latencyInSeconds float64,
-) {
+func (r *registry) ObserveStatement(sessionID clusterunique.ID, statement *Statement) {
 	if !r.enabled() {
 		return
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.mu.statements[sessionID] = append(r.mu.statements[sessionID], &Statement{
-		ID:               statementID.GetBytes(),
-		FingerprintID:    statementFingerprintID,
-		LatencyInSeconds: latencyInSeconds,
-	})
+	r.mu.statements[sessionID] = append(r.mu.statements[sessionID], statement)
 }
 
-func (r *registry) ObserveTransaction(sessionID clusterunique.ID, txnID uuid.UUID) {
+func (r *registry) ObserveTransaction(sessionID clusterunique.ID, transaction *Transaction) {
 	if !r.enabled() {
 		return
 	}
@@ -102,7 +91,7 @@ func (r *registry) ObserveTransaction(sessionID clusterunique.ID, txnID uuid.UUI
 		for _, s := range statements {
 			r.mu.outliers.Add(uint128.FromBytes(s.ID), &Outlier{
 				Session:     &Session{ID: sessionID.GetBytes()},
-				Transaction: &Transaction{ID: &txnID},
+				Transaction: transaction,
 				Statement:   s,
 			})
 		}

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -161,7 +161,7 @@ func (s *Container) RecordStatement(
 	}
 
 	s.outliersRegistry.ObserveStatement(value.SessionID, &outliers.Statement{
-		ID:               value.StatementID.GetBytes(),
+		ID:               &value.StatementID,
 		FingerprintID:    stmtFingerprintID,
 		LatencyInSeconds: value.ServiceLatency,
 	})

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/outliers"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
@@ -159,7 +160,11 @@ func (s *Container) RecordStatement(
 		}
 	}
 
-	s.outliersRegistry.ObserveStatement(value.SessionID, value.StatementID, stmtFingerprintID, value.ServiceLatency)
+	s.outliersRegistry.ObserveStatement(value.SessionID, &outliers.Statement{
+		ID:               value.StatementID.GetBytes(),
+		FingerprintID:    stmtFingerprintID,
+		LatencyInSeconds: value.ServiceLatency,
+	})
 
 	return stats.ID, nil
 }
@@ -269,7 +274,7 @@ func (s *Container) RecordTransaction(
 		stats.mu.data.ExecStats.MaxDiskUsage.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MaxDiskUsage))
 	}
 
-	s.outliersRegistry.ObserveTransaction(value.SessionID, value.TransactionID)
+	s.outliersRegistry.ObserveTransaction(value.SessionID, &outliers.Transaction{ID: &value.TransactionID})
 
 	return nil
 }

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -161,7 +161,7 @@ func (s *Container) RecordStatement(
 	}
 
 	s.outliersRegistry.ObserveStatement(value.SessionID, &outliers.Statement{
-		ID:               &value.StatementID,
+		ID:               value.StatementID,
 		FingerprintID:    stmtFingerprintID,
 		LatencyInSeconds: value.ServiceLatency,
 	})
@@ -274,7 +274,7 @@ func (s *Container) RecordTransaction(
 		stats.mu.data.ExecStats.MaxDiskUsage.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MaxDiskUsage))
 	}
 
-	s.outliersRegistry.ObserveTransaction(value.SessionID, &outliers.Transaction{ID: &value.TransactionID})
+	s.outliersRegistry.ObserveTransaction(value.SessionID, &outliers.Transaction{ID: value.TransactionID})
 
 	return nil
 }


### PR DESCRIPTION
This handful of commits slightly re-shapes the protocol buffer messages we use for tracking outliers, making some of the work in #81021 a little easier to express.