### PR TITLE
kv: Don't assume r.mu is held for First/LastIndex

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -337,9 +337,8 @@ func (r *Replica) raftLastIndexRLocked() uint64 {
 }
 
 // LastIndex implements the raft.Storage interface.
-// LastIndex requires that r.mu is held for reading.
 func (r *replicaRaftStorage) LastIndex() (uint64, error) {
-	return (*Replica)(r).raftLastIndexRLocked(), nil
+	return (*Replica)(r).GetLastIndex(), nil
 }
 
 // GetLastIndex returns the index of the last entry in the replica's Raft log.
@@ -356,9 +355,8 @@ func (r *Replica) raftFirstIndexRLocked() uint64 {
 }
 
 // FirstIndex implements the raft.Storage interface.
-// FirstIndex requires that r.mu is held for reading.
 func (r *replicaRaftStorage) FirstIndex() (uint64, error) {
-	return (*Replica)(r).raftFirstIndexRLocked(), nil
+	return (*Replica)(r).GetFirstIndex(), nil
 }
 
 // GetFirstIndex returns the index of the first entry in the replica's Raft log.


### PR DESCRIPTION
In a previous commit to clean up the raftstorage interface,
there was a change to stop using the raft storage interface methods
since they could throw an error. However there was no guarantee
that callers would hold the mu lock before calling. Clean up the
code to acquire the mu lock.

Release note: none