### PR TITLE
ui: fix alignment on custom scale

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.tsx
@@ -270,6 +270,9 @@ export const getValidOption = (
   currentScale: TimeScale,
   options: TimeScaleOptions,
 ): TimeScale => {
+  if (currentScale.key === "Custom") {
+    return currentScale;
+  }
   if (!(currentScale.key in options)) {
     const firstValidKey = Object.keys(options)[0];
     return {


### PR DESCRIPTION
The check for valid options with the
removal of some options on #83229 didn't took
the custom values into consideration.
This commit add the option back, allowing the alignment
on custom values.

Release note (bug fix): Custom time period selection is now aligning
between Metrics and SQL Activity page.