### PR TITLE
release-21.2: util/mon: add monitor address to logging messages

### DIFF
--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -118,6 +118,9 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	// Makes sure no values are set when no environment variables are set.
 	cfg := MakeConfig(context.Background(), st)
 	cfgExpected := MakeConfig(context.Background(), st)
+	// Temp storage disk monitors will have slightly different names, so we
+	// override them to point to the same one.
+	cfgExpected.TempStorageConfig.Mon = cfg.TempStorageConfig.Mon
 
 	resetEnvVar()
 	cfg.readEnvironmentVariables()

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -198,6 +198,10 @@ type BytesMonitor struct {
 
 	// name identifies this monitor in logging messages.
 	name redact.RedactableString
+	// nameWithPointer contains name with the address of the monitor attached to
+	// it. This can be used in logging messages to uniquely identify all
+	// messages for a single monitor.
+	nameWithPointer redact.RedactableString
 
 	// resource specifies what kind of resource the monitor is tracking
 	// allocations for. Specific behavior is delegated to this resource (e.g.
@@ -301,6 +305,7 @@ func NewMonitorWithLimit(
 		poolAllocationSize:   increment,
 		settings:             settings,
 	}
+	m.nameWithPointer = redact.Sprintf("%s (%p)", name, redact.Safe(m))
 	m.mu.curBytesCount = curCount
 	m.mu.maxBytesHist = maxHist
 	return m
@@ -346,10 +351,10 @@ func (mm *BytesMonitor) Start(ctx context.Context, pool *BytesMonitor, reserved 
 	if log.V(2) {
 		poolname := redact.RedactableString("(none)")
 		if pool != nil {
-			poolname = pool.name
+			poolname = pool.nameWithPointer
 		}
 		log.InfofDepth(ctx, 1, "%s: starting monitor, reserved %s, pool %s",
-			mm.name,
+			mm.nameWithPointer,
 			humanizeutil.IBytes(mm.reserved.used),
 			poolname)
 	}
@@ -379,6 +384,7 @@ func NewUnlimitedMonitor(
 		reserved:             MakeStandaloneBudget(math.MaxInt64),
 		settings:             settings,
 	}
+	m.nameWithPointer = redact.Sprintf("%s (%p)", name, redact.Safe(m))
 	m.mu.curBytesCount = curCount
 	m.mu.maxBytesHist = maxHist
 	return m
@@ -407,7 +413,7 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 	// monitor is not shared any more.
 	if log.V(1) && mm.mu.maxAllocated >= bytesMaxUsageLoggingThreshold {
 		log.InfofDepth(ctx, 1, "%s, bytes usage max %s",
-			mm.name,
+			mm.nameWithPointer,
 			humanizeutil.IBytes(mm.mu.maxAllocated))
 	}
 
@@ -686,7 +692,7 @@ func (mm *BytesMonitor) reserveBytes(ctx context.Context, x int64) error {
 			// many small allocations.
 			if bits.Len64(uint64(mm.mu.curAllocated)) != bits.Len64(uint64(mm.mu.curAllocated-x)) {
 				log.Infof(ctx, "%s: bytes usage increases to %s (+%d)",
-					mm.name,
+					mm.nameWithPointer,
 					humanizeutil.IBytes(mm.mu.curAllocated), x)
 			}
 		}
@@ -696,7 +702,7 @@ func (mm *BytesMonitor) reserveBytes(ctx context.Context, x int64) error {
 		// We avoid VEventf here because we want to avoid computing the
 		// trace string if there is nothing to log.
 		log.Infof(ctx, "%s: now at %d bytes (+%d) - %s",
-			mm.name, mm.mu.curAllocated, x, util.GetSmallTrace(3))
+			mm.nameWithPointer, mm.mu.curAllocated, x, util.GetSmallTrace(3))
 	}
 	return nil
 }
@@ -722,7 +728,7 @@ func (mm *BytesMonitor) releaseBytes(ctx context.Context, sz int64) {
 		// We avoid VEventf here because we want to avoid computing the
 		// trace string if there is nothing to log.
 		log.Infof(ctx, "%s: now at %d bytes (-%d) - %s",
-			mm.name, mm.mu.curAllocated, sz, util.GetSmallTrace(5))
+			mm.nameWithPointer, mm.mu.curAllocated, sz, util.GetSmallTrace(5))
 	}
 }
 
@@ -738,7 +744,7 @@ func (mm *BytesMonitor) increaseBudget(ctx context.Context, minExtra int64) erro
 		)
 	}
 	if log.V(2) {
-		log.Infof(ctx, "%s: requesting %d bytes from the pool", mm.name, minExtra)
+		log.Infof(ctx, "%s: requesting %d bytes from the pool", mm.nameWithPointer, minExtra)
 	}
 
 	return mm.mu.curBudget.Grow(ctx, minExtra)
@@ -762,7 +768,7 @@ func (mm *BytesMonitor) roundSize(sz int64) int64 {
 func (mm *BytesMonitor) releaseBudget(ctx context.Context) {
 	// NB: mm.mu need not be locked here, as this is only called from StopMonitor().
 	if log.V(2) {
-		log.Infof(ctx, "%s: releasing %d bytes to the pool", mm.name, mm.mu.curBudget.allocated())
+		log.Infof(ctx, "%s: releasing %d bytes to the pool", mm.nameWithPointer, mm.mu.curBudget.allocated())
 	}
 	mm.mu.curBudget.Clear(ctx)
 }

--- a/pkg/util/smalltrace.go
+++ b/pkg/util/smalltrace.go
@@ -42,7 +42,7 @@ func GetSmallTrace(skip int) redact.RedactableString {
 		if index := strings.LastIndexByte(file, '/'); index >= 0 {
 			file = file[index+1:]
 		}
-		callers.Printf("%s%s:%d:%s", callerPrefix, file, f.Line, function)
+		callers.Printf("%s%s:%d:%s", callerPrefix, redact.SafeString(file), f.Line, redact.SafeString(function))
 		callerPrefix = ","
 		if !more {
 			break

--- a/pkg/util/smalltrace_test.go
+++ b/pkg/util/smalltrace_test.go
@@ -23,7 +23,7 @@ import (
 
 func testSmallTrace2(t *testing.T) {
 	s := GetSmallTrace(2)
-	if !strings.Contains(string(s), "‹smalltrace_test.go›:‹1002›:‹util.testSmallTrace2›,‹smalltrace_test.go›:‹1009›:‹util.testSmallTrace›,‹smalltrace_test.go›:‹1013›:‹util.TestGenerateSmallTrace›") {
+	if !strings.Contains(string(s), "smalltrace_test.go:‹1002›:util.testSmallTrace2,smalltrace_test.go:‹1009›:util.testSmallTrace,smalltrace_test.go:‹1013›:util.TestGenerateSmallTrace") {
 		t.Fatalf("trace not generated properly: %q", s)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #79682.

/cc @cockroachdb/release

---

This will allow us to uniquely identify all messages coming from
a single monitor. Additionally, this commit fixes the redactability of
the file name and function name when getting a stack trace.

Release note: None

Release justification: low-risk debugging improvement.