### PR TITLE
roachtest: fix zipping of artifacts to include other zips

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1439,7 +1439,9 @@ func zipArtifacts(path string) error {
 			if err != nil {
 				return err
 			}
-			if !info.IsDir() && strings.HasSuffix(path, ".zip") {
+			dir, _ := filepath.Split(rel(path))
+			isTopLevel := dir == ""
+			if !info.IsDir() && isTopLevel && strings.HasSuffix(path, ".zip") {
 				// Skip any top-level zip files, which notably includes itself
 				// and, if present, the debug.zip.
 				return nil


### PR DESCRIPTION
When artifacts are zipped in preparation for being published to
TeamCity, other zip files are skipped. The idea is that we won't try
to recursively zip artifacts.zip itself, or debug.zip, which is
published separately. However, some tests (notably, `tpchvec`)
download their own zip files in the `logs` directory so that they'll
be available for analysis when a test fails.

While there was an intention to skip only top-level zip files (as
indicated by existing comments), the code itself would skip any zip
files found in the artifacts directory. This commit updates the zipping
logic to skip only toplevel zip files, allowing tests to write their
own zip files to the `logs` directory and have them available for
inspection later.

Release note: None.