### PR TITLE
kv: use atomic bool to avoid read lock in Replica.IsInitialized

### DIFF
--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -114,7 +114,7 @@ func (r *Replica) canUnquiesceRLocked() bool {
 		// so it is important that they are cheap. Keeping them quiesced instead of
 		// letting them unquiesce and tick every 200ms indefinitely avoids a
 		// meaningful amount of periodic work for each uninitialized replica.
-		r.isInitializedRLocked() &&
+		r.IsInitialized() &&
 		// A replica's Raft group begins in a dormant state and is initialized
 		// lazily in response to any Raft traffic (see stepRaftGroup) or KV request
 		// traffic (see maybeInitializeRaftGroup). If it has yet to be initialized,

--- a/pkg/kv/kvserver/split_trigger_helper.go
+++ b/pkg/kv/kvserver/split_trigger_helper.go
@@ -28,7 +28,7 @@ type replicaMsgAppDropper Replica
 func (rd *replicaMsgAppDropper) Args() (initialized bool, age time.Duration) {
 	r := (*Replica)(rd)
 	r.mu.RLock()
-	initialized = r.isInitializedRLocked()
+	initialized = r.IsInitialized()
 	creationTime := r.creationTime
 	r.mu.RUnlock()
 	age = timeutil.Since(creationTime)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -411,7 +411,7 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 		rs.visited++
 		repl.mu.RLock()
 		destroyed := repl.mu.destroyStatus
-		initialized := repl.isInitializedRLocked()
+		initialized := repl.IsInitialized()
 		repl.mu.RUnlock()
 		if initialized && destroyed.IsAlive() && !visitor(repl) {
 			break

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -121,8 +121,8 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 		}
 
 		// This is a fatal error as an initialized replica can never become
-		/// uninitialized.
-		if !rep.isInitializedRLocked() {
+		// uninitialized.
+		if !rep.IsInitialized() {
 			rep.mu.Unlock()
 			rep.readOnlyCmdMu.Unlock()
 			log.Fatalf(ctx, "uninitialized replica cannot be removed with removeInitializedReplica: %v", rep)
@@ -250,7 +250,7 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 			log.Fatalf(ctx, "uninitialized replica unexpectedly already removed")
 		}
 
-		if rep.isInitializedRLocked() {
+		if rep.IsInitialized() {
 			rep.mu.Unlock()
 			rep.readOnlyCmdMu.Unlock()
 			log.Fatalf(ctx, "cannot remove initialized replica in removeUninitializedReplica: %v", rep)


### PR DESCRIPTION
According to a CPU profile acquired while running TPC-E, the read lock acquired in `Replica.IsInitialized` is the second most expensive read lock in terms of CPU cycles consumed. This doesn't mean that it's the most expensive in terms of blocking, but it still indicates that the lock is frequently acquired.

```
----------------------------------------------------------+-------------
                                             0.29s 43.28% |   github.com/cockroachdb/pebble/internal/cache.(*shard).Get github.com/cockroachdb/pebble/internal/cache/external/com_github_cockroachdb_pebble/internal/cache/clockpro.go:117 (inline)
                                             0.05s  7.46% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).IsInitialized github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_init.go:249 (inline)
...
     0.67s  0.39% 24.00%      0.67s  0.39%                | sync.(*RWMutex).RLock GOROOT/src/sync/rwmutex.go:61
----------------------------------------------------------+-------------
```

The two main callers of this method are `Store.Send` (on each request) and `Replica.handleRaftReadyRaftMuLocked` (on each raft ready iteration):

```
----------------------------------------------------------+-------------
                                             0.04s 80.00% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Store).Send github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/store_send.go:176
                                             0.01s 20.00% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).handleRaftReadyRaftMuLocked github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_raft.go:829
     0.04s 0.023% 0.023%      0.05s 0.029%                | github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).IsInitialized github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_init.go:251
                                             0.01s 20.00% |   sync.(*RWMutex).RUnlock GOROOT/src/sync/rwmutex.go:81
----------------------------------------------------------+-------------
```

This commit makes the method cheaper by replacing the lock with an atomic read. Once a replica is initialized, it stays initialized, so this state is well suited to be stored in an atomic value.

At a minimum, this offsets the new rlock acquired by https://github.com/cockroachdb/cockroach/pull/78980.