### PR TITLE
coexec: normalize the timestamp subtraction like postgres

### DIFF
--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -9020,7 +9020,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						nanos := arg1.Sub(arg2).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -9038,7 +9038,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						nanos := arg1.Sub(arg2).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -9057,7 +9057,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -9071,7 +9071,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -8406,7 +8406,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := p.constArg.Sub(arg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -8420,7 +8420,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := p.constArg.Sub(arg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -8438,7 +8438,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -8449,7 +8449,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -8403,7 +8403,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := arg.Sub(p.constArg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -8417,7 +8417,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := arg.Sub(p.constArg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -8435,7 +8435,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -8446,7 +8446,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -599,7 +599,7 @@ func (c timestampCustomizer) getBinOpAssignFunc() assignFunc {
 		case treebin.Minus:
 			return fmt.Sprintf(`
 		  nanos := %[2]s.Sub(%[3]s).Nanoseconds()
-		  %[1]s = duration.MakeDuration(nanos, 0, 0)
+		  %[1]s = duration.MakeDurationJustifyHours(nanos, 0, 0)
 		  `,
 				targetElem, leftElem, rightElem)
 		default:

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -539,3 +539,14 @@ query T
 SELECT to_timestamp(NULL)
 ----
 NULL
+
+# Regression test for #83094 (vectorized engine incorrectly formatting an
+# interval).
+statement ok
+CREATE TABLE t (t1 timestamptz, t2 timestamptz);
+INSERT INTO t VALUES ('2022-01-01 00:00:00.000000+00:00', '2022-01-02 00:00:00.000000+00:00');
+
+query T
+SELECT (t2 - t1) FROM t
+----
+1 day


### PR DESCRIPTION
This commit fixes an oversight of #56667 (which fixed the normalization
of the timestamp subtraction) where we forgot to update the vectorized
code path as well. The regression tests added in that PR happened to be
complex enough so that the vectorized engine would fall back to wrapping
a row-by-row processor, so they didn't catch this.

Fixes: #83094.

Release note (bug fix): CockroachDB previously would not normalize
`timestamp/timestamptz - timestamp/timestamptz` like Postgres does in
some cases (depending on the query), and this is now fixed.