### PR TITLE
storage/metamorphic: Add MVCC delete range using tombstone

### DIFF
--- a/pkg/storage/metamorphic/generator.go
+++ b/pkg/storage/metamorphic/generator.go
@@ -70,7 +70,7 @@ func (e *engineConfig) String() string {
 	return e.name
 }
 
-var engineConfigStandard = engineConfig{"standard=0", storage.DefaultPebbleOptions()}
+var engineConfigStandard = engineConfig{"standard=0", standardOptions(0)}
 
 type engineSequence struct {
 	name    string

--- a/pkg/storage/metamorphic/options.go
+++ b/pkg/storage/metamorphic/options.go
@@ -100,11 +100,15 @@ func standardOptions(i int) *pebble.Options {
 	if err := opts.Parse(stdOpts[i], nil); err != nil {
 		panic(err)
 	}
+	// Enable range keys in all options.
+	opts.FormatMajorVersion = pebble.FormatRangeKeys
 	return opts
 }
 
 func randomOptions() *pebble.Options {
 	opts := storage.DefaultPebbleOptions()
+	// Enable range keys in all options.
+	opts.FormatMajorVersion = pebble.FormatRangeKeys
 
 	rng, _ := randutil.NewTestRand()
 	opts.BytesPerSync = 1 << rngIntRange(rng, 8, 30)


### PR DESCRIPTION
This change adds MVCCDeleteRangeUsingTombstone to the MVCC
metamorphic tests. MVCCDeleteRange had already existed in
this test suite, so this ended up being a relatively simple
addition.

One part of #82545, with possibly more parts to follow
as other MVCC-level operations are added that utilize
`writer.{Put,Clear}{MVCC,Engine}RangeKey`.

Release note: None.