### PR TITLE
release-22.1: builtins: check privileges for crdb_internal builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -53,6 +53,19 @@ SELECT crdb_internal.repair_ttl_table_scheduled_job('tbl'::regclass::oid)
 statement ok
 SELECT crdb_internal.validate_ttl_scheduled_jobs()
 
+let $tbl_oid
+SELECT 'tbl'::regclass::oid
+
+user testuser
+
+statement error insufficient privilege
+SELECT crdb_internal.repair_ttl_table_scheduled_job($tbl_oid)
+
+statement error insufficient privilege
+SELECT crdb_internal.validate_ttl_scheduled_jobs()
+
+user root
+
 statement error resetting "ttl_expire_after" is not permitted\nHINT: use `RESET \(ttl\)` to remove TTL from the table
 ALTER TABLE tbl RESET (ttl_expire_after)
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6571,6 +6571,13 @@ table's zone configuration this will return NULL.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Void),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				if err != nil {
+					return nil, err
+				}
+				if !isAdmin {
+					return nil, errInsufficientPriv
+				}
 				return tree.DVoidDatum, evalCtx.Planner.ValidateTTLScheduledJobsInCurrentDB(evalCtx.Context)
 			},
 			Info:       `Validate all TTL tables have a valid scheduled job attached.`,
@@ -6586,6 +6593,13 @@ table's zone configuration this will return NULL.`,
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Void),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				if err != nil {
+					return nil, err
+				}
+				if !isAdmin {
+					return nil, errInsufficientPriv
+				}
 				oid := tree.MustBeDOid(args[0])
 				if err := evalCtx.Planner.RepairTTLScheduledJobForTable(evalCtx.Ctx(), int64(oid.DInt)); err != nil {
 					return nil, err


### PR DESCRIPTION
Backport 1/1 commits from #83952.

/cc @cockroachdb/release

---

Release note (sql change): crdb_internal.validate_ttl_scheduled_jobs and
crdb_internal.repair_ttl_table_scheduled_job can now only be run by
admins.

Release justification: small code change improving security