### PR TITLE
importccl: enable importing MySQL BIT columns

### DIFF
--- a/pkg/sql/importer/read_import_mysql.go
+++ b/pkg/sql/importer/read_import_mysql.go
@@ -747,11 +747,14 @@ func mysqlColToCockroach(
 	case mysqltypes.Geometry:
 		return nil, unimplemented.NewWithIssue(32559, "cannot import GEOMETRY columns at this time")
 	case mysqltypes.Bit:
-		if length > 64 {
+		switch {
+		case length == 1:
+			def.Type = types.Bool
+		case length <= 64:
+			def.Type = types.Int
+		default:
 			return nil, errors.Errorf("BIT of length %d is not supported", length)
 		}
-		
-		def.Type = types.Int
 	default:
 		return nil, unimplemented.Newf(fmt.Sprintf("import.mysqlcoltype.%s", typ),
 			"unsupported mysql type %q", col.Type)

--- a/pkg/sql/importer/read_import_mysql.go
+++ b/pkg/sql/importer/read_import_mysql.go
@@ -747,9 +747,11 @@ func mysqlColToCockroach(
 	case mysqltypes.Geometry:
 		return nil, unimplemented.NewWithIssue(32559, "cannot import GEOMETRY columns at this time")
 	case mysqltypes.Bit:
-		return nil, errors.WithHint(
-			unimplemented.NewWithIssue(32561, "cannot import BIT columns at this time"),
-			"try converting the column to a 64-bit integer before import")
+		if length > 64 {
+			return nil, errors.Errorf("BIT of length %d is not supported", length)
+		}
+		
+		def.Type = types.Int
 	default:
 		return nil, unimplemented.Newf(fmt.Sprintf("import.mysqlcoltype.%s", typ),
 			"unsupported mysql type %q", col.Type)

--- a/pkg/sql/importer/testdata/mysqldump/everything.cockroach-schema.sql
+++ b/pkg/sql/importer/testdata/mysqldump/everything.cockroach-schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE everything (
   f75   FLOAT4,
   j     JSON,
   bit0  INT8,
+  bit1  BOOL,
   bit32 INT8,
   CONSTRAINT imported_from_enum_e CHECK (e IN ('Small':::STRING, 'Medium':::STRING, 'Large':::STRING))
 )

--- a/pkg/sql/importer/testdata/mysqldump/everything.cockroach-schema.sql
+++ b/pkg/sql/importer/testdata/mysqldump/everything.cockroach-schema.sql
@@ -37,5 +37,7 @@ CREATE TABLE everything (
   f47   DOUBLE PRECISION,
   f75   FLOAT4,
   j     JSON,
+  bit0  INT8,
+  bit32 INT8,
   CONSTRAINT imported_from_enum_e CHECK (e IN ('Small':::STRING, 'Medium':::STRING, 'Large':::STRING))
 )

--- a/pkg/sql/importer/testdata/mysqldump/everything.sql
+++ b/pkg/sql/importer/testdata/mysqldump/everything.sql
@@ -52,6 +52,8 @@ CREATE TABLE `everything` (
   `f47` double DEFAULT NULL,
   `f75` float(7,5) DEFAULT NULL,
   `j` json DEFAULT NULL,
+  `bit0` bit DEFAULT NULL,
+  `bit32` bit(32) DEFAULT NULL,
   PRIMARY KEY (`i`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -62,7 +64,7 @@ CREATE TABLE `everything` (
 
 LOCK TABLES `everything` WRITE;
 /*!40000 ALTER TABLE `everything` DISABLE KEYS */;
-INSERT INTO `everything` VALUES (1,'c','this is s\'s default value',NULL,'Small',_binary 'bin\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',NULL,NULL,'2000-01-01 00:00:00',NULL,'2018-11-19 20:27:42',NULL,NULL,NULL,-12.345,-2,0000000001,5,NULL,NULL,NULL,-1.5,NULL,NULL,NULL,NULL,NULL,'{\"a\": \"b\", \"c\": {\"d\": [\"e\", 11, null]}}'),(2,'c2','this is s\'s default value',NULL,'Large',_binary 'bin2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',NULL,NULL,'2000-01-01 00:00:00',NULL,'2018-11-19 20:27:42',NULL,NULL,NULL,12.345,3,3525343334,5,NULL,NULL,NULL,1.2,NULL,NULL,NULL,NULL,NULL,'{}');
+INSERT INTO `everything` VALUES (1,'c','this is s\'s default value',NULL,'Small',_binary 'bin\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',NULL,NULL,'2000-01-01 00:00:00',NULL,'2018-11-19 20:27:42',NULL,NULL,NULL,-12.345,-2,0000000001,5,NULL,NULL,NULL,-1.5,NULL,NULL,NULL,NULL,NULL,'{\"a\": \"b\", \"c\": {\"d\": [\"e\", 11, null]}}'),(2,'c2','this is s\'s default value',NULL,'Large',_binary 'bin2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',NULL,NULL,'2000-01-01 00:00:00',NULL,'2018-11-19 20:27:42',NULL,NULL,NULL,12.345,3,3525343334,5,NULL,NULL,NULL,1.2,NULL,NULL,NULL,NULL,NULL,'{}',_binary '\1\0\0\0\0\0\0',NULL);
 /*!40000 ALTER TABLE `everything` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/pkg/sql/importer/testdata/mysqldump/everything.sql
+++ b/pkg/sql/importer/testdata/mysqldump/everything.sql
@@ -53,6 +53,7 @@ CREATE TABLE `everything` (
   `f75` float(7,5) DEFAULT NULL,
   `j` json DEFAULT NULL,
   `bit0` bit DEFAULT NULL,
+  `bit1` bit(1) DEFAULT NULL,
   `bit32` bit(32) DEFAULT NULL,
   PRIMARY KEY (`i`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -64,7 +65,7 @@ CREATE TABLE `everything` (
 
 LOCK TABLES `everything` WRITE;
 /*!40000 ALTER TABLE `everything` DISABLE KEYS */;
-INSERT INTO `everything` VALUES (1,'c','this is s\'s default value',NULL,'Small',_binary 'bin\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',NULL,NULL,'2000-01-01 00:00:00',NULL,'2018-11-19 20:27:42',NULL,NULL,NULL,-12.345,-2,0000000001,5,NULL,NULL,NULL,-1.5,NULL,NULL,NULL,NULL,NULL,'{\"a\": \"b\", \"c\": {\"d\": [\"e\", 11, null]}}'),(2,'c2','this is s\'s default value',NULL,'Large',_binary 'bin2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',NULL,NULL,'2000-01-01 00:00:00',NULL,'2018-11-19 20:27:42',NULL,NULL,NULL,12.345,3,3525343334,5,NULL,NULL,NULL,1.2,NULL,NULL,NULL,NULL,NULL,'{}',_binary '\1\0\0\0\0\0\0',NULL);
+INSERT INTO `everything` VALUES (1,'c','this is s\'s default value',NULL,'Small',_binary 'bin\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',NULL,NULL,'2000-01-01 00:00:00',NULL,'2018-11-19 20:27:42',NULL,NULL,NULL,-12.345,-2,0000000001,5,NULL,NULL,NULL,-1.5,NULL,NULL,NULL,NULL,NULL,'{\"a\": \"b\", \"c\": {\"d\": [\"e\", 11, null]}}'),(2,'c2','this is s\'s default value',NULL,'Large',_binary 'bin2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',NULL,NULL,'2000-01-01 00:00:00',NULL,'2018-11-19 20:27:42',NULL,NULL,NULL,12.345,3,3525343334,5,NULL,NULL,NULL,1.2,NULL,NULL,NULL,NULL,NULL,'{}',_binary '\1\0\0\0\0\0\0',_binary '\0',NULL);
 /*!40000 ALTER TABLE `everything` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;


### PR DESCRIPTION
Referring to https://github.com/cockroachdb/cockroach/issues/32561, when importing MySQL BIT colums, this type is no longer being rejected and is instead being read as a 64-bit integer.

With a simple test, I noticed that CockroachDB integers can consume 2 bytes on small numbers. However, this is more than needed to represent BIT(1). So, in addition to the initial discussions of the above issue, I have added a special case to represent BIT(1) as a Bool to consume 1 byte.