### PR TITLE
release-21.2: backport a doc fix

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -279,8 +279,6 @@ An event of type `set_cluster_setting` is recorded when a cluster setting is cha
 Events in this category are generated when a table has been
 marked as audited via `ALTER TABLE ... EXPERIMENTAL_AUDIT SET`.
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
-
 Note: These events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They
 are only emitted via external logging.

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -51,8 +51,6 @@ message CommonSQLExecDetails {
 // Events in this category are generated when a table has been
 // marked as audited via `ALTER TABLE ... EXPERIMENTAL_AUDIT SET`.
 //
-// {% include {{ page.version.version }}/misc/experimental-warning.md %}
-//
 // Note: These events are not written to `system.eventlog`, even
 // when the cluster setting `system.eventlog.enabled` is set. They
 // are only emitted via external logging.


### PR DESCRIPTION
Backporting 1/1 commit from #78255 

Informs #84024

cc @cockroachdb/release 

Release justification: doc-only change