### PR TITLE
sql: prevent int64 overflow when encoding large intervals

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -713,3 +713,32 @@ millisecond   1111 years 4 mons 1 day 01:01:01.001
 milliseconds  1111 years 4 mons 1 day 01:01:01.001
 microsecond   1111 years 4 mons 1 day 01:01:01.001001
 microseconds  1111 years 4 mons 1 day 01:01:01.001001
+
+# Regression test for #83756. Interval encoding overflow should be detected
+# correctly.
+statement ok
+CREATE TABLE t83756 (i INTERVAL PRIMARY KEY);
+
+# These intervals do not overflow.
+statement ok
+INSERT INTO t83756 VALUES ('106751 days 23:47:16.854775');
+INSERT INTO t83756 VALUES ('-106751 days -23:47:16.854775');
+
+# These intervals overflow.
+# TODO(#84078): These intervals overflow due to limitations of our INTERVAL key
+# encoding. All values in the range [-178000000 years, 178000000 years] should
+# be allowed.
+statement error overflow during Encode
+INSERT INTO t83756 VALUES ('106751 days 23:47:16.854776');
+
+statement error overflow during Encode
+INSERT INTO t83756 VALUES ('-106751 days -23:47:16.854776');
+
+# These intervals overflow when multiplying the days and the number of
+# nanoseconds in a day, even though the total nanosecond calculation would not
+# overflow.
+statement error overflow during Encode
+INSERT INTO t83756 VALUES ('-3558 months 106752 days');
+
+statement error overflow during Encode
+INSERT INTO t83756 VALUES ('3558 months -106752 days');

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -225,6 +225,8 @@ func performCastWithoutPrecisionTruncation(
 			}
 			res = tree.NewDInt(tree.DInt(v.UnixEpochDays()))
 		case *tree.DInterval:
+			// TODO(mgartner): This cast is not supported in Postgres. We should
+			// remove it.
 			iv, ok := v.AsInt64()
 			if !ok {
 				return nil, tree.ErrIntOutOfRange

--- a/pkg/util/duration/duration_test.go
+++ b/pkg/util/duration/duration_test.go
@@ -57,6 +57,10 @@ var positiveDurationTests = []durationTest{
 	{1, Duration{Months: 1, Days: 10, nanos: 0}, false},
 	{0, Duration{Months: 0, Days: 40, nanos: 0}, false},
 	{1, Duration{Months: 2, Days: 0, nanos: 0}, false},
+	// '106751 days 23:47:16.854775' should not overflow.
+	{1, Duration{Months: 0, Days: 106751, nanos: 85636854775000}, false},
+	// '106751 days 23:47:16.854776' should overflow.
+	{1, Duration{Months: 0, Days: 106751, nanos: 85636854776000}, true},
 	{1, Duration{Months: math.MaxInt64 - 1, Days: DaysPerMonth - 1, nanos: nanosInDay * 2}, true},
 	{1, Duration{Months: math.MaxInt64 - 1, Days: DaysPerMonth * 2, nanos: nanosInDay * 2}, true},
 	{1, Duration{Months: math.MaxInt64, Days: math.MaxInt64, nanos: nanosInMonth + nanosInDay}, true},


### PR DESCRIPTION
This commit fixes an `int64` overflow bug that could occur when encoding
`INTERVAL` values that are greater than about 292 years or less then
about -292 years. The encoded `int64` could overflow into a value of the
wrong sign, causing corrupt indexes and incorrect query results.

The bug was caused because the encoding logic incorrectly approximated
when an `INTERVAL` would overflow an encoded `int64`. It aimed to be
conservative such that it would return an overflow error for all
`INTERVAL` values that overflow, and sometimes return an overflow error
for `INTERVAL` values the do not overflow. However, it did not catch all
values which overflow.

The bug has been fixed by using exact overflow checks rather than
approximate checks.

Fixes #83756

Release note (bug fix): A bug has been fixed that could corrupt indexes
and cause incorrect query results with `INTERVAL` values greater than
about 292 years or less than about -292 years.