### PR TITLE
rttanalysis: set cpu tag to enable parallelism

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":rttanalysis"],
     shard_count = 16,
+    tags = ["cpu:16"],
     deps = [
         "//pkg/base",
         "//pkg/security/securityassets",

--- a/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
+++ b/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     shard_count = 16,
+    tags = ["cpu:16"],
     deps = [
         "//pkg/base",
         "//pkg/bench/rttanalysis",


### PR DESCRIPTION
In this test, we use the internal go parallelism to accellerate the test.
If we don't request more cpu cores, the tests are slow.

Release note: None