### PR TITLE
opt: fix nil pointer exception in SplitGroupByScanIntoUnionScans rule

### DIFF
--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -544,7 +544,6 @@ func (c *CustomFuncs) splitScanIntoUnionScansOrSelects(
 	var noLimitSpans constraint.Spans
 	var last memo.RelExpr
 	queue := list.New()
-	queueLength := 0
 	for i, n := 0, spans.Count(); i < n; i++ {
 		if i >= budgetExceededIndex {
 			// The Scan budget has been reached; no additional Scans can be created.
@@ -577,11 +576,10 @@ func (c *CustomFuncs) splitScanIntoUnionScansOrSelects(
 				)
 			}
 			queue.PushBack(newScanOrSelect)
-			queueLength++
 		}
 	}
 	var outCols opt.ColList
-	oddNumScans := (queueLength % 2) != 0
+	oddNumScans := (queue.Len() % 2) != 0
 
 	// Make the UNION ALLs as a balanced tree. This performs better for large
 	// numbers of spans than a left-deep tree because neighboring branches can

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -578,6 +578,13 @@ func (c *CustomFuncs) splitScanIntoUnionScansOrSelects(
 			queue.PushBack(newScanOrSelect)
 		}
 	}
+
+	// Return early if the queue is empty. This is possible if the first
+	// splittable span splits into a number of keys greater than maxScanCount.
+	if queue.Len() == 0 {
+		return nil, false
+	}
+
 	var outCols opt.ColList
 	oddNumScans := (queue.Len() % 2) != 0
 

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2950,6 +2950,30 @@ group-by (hash)
       └── array-agg [as=array_agg:10, outer=(1)]
            └── r:1
 
+# Regression test for #83973. Do not attempt to split a scan when the first
+# splittable span splits into too many keys.
+exec-ddl
+CREATE TABLE t83973 (a INT PRIMARY KEY, b INT);
+----
+
+opt expect-not=SplitGroupByScanIntoUnionScans
+SELECT b FROM t83973
+WHERE (a NOT BETWEEN (1) AND (1 + 1) AND (a IS DISTINCT FROM -1000))
+GROUP BY b;
+----
+distinct-on
+ ├── columns: b:2
+ ├── grouping columns: b:2
+ ├── key: (2)
+ └── scan t83973
+      ├── columns: a:1!null b:2
+      ├── constraint: /1
+      │    ├── [ - /-1001]
+      │    ├── [/-999 - /0]
+      │    └── [/3 - ]
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
 # ------------------------------------------------------------------------
 # EliminateIndexJoinOrProjectInsideGroupBy
 # ------------------------------------------------------------------------


### PR DESCRIPTION
#### opt: remove unnecessary queueLength variable in splitScanIntoUnionScansOrSelects

Release note: None

#### opt: fix nil pointer exception in SplitGroupByScanIntoUnionScans rule

This commit fixes a nil pointer exception in the
`SplitGroupByScanIntoUnionScans` rule that occurs when the first
splittable span in a constraint has more individual keys than the
`maxScanCount` of 256.

Fixes #83973

Release note (bug fix): A bug has been fixed that could cause internal
errors in rare cases when running queries with `GROUP BY` clauses.
