### PR TITLE
rditer: replace `ReplicaDataEngineIterator` with `IterateReplicaKeySpans`

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3761,48 +3761,65 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		// ultimately keep the last one.
 		sendingEngSnapshot := sendingEng.NewSnapshot()
 		defer sendingEngSnapshot.Close()
-		keySpans := rditer.MakeReplicatedKeySpans(inSnap.Desc)
-		it := rditer.NewReplicaEngineDataIterator(
-			inSnap.Desc, sendingEngSnapshot, true /* replicatedOnly */)
-		defer it.Close()
 
-		// Write a range deletion tombstone to each of the SSTs then put in the
-		// kv entries from the sender of the snapshot.
+		// Write a Pebble range deletion tombstone to each of the SSTs then put in
+		// the kv entries from the sender of the snapshot.
 		ctx := context.Background()
 		st := cluster.MakeTestingClusterSettings()
 
-		ok, err := it.SeekStart()
-		require.NoError(t, err)
-		for _, s := range keySpans {
-			sstFile := &storage.MemFile{}
-			sst := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
-			if err := sst.ClearRawRange(s.Key, s.EndKey); err != nil {
-				return err
-			}
-
-			// Keep adding kv data to the SST until the key exceeds the
-			// bounds of the range, then proceed to the next range.
-			for ; ok && err == nil; ok, err = it.Next() {
-				var key storage.EngineKey
-				if key, err = it.UnsafeKey(); err != nil {
-					return err
-				}
-				if s.EndKey.Compare(key.Key) <= 0 {
-					break
-				}
-				if err := sst.PutEngineKey(key, it.UnsafeValue()); err != nil {
-					return err
-				}
-			}
-			if err != nil {
-				return err
-			}
-			if err := sst.Finish(); err != nil {
-				return err
-			}
-			sst.Close()
-			expectedSSTs = append(expectedSSTs, sstFile.Data())
+		type sstFileWriter struct {
+			span   roachpb.Span
+			file   *storage.MemFile
+			writer storage.SSTWriter
 		}
+		keySpans := rditer.MakeReplicatedKeySpans(inSnap.Desc)
+		sstFileWriters := map[string]sstFileWriter{}
+		for _, span := range keySpans {
+			file := &storage.MemFile{}
+			writer := storage.MakeIngestionSSTWriter(ctx, st, file)
+			if err := writer.ClearRawRange(span.Key, span.EndKey); err != nil {
+				return err
+			}
+			sstFileWriters[string(span.Key)] = sstFileWriter{
+				span:   span,
+				file:   file,
+				writer: writer,
+			}
+		}
+
+		err := rditer.IterateReplicaKeySpans(inSnap.Desc, sendingEngSnapshot, true, /* replicatedOnly */
+			func(iter storage.EngineIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+				fw, ok := sstFileWriters[string(span.Key)]
+				if !ok || !fw.span.Equal(span) {
+					return errors.Errorf("unexpected span %s", span)
+				}
+				var err error
+				for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
+					var key storage.EngineKey
+					if key, err = iter.UnsafeEngineKey(); err != nil {
+						return err
+					}
+					if err := fw.writer.PutEngineKey(key, iter.UnsafeValue()); err != nil {
+						return err
+					}
+				}
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+		if err != nil {
+			return err
+		}
+
+		for _, span := range keySpans {
+			fw := sstFileWriters[string(span.Key)]
+			if err := fw.writer.Finish(); err != nil {
+				return err
+			}
+			expectedSSTs = append(expectedSSTs, fw.file.Data())
+		}
+
 		if len(expectedSSTs) != 5 {
 			return errors.Errorf("len of expectedSSTs should expected to be %d, but got %d",
 				5, len(expectedSSTs))

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5854,8 +5854,8 @@ func TestRaftSnapshotsWithMVCCRangeKeysEverywhere(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, desc := range descs {
-		for _, keyRange := range rditer.MakeReplicatedKeyRanges(&desc) {
-			prefix := append(keyRange.Start.Clone(), ':')
+		for _, span := range rditer.MakeReplicatedKeySpans(&desc) {
+			prefix := append(span.Key.Clone(), ':')
 			require.NoError(t, engine.PutMVCCRangeKey(storage.MVCCRangeKey{
 				StartKey:  append(prefix.Clone(), 'a'),
 				EndKey:    append(prefix.Clone(), 'z'),
@@ -5886,17 +5886,17 @@ func TestRaftSnapshotsWithMVCCRangeKeysEverywhere(t *testing.T) {
 	for _, srvIdx := range []int{1, 2} {
 		e := tc.GetFirstStoreFromServer(t, srvIdx).Engine()
 		for _, desc := range descs {
-			for _, keyRange := range rditer.MakeReplicatedKeyRanges(&desc) {
-				prefix := append(keyRange.Start.Clone(), ':')
+			for _, span := range rditer.MakeReplicatedKeySpans(&desc) {
+				prefix := append(span.Key.Clone(), ':')
 
 				iter := e.NewEngineIterator(storage.IterOptions{
 					KeyTypes:   storage.IterKeyTypeRangesOnly,
-					LowerBound: keyRange.Start,
-					UpperBound: keyRange.End,
+					LowerBound: span.Key,
+					UpperBound: span.EndKey,
 				})
 				defer iter.Close()
 
-				ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: keyRange.Start})
+				ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: span.Key})
 				require.NoError(t, err)
 				require.True(t, ok)
 				bounds, err := iter.EngineRangeBounds()

--- a/pkg/kv/kvserver/rditer/BUILD.bazel
+++ b/pkg/kv/kvserver/rditer/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/util/iterutil",
     ],
 )
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -16,12 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 )
 
-// KeyRange is a helper struct for the ReplicaMVCCDataIterator and
-// ReplicaEngineDataIterator.
-type KeyRange struct {
-	Start, End roachpb.Key
-}
-
 // ReplicaDataIteratorOptions defines ReplicaMVCCDataIterator creation options.
 type ReplicaDataIteratorOptions struct {
 	// See NewReplicaMVCCDataIterator for details.
@@ -35,7 +29,7 @@ type ReplicaDataIteratorOptions struct {
 // ReplicaMVCCDataIterator provides a complete iteration over MVCC or unversioned
 // (which can be made to look like an MVCCKey) key / value
 // rows in a range, including system-local metadata and user data.
-// The ranges keyRange slice specifies the key ranges which comprise
+// The ranges keyRange slice specifies the key spans which comprise
 // the range's data. This cannot be used to iterate over keys that are not
 // representable as MVCCKeys, except when such non-MVCCKeys are limited to
 // intents, which can be made to look like interleaved MVCCKeys. Most callers
@@ -44,13 +38,13 @@ type ReplicaDataIteratorOptions struct {
 // A ReplicaMVCCDataIterator provides a subset of the engine.MVCCIterator interface.
 //
 // TODO(sumeer): merge with ReplicaEngineDataIterator. We can use an EngineIterator
-// for MVCC key ranges and convert from EngineKey to MVCCKey.
+// for MVCC key spans and convert from EngineKey to MVCCKey.
 type ReplicaMVCCDataIterator struct {
 	ReplicaDataIteratorOptions
 
 	reader   storage.Reader
 	curIndex int
-	ranges   []KeyRange
+	spans    []roachpb.Span
 	// When it is non-nil, it represents the iterator for curIndex.
 	// A non-nil it is valid, else it is either done, or err != nil.
 	it  storage.MVCCIterator
@@ -58,15 +52,15 @@ type ReplicaMVCCDataIterator struct {
 }
 
 // ReplicaEngineDataIterator provides a complete iteration over all data in a
-// range, including system-local metadata and user data. The ranges KeyRange
-// slice specifies the key ranges which comprise the range's data.
+// range, including system-local metadata and user data. The ranges Span slice
+// specifies the key spans which comprise the range's data.
 //
 // The iterator iterates over both point keys and range keys (i.e. MVCC range
-// tombstones), but in a somewhat peculiar order: for each key range, it first
+// tombstones), but in a somewhat peculiar order: for each key span, it first
 // iterates over all point keys in order, then over all range keys in order,
 // signalled via HasPointAndRange(). This allows efficient non-interleaved
-// iteration of point/range keys, and keeps them grouped by key range for
-// efficient Raft snapshot ingestion into a single SST per key range.
+// iteration of point/range keys, and keeps them grouped by key span for
+// efficient Raft snapshot ingestion into a single SST per key span.
 //
 // TODO(erikgrinaker): Reconsider the above ordering/scheme for point/range
 // keys.
@@ -74,40 +68,40 @@ type ReplicaEngineDataIterator struct {
 	reader     storage.Reader
 	curIndex   int
 	curKeyType storage.IterKeyType
-	ranges     []KeyRange
+	spans      []roachpb.Span
 	it         storage.EngineIterator
 }
 
-// MakeAllKeyRanges returns all key ranges for the given Range, in
+// MakeAllKeySpans returns all key spans for the given Range, in
 // sorted order.
-func MakeAllKeyRanges(d *roachpb.RangeDescriptor) []KeyRange {
-	return makeRangeKeyRanges(d, false /* replicatedOnly */)
+func MakeAllKeySpans(d *roachpb.RangeDescriptor) []roachpb.Span {
+	return makeRangeKeySpans(d, false /* replicatedOnly */)
 }
 
-// MakeReplicatedKeyRanges returns all key ranges that are fully Raft
+// MakeReplicatedKeySpans returns all key spans that are fully Raft
 // replicated for the given Range.
 //
 // NOTE: The logic for receiving snapshot relies on this function returning the
-// ranges in the following sorted order:
+// spans in the following sorted order:
 //
-// 1. Replicated range-id local key range
-// 2. Range-local key range
-// 3. Lock-table key ranges
-// 4. User key range
-func MakeReplicatedKeyRanges(d *roachpb.RangeDescriptor) []KeyRange {
-	return makeRangeKeyRanges(d, true /* replicatedOnly */)
+// 1. Replicated range-id local key span.
+// 2. Range-local key span.
+// 3. Lock-table key spans.
+// 4. User key span.
+func MakeReplicatedKeySpans(d *roachpb.RangeDescriptor) []roachpb.Span {
+	return makeRangeKeySpans(d, true /* replicatedOnly */)
 }
 
-func makeRangeKeyRanges(d *roachpb.RangeDescriptor, replicatedOnly bool) []KeyRange {
-	rangeIDLocal := MakeRangeIDLocalKeyRange(d.RangeID, replicatedOnly)
-	rangeLocal := makeRangeLocalKeyRange(d)
-	rangeLockTable := makeRangeLockTableKeyRanges(d)
-	user := MakeUserKeyRange(d)
-	ranges := make([]KeyRange, 5)
+func makeRangeKeySpans(d *roachpb.RangeDescriptor, replicatedOnly bool) []roachpb.Span {
+	rangeIDLocal := MakeRangeIDLocalKeySpan(d.RangeID, replicatedOnly)
+	rangeLocal := makeRangeLocalKeySpan(d)
+	rangeLockTable := makeRangeLockTableKeySpans(d)
+	user := MakeUserKeySpan(d)
+	ranges := make([]roachpb.Span, 5)
 	ranges[0] = rangeIDLocal
 	ranges[1] = rangeLocal
 	if len(rangeLockTable) != 2 {
-		panic("unexpected number of lock table ranges")
+		panic("unexpected number of lock table key spans")
 	}
 	ranges[2] = rangeLockTable[0]
 	ranges[3] = rangeLockTable[1]
@@ -115,34 +109,34 @@ func makeRangeKeyRanges(d *roachpb.RangeDescriptor, replicatedOnly bool) []KeyRa
 	return ranges
 }
 
-// MakeReplicatedKeyRangesExceptLockTable returns all key ranges that are fully Raft
-// replicated for the given Range, except for the lock table ranges. These are
+// MakeReplicatedKeySpansExceptLockTable returns all key spans that are fully Raft
+// replicated for the given Range, except for the lock table spans. These are
 // returned in the following sorted order:
-// 1. Replicated range-id local key range
-// 2. Range-local key range
-// 3. User key range
-func MakeReplicatedKeyRangesExceptLockTable(d *roachpb.RangeDescriptor) []KeyRange {
-	return []KeyRange{
-		MakeRangeIDLocalKeyRange(d.RangeID, true /* replicatedOnly */),
-		makeRangeLocalKeyRange(d),
-		MakeUserKeyRange(d),
+// 1. Replicated range-id local key span.
+// 2. Range-local key span.
+// 3. User key span.
+func MakeReplicatedKeySpansExceptLockTable(d *roachpb.RangeDescriptor) []roachpb.Span {
+	return []roachpb.Span{
+		MakeRangeIDLocalKeySpan(d.RangeID, true /* replicatedOnly */),
+		makeRangeLocalKeySpan(d),
+		MakeUserKeySpan(d),
 	}
 }
 
-// MakeReplicatedKeyRangesExceptRangeID returns all key ranges that are fully Raft
-// replicated for the given Range, except for the replicated range-id local key range.
+// MakeReplicatedKeySpansExceptRangeID returns all key spans that are fully Raft
+// replicated for the given Range, except for the replicated range-id local key span.
 // These are returned in the following sorted order:
-// 1. Range-local key range
-// 2. Lock-table key ranges
-// 3. User key range
-func MakeReplicatedKeyRangesExceptRangeID(d *roachpb.RangeDescriptor) []KeyRange {
-	rangeLocal := makeRangeLocalKeyRange(d)
-	rangeLockTable := makeRangeLockTableKeyRanges(d)
-	user := MakeUserKeyRange(d)
-	ranges := make([]KeyRange, 4)
+// 1. Range-local key span.
+// 2. Lock-table key spans.
+// 3. User key span.
+func MakeReplicatedKeySpansExceptRangeID(d *roachpb.RangeDescriptor) []roachpb.Span {
+	rangeLocal := makeRangeLocalKeySpan(d)
+	rangeLockTable := makeRangeLockTableKeySpans(d)
+	user := MakeUserKeySpan(d)
+	ranges := make([]roachpb.Span, 4)
 	ranges[0] = rangeLocal
 	if len(rangeLockTable) != 2 {
-		panic("unexpected number of lock table ranges")
+		panic("unexpected number of lock table key spans")
 	}
 	ranges[1] = rangeLockTable[0]
 	ranges[2] = rangeLockTable[1]
@@ -150,10 +144,10 @@ func MakeReplicatedKeyRangesExceptRangeID(d *roachpb.RangeDescriptor) []KeyRange
 	return ranges
 }
 
-// MakeRangeIDLocalKeyRange returns the range-id local key range. If
+// MakeRangeIDLocalKeySpan returns the range-id local key span. If
 // replicatedOnly is true, then it returns only the replicated keys, otherwise,
 // it only returns both the replicated and unreplicated keys.
-func MakeRangeIDLocalKeyRange(rangeID roachpb.RangeID, replicatedOnly bool) KeyRange {
+func MakeRangeIDLocalKeySpan(rangeID roachpb.RangeID, replicatedOnly bool) roachpb.Span {
 	var prefixFn func(roachpb.RangeID) roachpb.Key
 	if replicatedOnly {
 		prefixFn = keys.MakeRangeIDReplicatedPrefix
@@ -161,25 +155,25 @@ func MakeRangeIDLocalKeyRange(rangeID roachpb.RangeID, replicatedOnly bool) KeyR
 		prefixFn = keys.MakeRangeIDPrefix
 	}
 	sysRangeIDKey := prefixFn(rangeID)
-	return KeyRange{
-		Start: sysRangeIDKey,
-		End:   sysRangeIDKey.PrefixEnd(),
+	return roachpb.Span{
+		Key:    sysRangeIDKey,
+		EndKey: sysRangeIDKey.PrefixEnd(),
 	}
 }
 
-// makeRangeLocalKeyRange returns the range local key range. Range-local keys
-// are replicated keys that do not belong to the range they would naturally
+// makeRangeLocalKeySpan returns the range local key span. Range-local keys
+// are replicated keys that do not belong to the span they would naturally
 // sort into. For example, /Local/Range/Table/1 would sort into [/Min,
 // /System), but it actually belongs to [/Table/1, /Table/2).
-func makeRangeLocalKeyRange(d *roachpb.RangeDescriptor) KeyRange {
-	return KeyRange{
-		Start: keys.MakeRangeKeyPrefix(d.StartKey),
-		End:   keys.MakeRangeKeyPrefix(d.EndKey),
+func makeRangeLocalKeySpan(d *roachpb.RangeDescriptor) roachpb.Span {
+	return roachpb.Span{
+		Key:    keys.MakeRangeKeyPrefix(d.StartKey),
+		EndKey: keys.MakeRangeKeyPrefix(d.EndKey),
 	}
 }
 
-// makeRangeLockTableKeyRanges returns the 2 lock table key ranges.
-func makeRangeLockTableKeyRanges(d *roachpb.RangeDescriptor) [2]KeyRange {
+// makeRangeLockTableKeySpans returns the 2 lock table key spans.
+func makeRangeLockTableKeySpans(d *roachpb.RangeDescriptor) [2]roachpb.Span {
 	// Handle doubly-local lock table keys since range descriptor key
 	// is a range local key that can have a replicated lock acquired on it.
 	startRangeLocal, _ := keys.LockTableSingleKey(keys.MakeRangeKeyPrefix(d.StartKey), nil)
@@ -194,37 +188,37 @@ func makeRangeLockTableKeyRanges(d *roachpb.RangeDescriptor) [2]KeyRange {
 	}
 	startGlobal, _ := keys.LockTableSingleKey(globalStartKey, nil)
 	endGlobal, _ := keys.LockTableSingleKey(roachpb.Key(d.EndKey), nil)
-	return [2]KeyRange{
+	return [2]roachpb.Span{
 		{
-			Start: startRangeLocal,
-			End:   endRangeLocal,
+			Key:    startRangeLocal,
+			EndKey: endRangeLocal,
 		},
 		{
-			Start: startGlobal,
-			End:   endGlobal,
+			Key:    startGlobal,
+			EndKey: endGlobal,
 		},
 	}
 }
 
-// MakeUserKeyRange returns the user key range.
-func MakeUserKeyRange(d *roachpb.RangeDescriptor) KeyRange {
+// MakeUserKeySpan returns the user key span.
+func MakeUserKeySpan(d *roachpb.RangeDescriptor) roachpb.Span {
 	userKeys := d.KeySpan()
-	return KeyRange{
-		Start: userKeys.Key.AsRawKey(),
-		End:   userKeys.EndKey.AsRawKey(),
+	return roachpb.Span{
+		Key:    userKeys.Key.AsRawKey(),
+		EndKey: userKeys.EndKey.AsRawKey(),
 	}
 }
 
 // NewReplicaMVCCDataIterator creates a ReplicaMVCCDataIterator for the given
-// replica. It iterates over the replicated key ranges excluding the lock
-// table key range. Separated locks are made to appear as interleaved. The
+// replica. It iterates over the replicated key spans excluding the lock
+// table key span. Separated locks are made to appear as interleaved. The
 // iterator can do one of reverse or forward iteration, based on whether
 // Reverse is true or false in ReplicaDataIteratorOptions, respectively.
 // With reverse iteration, it is initially positioned at the end of the last
 // range, else it is initially positioned at the start of the first range.
 //
 // The iterator requires the reader.ConsistentIterators is true, since it
-// creates a different iterator for each replicated key range. This is because
+// creates a different iterator for each replicated key span. This is because
 // MVCCIterator only allows changing the upper-bound of an existing iterator,
 // and not both upper and lower bound.
 //
@@ -239,10 +233,10 @@ func NewReplicaMVCCDataIterator(
 	ri := &ReplicaMVCCDataIterator{
 		ReplicaDataIteratorOptions: opts,
 		reader:                     reader,
-		ranges:                     MakeReplicatedKeyRangesExceptLockTable(d),
+		spans:                      MakeReplicatedKeySpansExceptLockTable(d),
 	}
 	if ri.Reverse {
-		ri.curIndex = len(ri.ranges) - 1
+		ri.curIndex = len(ri.spans) - 1
 	} else {
 		ri.curIndex = 0
 	}
@@ -256,20 +250,20 @@ func (ri *ReplicaMVCCDataIterator) tryCloseAndCreateIter() {
 			ri.it.Close()
 			ri.it = nil
 		}
-		if ri.curIndex < 0 || ri.curIndex >= len(ri.ranges) {
+		if ri.curIndex < 0 || ri.curIndex >= len(ri.spans) {
 			return
 		}
 		ri.it = ri.reader.NewMVCCIterator(
 			ri.IterKind,
 			storage.IterOptions{
-				LowerBound: ri.ranges[ri.curIndex].Start,
-				UpperBound: ri.ranges[ri.curIndex].End,
+				LowerBound: ri.spans[ri.curIndex].Key,
+				UpperBound: ri.spans[ri.curIndex].EndKey,
 				KeyTypes:   ri.KeyTypes,
 			})
 		if ri.Reverse {
-			ri.it.SeekLT(storage.MakeMVCCMetadataKey(ri.ranges[ri.curIndex].End))
+			ri.it.SeekLT(storage.MakeMVCCMetadataKey(ri.spans[ri.curIndex].EndKey))
 		} else {
-			ri.it.SeekGE(storage.MakeMVCCMetadataKey(ri.ranges[ri.curIndex].Start))
+			ri.it.SeekGE(storage.MakeMVCCMetadataKey(ri.spans[ri.curIndex].Key))
 		}
 		if valid, err := ri.it.Valid(); valid || err != nil {
 			ri.err = err
@@ -386,24 +380,24 @@ func NewReplicaEngineDataIterator(
 		panic("ReplicaEngineDataIterator requires consistent iterators")
 	}
 
-	var ranges []KeyRange
+	var ranges []roachpb.Span
 	if replicatedOnly {
-		ranges = MakeReplicatedKeyRanges(desc)
+		ranges = MakeReplicatedKeySpans(desc)
 	} else {
-		ranges = MakeAllKeyRanges(desc)
+		ranges = MakeAllKeySpans(desc)
 	}
 
 	return &ReplicaEngineDataIterator{
 		reader: reader,
-		ranges: ranges,
+		spans:  ranges,
 	}
 }
 
-// nextIter creates an iterator for the next non-empty key range/type and seeks
-// it, closing the existing iterator if any. Returns false if all key ranges and
+// nextIter creates an iterator for the next non-empty key span/type and seeks
+// it, closing the existing iterator if any. Returns false if all key spans and
 // key types have been exhausted.
 //
-// TODO(erikgrinaker): Rather than creating a new iterator for each key range,
+// TODO(erikgrinaker): Rather than creating a new iterator for each key span,
 // we could expose an API to reconfigure the iterator with new bounds. However,
 // the caller could also use e.g. a pebbleReadOnly which reuses the iterator
 // internally. This should be benchmarked.
@@ -414,7 +408,7 @@ func (ri *ReplicaEngineDataIterator) nextIter() (bool, error) {
 			ri.curKeyType = storage.IterKeyTypePointsOnly
 		} else if ri.curKeyType == storage.IterKeyTypePointsOnly {
 			ri.curKeyType = storage.IterKeyTypeRangesOnly
-		} else if ri.curIndex+1 < len(ri.ranges) {
+		} else if ri.curIndex+1 < len(ri.spans) {
 			ri.curIndex++
 			ri.curKeyType = storage.IterKeyTypePointsOnly
 		} else {
@@ -423,13 +417,13 @@ func (ri *ReplicaEngineDataIterator) nextIter() (bool, error) {
 		if ri.it != nil {
 			ri.it.Close()
 		}
-		keyRange := ri.ranges[ri.curIndex]
+		keySpan := ri.spans[ri.curIndex]
 		ri.it = ri.reader.NewEngineIterator(storage.IterOptions{
 			KeyTypes:   ri.curKeyType,
-			LowerBound: keyRange.Start,
-			UpperBound: keyRange.End,
+			LowerBound: keySpan.Key,
+			UpperBound: keySpan.EndKey,
 		})
-		if ok, err := ri.it.SeekEngineKeyGE(storage.EngineKey{Key: keyRange.Start}); ok || err != nil {
+		if ok, err := ri.it.SeekEngineKeyGE(storage.EngineKey{Key: keySpan.Key}); ok || err != nil {
 			return ok, err
 		}
 	}
@@ -443,7 +437,7 @@ func (ri *ReplicaEngineDataIterator) Close() {
 	}
 }
 
-// SeekStart seeks the iterator to the start of the key ranges.
+// SeekStart seeks the iterator to the start of the key spans.
 // It returns false if the iterator did not find any data.
 func (ri *ReplicaEngineDataIterator) SeekStart() (bool, error) {
 	if ri.it != nil {

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -203,49 +203,59 @@ func verifyRDReplicatedOnlyMVCCIter(
 	})
 }
 
-// verifyRDEngineIter verifies that the ReplicaEngineDataIterator returns the
+// verifyIterateReplicaKeySpans verifies that IterateReplicaKeySpans returns the
 // expected keys in the expected order. The expected keys can be either MVCCKey
 // or MVCCRangeKey.
-func verifyRDEngineIter(
+func verifyIterateReplicaKeySpans(
 	t *testing.T,
 	desc *roachpb.RangeDescriptor,
 	eng storage.Engine,
 	replicatedOnly bool,
 	expectedKeys []interface{},
 ) {
-	readWriter := eng.NewReadOnly(storage.StandardDurability)
+	readWriter := eng.NewSnapshot()
 	defer readWriter.Close()
-	iter := NewReplicaEngineDataIterator(desc, readWriter, replicatedOnly)
-	defer iter.Close()
 
 	actualKeys := []interface{}{}
-	var ok bool
-	var err error
-	for ok, err = iter.SeekStart(); ok && err == nil; ok, err = iter.Next() {
-		hasPoint, hasRange := iter.HasPointAndRange()
-		if hasPoint {
-			key, err := iter.UnsafeKey()
-			require.NoError(t, err)
-			require.True(t, key.IsMVCCKey())
-			mvccKey, err := key.ToMVCCKey()
-			require.NoError(t, err)
-			actualKeys = append(actualKeys, mvccKey.Clone())
-		}
-		if hasRange {
-			bounds, err := iter.RangeBounds()
-			require.NoError(t, err)
-			for _, rk := range iter.RangeKeys() {
-				ts, err := storage.DecodeMVCCTimestampSuffix(rk.Version)
+	require.NoError(t, IterateReplicaKeySpans(desc, readWriter, replicatedOnly,
+		func(iter storage.EngineIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+			var err error
+			for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
+				// Span should not be empty.
+				require.NotZero(t, span)
+
+				// Key should be in the given span.
+				key, err := iter.UnsafeEngineKey()
 				require.NoError(t, err)
-				actualKeys = append(actualKeys, storage.MVCCRangeKey{
-					StartKey:  bounds.Key.Clone(),
-					EndKey:    bounds.EndKey.Clone(),
-					Timestamp: ts,
-				})
+				require.True(t, key.IsMVCCKey())
+				require.True(t, span.ContainsKey(key.Key), "%s not in %s", key, span)
+
+				switch keyType {
+				case storage.IterKeyTypePointsOnly:
+					mvccKey, err := key.ToMVCCKey()
+					require.NoError(t, err)
+					actualKeys = append(actualKeys, mvccKey.Clone())
+
+				case storage.IterKeyTypeRangesOnly:
+					bounds, err := iter.EngineRangeBounds()
+					require.NoError(t, err)
+					require.True(t, span.Contains(bounds), "%s not contained in %s", bounds, span)
+					for _, rk := range iter.EngineRangeKeys() {
+						ts, err := storage.DecodeMVCCTimestampSuffix(rk.Version)
+						require.NoError(t, err)
+						actualKeys = append(actualKeys, storage.MVCCRangeKey{
+							StartKey:  bounds.Key.Clone(),
+							EndKey:    bounds.EndKey.Clone(),
+							Timestamp: ts,
+						})
+					}
+
+				default:
+					t.Fatalf("unexpected key type %v", keyType)
+				}
 			}
-		}
-	}
-	require.NoError(t, err)
+			return err
+		}))
 	require.Equal(t, expectedKeys, actualKeys)
 }
 
@@ -264,8 +274,8 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 	}
 
 	verifyRDReplicatedOnlyMVCCIter(t, desc, eng, []storage.MVCCKey{}, []storage.MVCCRangeKey{})
-	verifyRDEngineIter(t, desc, eng, false, []interface{}{})
-	verifyRDEngineIter(t, desc, eng, true, []interface{}{})
+	verifyIterateReplicaKeySpans(t, desc, eng, false, []interface{}{})
+	verifyIterateReplicaKeySpans(t, desc, eng, true, []interface{}{})
 }
 
 // TestReplicaDataIterator creates three ranges (a-b, b-c, c-d) and fills each
@@ -311,8 +321,8 @@ func TestReplicaDataIterator(t *testing.T) {
 		t.Run(tc.desc.RSpan().String(), func(t *testing.T) {
 
 			// Verify the replicated and unreplicated engine contents.
-			verifyRDEngineIter(t, &tc.desc, eng, false, tc.allKeys)
-			verifyRDEngineIter(t, &tc.desc, eng, true, tc.replicatedKeys)
+			verifyIterateReplicaKeySpans(t, &tc.desc, eng, false, tc.allKeys)
+			verifyIterateReplicaKeySpans(t, &tc.desc, eng, true, tc.replicatedKeys)
 
 			// Verify the replicated MVCC contents.
 			var pointKeys []storage.MVCCKey
@@ -379,11 +389,8 @@ func TestReplicaDataIteratorGlobalRangeKey(t *testing.T) {
 	}
 	for _, desc := range descs {
 		t.Run(desc.KeySpan().String(), func(t *testing.T) {
-			// An iterator should see range keys spanning all relevant key spans.
+			// Iterators should see range keys spanning all relevant key spans.
 			testutils.RunTrueAndFalse(t, "replicatedOnly", func(t *testing.T, replicatedOnly bool) {
-				rangeIter := NewReplicaEngineDataIterator(&desc, snapshot, replicatedOnly)
-				defer rangeIter.Close()
-
 				var expectedSpans []roachpb.Span
 				if replicatedOnly {
 					expectedSpans = MakeReplicatedKeySpans(&desc)
@@ -392,14 +399,24 @@ func TestReplicaDataIteratorGlobalRangeKey(t *testing.T) {
 				}
 
 				var actualSpans []roachpb.Span
-				var ok bool
-				var err error
-				for ok, err = rangeIter.SeekStart(); ok && err == nil; ok, err = rangeIter.Next() {
-					bounds, err := rangeIter.RangeBounds()
-					require.NoError(t, err)
-					actualSpans = append(actualSpans, bounds.Clone())
-				}
-				require.NoError(t, err)
+				require.NoError(t, IterateReplicaKeySpans(&desc, snapshot, replicatedOnly,
+					func(iter storage.EngineIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+						// We should never see any point keys.
+						require.Equal(t, storage.IterKeyTypeRangesOnly, keyType)
+
+						// The iterator should already be positioned on the range key, which should
+						// span the entire key span and be the only range key.
+						bounds, err := iter.EngineRangeBounds()
+						require.NoError(t, err)
+						require.Equal(t, span, bounds)
+						actualSpans = append(actualSpans, bounds.Clone())
+
+						ok, err := iter.NextEngineKey()
+						require.NoError(t, err)
+						require.False(t, ok)
+
+						return nil
+					}))
 				require.Equal(t, expectedSpans, actualSpans)
 			})
 		})
@@ -490,14 +507,15 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 
 	for i := 0; i < b.N; i++ {
 		for _, desc := range descs {
-			iter := NewReplicaEngineDataIterator(&desc, snapshot, false /* replicatedOnly */)
-			defer iter.Close()
-			var ok bool
-			var err error
-			for ok, err = iter.SeekStart(); ok && err == nil; ok, err = iter.Next() {
-				_, _ = iter.UnsafeKey()
-				_ = iter.UnsafeValue()
-			}
+			err := IterateReplicaKeySpans(&desc, snapshot, false, /* replicatedOnly */
+				func(iter storage.EngineIterator, _ roachpb.Span, _ storage.IterKeyType) error {
+					var err error
+					for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
+						_, _ = iter.UnsafeEngineKey()
+						_ = iter.UnsafeValue()
+					}
+					return err
+				})
 			if err != nil {
 				require.NoError(b, err)
 			}

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -706,14 +706,14 @@ func (*Replica) sha512(
 		// TODO(sumeer): When we have replicated locks other than exclusive locks,
 		// we will probably not have any interleaved intents so we could stop
 		// using MVCCKeyAndIntentsIterKind and consider all locks here.
-		for _, span := range rditer.MakeReplicatedKeyRangesExceptLockTable(&desc) {
+		for _, span := range rditer.MakeReplicatedKeySpansExceptLockTable(&desc) {
 			iter := snap.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 				KeyTypes:   storage.IterKeyTypePointsAndRanges,
-				LowerBound: span.Start,
-				UpperBound: span.End,
+				LowerBound: span.Key,
+				UpperBound: span.EndKey,
 			})
 			spanMS, err := storage.ComputeStatsForRangeWithVisitors(
-				iter, span.Start, span.End, 0 /* nowNanos */, pointKeyVisitor, rangeKeyVisitor)
+				iter, span.Key, span.EndKey, 0 /* nowNanos */, pointKeyVisitor, rangeKeyVisitor)
 			iter.Close()
 			if err != nil {
 				return nil, err

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -1711,44 +1712,42 @@ func getExpectedSnapshotSizeBytes(
 	}
 	defer snap.Close()
 
-	totalBytes := int64(0)
-	var b storage.Batch
-	defer func() {
-		b.Close()
-	}()
-	b = originStore.Engine().NewUnindexedBatch(true)
-	iter := snap.Iter
-	var ok bool
-	for ok, err = iter.SeekStart(); ok && err == nil; ok, err = iter.Next() {
-		hasPoint, hasRange := iter.HasPointAndRange()
-		if hasPoint {
-			var unsafeKey storage.EngineKey
-			if unsafeKey, err = iter.UnsafeKey(); err != nil {
-				return 0, err
-			}
-			if err := b.PutEngineKey(unsafeKey, iter.UnsafeValue()); err != nil {
-				return 0, err
-			}
-		}
-		if hasRange {
-			bounds, err := iter.RangeBounds()
-			if err != nil {
-				return 0, err
-			}
-			for _, rkv := range iter.RangeKeys() {
-				err := b.PutEngineRangeKey(bounds.Key, bounds.EndKey, rkv.Version, rkv.Value)
-				if err != nil {
-					return 0, err
+	b := originStore.Engine().NewUnindexedBatch(true)
+	defer b.Close()
+
+	err = rditer.IterateReplicaKeySpans(snap.State.Desc, snap.EngineSnap, true, /* replicatedOnly */
+		func(iter storage.EngineIterator, _ roachpb.Span, keyType storage.IterKeyType) error {
+			var err error
+			for ok := true; ok && err == nil; ok, err = iter.NextEngineKey() {
+				switch keyType {
+				case storage.IterKeyTypePointsOnly:
+					unsafeKey, err := iter.UnsafeEngineKey()
+					if err != nil {
+						return err
+					}
+					if err := b.PutEngineKey(unsafeKey, iter.UnsafeValue()); err != nil {
+						return err
+					}
+
+				case storage.IterKeyTypeRangesOnly:
+					bounds, err := iter.EngineRangeBounds()
+					if err != nil {
+						return err
+					}
+					for _, rkv := range iter.EngineRangeKeys() {
+						err := b.PutEngineRangeKey(bounds.Key, bounds.EndKey, rkv.Version, rkv.Value)
+						if err != nil {
+							return err
+						}
+					}
+
+				default:
+					return errors.Errorf("unexpected key type %v", keyType)
 				}
 			}
-		}
-	}
-	if err != nil {
-		return 0, err
-	}
-	totalBytes += int64(b.Len())
-
-	return totalBytes, nil
+			return err
+		})
+	return int64(b.Len()), err
 }
 
 // Tests the accuracy of the 'range.snapshots.rebalancing.rcvd-bytes' and

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -746,11 +746,11 @@ func clearRangeData(
 	rangeIDLocalOnly bool,
 	mustClearRange bool,
 ) error {
-	var keyRanges []rditer.KeyRange
+	var keySpans []roachpb.Span
 	if rangeIDLocalOnly {
-		keyRanges = []rditer.KeyRange{rditer.MakeRangeIDLocalKeyRange(desc.RangeID, false)}
+		keySpans = []roachpb.Span{rditer.MakeRangeIDLocalKeySpan(desc.RangeID, false)}
 	} else {
-		keyRanges = rditer.MakeAllKeyRanges(desc)
+		keySpans = rditer.MakeAllKeySpans(desc)
 	}
 	var clearRangeFn func(storage.Reader, storage.Writer, roachpb.Key, roachpb.Key) error
 	if mustClearRange {
@@ -761,8 +761,8 @@ func clearRangeData(
 		clearRangeFn = storage.ClearRangeWithHeuristic
 	}
 
-	for _, keyRange := range keyRanges {
-		if err := clearRangeFn(reader, writer, keyRange.Start, keyRange.End); err != nil {
+	for _, keySpan := range keySpans {
+		if err := clearRangeFn(reader, writer, keySpan.Key, keySpan.EndKey); err != nil {
 			return err
 		}
 	}
@@ -1092,11 +1092,11 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	subsumedRepls []*Replica,
 	subsumedNextReplicaID roachpb.ReplicaID,
 ) error {
-	// NB: we don't clear RangeID local key ranges here. That happens
+	// NB: we don't clear RangeID local key spans here. That happens
 	// via the call to preDestroyRaftMuLocked.
-	getKeyRanges := rditer.MakeReplicatedKeyRangesExceptRangeID
-	keyRanges := getKeyRanges(desc)
-	totalKeyRanges := append([]rditer.KeyRange(nil), keyRanges...)
+	getKeySpans := rditer.MakeReplicatedKeySpansExceptRangeID
+	keySpans := getKeySpans(desc)
+	totalKeySpans := append([]roachpb.Span(nil), keySpans...)
 	for _, sr := range subsumedRepls {
 		// We mark the replica as destroyed so that new commands are not
 		// accepted. This destroy status will be detected after the batch
@@ -1140,15 +1140,15 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 			}
 		}
 
-		srKeyRanges := getKeyRanges(sr.Desc())
+		srKeySpans := getKeySpans(sr.Desc())
 		// Compute the total key space covered by the current replica and all
 		// subsumed replicas.
-		for i := range srKeyRanges {
-			if srKeyRanges[i].Start.Compare(totalKeyRanges[i].Start) < 0 {
-				totalKeyRanges[i].Start = srKeyRanges[i].Start
+		for i := range srKeySpans {
+			if srKeySpans[i].Key.Compare(totalKeySpans[i].Key) < 0 {
+				totalKeySpans[i].Key = srKeySpans[i].Key
 			}
-			if srKeyRanges[i].End.Compare(totalKeyRanges[i].End) > 0 {
-				totalKeyRanges[i].End = srKeyRanges[i].End
+			if srKeySpans[i].EndKey.Compare(totalKeySpans[i].EndKey) > 0 {
+				totalKeySpans[i].EndKey = srKeySpans[i].EndKey
 			}
 		}
 	}
@@ -1166,8 +1166,8 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 	// Since the merge is the first operation to happen, a follower could be down
 	// before it completes. It is reasonable for a snapshot for r1 from S3 to
 	// subsume both r1 and r2 in S1.
-	for i := range keyRanges {
-		if totalKeyRanges[i].End.Compare(keyRanges[i].End) > 0 {
+	for i := range keySpans {
+		if totalKeySpans[i].EndKey.Compare(keySpans[i].EndKey) > 0 {
 			subsumedReplSSTFile := &storage.MemFile{}
 			subsumedReplSST := storage.MakeIngestionSSTWriter(
 				ctx, r.ClusterSettings(), subsumedReplSSTFile,
@@ -1176,8 +1176,8 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 			if err := storage.ClearRangeWithHeuristic(
 				r.store.Engine(),
 				&subsumedReplSST,
-				keyRanges[i].End,
-				totalKeyRanges[i].End,
+				keySpans[i].EndKey,
+				totalKeySpans[i].EndKey,
 			); err != nil {
 				subsumedReplSST.Close()
 				return err
@@ -1199,9 +1199,9 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 		// Extending to the left implies that either we merged "to the left" (we
 		// don't), or that we're applying a snapshot for another range (we don't do
 		// that either). Something is severely wrong for this to happen.
-		if totalKeyRanges[i].Start.Compare(keyRanges[i].Start) < 0 {
-			log.Fatalf(ctx, "subsuming replica to our left; key range: %v; total key range %v",
-				keyRanges[i], totalKeyRanges[i])
+		if totalKeySpans[i].Key.Compare(keySpans[i].Key) < 0 {
+			log.Fatalf(ctx, "subsuming replica to our left; key span: %v; total key span %v",
+				keySpans[i], totalKeySpans[i])
 		}
 	}
 	return nil

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -285,10 +285,10 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 		StartKey: roachpb.RKey("d"),
 		EndKey:   roachpb.RKeyMax,
 	}
-	keyRanges := rditer.MakeReplicatedKeyRanges(&desc)
+	keySpans := rditer.MakeReplicatedKeySpans(&desc)
 
 	msstw, err := newMultiSSTWriter(
-		ctx, cluster.MakeTestingClusterSettings(), scratch, keyRanges, 0,
+		ctx, cluster.MakeTestingClusterSettings(), scratch, keySpans, 0,
 	)
 	require.NoError(t, err)
 	_, err = msstw.Finish(ctx)
@@ -305,12 +305,12 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 	// Construct an SST file for each of the key ranges and write a rangedel
 	// tombstone that spans from Start to End.
 	var expectedSSTs [][]byte
-	for _, r := range keyRanges {
+	for _, s := range keySpans {
 		func() {
 			sstFile := &storage.MemFile{}
 			sst := storage.MakeIngestionSSTWriter(ctx, cluster.MakeTestingClusterSettings(), sstFile)
 			defer sst.Close()
-			err := sst.ClearRawRange(r.Start, r.End)
+			err := sst.ClearRawRange(s.Key, s.EndKey)
 			require.NoError(t, err)
 			err = sst.Finish()
 			require.NoError(t, err)

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -142,11 +142,11 @@ type kvBatchSnapshotStrategy struct {
 // multiSSTWriter is a wrapper around an SSTWriter and SSTSnapshotStorageScratch
 // that handles chunking SSTs and persisting them to disk.
 type multiSSTWriter struct {
-	st        *cluster.Settings
-	scratch   *SSTSnapshotStorageScratch
-	currSST   storage.SSTWriter
-	keyRanges []rditer.KeyRange
-	currRange int
+	st       *cluster.Settings
+	scratch  *SSTSnapshotStorageScratch
+	currSST  storage.SSTWriter
+	keySpans []roachpb.Span
+	currSpan int
 	// The approximate size of the SST chunk to buffer in memory on the receiver
 	// before flushing to disk.
 	sstChunkSize int64
@@ -158,13 +158,13 @@ func newMultiSSTWriter(
 	ctx context.Context,
 	st *cluster.Settings,
 	scratch *SSTSnapshotStorageScratch,
-	keyRanges []rditer.KeyRange,
+	keySpans []roachpb.Span,
 	sstChunkSize int64,
 ) (multiSSTWriter, error) {
 	msstw := multiSSTWriter{
 		st:           st,
 		scratch:      scratch,
-		keyRanges:    keyRanges,
+		keySpans:     keySpans,
 		sstChunkSize: sstChunkSize,
 	}
 	if err := msstw.initSST(ctx); err != nil {
@@ -181,7 +181,7 @@ func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
 	newSST := storage.MakeIngestionSSTWriter(ctx, msstw.st, newSSTFile)
 	msstw.currSST = newSST
 	if err := msstw.currSST.ClearRawRange(
-		msstw.keyRanges[msstw.currRange].Start, msstw.keyRanges[msstw.currRange].End); err != nil {
+		msstw.keySpans[msstw.currSpan].Key, msstw.keySpans[msstw.currSpan].EndKey); err != nil {
 		msstw.currSST.Close()
 		return errors.Wrap(err, "failed to clear range on sst file writer")
 	}
@@ -194,13 +194,13 @@ func (msstw *multiSSTWriter) finalizeSST(ctx context.Context) error {
 		return errors.Wrap(err, "failed to finish sst")
 	}
 	msstw.dataSize += msstw.currSST.DataSize
-	msstw.currRange++
+	msstw.currSpan++
 	msstw.currSST.Close()
 	return nil
 }
 
 func (msstw *multiSSTWriter) Put(ctx context.Context, key storage.EngineKey, value []byte) error {
-	for msstw.keyRanges[msstw.currRange].End.Compare(key.Key) <= 0 {
+	for msstw.keySpans[msstw.currSpan].EndKey.Compare(key.Key) <= 0 {
 		// Finish the current SST, write to the file, and move to the next key
 		// range.
 		if err := msstw.finalizeSST(ctx); err != nil {
@@ -210,8 +210,8 @@ func (msstw *multiSSTWriter) Put(ctx context.Context, key storage.EngineKey, val
 			return err
 		}
 	}
-	if msstw.keyRanges[msstw.currRange].Start.Compare(key.Key) > 0 {
-		return errors.AssertionFailedf("client error: expected %s to fall in one of %s", key.Key, msstw.keyRanges)
+	if msstw.keySpans[msstw.currSpan].Key.Compare(key.Key) > 0 {
+		return errors.AssertionFailedf("client error: expected %s to fall in one of %s", key.Key, msstw.keySpans)
 	}
 	if err := msstw.currSST.PutEngineKey(key, value); err != nil {
 		return errors.Wrap(err, "failed to put in sst")
@@ -225,7 +225,7 @@ func (msstw *multiSSTWriter) PutRangeKey(
 	if start.Compare(end) >= 0 {
 		return errors.AssertionFailedf("start key %s must be before end key %s", end, start)
 	}
-	for msstw.keyRanges[msstw.currRange].End.Compare(start) <= 0 {
+	for msstw.keySpans[msstw.currSpan].EndKey.Compare(start) <= 0 {
 		// Finish the current SST, write to the file, and move to the next key
 		// range.
 		if err := msstw.finalizeSST(ctx); err != nil {
@@ -235,10 +235,10 @@ func (msstw *multiSSTWriter) PutRangeKey(
 			return err
 		}
 	}
-	if msstw.keyRanges[msstw.currRange].Start.Compare(start) > 0 ||
-		msstw.keyRanges[msstw.currRange].End.Compare(end) < 0 {
+	if msstw.keySpans[msstw.currSpan].Key.Compare(start) > 0 ||
+		msstw.keySpans[msstw.currSpan].EndKey.Compare(end) < 0 {
 		return errors.AssertionFailedf("client error: expected %s to fall in one of %s",
-			roachpb.Span{Key: start, EndKey: end}, msstw.keyRanges)
+			roachpb.Span{Key: start, EndKey: end}, msstw.keySpans)
 	}
 	if err := msstw.currSST.PutEngineRangeKey(start, end, suffix, value); err != nil {
 		return errors.Wrap(err, "failed to put range key in sst")
@@ -247,12 +247,12 @@ func (msstw *multiSSTWriter) PutRangeKey(
 }
 
 func (msstw *multiSSTWriter) Finish(ctx context.Context) (int64, error) {
-	if msstw.currRange < len(msstw.keyRanges) {
+	if msstw.currSpan < len(msstw.keySpans) {
 		for {
 			if err := msstw.finalizeSST(ctx); err != nil {
 				return 0, err
 			}
-			if msstw.currRange >= len(msstw.keyRanges) {
+			if msstw.currSpan >= len(msstw.keySpans) {
 				break
 			}
 			if err := msstw.initSST(ctx); err != nil {
@@ -270,20 +270,20 @@ func (msstw *multiSSTWriter) Close() {
 // Receive implements the snapshotStrategy interface.
 //
 // NOTE: This function assumes that the point and range (e.g. MVCC range
-// tombstone) KV pairs are sent grouped by the following key ranges in order:
+// tombstone) KV pairs are sent grouped by the following key spans in order:
 //
-// 1. Replicated range-id local key range
-// 2. Range-local key range
-// 3. Two lock-table key ranges (optional)
-// 4. User key range
+// 1. Replicated range-id local key span.
+// 2. Range-local key span.
+// 3. Two lock-table key spans (optional).
+// 4. User key span.
 //
-// For each key range above, all point keys are sent first (in sorted order) and
+// For each key span above, all point keys are sent first (in sorted order) and
 // then all range keys (in sorted order), possibly mixed in the same batch.
-// However, we currently only expect to see range keys in the user key range.
+// However, we currently only expect to see range keys in the user key span.
 //
-// This allows building individual SSTs per key range containing all point/range
-// KVs for that key range, without the SSTs spanning across wide swaths of the
-// key space across to the next key range.
+// This allows building individual SSTs per key span containing all point/range
+// KVs for that key span, without the SSTs spanning across wide swaths of the
+// key space across to the next key span.
 func (kvSS *kvBatchSnapshotStrategy) Receive(
 	ctx context.Context,
 	stream incomingSnapshotStream,
@@ -294,7 +294,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 
 	// At the moment we'll write at most five SSTs.
 	// TODO(jeffreyxiao): Re-evaluate as the default range size grows.
-	keyRanges := rditer.MakeReplicatedKeyRanges(header.State.Desc)
+	keyRanges := rditer.MakeReplicatedKeySpans(header.State.Desc)
 	msstw, err := newMultiSSTWriter(ctx, kvSS.st, kvSS.scratch, keyRanges, kvSS.sstChunkSize)
 	if err != nil {
 		return noSnap, err
@@ -356,7 +356,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 		}
 		if req.Final {
 			// We finished receiving all batches and log entries. It's possible that
-			// we did not receive any key-value pairs for some of the key ranges, but
+			// we did not receive any key-value pairs for some of the key spans, but
 			// we must still construct SSTs with range deletion tombstones to remove
 			// the data.
 			dataSize, err := msstw.Finish(ctx)
@@ -432,8 +432,8 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 	var err error
 	for ok, err = iter.SeekStart(); ok && err == nil; ok, err = iter.Next() {
 		// NB: EngineReplicaDataIterator will never expose point/range keys
-		// together: it first iterates over all point keys in a key range, then over
-		// all range keys in a key range, then moves onto the next key range.
+		// together: it first iterates over all point keys in a key span, then over
+		// all range keys in a key span, then moves onto the next key span.
 		hasPoint, hasRange := iter.HasPointAndRange()
 
 		if hasPoint {
@@ -672,7 +672,7 @@ func (s *Store) canAcceptSnapshotLocked(
 		return nil, existingDestroyStatus.err
 	}
 
-	// We have a key range [desc.StartKey,desc.EndKey) which we want to apply a
+	// We have a key span [desc.StartKey,desc.EndKey) which we want to apply a
 	// snapshot for. Is there a conflicting existing placeholder or an
 	// overlapping range?
 	if err := s.checkSnapshotOverlapLocked(ctx, snapHeader); err != nil {


### PR DESCRIPTION
See #83747 for prior discussion.

---

**rditer: rename "key range" to "key span" and use `roachpb.Span`**

This patch renames the concept "key range" to "key span", and the
functions now return regular `roachpb.Span` instead of `rditer.KeyRange`.
"Range" is already an overloaded term (I have used "range keys in the
range's key ranges" in a sentence!), and "key span" is a more widely used
term in the code.

Release note: None
  
**rditer: replace `ReplicaDataEngineIterator` with `IterateReplicaKeySpans`**

This patch replaces `ReplicaDataEngineIterator` with
`IterateReplicaKeySpans()`.

The Raft snapshot protocol requires an unusual iteration order: for each
of the range's key spans, first send all point keys then send all range
keys. This allows ingesting SSTs that only span each key span (rather
than across wide swaths of the keyspace), with efficient, separate
iteration over point/range keys.

While the current `ReplicaDataEngineIterator` already does this, the
iteration order is rather peculiar, which can be unexpected to users.
`IterateReplicaKeySpans` attempts to make this iteration order more
explicit.

Other approaches were considered but rejected:

* Use an iterator generator, which returns the next iterator in the
  sequence. This was very unergonomic to use, since it required nested
  iteration loops (one over the iterators, and one per iterator) which
  make variable naming/reuse and iterator closing awkward.

* Use a visitor for each key instead of keyspan. This would again end up
  hiding the iteration sequence/structure. It also would make it
  impossible to skip across key spans, or do partial processing of a key
  span, since it could only abort the entire iteration.

Touches #82591.

Release note: None