### PR TITLE
kv/batcheval: replace command hash-map with array

### DIFF
--- a/pkg/kv/kvserver/batcheval/command.go
+++ b/pkg/kv/kvserver/batcheval/command.go
@@ -69,7 +69,11 @@ type Command struct {
 	EvalRO func(context.Context, storage.Reader, CommandArgs, roachpb.Response) (result.Result, error)
 }
 
-var cmds = make(map[roachpb.Method]Command)
+func (c Command) isEmpty() bool {
+	return c.EvalRW == nil && c.EvalRO == nil
+}
+
+var cmds [roachpb.NumMethods]Command
 
 // RegisterReadWriteCommand makes a read-write command available for execution.
 // It must only be called before any evaluation takes place.
@@ -98,7 +102,7 @@ func RegisterReadOnlyCommand(
 }
 
 func register(method roachpb.Method, command Command) {
-	if _, ok := cmds[method]; ok {
+	if !cmds[method].isEmpty() {
 		log.Fatalf(context.TODO(), "cannot overwrite previously registered method %v", method)
 	}
 	cmds[method] = command
@@ -107,12 +111,15 @@ func register(method roachpb.Method, command Command) {
 // UnregisterCommand is provided for testing and allows removing a command.
 // It is a no-op if the command is not registered.
 func UnregisterCommand(method roachpb.Method) {
-	delete(cmds, method)
+	cmds[method] = Command{}
 }
 
 // LookupCommand returns the command for the given method, with the boolean
 // indicating success or failure.
 func LookupCommand(method roachpb.Method) (Command, bool) {
-	cmd, ok := cmds[method]
-	return cmd, ok
+	if int(method) >= len(cmds) {
+		return Command{}, false
+	}
+	cmd := cmds[method]
+	return cmd, !cmd.isEmpty()
 }

--- a/pkg/kv/kvserver/batcheval/declare_test.go
+++ b/pkg/kv/kvserver/batcheval/declare_test.go
@@ -31,7 +31,11 @@ func TestRequestsSerializeWithAllKeys(t *testing.T) {
 	var allLatchSpans spanset.SpanSet
 	declareAllKeys(&allLatchSpans)
 
-	for method, command := range cmds {
+	for i, command := range cmds {
+		if command.isEmpty() {
+			continue
+		}
+		method := roachpb.Method(i)
 		if method == roachpb.Probe {
 			// Probe is special since it's a no-op round-trip through the replication
 			// layer. It does not declare any keys.


### PR DESCRIPTION
The per-request hash-map lookup showed up in CPU profiles while running TPC-E:
```
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                                0.03s 60.00% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).collectSpans github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_send.go:1093 (inline)
                                                0.02s 40.00% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.evaluateCommand github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_evaluate.go:483 (inline)
            0     0%     0%      0.05s 0.029%                | github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval.LookupCommand github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/command.go:116
                                                0.02s 40.00% |   runtime.mapaccess2_fast64 GOROOT/src/runtime/map_fast64.go:57
                                                0.02s 40.00% |   runtime.mapaccess2_fast64 GOROOT/src/runtime/map_fast64.go:84
                                                0.01s 20.00% |   runtime.mapaccess2_fast64 GOROOT/src/runtime/map_fast64.go:69
----------------------------------------------------------+-------------
```

It's easy enough to get rid of by replacing the hash-map with an array, like we do in other parts of the code.