### PR TITLE
server: log stacks on 500 errors

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -186,7 +186,7 @@ func (s *adminServer) RegisterGateway(
 // serverError logs the provided error and returns an error that should be returned by
 // the RPC endpoint method.
 func serverError(ctx context.Context, err error) error {
-	log.ErrorfDepth(ctx, 1, "%+s", err)
+	log.ErrorfDepth(ctx, 1, "%+v", err)
 	return errAdminAPIError
 }
 


### PR DESCRIPTION
Before this change, we'd just log the error body, which often is not very
helpful. The format specifier makes me think that the intention was to log
the stacks. This made debugging [this](https://github.com/cockroachdb/cockroach/pull/83677#issuecomment-1177612813)
trivial as opposed to hard.

Release note: None