### PR TITLE
ui: option to search exact statement on SQL Activity

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.tsx
@@ -79,6 +79,9 @@ export function getHighlightedText(
   if (!highlight || highlight.length === 0) {
     return text;
   }
+  if (highlight.startsWith('"') && highlight.endsWith('"')) {
+    highlight = highlight.substring(1, highlight.length - 1);
+  }
 
   highlight = highlight.replace(
     /[°§%()\[\]{}\\?´`'#|;:+^*-]+/g,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -165,6 +165,12 @@ export function filterBySearchQuery(
   search: string,
 ): boolean {
   const matchString = statement.label.toLowerCase();
+  // If search term is wrapped by quotes, do the exact search term.
+  if (search.startsWith('"') && search.endsWith('"')) {
+    search = search.substring(1, search.length - 1);
+    return matchString.includes(search);
+  }
+
   return search
     .toLowerCase()
     .split(" ")

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -119,20 +119,24 @@ export const searchTransactionsData = (
   transactions: Transaction[],
   statements: Statement[],
 ): Transaction[] => {
+  let searchTerms = search?.split(" ");
+  // If search term is wrapped by quotes, do the exact search term.
+  if (search?.startsWith('"') && search?.endsWith('"')) {
+    searchTerms = [search.substring(1, search.length - 1)];
+  }
+
   return transactions.filter((t: Transaction) =>
     search
-      ? search
-          .split(" ")
-          .every(val =>
-            collectStatementsText(
-              getStatementsByFingerprintId(
-                t.stats_data.statement_fingerprint_ids,
-                statements,
-              ),
-            )
-              .toLowerCase()
-              .includes(val.toLowerCase()),
+      ? searchTerms.every(val =>
+          collectStatementsText(
+            getStatementsByFingerprintId(
+              t.stats_data.statement_fingerprint_ids,
+              statements,
+            ),
           )
+            .toLowerCase()
+            .includes(val.toLowerCase()),
+        )
       : true,
   );
 };


### PR DESCRIPTION
Previously, when doing a search on SQL Activity page,
it was returning all statements that contained all terms
from the search, but not necessarily on the same order.
This commit adds an option when you wrap the search in quotes
it will only return results with the exact match in order.

https://www.loom.com/share/442c6eaee84b4c71a1acdef0b63b74bf

Release note (ui change): Ability to search for the exact terms
in order when wrapping the search in quotes.