### PR TITLE
release-22.1: sql: add txn_fingerprint_id to node_statement_statistics

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -193,10 +193,10 @@ SELECT * FROM crdb_internal.leases WHERE node_id < 0
 ----
 node_id  table_id  name  parent_id  expiration  deleted
 
-query ITTTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBBTTT colnames
+query ITTTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBBTTTT colnames
 SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
-node_id  application_name  flags  statement_id  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan sample_plan database_name exec_node_ids
+node_id  application_name  flags  statement_id  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan  sample_plan  database_name  exec_node_ids  txn_fingerprint_id
 
 query ITTTIIRRRRRRRRRRRRRRRRRR colnames
 SELECT * FROM crdb_internal.node_transaction_statistics WHERE node_id < 0

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2858,6 +2858,14 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			if err != nil {
 				return advanceInfo{}, err
 			}
+
+			if advInfo.txnEvent.eventType == txnUpgradeToExplicit {
+				ex.extraTxnState.txnFinishClosure.implicit = false
+				if err = ex.statsCollector.UpgradeImplicitTxn(ex.Ctx()); err != nil {
+					return advanceInfo{}, err
+				}
+			}
+
 		}
 	case txnStart:
 		atomic.StoreInt32(ex.extraTxnState.atomicAutoRetryCounter, 0)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2104,12 +2104,12 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent) {
 		ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionEndExecTransaction, timeutil.Now())
 		transactionFingerprintID :=
 			roachpb.TransactionFingerprintID(ex.extraTxnState.transactionStatementsHash.Sum())
