### PR TITLE
storage: close pebble iter gracefully when NewPebbleSSTIterator fails

### DIFF
--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -106,7 +106,7 @@ func newPebbleSSTIterator(files []sstable.ReadableFile, opts IterOptions) (*pebb
 
 	var err error
 	if p.iter, err = pebble.NewExternalIter(DefaultPebbleOptions(), &p.options, files); err != nil {
-		p.destroy()
+		p.Close()
 		return nil, err
 	}
 	return p, nil


### PR DESCRIPTION
Currently, if `pebble.NewExternalIter` sets pebbleIterator.inuse to True, but
then fails, the subsequent `pebbleIterator.destroy()` will panic unecessarily,
since the caller of `pebble.NewExternalIter` is not actually using the iter.
This bug causes TestBackupRestoreChecksum to flake in #83984.

To fix, this patch uses pebble.Close() to  gracefully close the pebbleIterator
if `pebble.NewExternalIter` fails.

Release Note: None