### PR TITLE
sql: disallow NULL in PARTITION BY LIST values

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -109,7 +109,7 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p2 VALUES IN (1)
 )
 
-statement error \(NULL\) cannot be present in more than one partition
+statement error NULL cannot be used in PARTITION values
 CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1, NULL),
     PARTITION p2 VALUES IN (2, NULL)
@@ -920,7 +920,7 @@ CREATE TABLE IF NOT EXISTS ok12 (
 )
   PARTITION BY LIST (a)
     (
-      PARTITION pu VALUES IN (NULL),
+      PARTITION pu VALUES IN (0),
       PARTITION p1 VALUES IN (1),
       PARTITION p2 VALUES IN (2)
     )
@@ -934,7 +934,7 @@ ok12  CREATE TABLE public.ok12 (
       c INT8 NULL,
       CONSTRAINT ok12_pkey PRIMARY KEY (a ASC, b ASC)
 ) PARTITION BY LIST (a) (
-  PARTITION pu VALUES IN ((NULL)),
+  PARTITION pu VALUES IN ((0)),
   PARTITION p1 VALUES IN ((1)),
   PARTITION p2 VALUES IN ((2))
 )
@@ -955,7 +955,7 @@ TABLE ok12
       └── partitions
            ├── pu
            │    └── partition by list prefixes
-           │         └── (NULL)
+           │         └── (0)
            ├── p1
            │    └── partition by list prefixes
            │         └── (1)

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -5,7 +5,7 @@ CREATE TABLE ok1 (
     a INT PRIMARY KEY, b INT,
     INDEX (b) PARTITION BY LIST (b) (
         PARTITION p1 VALUES IN (1),
-        PARTITION pu VALUES IN (NULL)
+        PARTITION pu VALUES IN (2)
     ),
     FAMILY "primary" (a, b)
 )
@@ -19,7 +19,7 @@ ok1  CREATE TABLE public.ok1 (
      CONSTRAINT ok1_pkey PRIMARY KEY (a ASC),
      INDEX ok1_b_idx (b ASC) PARTITION BY LIST (b) (
        PARTITION p1 VALUES IN ((1)),
-       PARTITION pu VALUES IN ((NULL))
+       PARTITION pu VALUES IN ((2))
      )
 )
 -- Warning: Partitioned table with no zone configurations.
@@ -152,7 +152,7 @@ CREATE TABLE inverted (
     a INT PRIMARY KEY, b INT, j JSON,
     INVERTED INDEX (b, j) PARTITION BY LIST (b) (
         PARTITION p1 VALUES IN (1),
-        PARTITION pu VALUES IN (NULL)
+        PARTITION pu VALUES IN (2)
     ),
     FAMILY "primary" (a, b, j)
 )
@@ -172,7 +172,7 @@ inverted  CREATE TABLE public.inverted (
           CONSTRAINT inverted_pkey PRIMARY KEY (a ASC),
           INVERTED INDEX inverted_b_j_idx (b ASC, j ASC) PARTITION BY LIST (b) (
             PARTITION p1 VALUES IN ((1)),
-            PARTITION pu VALUES IN ((NULL))
+            PARTITION pu VALUES IN ((2))
           ),
           INVERTED INDEX inv_idx (b ASC, j ASC) PARTITION BY LIST (b) (
             PARTITION p1 VALUES IN ((1))
@@ -262,3 +262,16 @@ NULL  10    1
 20    NULL  1
 20    20    1
 25    NULL  1
+
+# Disallow NULL partition values. No rows can match those values becuase NULL is
+# not equal to NULL, and they can cause incorrect query results. See #82774.
+statement error NULL cannot be used in PARTITION values
+CREATE TABLE t (
+  s  STRING,
+  i  INT,
+  b  BOOL,
+  UNIQUE INDEX u (s, i, b) PARTITION BY LIST (s, i, b) (
+    PARTITION part1 VALUES IN (('b', NULL, true)),
+    PARTITION DEFAULT VALUES IN ((default, default, default))
+  )
+)

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -538,7 +538,7 @@ func randIndexTableDefFromCols(
 				t.Exprs = make([]tree.Expr, prefixLen)
 				for k := 0; k < prefixLen; k++ {
 					colType := tree.MustBeStaticallyKnownType(cols[k].Type)
-					t.Exprs[k] = RandDatum(rng, colType, cols[k].Nullable.Nullability != tree.NotNull)
+					t.Exprs[k] = RandDatum(rng, colType, false /* nullOk */)
 					// Variable expressions are not supported in partitions, and NaN and
 					// infinity are considered variable expressions, so if one is
 					// generated then regenerate the value.


### PR DESCRIPTION
#### randgen: stop generating NULL values in partition values lists

If a partition values list contains a `NULL` value, no row will ever
match the values because `NULL` does not equal `NULL`. So this type of
partition is useless. The optimizer does not correctly handle these
partitions and can produce incorrect query results. In a future commit,
we will prevent a user from creating this type of partition.

Fixes #82774
Fixes #83025

Release note: None

#### sql: disallow NULL in PARTITION BY LIST values

There is no practical use case for including `NULL` in
`PARTITION BY LIST` values. Becuase `NULL` is not equal to `NULL`, no
rows will ever match the partition value. Also, the optimizer cannot
correctly handle these types of partitions and can generate incorrect
query plans (see #82774).

This commit prevents users from creating `PARTITION BY LIST` partitions
with `NULL` values.

Release note (sql change): NULL is no longer allowed in PARTITION BY
LIST values. No rows would ever match such a partition because of NULL
equality semantics - NULL is not equal to NULL.
