### PR TITLE
row: only store the accounted for memory if the reservation is approved

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -356,10 +356,11 @@ func (f *txnKVFetcher) SetupNextFetch(
 
 	// Account for the memory of the spans that we're taking the ownership of.
 	if f.acc != nil {
-		f.spansAccountedFor = spans.MemUsage()
-		if err := f.acc.Grow(ctx, f.spansAccountedFor); err != nil {
+		newSpansAccountedFor := spans.MemUsage()
+		if err := f.acc.Grow(ctx, newSpansAccountedFor); err != nil {
 			return err
 		}
+		f.spansAccountedFor = newSpansAccountedFor
 	}
 
 	if spanIDs != nil && len(spans) != len(spanIDs) {


### PR DESCRIPTION
Previously, we would update the counter about the reserved memory before
doing the reservation. If that reservation is denied, then later on, in
`txnKVFetcher.close` we could try to release more memory than we
registered. This is now fixed.

Addresses: #83935.

Release note: None