-		if !implicit {
-			ex.statsCollector.EndExplicitTransaction(
-				ctx,
-				transactionFingerprintID,
-			)
-		}
+
+		ex.statsCollector.EndTransaction(
+			ctx,
+			transactionFingerprintID,
+		)
+
 		if ex.server.cfg.TestingKnobs.BeforeTxnStatsRecorded != nil {
 			ex.server.cfg.TestingKnobs.BeforeTxnStatsRecorded(
 				ex.sessionData(),
@@ -2158,7 +2158,6 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 	ex.state.mu.RLock()
 	txnStart := ex.state.mu.txnStart
 	ex.state.mu.RUnlock()
-	implicit := ex.implicitTxn()
 
 	// Transaction received time is the time at which the statement that prompted
 	// the creation of this transaction was received.
@@ -2187,12 +2186,10 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 
 	ex.extraTxnState.shouldExecuteOnTxnFinish = true
 	ex.extraTxnState.txnFinishClosure.txnStartTime = txnStart
-	ex.extraTxnState.txnFinishClosure.implicit = implicit
+	ex.extraTxnState.txnFinishClosure.implicit = ex.implicitTxn()
 	ex.extraTxnState.shouldExecuteOnTxnRestart = true
 
-	if !implicit {
-		ex.statsCollector.StartExplicitTransaction()
-	}
+	ex.statsCollector.StartTransaction()
 }
 
 func (ex *connExecutor) recordTransactionFinish(

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -166,31 +165,6 @@ func (ex *connExecutor) recordStatementSummary(
 		Failed:       stmtErr != nil,
 		Database:     planner.SessionData().Database,
 		PlanHash:     planner.instrumentation.planGist.Hash(),
-	}
-
-	// We only populate the transaction fingerprint ID field if we are in an
-	// implicit transaction.
-	//
-	// TODO(azhng): This will require some big refactoring later, we already
-	//  compute statement's fingerprintID in RecordStatement().
-	//  However, we need to recompute the Fingerprint() here because this
-	//  is required to populate the transaction fingerprint ID field.
-	//
-	//  The reason behind it is that: for explicit transactions, we have a final
-	//  callback that will eventually invoke
-	//  statsCollector.EndExplicitTransaction() which will use the extraTxnState
-	//  stored in the connExecutor to compute the transaction fingerprintID.
-	//  Unfortunately, that callback is not invoked for implicit transactions,
-	//  because we don't create temporary stats container for the implicit
-	//  transactions. (The statement stats directly gets written to the actual
-	//  stats container). This means that, unless we populate the transaction
-	//  fingerprintID here, we will not have another chance to do so later.
-	if ex.implicitTxn() {
-		stmtFingerprintID := recordedStmtStatsKey.FingerprintID()
-		txnFingerprintHash := util.MakeFNV64()
-		txnFingerprintHash.Add(uint64(stmtFingerprintID))
-		recordedStmtStatsKey.TransactionFingerprintID =
-			roachpb.TransactionFingerprintID(txnFingerprintHash.Sum())
 	}
 
 	recordedStmtStats := sqlstats.RecordedStmtStats{

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -299,16 +299,6 @@ func (ih *instrumentationHelper) Finish(
 			Failed:      retErr != nil,
 			PlanHash:    ih.planGist.Hash(),
 		}
-		// We populate transaction fingerprint ID if this is an implicit transaction.
-		// See executor_statement_metrics.go:recordStatementSummary() for further
-		// explanation.
-		if ih.implicitTxn {
-			stmtFingerprintID := stmtStatsKey.FingerprintID()
-			txnFingerprintHash := util.MakeFNV64()
-			txnFingerprintHash.Add(uint64(stmtFingerprintID))
-			stmtStatsKey.TransactionFingerprintID =
-				roachpb.TransactionFingerprintID(txnFingerprintHash.Sum())
-		}
 		err = statsCollector.RecordStatementExecStats(stmtStatsKey, queryLevelStats)
 		if err != nil {
 			if log.V(2 /* level */) {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -314,10 +314,10 @@ SELECT * FROM crdb_internal.leases WHERE node_id < 0
 ----
 node_id  table_id  name  parent_id  expiration  deleted
 
-query ITTTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBBTTT colnames
+query ITTTTTIIITRRRRRRRRRRRRRRRRRRRRRRRRRRBBTTTT colnames
 SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
-node_id  application_name  flags  statement_id  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan sample_plan database_name exec_node_ids
+node_id  application_name  flags  statement_id  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var  bytes_read_avg  bytes_read_var  rows_read_avg  rows_read_var  network_bytes_avg  network_bytes_var  network_msgs_avg  network_msgs_var  max_mem_usage_avg  max_mem_usage_var  max_disk_usage_avg  max_disk_usage_var  contention_time_avg  contention_time_var  implicit_txn  full_scan  sample_plan  database_name  exec_node_ids  txn_fingerprint_id
 
 query ITTTIIRRRRRRRRRRRRRRRRRR colnames
 SELECT * FROM crdb_internal.node_transaction_statistics WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1011,7 +1011,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
    full_scan BOOL NOT NULL,
    sample_plan JSONB NULL,
    database_name STRING NOT NULL,
-   exec_node_ids INT8[] NOT NULL
+   exec_node_ids INT8[] NOT NULL,
+   txn_fingerprint_id STRING NULL
 )  CREATE TABLE crdb_internal.node_statement_statistics (
    node_id INT8 NOT NULL,
    application_name STRING NOT NULL,
@@ -1053,7 +1054,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
    full_scan BOOL NOT NULL,
    sample_plan JSONB NULL,
    database_name STRING NOT NULL,
-   exec_node_ids INT8[] NOT NULL
+   exec_node_ids INT8[] NOT NULL,
+   txn_fingerprint_id STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_transaction_statistics (
    node_id INT8 NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -5,13 +5,22 @@
 statement ok
 SET CLUSTER SETTING sql.stats.flush.enabled = false;
 
+statement ok
+SET enable_implicit_transaction_for_batch_statements = true;
+
 # Check that node_statement_statistics report per application
 
 statement ok
-SET application_name = hello; SELECT 1
+SET application_name = hello
 
 statement ok
-SET application_name = world; SELECT 2
+SELECT 1
+
+statement ok
+SET application_name = world
+
+statement ok
+SELECT 2
 
 query B
 SELECT count > 0 FROM crdb_internal.node_statement_statistics WHERE application_name IN ('hello', 'world')
@@ -43,6 +52,25 @@ SELECT key, count >= 1 FROM crdb_internal.node_statement_statistics WHERE applic
 ----
 SELECT _     true
 SELECT _, _  true
+
+# Check that multiple stmts in a simple query are executed as one txn.
+
+statement ok
+SET application_name = multi_stmts_test;
+
+statement ok
+select 1, 2; select 1, 2, 3; select 'ok'
+
+statement ok
+SET application_name = ''
+
+query T
+SELECT txn_fingerprint_id FROM crdb_internal.node_statement_statistics WHERE application_name = 'multi_stmts_test' ORDER BY txn_fingerprint_id
+----
+10413021493801724718
+10413021493801724718
+10413021493801724718
+17854018046052698166
 
 statement ok
 CREATE TABLE test(x INT, y INT, z INT); INSERT INTO test(x, y, z) VALUES (0,0,0);
@@ -109,7 +137,10 @@ SELECT x FROM test WHERE y = 1/z
 # Set a cluster setting to make it show up below. Which one is set
 # does not matter.
 statement ok
-SET CLUSTER SETTING debug.panic_on_failed_assertions = true; RESET CLUSTER SETTING debug.panic_on_failed_assertions
+SET CLUSTER SETTING debug.panic_on_failed_assertions = true
+
+statement ok
+RESET CLUSTER SETTING debug.panic_on_failed_assertions
 
 statement ok
 SHOW application_name
@@ -118,7 +149,10 @@ statement ok
 SHOW CLUSTER SETTING debug.panic_on_failed_assertions
 
 statement ok
-SET application_name = ''; RESET distsql
+SET application_name = '';
+
+statement ok
+RESET distsql
 
 skipif config 3node-tenant #52763
 query TT colnames
@@ -139,7 +173,7 @@ SELECT x FROM test WHERE y IN (_, _, __more3__)                   +
 SELECT x FROM test WHERE y NOT IN (_, _, __more3__)               ·
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = DEFAULT  ·
 SET CLUSTER SETTING "debug.panic_on_failed_assertions" = _        ·
-SET application_name = '_'                                          ·
+SET application_name = '_'                                        ·
 SET distsql = "on"                                                ·
 SHOW CLUSTER SETTING "debug.panic_on_failed_assertions"           ·
 SHOW application_name                                             ·
@@ -201,6 +235,10 @@ SET application_name = 'implicit_txn_test'
 statement ok
 BEGIN; SELECT x FROM test where y=1; COMMIT;
 
+# Upgraded implicit txn.
+statement ok
+select 1; BEGIN; select 1; select 1; COMMIT
+
 statement ok
 BEGIN;
 SELECT x, z FROM test;
@@ -219,6 +257,7 @@ SELECT key, implicit_txn
  WHERE application_name = 'implicit_txn_test' ORDER BY key, implicit_txn;
 ----
 key                             implicit_txn
+SELECT _                        false
 SELECT x FROM test WHERE y = _  false
 SELECT x FROM test WHERE y = _  false
 SELECT x FROM test WHERE y = _  true

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -456,13 +456,9 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 	recordStats := func(testCase *tc) {
 		var txnFingerprintID roachpb.TransactionFingerprintID
 		txnFingerprintIDHash := util.MakeFNV64()
-		if !testCase.implicit {
-			statsCollector.StartExplicitTransaction()
-		}
+		statsCollector.StartTransaction()
 		defer func() {
-			if !testCase.implicit {
-				statsCollector.EndExplicitTransaction(ctx, txnFingerprintID)
-			}
+			statsCollector.EndTransaction(ctx, txnFingerprintID)
 			require.NoError(t,
 				statsCollector.
 					RecordTransaction(ctx, txnFingerprintID, sqlstats.RecordedTxnStats{}))
@@ -568,7 +564,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 		for _, txn := range simulatedTxns {
 			// Collect stats for the simulated transaction.
 			txnFingerprintIDHash := util.MakeFNV64()
-			statsCollector.StartExplicitTransaction()
+			statsCollector.StartTransaction()
 
 			for _, fingerprint := range txn.stmtFingerprints {
 				stmtFingerprintID, err := statsCollector.RecordStatement(
@@ -581,7 +577,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			}
 
 			transactionFingerprintID := roachpb.TransactionFingerprintID(txnFingerprintIDHash.Sum())
-			statsCollector.EndExplicitTransaction(ctx, transactionFingerprintID)
+			statsCollector.EndTransaction(ctx, transactionFingerprintID)
 			err := statsCollector.RecordTransaction(ctx, transactionFingerprintID, sqlstats.RecordedTxnStats{})
 			require.NoError(t, err)
 

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -145,17 +145,20 @@ type StatsCollector interface {
 	// of the sessionphase.Times.
 	Reset(ApplicationStats, *sessionphase.Times)
 
-	// StartExplicitTransaction informs StatsCollector that all subsequent
-	// statements will be executed in the context an explicit transaction.
-	StartExplicitTransaction()
+	// StartTransaction sets up the StatsCollector for a new transaction.
+	StartTransaction()
 
-	// EndExplicitTransaction informs the StatsCollector that the explicit txn has
+	// EndTransaction informs the StatsCollector that the current txn has
 	// finished execution. (Either COMMITTED or ABORTED). This means the txn's
 	// fingerprint ID is now available. StatsCollector will now go back to update
 	// the transaction fingerprint ID field of all the statement statistics for that
 	// txn.
-	EndExplicitTransaction(ctx context.Context, transactionFingerprintID roachpb.TransactionFingerprintID,
-	)
+	EndTransaction(ctx context.Context, transactionFingerprintID roachpb.TransactionFingerprintID)
+
+	// UpgradeImplicitTxn informs the StatsCollector that the current txn has been
+	// upgraded to an explicit transaction, thus all previously recorded statements
+	// should be updated accordingly.
+	UpgradeImplicitTxn(ctx context.Context) error
 }
 
 // Storage provides clients with interface to perform read and write operations


### PR DESCRIPTION
This commit adds the `txn_fingerprint_id` column to
`crdb_internal.node_statement_statistics`.

Release note (sql): `txn_fingerprint_id` has been added to
`crdb_internal.node_statement_statistics`. The type of the
column is NULL or STRING.Backport 2/2 commits from #83616.

/cc @cockroachdb/release

---

# Commit 1
### sql: add txn_fingerprint_id to node_statement_statistics

This commit adds the `txn_fingerprint_id` column to
`crdb_internal.node_statement_statistics`.

Release note (sql): `txn_fingerprin_id` has been added to
`crdb_internal.node_statement_statistics`. The type of the
column is NULL or STRING.

------------------------------
# Commit 2
### sql, sqlstats: create temporary stats container for all txns

Fixes: #81470

Previously, the stats collector followed different procedures for stats
collection depending on whether or not the txn was explicit.

For explicit transactions, all the stmts in the txn must be recorded with
the same `transactionFingerprintID`, which is  only known after all stmts
in the txn have been executed. In order to record the correct
txnFingerprintID, a temporary stats container was created for stmts in the
current transaction. The `transactionFingerprintID` was then populated for
all stmts in the temp container, and the temp container was merged with
the parent.

For implict transactions, the assumption was there would only be a single
stmt in the txn, and so no temporary container was created, with stmts
being written directly to the application stats.

This assumption was incorrect, as it is possible for implicit txns to have
multiple stmts, such as stmts sent in a batch.

This commit ensures that stats are properly collected for implicit txns
with multiple stmts. The stats collector now follows the same procedure
for both explicit and implicit txns, creating a temporary container for
local txn stmts and merging on txn finish.

Release note (bug fix): Statement and transaction stats are now properly
recorded for implicit txns with multiple stmts.

Release justification: bug fix
