### PR TITLE
sqlsmith: add trigrams and other missing cmpops

### DIFF
--- a/pkg/sql/catalog/catformat/BUILD.bazel
+++ b/pkg/sql/catalog/catformat/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/geo/geoindex",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -216,6 +217,12 @@ func FormatIndexElements(
 			f.FormatNameP(&index.KeyColumnNames[i])
 		}
 		f.WriteByte(' ')
+		if index.Type == descpb.IndexDescriptor_INVERTED && len(index.InvertedColumnKinds) > 0 {
+			switch index.InvertedColumnKinds[0] {
+			case catpb.InvertedIndexColumnKind_TRIGRAM:
+				f.WriteString("gin_trgm_ops ")
+			}
+		}
 		f.WriteString(index.KeyColumnDirections[i].String())
 	}
 	return nil

--- a/pkg/sql/randgen/expr.go
+++ b/pkg/sql/randgen/expr.go
@@ -85,6 +85,7 @@ func isAllowedPartialIndexColType(columnTableDef *tree.ColumnTableDef) bool {
 	}
 }
 
+// TODO(jordan): should we be including more comparison operators here?
 var cmpOps = []treecmp.ComparisonOperatorSymbol{treecmp.EQ, treecmp.NE, treecmp.LT, treecmp.LE, treecmp.GE, treecmp.GT}
 
 // randBoolColumnExpr returns a random boolean expression with the given column.

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -274,6 +274,20 @@ func TestShowCreateTable(t *testing.T) {
 	INDEX %[1]s_a_idx (a ASC) USING HASH WITH (bucket_count=8)
 )`,
 		},
+		// Check trigram inverted indexes.
+		{
+			CreateStatement: `CREATE TABLE %s (
+        id INT PRIMARY KEY,
+				a TEXT,
+				INVERTED INDEX (a gin_trgm_ops)
+			)`,
+			Expect: `CREATE TABLE public.%[1]s (
+	id INT8 NOT NULL,
+	a STRING NULL,
+	CONSTRAINT %[1]s_pkey PRIMARY KEY (id ASC),
+	INVERTED INDEX %[1]s_a_idx (a gin_trgm_ops ASC)
+)`,
+		},
 	}
 	sqltestutils.ShowCreateTableTest(t, "" /* extraQuerySetup */, testCases)
 }


### PR DESCRIPTION
Resolves #83933.

Previously, sqlsmith and randgen were missing some important expression
types:

1. Trigram inverted indexes. Now, they're generated sometimes when a
   string column is the last column in an index.
2. The string % string, inet << inet and inet >> inet "comparison"
   operators. These are listed under the binary operator list, so they
   weren't getting automatically included when picking a random
   comparison operator. This is now corrected.
3. Several less common cmp ops were missing, such as LIKE, ILIKE, @>,
   <@, ?, ?|, ?&, IN, SIMILAR TO, ~, ~*, &&, IS DISTINCT FROM. These are
   now included.

Release note: None