### PR TITLE
release-21.2: coexec: normalize the timestamp subtraction like postgres

### DIFF
--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -9480,7 +9480,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := p.constArg.Sub(arg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -9494,7 +9494,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := p.constArg.Sub(arg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -9512,7 +9512,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -9523,7 +9523,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := p.constArg.Sub(arg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -9476,7 +9476,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := arg.Sub(p.constArg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -9490,7 +9490,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						nanos := arg.Sub(p.constArg).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -9508,7 +9508,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -9519,7 +9519,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					nanos := arg.Sub(p.constArg).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -10105,7 +10105,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						nanos := arg1.Sub(arg2).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -10123,7 +10123,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 						arg2 := col2.Get(i)
 
 						nanos := arg1.Sub(arg2).Nanoseconds()
-						projCol[i] = duration.MakeDuration(nanos, 0, 0)
+						projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 					}
 				}
@@ -10142,7 +10142,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			} else {
@@ -10156,7 +10156,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 					arg2 := col2.Get(i)
 
 					nanos := arg1.Sub(arg2).Nanoseconds()
-					projCol[i] = duration.MakeDuration(nanos, 0, 0)
+					projCol[i] = duration.MakeDurationJustifyHours(nanos, 0, 0)
 
 				}
 			}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -606,7 +606,7 @@ func (c timestampCustomizer) getBinOpAssignFunc() assignFunc {
 		case tree.Minus:
 			return fmt.Sprintf(`
 		  nanos := %[2]s.Sub(%[3]s).Nanoseconds()
-		  %[1]s = duration.MakeDuration(nanos, 0, 0)
+		  %[1]s = duration.MakeDurationJustifyHours(nanos, 0, 0)
 		  `,
 				targetElem, leftElem, rightElem)
 		default:

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -516,3 +516,14 @@ SELECT date_trunc('day', t), date_trunc('hour', t) FROM (VALUES
 ----
 2020-10-25 00:00:00 +0300 EEST  2020-10-25 03:00:00 +0300 EEST
 2020-10-25 00:00:00 +0300 EEST  2020-10-25 03:00:00 +0200 EET
+
+# Regression test for #83094 (vectorized engine incorrectly formatting an
+# interval).
+statement ok
+CREATE TABLE t (t1 timestamptz, t2 timestamptz);
+INSERT INTO t VALUES ('2022-01-01 00:00:00.000000+00:00', '2022-01-02 00:00:00.000000+00:00');
+
+query T
+SELECT (t2 - t1) FROM t
+----
+1 day


### PR DESCRIPTION
Backport 1/1 commits from #83944.

/cc @cockroachdb/release

---

This commit fixes an oversight of #56667 (which fixed the normalization
of the timestamp subtraction) where we forgot to update the vectorized
code path as well. The regression tests added in that PR happened to be
complex enough so that the vectorized engine would fall back to wrapping
a row-by-row processor, so they didn't catch this.

Fixes: #83094.

Release note (bug fix): CockroachDB previously would not normalize
`timestamp/timestamptz - timestamp/timestamptz` like Postgres does in
some cases (depending on the query), and this is now fixed.

Release justification: bug fix.