### PR TITLE
kv: avoid heap alloc of RangeAppliedState per Raft apply batch

### DIFF
--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -184,7 +184,7 @@ func (r *replicaTruncatorTest) writeRaftAppliedIndex(
 	t *testing.T, eng storage.Engine, raftAppliedIndex uint64, flush bool,
 ) {
 	require.NoError(t, r.stateLoader.SetRangeAppliedState(context.Background(), eng,
-		raftAppliedIndex, 0, 0, &enginepb.MVCCStats{}, nil))
+		raftAppliedIndex, 0, 0, &enginepb.MVCCStats{}, nil, nil))
 	// Flush to make it satisfy the contract of OnlyReadGuaranteedDurable in
 	// Pebble.
 	if flush {

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -435,6 +435,9 @@ type replicaAppBatch struct {
 	emptyEntries int
 	mutations    int
 	start        time.Time
+
+	// Reused by addAppliedStateKeyToBatch to avoid heap allocations.
+	asAlloc enginepb.RangeAppliedState
 }
 
 // Stage implements the apply.Batch interface. The method handles the first
@@ -1038,7 +1041,7 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 	loader := &b.r.raftMu.stateLoader
 	return loader.SetRangeAppliedState(
 		ctx, b.batch, b.state.RaftAppliedIndex, b.state.LeaseAppliedIndex, b.state.RaftAppliedIndexTerm,
-		b.state.Stats, &b.state.RaftClosedTimestamp,
+		b.state.Stats, &b.state.RaftClosedTimestamp, &b.asAlloc,
 	)
 }
 

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -732,7 +732,7 @@ func (*Replica) sha512(
 	result.PersistedMS = rangeAppliedState.RangeStats.ToStats()
 
 	if statsOnly {
-		b, err := protoutil.Marshal(&rangeAppliedState)
+		b, err := protoutil.Marshal(rangeAppliedState)
 		if err != nil {
 			return nil, err
 		}
@@ -743,7 +743,7 @@ func (*Replica) sha512(
 			}
 			kv.Key = keys.RangeAppliedStateKey(desc.RangeID)
 			var v roachpb.Value
-			if err := v.SetProto(&rangeAppliedState); err != nil {
+			if err := v.SetProto(rangeAppliedState); err != nil {
 				return nil, err
 			}
 			kv.Value = v.RawBytes


### PR DESCRIPTION
This commit hangs a `RangeAppliedState` struct off of `replicaAppBatch`
so that a Raft application batch can avoid a heap allocation during its
call to `addAppliedStateKeyToBatch`.

```
name                        old time/op    new time/op    delta
KV/Insert/Native/rows=1-10    46.3µs ± 7%    46.3µs ± 4%    ~     (p=0.553 n=19+18)
KV/Insert/SQL/rows=1-10        141µs ±18%     133µs ± 7%    ~     (p=0.075 n=19+18)

name                        old alloc/op   new alloc/op   delta
KV/Insert/Native/rows=1-10    15.6kB ± 2%    15.4kB ± 1%  -1.46%  (p=0.000 n=20+20)
KV/Insert/SQL/rows=1-10       43.0kB ± 0%    42.9kB ± 0%  -0.43%  (p=0.000 n=19+19)

name                        old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1-10       131 ± 0%       130 ± 0%  -0.76%  (p=0.000 n=19+20)
KV/Insert/SQL/rows=1-10          350 ± 0%       349 ± 0%  -0.29%  (p=0.000 n=16+19)
```