### PR TITLE
release-22.1: coexec: normalize the timestamp subtraction like postgres

### DIFF
--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -8801,7 +8801,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := p.constArg.Sub(arg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -8815,7 +8815,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := p.constArg.Sub(arg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -8833,7 +8833,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -8844,7 +8844,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -8798,7 +8798,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := arg.Sub(p.constArg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -8812,7 +8812,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := arg.Sub(p.constArg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -8830,7 +8830,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -8841,7 +8841,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -9427,7 +9427,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						nanos := arg1.Sub(arg2).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -9445,7 +9445,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						nanos := arg1.Sub(arg2).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -9464,7 +9464,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -9478,7 +9478,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -599,7 +599,7 @@ func (c timestampCustomizer) getBinOpAssignFunc() assignFunc {
 		case treebin.Minus:
 			return fmt.Sprintf(`
 		  nanos := %[2]s.Sub(%[3]s).Nanoseconds()
-		  %[1]s = duration.MakeDuration(nanos, 0, 0)
+		  %[1]s = duration.MakeDurationJustifyHours(nanos, 0, 0)
 		  `,
 				targetElem, leftElem, rightElem)
 		default:

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -516,3 +516,14 @@ SELECT date_trunc('day', t), date_trunc('hour', t) FROM (VALUES
 ----
 2020-10-25 00:00:00 +0300 EEST  2020-10-25 03:00:00 +0300 EEST
 2020-10-25 00:00:00 +0300 EEST  2020-10-25 03:00:00 +0200 EET
+
+# Regression test for #83094 (vectorized engine incorrectly formatting an
+# interval).
+statement ok
+CREATE TABLE t (t1 timestamptz, t2 timestamptz);
+INSERT INTO t VALUES ('2022-01-01 00:00:00.000000+00:00', '2022-01-02 00:00:00.000000+00:00');
+
+query T
+SELECT (t2 - t1) FROM t
+----
+1 day


### PR DESCRIPTION
Backport 1/1 commits from #83944.

/cc @cockroachdb/release

---

This commit fixes an oversight of #56667 (which fixed the normalization
of the timestamp subtraction) where we forgot to update the vectorized
code path as well. The regression tests added in that PR happened to be
complex enough so that the vectorized engine would fall back to wrapping
a row-by-row processor, so they didn't catch this.

Fixes: #83094.

Release note (bug fix): CockroachDB previously would not normalize
`timestamp/timestamptz - timestamp/timestamptz` like Postgres does in
some cases (depending on the query), and this is now fixed.

Release justification: bug fix.