### PR TITLE
release-21.2: builtins: require admin to use crdb_internal.compact_engine_spans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -735,6 +735,10 @@ SELECT crdb_internal.compact_engine_span(1, 23, decode('c08989', 'hex'), decode(
 query error is not less than end
 SELECT crdb_internal.compact_engine_span(1, 1, decode('c0898a', 'hex'), decode('c08989', 'hex'))
 
+user testuser
+query error crdb_internal.compact_engine_span\(\): insufficient privilege
+SELECT crdb_internal.compact_engine_span(1, 1, decode('c08989', 'hex'), decode('c0898a', 'hex'))
+
 subtest builtin_is_admin
 
 user root

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5811,6 +5811,13 @@ value if you rely on the HLC for accuracy.`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+				if err != nil {
+					return nil, err
+				}
+				if !isAdmin {
+					return nil, errInsufficientPriv
+				}
 				nodeID := int32(tree.MustBeDInt(args[0]))
 				storeID := int32(tree.MustBeDInt(args[1]))
 				startKey := []byte(tree.MustBeDBytes(args[2]))


### PR DESCRIPTION
Backport 1/1 commits from #84036.

/cc @cockroachdb/release

Release justification: bug fix

---

Release note (sql change): crdb_internal.compact_engine_spans can
now only be run by admins.
