### PR TITLE
server: pass AC soft slot granter to Pebble

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -204,6 +204,18 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	ctx := cfg.AmbientCtx.AnnotateCtx(context.Background())
 
+	admissionOptions := admission.DefaultOptions
+	if opts, ok := cfg.TestingKnobs.AdmissionControl.(*admission.Options); ok {
+		admissionOptions.Override(opts)
+	}
+	admissionOptions.Settings = st
+	gcoords, metrics := admission.NewGrantCoordinators(cfg.AmbientCtx, admissionOptions)
+	ssg, err := admission.MakeSoftSlotGranter(gcoords.Regular)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to soft slot granter")
+	}
+	cfg.SoftSlotGranter = ssg
+
 	engines, err := cfg.CreateEngines(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create engines")
@@ -368,12 +380,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 	tcsFactory := kvcoord.NewTxnCoordSenderFactory(txnCoordSenderFactoryCfg, distSender)
 
-	admissionOptions := admission.DefaultOptions
-	if opts, ok := cfg.TestingKnobs.AdmissionControl.(*admission.Options); ok {
-		admissionOptions.Override(opts)
-	}
-	admissionOptions.Settings = st
-	gcoords, metrics := admission.NewGrantCoordinators(cfg.AmbientCtx, admissionOptions)
 	for i := range metrics {
 		registry.AddMetricStruct(metrics[i])
 	}

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -56,6 +56,14 @@ var L0SubLevelCountOverloadThreshold = settings.RegisterIntSetting(
 	"when the L0 sub-level count exceeds this threshold, the store is considered overloaded",
 	l0SubLevelCountOverloadThreshold, settings.PositiveInt)
 
+// EnabledSoftSlotGranting can be set to false to disable soft slot granting.
+var EnabledSoftSlotGranting = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"admission.soft_slot_granting.enabled",
+	"soft slot granting is disabled if this setting is set to false",
+	true,
+)
+
 // grantChainID is the ID for a grant chain. See continueGrantChain for
 // details.
 type grantChainID uint64
@@ -2308,6 +2316,9 @@ func MakeSoftSlotGranter(gc *GrantCoordinator) (*SoftSlotGranter, error) {
 // TryGetSlots attempts to acquire count slots and returns what was acquired
 // (possibly 0).
 func (ssg *SoftSlotGranter) TryGetSlots(count int) int {
+	if !EnabledSoftSlotGranting.Get(&ssg.kvGranter.coord.settings.SV) {
+		return 0
+	}
 	return ssg.kvGranter.tryGetSoftSlots(count)
 }
 

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -100,6 +100,7 @@ func (kvsa *kvSlotAdjuster) setModerateSlotsClamp(val int) {
 //
 // init-grant-coordinator min-cpu=<int> max-cpu=<int> sql-kv-tokens=<int>
 // sql-sql-tokens=<int> sql-leaf=<int> sql-root=<int>
+// enabled-soft-slot-granting=<bool>
 // set-has-waiting-requests work=<kind> v=<true|false>
 // set-return-value-from-granted work=<kind> v=<int>
 // try-get work=<kind> [v=<int>]
@@ -169,6 +170,14 @@ func TestGranterBasic(t *testing.T) {
 			var err error
 			ssg, err = MakeSoftSlotGranter(coord)
 			require.NoError(t, err)
+			if d.HasArg("enabled-soft-slot-granting") {
+				var enabledSoftSlotGranting bool
+				d.ScanArgs(t, "enabled-soft-slot-granting", &enabledSoftSlotGranting)
+				if !enabledSoftSlotGranting {
+					EnabledSoftSlotGranting.Override(context.Background(), &settings.SV, false)
+				}
+			}
+
 			return flushAndReset()
 
 		case "init-store-grant-coordinator":

--- a/pkg/util/admission/testdata/granter
+++ b/pkg/util/admission/testdata/granter
@@ -778,3 +778,16 @@ cpu-load runnable=0 procs=2 clamp=3
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 3 used-soft: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+init-grant-coordinator min-cpu=1 max-cpu=3 sql-kv-tokens=2 sql-sql-tokens=1 sql-leaf=2 sql-root=1 enabled-soft-slot-granting=false
+----
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+
+try-get-soft-slots slots=1
+----
+requested: 1, granted: 0
+GrantCoordinator:
+(chain: id: 1 active: false index: 0) kv: used: 0, high(moderate)-total: 1(1) moderate-clamp: 3 sql-kv-response: avail: 2
+sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1


### PR DESCRIPTION
Allow Pebble to make use of the AC soft slot granter to
perform additional CPU work.

Release note: None