### PR TITLE
ui: add mvcc info to Database page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
@@ -68,3 +68,12 @@
     fill: $colors--functional-orange-3;
   }
 }
+
+.multiple-lines-info {
+  margin-bottom: 0px
+}
+
+.bold {
+  font-weight: $font-weight--extra-bold;
+  color: $colors--neutral-8;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.stories.tsx
@@ -105,6 +105,9 @@ function createTable(): DatabaseDetailsPageDataTable {
       grants: grants,
       statsLastUpdated: moment("0001-01-01T00:00:00Z"),
       hasIndexRecommendations: false,
+      livePercentage: _.random(0, 100),
+      liveBytes: _.random(0, 10000),
+      totalBytes: _.random(0, 10000),
     },
     stats: {
       loading: false,

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
@@ -148,3 +148,8 @@
     }
   }
 }
+
+.bold {
+  font-weight: $font-weight--extra-bold;
+  color: $colors--neutral-8;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -34,6 +34,9 @@ const withLoadingIndicator: DatabaseTablePageProps = {
     indexNames: [],
     grants: [],
     statsLastUpdated: moment("0001-01-01T00:00:00Z"),
+    livePercentage: 2.7,
+    liveBytes: 12345,
+    totalBytes: 456789,
   },
   stats: {
     loading: true,
@@ -91,6 +94,9 @@ const withData: DatabaseTablePageProps = {
       },
     ],
     statsLastUpdated: moment("0001-01-01T00:00:00Z"),
+    livePercentage: 2.7,
+    liveBytes: 12345,
+    totalBytes: 456789,
   },
   showNodeRegionsSection: true,
   stats: {

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -113,6 +113,9 @@ export const lockingStrength = docsURL(
 export const transactionLayerOverview = docsURL(
   "architecture/transaction-layer.html#overview",
 );
+export const mvccGarbage = docsURLNoVersion(
+  "architecture/storage-layer.html#mvcc",
+);
 
 // Not actually a docs URL.
 export const startTrial = "https://www.cockroachlabs.com/pricing/start-trial/";

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -163,6 +163,9 @@ describe("Database Details Page", function () {
             grants: [],
             statsLastUpdated: null,
             hasIndexRecommendations: false,
+            livePercentage: 0,
+            liveBytes: 0,
+            totalBytes: 0,
           },
           stats: {
             loading: false,
@@ -184,6 +187,9 @@ describe("Database Details Page", function () {
             grants: [],
             statsLastUpdated: null,
             hasIndexRecommendations: false,
+            livePercentage: 0,
+            totalBytes: 0,
+            liveBytes: 0,
           },
           stats: {
             loading: false,
@@ -257,6 +263,9 @@ describe("Database Details Page", function () {
         },
       ],
       stats_last_created_at: makeTimestamp("0001-01-01T00:00:00Z"),
+      data_total_bytes: new Long(456789),
+      data_live_bytes: new Long(12345),
+      data_live_percentage: 2.0,
     });
 
     fakeApi.stubTableDetails("things", "bar", {
@@ -306,6 +315,9 @@ describe("Database Details Page", function () {
         },
       ],
       stats_last_created_at: makeTimestamp("0001-01-01T00:00:00Z"),
+      data_total_bytes: new Long(456789),
+      data_live_bytes: new Long(12345),
+      data_live_percentage: 2.0,
     });
 
     await driver.refreshDatabaseDetails();
@@ -324,6 +336,9 @@ describe("Database Details Page", function () {
         makeTimestamp("0001-01-01T00:00:00Z"),
       ),
       hasIndexRecommendations: false,
+      liveBytes: 12345,
+      totalBytes: 456789,
+      livePercentage: 2.0,
     });
 
     driver.assertTableDetails("bar", {
@@ -338,6 +353,9 @@ describe("Database Details Page", function () {
         makeTimestamp("0001-01-01T00:00:00Z"),
       ),
       hasIndexRecommendations: false,
+      liveBytes: 12345,
+      totalBytes: 456789,
+      livePercentage: 2.0,
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -149,6 +149,11 @@ export const mapStateToProps = createSelector(
               : null,
             hasIndexRecommendations:
               details?.data?.has_index_recommendations || false,
+            totalBytes: FixLong(
+              details?.data?.data_total_bytes || 0,
+            ).toNumber(),
+            liveBytes: FixLong(details?.data?.data_live_bytes || 0).toNumber(),
+            livePercentage: details?.data?.data_live_percentage || 0,
           },
           stats: {
             loading: !!stats?.inFlight,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -180,6 +180,9 @@ describe("Database Table Page", function () {
           indexNames: [],
           grants: [],
           statsLastUpdated: null,
+          livePercentage: 0,
+          liveBytes: 0,
+          totalBytes: 0,
         },
         automaticStatsCollectionEnabled: true,
         stats: {
@@ -216,6 +219,9 @@ describe("Database Table Page", function () {
         num_replicas: 5,
       },
       stats_last_created_at: makeTimestamp("0001-01-01T00:00:00Z"),
+      data_total_bytes: new Long(456789),
+      data_live_bytes: new Long(12345),
+      data_live_percentage: 2.0,
     });
 
     await driver.refreshTableDetails();
@@ -234,6 +240,9 @@ describe("Database Table Page", function () {
       statsLastUpdated: util.TimestampToMoment(
         makeTimestamp("0001-01-01T00:00:00Z"),
       ),
+      livePercentage: 2.0,
+      liveBytes: 12345,
+      totalBytes: 456789,
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -131,6 +131,9 @@ export const mapStateToProps = createSelector(
         statsLastUpdated: details?.data?.stats_last_created_at
           ? util.TimestampToMoment(details?.data?.stats_last_created_at)
           : null,
+        totalBytes: FixLong(details?.data?.data_total_bytes || 0).toNumber(),
+        liveBytes: FixLong(details?.data?.data_live_bytes || 0).toNumber(),
+        livePercentage: details?.data?.data_live_percentage || 0,
       },
       showNodeRegionsSection,
       automaticStatsCollectionEnabled,


### PR DESCRIPTION
This commit adds the mvcc info to:
- Column on the tables list inside Database page
- Table Details page

Fixes https://github.com/cockroachdb/cockroach/issues/82617

<img width="1429" alt="Screen Shot 2022-07-11 at 5 20 04 PM" src="https://user-images.githubusercontent.com/1017486/178360499-b8c53f64-726f-4a37-adf9-a6047fb6d7bf.png">

<img width="551" alt="Screen Shot 2022-07-11 at 5 20 53 PM" src="https://user-images.githubusercontent.com/1017486/178360553-155b78bf-9c08-49e3-ad72-97822aced286.png">


<img width="269" alt="Screen Shot 2022-07-08 at 5 35 49 PM" src="https://user-images.githubusercontent.com/1017486/178073512-6566e288-643a-4f64-96fb-7ccb843c24ea.png">



Release note (ui change): Adds mvcc info to tables list inside
the Database page and on the Tables details page.