### PR TITLE
colexec: fixed nullableArgs projection operators 

### DIFF
--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -72,10 +72,6 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -111,11 +107,6 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -141,11 +132,6 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -168,10 +154,6 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -207,11 +189,6 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -237,11 +214,6 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -264,10 +236,6 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -303,11 +271,6 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -333,11 +296,6 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -360,10 +318,6 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -399,11 +353,6 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -429,11 +378,6 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -456,10 +400,6 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -495,11 +435,6 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -525,11 +460,6 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -552,10 +482,6 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -591,11 +517,6 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -621,11 +542,6 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -648,10 +564,6 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -687,11 +599,6 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -717,11 +624,6 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -744,10 +646,6 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -783,11 +681,6 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -813,11 +706,6 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -840,10 +728,6 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -879,11 +763,6 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -909,11 +788,6 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -938,10 +812,6 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -989,11 +859,6 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1031,11 +896,6 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1058,10 +918,6 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1097,11 +953,6 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1127,11 +978,6 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1154,10 +1000,6 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1193,11 +1035,6 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1223,11 +1060,6 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1250,10 +1082,6 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1289,11 +1117,6 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1319,11 +1142,6 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1346,10 +1164,6 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1385,11 +1199,6 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1415,11 +1224,6 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1442,10 +1246,6 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1481,11 +1281,6 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1511,11 +1306,6 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1538,10 +1328,6 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1577,11 +1363,6 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1607,11 +1388,6 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1634,10 +1410,6 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1673,11 +1445,6 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1703,11 +1470,6 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1730,10 +1492,6 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1769,11 +1527,6 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1799,11 +1552,6 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1826,10 +1574,6 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1865,11 +1609,6 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1895,11 +1634,6 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1924,10 +1658,6 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1975,11 +1705,6 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2017,11 +1742,6 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2044,10 +1764,6 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2083,11 +1799,6 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2113,11 +1824,6 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2140,10 +1846,6 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2179,11 +1881,6 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2209,11 +1906,6 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2236,10 +1928,6 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2275,11 +1963,6 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2305,11 +1988,6 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2332,10 +2010,6 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2371,11 +2045,6 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2401,11 +2070,6 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2428,10 +2092,6 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2467,11 +2127,6 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2497,11 +2152,6 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2524,10 +2174,6 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2563,11 +2209,6 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2593,11 +2234,6 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2620,10 +2256,6 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2659,11 +2291,6 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2689,11 +2316,6 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2716,10 +2338,6 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2755,11 +2373,6 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2785,11 +2398,6 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2812,10 +2420,6 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2851,11 +2455,6 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2881,11 +2480,6 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2910,10 +2504,6 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2961,11 +2551,6 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3003,11 +2588,6 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3030,10 +2610,6 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3083,11 +2659,6 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3127,11 +2698,6 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3154,10 +2720,6 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3207,11 +2769,6 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3251,11 +2808,6 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3278,10 +2830,6 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3331,11 +2879,6 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3375,11 +2918,6 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3402,10 +2940,6 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3453,11 +2987,6 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3495,11 +3024,6 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3522,10 +3046,6 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3573,11 +3093,6 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3615,11 +3130,6 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3642,10 +3152,6 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3693,11 +3199,6 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3735,11 +3236,6 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3762,10 +3258,6 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3813,11 +3305,6 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3855,11 +3342,6 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3882,10 +3364,6 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3937,11 +3415,6 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3983,11 +3456,6 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4012,10 +3480,6 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4072,11 +3536,6 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4123,11 +3582,6 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4150,10 +3604,6 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4201,11 +3651,6 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4243,11 +3688,6 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4270,10 +3710,6 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4321,11 +3757,6 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4363,11 +3794,6 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4390,10 +3816,6 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4441,11 +3863,6 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4483,11 +3900,6 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4510,10 +3922,6 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4565,11 +3973,6 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4611,11 +4014,6 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4640,10 +4038,6 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4700,11 +4094,6 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4751,11 +4140,6 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4778,10 +4162,6 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4829,11 +4209,6 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4871,11 +4246,6 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4898,10 +4268,6 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4949,11 +4315,6 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4991,11 +4352,6 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5018,10 +4374,6 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5069,11 +4421,6 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5111,11 +4458,6 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5138,10 +4480,6 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5193,11 +4531,6 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5239,11 +4572,6 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5268,10 +4596,6 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5328,11 +4652,6 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5379,11 +4698,6 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5406,10 +4720,6 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5451,11 +4761,6 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5487,11 +4792,6 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5514,10 +4814,6 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5559,11 +4855,6 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5595,11 +4886,6 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5622,10 +4908,6 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5667,11 +4949,6 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5703,11 +4980,6 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5730,10 +5002,6 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5765,11 +5033,6 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5791,11 +5054,6 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg1.Add(arg2)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5820,10 +5078,6 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5880,11 +5134,6 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5931,11 +5180,6 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5960,10 +5204,6 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6020,11 +5260,6 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6071,11 +5306,6 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6100,10 +5330,6 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6160,11 +5386,6 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6211,11 +5432,6 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6240,10 +5456,6 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6300,11 +5512,6 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6351,11 +5558,6 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6380,10 +5582,6 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6440,11 +5638,6 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6491,11 +5684,6 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6518,10 +5706,6 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6571,11 +5755,6 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6615,11 +5794,6 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6642,10 +5816,6 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6695,11 +5865,6 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6739,11 +5904,6 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6766,10 +5926,6 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6819,11 +5975,6 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6863,11 +6014,6 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6890,10 +6036,6 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6941,11 +6083,6 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6983,11 +6120,6 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7010,10 +6142,6 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7061,11 +6189,6 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7103,11 +6226,6 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7130,10 +6248,6 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7181,11 +6295,6 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7223,11 +6332,6 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7250,10 +6354,6 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7301,11 +6401,6 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7343,11 +6438,6 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7370,10 +6460,6 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7425,11 +6511,6 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7471,11 +6552,6 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7500,10 +6576,6 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7560,11 +6632,6 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7611,11 +6678,6 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7638,10 +6700,6 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7689,11 +6747,6 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7731,11 +6784,6 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7758,10 +6806,6 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7809,11 +6853,6 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7851,11 +6890,6 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7878,10 +6912,6 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7929,11 +6959,6 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7971,11 +6996,6 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7998,10 +7018,6 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8053,11 +7069,6 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8099,11 +7110,6 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8128,10 +7134,6 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8188,11 +7190,6 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8239,11 +7236,6 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8266,10 +7258,6 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8317,11 +7305,6 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8359,11 +7342,6 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8386,10 +7364,6 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8437,11 +7411,6 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8479,11 +7448,6 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8506,10 +7470,6 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8557,11 +7517,6 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8599,11 +7554,6 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8626,10 +7576,6 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8681,11 +7627,6 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8727,11 +7668,6 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8756,10 +7692,6 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8816,11 +7748,6 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8867,11 +7794,6 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8894,10 +7816,6 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8939,11 +7857,6 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8975,11 +7888,6 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9002,10 +7910,6 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9043,11 +7947,6 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9075,11 +7974,6 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9102,10 +7996,6 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9147,11 +8037,6 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9183,11 +8068,6 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9210,10 +8090,6 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9245,11 +8121,6 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9271,11 +8142,6 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg1.Sub(arg2)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9300,10 +8166,6 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9360,11 +8222,6 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9411,11 +8268,6 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9438,10 +8290,6 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9489,11 +8337,6 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9531,11 +8374,6 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9558,10 +8396,6 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9602,11 +8436,6 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9637,11 +8466,6 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9664,10 +8488,6 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9708,11 +8528,6 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9743,11 +8558,6 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9770,10 +8580,6 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9814,11 +8620,6 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9849,11 +8650,6 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9878,10 +8674,6 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9929,11 +8721,6 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9971,11 +8758,6 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10000,10 +8782,6 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10060,11 +8838,6 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10111,11 +8884,6 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10140,10 +8908,6 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10199,11 +8963,6 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10249,11 +9008,6 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10278,10 +9032,6 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10338,11 +9088,6 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10389,11 +9134,6 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10418,10 +9158,6 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10478,11 +9214,6 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10529,11 +9260,6 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10558,10 +9284,6 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10618,11 +9340,6 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10669,11 +9386,6 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10696,10 +9408,6 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10749,11 +9457,6 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10793,11 +9496,6 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10820,10 +9518,6 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10873,11 +9567,6 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10917,11 +9606,6 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10944,10 +9628,6 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10997,11 +9677,6 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11041,11 +9716,6 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11068,10 +9738,6 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11119,11 +9785,6 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11161,11 +9822,6 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11188,10 +9844,6 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11233,11 +9885,6 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11269,11 +9916,6 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11296,10 +9938,6 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11363,11 +10001,6 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11421,11 +10054,6 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11448,10 +10076,6 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11515,11 +10139,6 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11573,11 +10192,6 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11600,10 +10214,6 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11667,11 +10277,6 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11725,11 +10330,6 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11752,10 +10352,6 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11807,11 +10403,6 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11853,11 +10444,6 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11880,10 +10466,6 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11915,11 +10497,6 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11941,11 +10518,6 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11968,10 +10540,6 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12035,11 +10603,6 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12093,11 +10656,6 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12120,10 +10678,6 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12187,11 +10741,6 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12245,11 +10794,6 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12272,10 +10816,6 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12339,11 +10879,6 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12397,11 +10932,6 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12424,10 +10954,6 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12479,11 +11005,6 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12525,11 +11046,6 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12552,10 +11068,6 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12587,11 +11099,6 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12613,11 +11120,6 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12640,10 +11142,6 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12707,11 +11205,6 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12765,11 +11258,6 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12792,10 +11280,6 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12859,11 +11343,6 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12917,11 +11396,6 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12944,10 +11418,6 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13011,11 +11481,6 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13069,11 +11534,6 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13096,10 +11556,6 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13151,11 +11607,6 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13197,11 +11648,6 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13224,10 +11670,6 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13259,11 +11701,6 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13285,11 +11722,6 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13312,10 +11744,6 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13357,11 +11785,6 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13393,11 +11816,6 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13420,10 +11838,6 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13455,11 +11869,6 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13481,11 +11890,6 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.MulFloat(float64(arg1))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13508,10 +11912,6 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13543,11 +11943,6 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13569,11 +11964,6 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13596,10 +11986,6 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13631,11 +12017,6 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13657,11 +12038,6 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13684,10 +12060,6 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13719,11 +12091,6 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13745,11 +12112,6 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13772,10 +12134,6 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13807,11 +12165,6 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13833,11 +12186,6 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 					projCol[i] = arg1.MulFloat(float64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13860,10 +12208,6 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13905,11 +12249,6 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13941,11 +12280,6 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 					projCol[i] = arg1.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13968,10 +12302,6 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14029,11 +12359,6 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14081,11 +12406,6 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14108,10 +12428,6 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14169,11 +12485,6 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14221,11 +12532,6 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14248,10 +12554,6 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14309,11 +12611,6 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14361,11 +12658,6 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14388,10 +12680,6 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14447,11 +12735,6 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14497,11 +12780,6 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14524,10 +12802,6 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14583,11 +12857,6 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14633,11 +12902,6 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14660,10 +12924,6 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14719,11 +12979,6 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14769,11 +13024,6 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14796,10 +13046,6 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14855,11 +13101,6 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14905,11 +13146,6 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14932,10 +13168,6 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14995,11 +13227,6 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15049,11 +13276,6 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15076,10 +13298,6 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15135,11 +13353,6 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15185,11 +13398,6 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15212,10 +13420,6 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15271,11 +13475,6 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15321,11 +13520,6 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15348,10 +13542,6 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15407,11 +13597,6 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15457,11 +13642,6 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15484,10 +13664,6 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15547,11 +13723,6 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15601,11 +13772,6 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15628,10 +13794,6 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15687,11 +13849,6 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15737,11 +13894,6 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15764,10 +13916,6 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15823,11 +13971,6 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15873,11 +14016,6 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15900,10 +14038,6 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15959,11 +14093,6 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16009,11 +14138,6 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16036,10 +14160,6 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16099,11 +14219,6 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16153,11 +14268,6 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16180,10 +14290,6 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16233,11 +14339,6 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16277,11 +14378,6 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16304,10 +14400,6 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16347,11 +14439,6 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16381,11 +14468,6 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 					projCol[i] = arg1.Div(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16408,10 +14490,6 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16451,11 +14529,6 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16485,11 +14558,6 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 					projCol[i] = arg1.Div(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16512,10 +14580,6 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16555,11 +14619,6 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16589,11 +14648,6 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 					projCol[i] = arg1.Div(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16616,10 +14670,6 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16659,11 +14709,6 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16693,11 +14738,6 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 					projCol[i] = arg1.DivFloat(float64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16720,10 +14760,6 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16781,11 +14817,6 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16833,11 +14864,6 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16860,10 +14886,6 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16921,11 +14943,6 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16973,11 +14990,6 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17000,10 +15012,6 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17061,11 +15069,6 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17113,11 +15116,6 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17140,10 +15138,6 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17199,11 +15193,6 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17249,11 +15238,6 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17276,10 +15260,6 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17325,11 +15305,6 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17365,11 +15340,6 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17392,10 +15362,6 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17441,11 +15407,6 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17481,11 +15442,6 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17508,10 +15464,6 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17557,11 +15509,6 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17597,11 +15544,6 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17624,10 +15566,6 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17687,11 +15625,6 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17741,11 +15674,6 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17768,10 +15696,6 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17817,11 +15741,6 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17857,11 +15776,6 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17884,10 +15798,6 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17933,11 +15843,6 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17973,11 +15878,6 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18000,10 +15900,6 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18049,11 +15945,6 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18089,11 +15980,6 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18116,10 +16002,6 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18179,11 +16061,6 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18233,11 +16110,6 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18260,10 +16132,6 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18309,11 +16177,6 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18349,11 +16212,6 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18376,10 +16234,6 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18425,11 +16279,6 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18465,11 +16314,6 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18492,10 +16336,6 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18541,11 +16381,6 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18581,11 +16416,6 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18608,10 +16438,6 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18671,11 +16497,6 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18725,11 +16546,6 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18752,10 +16568,6 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18805,11 +16617,6 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18849,11 +16656,6 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18876,10 +16678,6 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18937,11 +16735,6 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18989,11 +16782,6 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19016,10 +16804,6 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19077,11 +16861,6 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19129,11 +16908,6 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19156,10 +16930,6 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19217,11 +16987,6 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19269,11 +17034,6 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19296,10 +17056,6 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19355,11 +17111,6 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19405,11 +17156,6 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19432,10 +17178,6 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19481,11 +17223,6 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19521,11 +17258,6 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19548,10 +17280,6 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19597,11 +17325,6 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19637,11 +17360,6 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19664,10 +17382,6 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19713,11 +17427,6 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19753,11 +17462,6 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19780,10 +17484,6 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19843,11 +17543,6 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19897,11 +17592,6 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19924,10 +17614,6 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19973,11 +17659,6 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20013,11 +17694,6 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20040,10 +17716,6 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20089,11 +17761,6 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20129,11 +17796,6 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20156,10 +17818,6 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20205,11 +17863,6 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20245,11 +17898,6 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20272,10 +17920,6 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20335,11 +17979,6 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20389,11 +18028,6 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20416,10 +18050,6 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20465,11 +18095,6 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20505,11 +18130,6 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20532,10 +18152,6 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20581,11 +18197,6 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20621,11 +18232,6 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20648,10 +18254,6 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20697,11 +18299,6 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20737,11 +18334,6 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20764,10 +18356,6 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20827,11 +18415,6 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20881,11 +18464,6 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20908,10 +18486,6 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20961,11 +18535,6 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21005,11 +18574,6 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21032,10 +18596,6 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21085,11 +18645,6 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21129,11 +18684,6 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21156,10 +18706,6 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21209,11 +18755,6 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21253,11 +18794,6 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21280,10 +18816,6 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21333,11 +18865,6 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21377,11 +18904,6 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21404,10 +18926,6 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21455,11 +18973,6 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21497,11 +19010,6 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21524,10 +19032,6 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21587,11 +19091,6 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21641,11 +19140,6 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21668,10 +19162,6 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21731,11 +19221,6 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21785,11 +19270,6 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21812,10 +19292,6 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21875,11 +19351,6 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21929,11 +19400,6 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21956,10 +19422,6 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22011,11 +19473,6 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22057,11 +19514,6 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22084,10 +19536,6 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22147,11 +19595,6 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22201,11 +19644,6 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22228,10 +19666,6 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22291,11 +19725,6 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22345,11 +19774,6 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22372,10 +19796,6 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22435,11 +19855,6 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22489,11 +19904,6 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22516,10 +19926,6 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22571,11 +19977,6 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22617,11 +20018,6 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22644,10 +20040,6 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22707,11 +20099,6 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22761,11 +20148,6 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22788,10 +20170,6 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22851,11 +20229,6 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22905,11 +20278,6 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22932,10 +20300,6 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22995,11 +20359,6 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23049,11 +20408,6 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23076,10 +20430,6 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23131,11 +20481,6 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23177,11 +20522,6 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23204,10 +20544,6 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23249,11 +20585,6 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23285,11 +20616,6 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23312,10 +20638,6 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23359,11 +20681,6 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23397,11 +20714,6 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23424,10 +20736,6 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23469,11 +20777,6 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23505,11 +20808,6 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23534,10 +20832,6 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23585,11 +20879,6 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23627,11 +20916,6 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23654,10 +20938,6 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23705,11 +20985,6 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23747,11 +21022,6 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23774,10 +21044,6 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23825,11 +21091,6 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23867,11 +21128,6 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23894,10 +21150,6 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23945,11 +21197,6 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23987,11 +21234,6 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24014,10 +21256,6 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24065,11 +21303,6 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24107,11 +21340,6 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24134,10 +21362,6 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24185,11 +21409,6 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24227,11 +21446,6 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24254,10 +21468,6 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24305,11 +21515,6 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24347,11 +21552,6 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24374,10 +21574,6 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24425,11 +21621,6 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24467,11 +21658,6 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24494,10 +21680,6 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24545,11 +21727,6 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24587,11 +21764,6 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24614,10 +21786,6 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24665,11 +21833,6 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24707,11 +21870,6 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24736,10 +21894,6 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24796,11 +21950,6 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24847,11 +21996,6 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24876,10 +22020,6 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24936,11 +22076,6 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24987,11 +22122,6 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25016,10 +22146,6 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25076,11 +22202,6 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25127,11 +22248,6 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25154,10 +22270,6 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25205,11 +22317,6 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25247,11 +22354,6 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25274,10 +22376,6 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25325,11 +22423,6 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25367,11 +22460,6 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25394,10 +22482,6 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25445,11 +22529,6 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25487,11 +22566,6 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25514,10 +22588,6 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25565,11 +22635,6 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25607,11 +22672,6 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25634,10 +22694,6 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25685,11 +22741,6 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25727,11 +22778,6 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25754,10 +22800,6 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25805,11 +22847,6 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25847,11 +22884,6 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25874,10 +22906,6 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25925,11 +22953,6 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25967,11 +22990,6 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25994,10 +23012,6 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26045,11 +23059,6 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26087,11 +23096,6 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26114,10 +23118,6 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26165,11 +23165,6 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26207,11 +23202,6 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26236,10 +23226,6 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26296,11 +23282,6 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26347,11 +23328,6 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26376,10 +23352,6 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26436,11 +23408,6 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26487,11 +23454,6 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26516,10 +23478,6 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26576,11 +23534,6 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26627,11 +23580,6 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26654,10 +23602,6 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26711,11 +23655,6 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26759,11 +23698,6 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26786,10 +23720,6 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26838,11 +23768,6 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26881,11 +23806,6 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26908,10 +23828,6 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26960,11 +23876,6 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27003,11 +23914,6 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27030,10 +23936,6 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27082,11 +23984,6 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27125,11 +24022,6 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27152,10 +24044,6 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27227,11 +24115,6 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27293,11 +24176,6 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27320,10 +24198,6 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27390,11 +24264,6 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27451,11 +24320,6 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27478,10 +24342,6 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27548,11 +24408,6 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27609,11 +24464,6 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27636,10 +24486,6 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27706,11 +24552,6 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27767,11 +24608,6 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27794,10 +24630,6 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27845,11 +24677,6 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27887,11 +24714,6 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27914,10 +24736,6 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27985,11 +24803,6 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28047,11 +24860,6 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28074,10 +24882,6 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28137,11 +24941,6 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28191,11 +24990,6 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28218,10 +25012,6 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28263,11 +25053,6 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28299,11 +25084,6 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28326,10 +25106,6 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28385,11 +25161,6 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28435,11 +25206,6 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28462,10 +25228,6 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28521,11 +25283,6 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28571,11 +25328,6 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28598,10 +25350,6 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28657,11 +25405,6 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28707,11 +25450,6 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28734,10 +25472,6 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28797,11 +25531,6 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28851,11 +25580,6 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28878,10 +25602,6 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28925,11 +25645,6 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28963,11 +25678,6 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28990,10 +25700,6 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29059,11 +25765,6 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29119,11 +25820,6 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29146,10 +25842,6 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29215,11 +25907,6 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29275,11 +25962,6 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29302,10 +25984,6 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29371,11 +26049,6 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29431,11 +26104,6 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29458,10 +26126,6 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29543,11 +26207,6 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29619,11 +26278,6 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29646,10 +26300,6 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29705,11 +26355,6 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29755,11 +26400,6 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29782,10 +26422,6 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29851,11 +26487,6 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29911,11 +26542,6 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29938,10 +26564,6 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30007,11 +26629,6 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30067,11 +26684,6 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30094,10 +26706,6 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30163,11 +26771,6 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30223,11 +26826,6 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30250,10 +26848,6 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30335,11 +26929,6 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30411,11 +27000,6 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30438,10 +27022,6 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30497,11 +27077,6 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30547,11 +27122,6 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30574,10 +27144,6 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30643,11 +27209,6 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30703,11 +27264,6 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30730,10 +27286,6 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30799,11 +27351,6 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30859,11 +27406,6 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30886,10 +27428,6 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30955,11 +27493,6 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31015,11 +27548,6 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31042,10 +27570,6 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31127,11 +27651,6 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31203,11 +27722,6 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31230,10 +27744,6 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31289,11 +27799,6 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31339,11 +27844,6 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31366,10 +27866,6 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31451,11 +27947,6 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31527,11 +28018,6 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31554,10 +28040,6 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31639,11 +28121,6 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31715,11 +28192,6 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31742,10 +28214,6 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31827,11 +28295,6 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31903,11 +28366,6 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31930,10 +28388,6 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32015,11 +28469,6 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32091,11 +28540,6 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32118,10 +28562,6 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32181,11 +28621,6 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32235,11 +28670,6 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32262,10 +28692,6 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32323,11 +28749,6 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32375,11 +28796,6 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32402,10 +28818,6 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32449,11 +28861,6 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32487,11 +28894,6 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32514,10 +28916,6 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32571,11 +28969,6 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32619,11 +29012,6 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32646,10 +29034,6 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32695,11 +29079,6 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32735,11 +29114,6 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32762,10 +29136,6 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32825,11 +29195,6 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32879,11 +29244,6 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32906,10 +29266,6 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32951,11 +29307,6 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32987,11 +29338,6 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33014,10 +29360,6 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33073,11 +29415,6 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33123,11 +29460,6 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33150,10 +29482,6 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33209,11 +29537,6 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33259,11 +29582,6 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33286,10 +29604,6 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33345,11 +29659,6 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33395,11 +29704,6 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33422,10 +29726,6 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33485,11 +29785,6 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33539,11 +29834,6 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33566,10 +29856,6 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33613,11 +29899,6 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33651,11 +29932,6 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33678,10 +29954,6 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33747,11 +30019,6 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33807,11 +30074,6 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33834,10 +30096,6 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33903,11 +30161,6 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33963,11 +30216,6 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33990,10 +30238,6 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34059,11 +30303,6 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34119,11 +30358,6 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34146,10 +30380,6 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34231,11 +30461,6 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34307,11 +30532,6 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34334,10 +30554,6 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34393,11 +30609,6 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34443,11 +30654,6 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34470,10 +30676,6 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34539,11 +30741,6 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34599,11 +30796,6 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34626,10 +30818,6 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34695,11 +30883,6 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34755,11 +30938,6 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34782,10 +30960,6 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34851,11 +31025,6 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34911,11 +31080,6 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34938,10 +31102,6 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35023,11 +31183,6 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35099,11 +31254,6 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35126,10 +31276,6 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35185,11 +31331,6 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35235,11 +31376,6 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35262,10 +31398,6 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35331,11 +31463,6 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35391,11 +31518,6 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35418,10 +31540,6 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35487,11 +31605,6 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35547,11 +31660,6 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35574,10 +31682,6 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35643,11 +31747,6 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35703,11 +31802,6 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35730,10 +31824,6 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35815,11 +31905,6 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35891,11 +31976,6 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35918,10 +31998,6 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35977,11 +32053,6 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36027,11 +32098,6 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36054,10 +32120,6 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36139,11 +32201,6 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36215,11 +32272,6 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36242,10 +32294,6 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36327,11 +32375,6 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36403,11 +32446,6 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36430,10 +32468,6 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36515,11 +32549,6 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36591,11 +32620,6 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36618,10 +32642,6 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36703,11 +32723,6 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36779,11 +32794,6 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36806,10 +32816,6 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36869,11 +32875,6 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36923,11 +32924,6 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36950,10 +32946,6 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37011,11 +33003,6 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37063,11 +33050,6 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37090,10 +33072,6 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37137,11 +33115,6 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37175,11 +33148,6 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37202,10 +33170,6 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37259,11 +33223,6 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37307,11 +33266,6 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37334,10 +33288,6 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37383,11 +33333,6 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37423,11 +33368,6 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37450,10 +33390,6 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37513,11 +33449,6 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37567,11 +33498,6 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37594,10 +33520,6 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37639,11 +33561,6 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37675,11 +33592,6 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37702,10 +33614,6 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37761,11 +33669,6 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37811,11 +33714,6 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37838,10 +33736,6 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37897,11 +33791,6 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37947,11 +33836,6 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37974,10 +33858,6 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38033,11 +33913,6 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38083,11 +33958,6 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38110,10 +33980,6 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38173,11 +34039,6 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38227,11 +34088,6 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38254,10 +34110,6 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38301,11 +34153,6 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38339,11 +34186,6 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38366,10 +34208,6 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38435,11 +34273,6 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38495,11 +34328,6 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38522,10 +34350,6 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38591,11 +34415,6 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38651,11 +34470,6 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38678,10 +34492,6 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38747,11 +34557,6 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38807,11 +34612,6 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38834,10 +34634,6 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38919,11 +34715,6 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38995,11 +34786,6 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39022,10 +34808,6 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39081,11 +34863,6 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39131,11 +34908,6 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39158,10 +34930,6 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39227,11 +34995,6 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39287,11 +35050,6 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39314,10 +35072,6 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39383,11 +35137,6 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39443,11 +35192,6 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39470,10 +35214,6 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39539,11 +35279,6 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39599,11 +35334,6 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39626,10 +35356,6 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39711,11 +35437,6 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39787,11 +35508,6 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39814,10 +35530,6 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39873,11 +35585,6 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39923,11 +35630,6 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39950,10 +35652,6 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40019,11 +35717,6 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40079,11 +35772,6 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40106,10 +35794,6 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40175,11 +35859,6 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40235,11 +35914,6 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40262,10 +35936,6 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40331,11 +36001,6 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40391,11 +36056,6 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40418,10 +36078,6 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40503,11 +36159,6 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40579,11 +36230,6 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40606,10 +36252,6 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40665,11 +36307,6 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40715,11 +36352,6 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40742,10 +36374,6 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40827,11 +36455,6 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40903,11 +36526,6 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40930,10 +36548,6 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41015,11 +36629,6 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41091,11 +36700,6 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41118,10 +36722,6 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41203,11 +36803,6 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41279,11 +36874,6 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41306,10 +36896,6 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41391,11 +36977,6 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41467,11 +37048,6 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41494,10 +37070,6 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41557,11 +37129,6 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41611,11 +37178,6 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41638,10 +37200,6 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41699,11 +37257,6 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41751,11 +37304,6 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41778,10 +37326,6 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41825,11 +37369,6 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41863,11 +37402,6 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41890,10 +37424,6 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41947,11 +37477,6 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41995,11 +37520,6 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42022,10 +37542,6 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42071,11 +37587,6 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42111,11 +37622,6 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42138,10 +37644,6 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42201,11 +37703,6 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42255,11 +37752,6 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42282,10 +37774,6 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42327,11 +37815,6 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42363,11 +37846,6 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42390,10 +37868,6 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42449,11 +37923,6 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42499,11 +37968,6 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42526,10 +37990,6 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42585,11 +38045,6 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42635,11 +38090,6 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42662,10 +38112,6 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42721,11 +38167,6 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42771,11 +38212,6 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42798,10 +38234,6 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42861,11 +38293,6 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42915,11 +38342,6 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42942,10 +38364,6 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42989,11 +38407,6 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43027,11 +38440,6 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43054,10 +38462,6 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43123,11 +38527,6 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43183,11 +38582,6 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43210,10 +38604,6 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43279,11 +38669,6 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43339,11 +38724,6 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43366,10 +38746,6 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43435,11 +38811,6 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43495,11 +38866,6 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43522,10 +38888,6 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43607,11 +38969,6 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43683,11 +39040,6 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43710,10 +39062,6 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43769,11 +39117,6 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43819,11 +39162,6 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43846,10 +39184,6 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43915,11 +39249,6 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43975,11 +39304,6 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44002,10 +39326,6 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44071,11 +39391,6 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44131,11 +39446,6 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44158,10 +39468,6 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44227,11 +39533,6 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44287,11 +39588,6 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44314,10 +39610,6 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44399,11 +39691,6 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44475,11 +39762,6 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44502,10 +39784,6 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44561,11 +39839,6 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44611,11 +39884,6 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44638,10 +39906,6 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44707,11 +39971,6 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44767,11 +40026,6 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44794,10 +40048,6 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44863,11 +40113,6 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44923,11 +40168,6 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44950,10 +40190,6 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45019,11 +40255,6 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45079,11 +40310,6 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45106,10 +40332,6 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45191,11 +40413,6 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45267,11 +40484,6 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45294,10 +40506,6 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45353,11 +40561,6 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45403,11 +40606,6 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45430,10 +40628,6 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45515,11 +40709,6 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45591,11 +40780,6 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45618,10 +40802,6 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45703,11 +40883,6 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45779,11 +40954,6 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45806,10 +40976,6 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45891,11 +41057,6 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45967,11 +41128,6 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45994,10 +41150,6 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46079,11 +41231,6 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46155,11 +41302,6 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46182,10 +41324,6 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46245,11 +41383,6 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46299,11 +41432,6 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46326,10 +41454,6 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46387,11 +41511,6 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46439,11 +41558,6 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46466,10 +41580,6 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46513,11 +41623,6 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46551,11 +41656,6 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46578,10 +41678,6 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46635,11 +41731,6 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46683,11 +41774,6 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46710,10 +41796,6 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46759,11 +41841,6 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46799,11 +41876,6 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46826,10 +41898,6 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46889,11 +41957,6 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46943,11 +42006,6 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46970,10 +42028,6 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47015,11 +42069,6 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47051,11 +42100,6 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47078,10 +42122,6 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47137,11 +42177,6 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47187,11 +42222,6 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47214,10 +42244,6 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47273,11 +42299,6 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47323,11 +42344,6 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47350,10 +42366,6 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47409,11 +42421,6 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47459,11 +42466,6 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47486,10 +42488,6 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47549,11 +42547,6 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47603,11 +42596,6 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47630,10 +42618,6 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47677,11 +42661,6 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47715,11 +42694,6 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47742,10 +42716,6 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47811,11 +42781,6 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47871,11 +42836,6 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47898,10 +42858,6 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47967,11 +42923,6 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48027,11 +42978,6 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48054,10 +43000,6 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48123,11 +43065,6 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48183,11 +43120,6 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48210,10 +43142,6 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48295,11 +43223,6 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48371,11 +43294,6 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48398,10 +43316,6 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48457,11 +43371,6 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48507,11 +43416,6 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48534,10 +43438,6 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48603,11 +43503,6 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48663,11 +43558,6 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48690,10 +43580,6 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48759,11 +43645,6 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48819,11 +43700,6 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48846,10 +43722,6 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48915,11 +43787,6 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48975,11 +43842,6 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49002,10 +43864,6 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49087,11 +43945,6 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49163,11 +44016,6 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49190,10 +44038,6 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49249,11 +44093,6 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49299,11 +44138,6 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49326,10 +44160,6 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49395,11 +44225,6 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49455,11 +44280,6 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49482,10 +44302,6 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49551,11 +44367,6 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49611,11 +44422,6 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49638,10 +44444,6 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49707,11 +44509,6 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49767,11 +44564,6 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49794,10 +44586,6 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49879,11 +44667,6 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49955,11 +44738,6 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49982,10 +44760,6 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50041,11 +44815,6 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50091,11 +44860,6 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50118,10 +44882,6 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50203,11 +44963,6 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50279,11 +45034,6 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50306,10 +45056,6 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50391,11 +45137,6 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50467,11 +45208,6 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50494,10 +45230,6 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50579,11 +45311,6 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50655,11 +45382,6 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50682,10 +45404,6 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50767,11 +45485,6 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50843,11 +45556,6 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50870,10 +45578,6 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50933,11 +45637,6 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50987,11 +45686,6 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51014,10 +45708,6 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51075,11 +45765,6 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51127,11 +45812,6 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51154,10 +45834,6 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51201,11 +45877,6 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51239,11 +45910,6 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51266,10 +45932,6 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51323,11 +45985,6 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51371,11 +46028,6 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51398,10 +46050,6 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51447,11 +46095,6 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51487,11 +46130,6 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51514,10 +46152,6 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51577,11 +46211,6 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51631,11 +46260,6 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51658,10 +46282,6 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51703,11 +46323,6 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51739,11 +46354,6 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51766,10 +46376,6 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51825,11 +46431,6 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51875,11 +46476,6 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51902,10 +46498,6 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51961,11 +46553,6 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52011,11 +46598,6 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52038,10 +46620,6 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52097,11 +46675,6 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52147,11 +46720,6 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52174,10 +46742,6 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52237,11 +46801,6 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52291,11 +46850,6 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52318,10 +46872,6 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52365,11 +46915,6 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52403,11 +46948,6 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52430,10 +46970,6 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52499,11 +47035,6 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52559,11 +47090,6 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52586,10 +47112,6 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52655,11 +47177,6 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52715,11 +47232,6 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52742,10 +47254,6 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52811,11 +47319,6 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52871,11 +47374,6 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52898,10 +47396,6 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52983,11 +47477,6 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53059,11 +47548,6 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53086,10 +47570,6 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53145,11 +47625,6 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53195,11 +47670,6 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53222,10 +47692,6 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53291,11 +47757,6 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53351,11 +47812,6 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53378,10 +47834,6 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53447,11 +47899,6 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53507,11 +47954,6 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53534,10 +47976,6 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53603,11 +48041,6 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53663,11 +48096,6 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53690,10 +48118,6 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53775,11 +48199,6 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53851,11 +48270,6 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53878,10 +48292,6 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53937,11 +48347,6 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53987,11 +48392,6 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54014,10 +48414,6 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54083,11 +48479,6 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54143,11 +48534,6 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54170,10 +48556,6 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54239,11 +48621,6 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54299,11 +48676,6 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54326,10 +48698,6 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54395,11 +48763,6 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54455,11 +48818,6 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54482,10 +48840,6 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54567,11 +48921,6 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54643,11 +48992,6 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54670,10 +49014,6 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54729,11 +49069,6 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54779,11 +49114,6 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54806,10 +49136,6 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54891,11 +49217,6 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54967,11 +49288,6 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54994,10 +49310,6 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55079,11 +49391,6 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55155,11 +49462,6 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55182,10 +49484,6 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55267,11 +49565,6 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55343,11 +49636,6 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55370,10 +49658,6 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55455,11 +49739,6 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55531,11 +49810,6 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55558,10 +49832,6 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55621,11 +49891,6 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55675,11 +49940,6 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55702,10 +49962,6 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55763,11 +50019,6 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55815,11 +50066,6 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55842,10 +50088,6 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55889,11 +50131,6 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55927,11 +50164,6 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55954,10 +50186,6 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -56011,11 +50239,6 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -56059,11 +50282,6 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -56086,10 +50304,6 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -56135,11 +50349,6 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -56175,11 +50384,6 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -49,10 +49,11 @@ var (
 // projOpBase contains all of the fields for non-constant projections.
 type projOpBase struct {
 	colexecop.OneInputHelper
-	allocator *colmem.Allocator
-	col1Idx   int
-	col2Idx   int
-	outputIdx int
+	allocator    *colmem.Allocator
+	col1Idx      int
+	col2Idx      int
+	outputIdx    int
+	nullableArgs bool
 }
 
 type projBitandInt16Int16Op struct {
@@ -73,7 +74,9 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -155,7 +158,9 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -237,7 +242,9 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -319,7 +326,9 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -401,7 +410,9 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -483,7 +494,9 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -565,7 +578,9 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -647,7 +662,9 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -729,7 +746,9 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -813,7 +832,9 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -919,7 +940,9 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1001,7 +1024,9 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1083,7 +1108,9 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1165,7 +1192,9 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1247,7 +1276,9 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1329,7 +1360,9 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1411,7 +1444,9 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1493,7 +1528,9 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1575,7 +1612,9 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1659,7 +1698,9 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1765,7 +1806,9 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1847,7 +1890,9 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1929,7 +1974,9 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2011,7 +2058,9 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2093,7 +2142,9 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2175,7 +2226,9 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2257,7 +2310,9 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2339,7 +2394,9 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2421,7 +2478,9 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2505,7 +2564,9 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2611,7 +2672,9 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2721,7 +2784,9 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2831,7 +2896,9 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2941,7 +3008,9 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3047,7 +3116,9 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3153,7 +3224,9 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3259,7 +3332,9 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3365,7 +3440,9 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3481,7 +3558,9 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3605,7 +3684,9 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3711,7 +3792,9 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3817,7 +3900,9 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3923,7 +4008,9 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4039,7 +4126,9 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4163,7 +4252,9 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4269,7 +4360,9 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4375,7 +4468,9 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4481,7 +4576,9 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4597,7 +4694,9 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4721,7 +4820,9 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4815,7 +4916,9 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4909,7 +5012,9 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5003,7 +5108,9 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5079,7 +5186,9 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5205,7 +5314,9 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5331,7 +5442,9 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5457,7 +5570,9 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5583,7 +5698,9 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5707,7 +5824,9 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5817,7 +5936,9 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5927,7 +6048,9 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6037,7 +6160,9 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6143,7 +6268,9 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6249,7 +6376,9 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6355,7 +6484,9 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6461,7 +6592,9 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6577,7 +6710,9 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6701,7 +6836,9 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6807,7 +6944,9 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6913,7 +7052,9 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7019,7 +7160,9 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7135,7 +7278,9 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7259,7 +7404,9 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7365,7 +7512,9 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7471,7 +7620,9 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7577,7 +7728,9 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7693,7 +7846,9 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7817,7 +7972,9 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7911,7 +8068,9 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7997,7 +8156,9 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8091,7 +8252,9 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8167,7 +8330,9 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8291,7 +8456,9 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8397,7 +8564,9 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8489,7 +8658,9 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8581,7 +8752,9 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8675,7 +8848,9 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8783,7 +8958,9 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8909,7 +9086,9 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9033,7 +9212,9 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9159,7 +9340,9 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9285,7 +9468,9 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9409,7 +9594,9 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9519,7 +9706,9 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9629,7 +9818,9 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9739,7 +9930,9 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9845,7 +10038,9 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9939,7 +10134,9 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10077,7 +10274,9 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10215,7 +10414,9 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10353,7 +10554,9 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10467,7 +10670,9 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10541,7 +10746,9 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10679,7 +10886,9 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10817,7 +11026,9 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10955,7 +11166,9 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11069,7 +11282,9 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11143,7 +11358,9 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11281,7 +11498,9 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11419,7 +11638,9 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11557,7 +11778,9 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11671,7 +11894,9 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11745,7 +11970,9 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11839,7 +12066,9 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11913,7 +12142,9 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11987,7 +12218,9 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12061,7 +12294,9 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12135,7 +12370,9 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12209,7 +12446,9 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12303,7 +12542,9 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12429,7 +12670,9 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12555,7 +12798,9 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12681,7 +12926,9 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12803,7 +13050,9 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12925,7 +13174,9 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13047,7 +13298,9 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13169,7 +13422,9 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13299,7 +13554,9 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13421,7 +13678,9 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13543,7 +13802,9 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13665,7 +13926,9 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13795,7 +14058,9 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13917,7 +14182,9 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14039,7 +14306,9 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14161,7 +14430,9 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14291,7 +14562,9 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14401,7 +14674,9 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14491,7 +14766,9 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14581,7 +14858,9 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14671,7 +14950,9 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14761,7 +15042,9 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14887,7 +15170,9 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15013,7 +15298,9 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15139,7 +15426,9 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15261,7 +15550,9 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15363,7 +15654,9 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15465,7 +15758,9 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15567,7 +15862,9 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15697,7 +15994,9 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15799,7 +16098,9 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15901,7 +16202,9 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16003,7 +16306,9 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16133,7 +16438,9 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16235,7 +16542,9 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16337,7 +16646,9 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16439,7 +16750,9 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16569,7 +16882,9 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16679,7 +16994,9 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16805,7 +17122,9 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16931,7 +17250,9 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17057,7 +17378,9 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17179,7 +17502,9 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17281,7 +17606,9 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17383,7 +17710,9 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17485,7 +17814,9 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17615,7 +17946,9 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17717,7 +18050,9 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17819,7 +18154,9 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17921,7 +18258,9 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18051,7 +18390,9 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18153,7 +18494,9 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18255,7 +18598,9 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18357,7 +18702,9 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18487,7 +18834,9 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18597,7 +18946,9 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18707,7 +19058,9 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18817,7 +19170,9 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18927,7 +19282,9 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19033,7 +19390,9 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19163,7 +19522,9 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19293,7 +19654,9 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19423,7 +19786,9 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19537,7 +19902,9 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19667,7 +20034,9 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19797,7 +20166,9 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19927,7 +20298,9 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20041,7 +20414,9 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20171,7 +20546,9 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20301,7 +20678,9 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20431,7 +20810,9 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20545,7 +20926,9 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20639,7 +21022,9 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20737,7 +21122,9 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20833,7 +21220,9 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20939,7 +21328,9 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21045,7 +21436,9 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21151,7 +21544,9 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21257,7 +21652,9 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21363,7 +21760,9 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21469,7 +21868,9 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21575,7 +21976,9 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21681,7 +22084,9 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21787,7 +22192,9 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21895,7 +22302,9 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22021,7 +22430,9 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22147,7 +22558,9 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22271,7 +22684,9 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22377,7 +22792,9 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22483,7 +22900,9 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22589,7 +23008,9 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22695,7 +23116,9 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22801,7 +23224,9 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22907,7 +23332,9 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23013,7 +23440,9 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23119,7 +23548,9 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23227,7 +23658,9 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23353,7 +23786,9 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23479,7 +23914,9 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23603,7 +24040,9 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23721,7 +24160,9 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23829,7 +24270,9 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23937,7 +24380,9 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24045,7 +24490,9 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24199,7 +24646,9 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24343,7 +24792,9 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24487,7 +24938,9 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24631,7 +25084,9 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24737,7 +25192,9 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24883,7 +25340,9 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25013,7 +25472,9 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25107,7 +25568,9 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25229,7 +25692,9 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25351,7 +25816,9 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25473,7 +25940,9 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25603,7 +26072,9 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25701,7 +26172,9 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25843,7 +26316,9 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25985,7 +26460,9 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26127,7 +26604,9 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26301,7 +26780,9 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26423,7 +26904,9 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26565,7 +27048,9 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26707,7 +27192,9 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26849,7 +27336,9 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27023,7 +27512,9 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27145,7 +27636,9 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27287,7 +27780,9 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27429,7 +27924,9 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27571,7 +28068,9 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27745,7 +28244,9 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27867,7 +28368,9 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28041,7 +28544,9 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28215,7 +28720,9 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28389,7 +28896,9 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28563,7 +29072,9 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28693,7 +29204,9 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28819,7 +29332,9 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28917,7 +29432,9 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29035,7 +29552,9 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29137,7 +29656,9 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29267,7 +29788,9 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29361,7 +29884,9 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29483,7 +30008,9 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29605,7 +30132,9 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29727,7 +30256,9 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29857,7 +30388,9 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29955,7 +30488,9 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30097,7 +30632,9 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30239,7 +30776,9 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30381,7 +30920,9 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30555,7 +31096,9 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30677,7 +31220,9 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30819,7 +31364,9 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30961,7 +31508,9 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31103,7 +31652,9 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31277,7 +31828,9 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31399,7 +31952,9 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31541,7 +32096,9 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31683,7 +32240,9 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31825,7 +32384,9 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31999,7 +32560,9 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32121,7 +32684,9 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32295,7 +32860,9 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32469,7 +33036,9 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32643,7 +33212,9 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32817,7 +33388,9 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32947,7 +33520,9 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33073,7 +33648,9 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33171,7 +33748,9 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33289,7 +33868,9 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33391,7 +33972,9 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33521,7 +34104,9 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33615,7 +34200,9 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33737,7 +34324,9 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33859,7 +34448,9 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33981,7 +34572,9 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34111,7 +34704,9 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34209,7 +34804,9 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34351,7 +34948,9 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34493,7 +35092,9 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34635,7 +35236,9 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34809,7 +35412,9 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34931,7 +35536,9 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35073,7 +35680,9 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35215,7 +35824,9 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35357,7 +35968,9 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35531,7 +36144,9 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35653,7 +36268,9 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35795,7 +36412,9 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35937,7 +36556,9 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36079,7 +36700,9 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36253,7 +36876,9 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36375,7 +37000,9 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36549,7 +37176,9 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36723,7 +37352,9 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36897,7 +37528,9 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37071,7 +37704,9 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37201,7 +37836,9 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37327,7 +37964,9 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37425,7 +38064,9 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37543,7 +38184,9 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37645,7 +38288,9 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37775,7 +38420,9 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37869,7 +38516,9 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37991,7 +38640,9 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38113,7 +38764,9 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38235,7 +38888,9 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38365,7 +39020,9 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38463,7 +39120,9 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38605,7 +39264,9 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38747,7 +39408,9 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38889,7 +39552,9 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39063,7 +39728,9 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39185,7 +39852,9 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39327,7 +39996,9 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39469,7 +40140,9 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39611,7 +40284,9 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39785,7 +40460,9 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39907,7 +40584,9 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40049,7 +40728,9 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40191,7 +40872,9 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40333,7 +41016,9 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40507,7 +41192,9 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40629,7 +41316,9 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40803,7 +41492,9 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40977,7 +41668,9 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41151,7 +41844,9 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41325,7 +42020,9 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41455,7 +42152,9 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41581,7 +42280,9 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41679,7 +42380,9 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41797,7 +42500,9 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41899,7 +42604,9 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42029,7 +42736,9 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42123,7 +42832,9 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42245,7 +42956,9 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42367,7 +43080,9 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42489,7 +43204,9 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42619,7 +43336,9 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42717,7 +43436,9 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42859,7 +43580,9 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43001,7 +43724,9 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43143,7 +43868,9 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43317,7 +44044,9 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43439,7 +44168,9 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43581,7 +44312,9 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43723,7 +44456,9 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43865,7 +44600,9 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44039,7 +44776,9 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44161,7 +44900,9 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44303,7 +45044,9 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44445,7 +45188,9 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44587,7 +45332,9 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44761,7 +45508,9 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44883,7 +45632,9 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45057,7 +45808,9 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45231,7 +45984,9 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45405,7 +46160,9 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45579,7 +46336,9 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45709,7 +46468,9 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45835,7 +46596,9 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45933,7 +46696,9 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46051,7 +46816,9 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46153,7 +46920,9 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46283,7 +47052,9 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46377,7 +47148,9 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46499,7 +47272,9 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46621,7 +47396,9 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46743,7 +47520,9 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46873,7 +47652,9 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46971,7 +47752,9 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47113,7 +47896,9 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47255,7 +48040,9 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47397,7 +48184,9 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47571,7 +48360,9 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47693,7 +48484,9 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47835,7 +48628,9 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47977,7 +48772,9 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48119,7 +48916,9 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48293,7 +49092,9 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48415,7 +49216,9 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48557,7 +49360,9 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48699,7 +49504,9 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48841,7 +49648,9 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49015,7 +49824,9 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49137,7 +49948,9 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49311,7 +50124,9 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49485,7 +50300,9 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49659,7 +50476,9 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49833,7 +50652,9 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49963,7 +50784,9 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50089,7 +50912,9 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50187,7 +51012,9 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50305,7 +51132,9 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50403,6 +51232,7 @@ func GetProjectionOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projOpBase := projOpBase{
@@ -50411,6 +51241,7 @@ func GetProjectionOperator(
 		col1Idx:        col1Idx,
 		col2Idx:        col2Idx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 
 	leftType, rightType := inputTypes[col1Idx], inputTypes[col2Idx]

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -79,10 +79,11 @@ func _ASSIGN(_, _, _, _, _, _ interface{}) {
 // projOpBase contains all of the fields for non-constant projections.
 type projOpBase struct {
 	colexecop.OneInputHelper
-	allocator *colmem.Allocator
-	col1Idx   int
-	col2Idx   int
-	outputIdx int
+	allocator    *colmem.Allocator
+	col1Idx      int
+	col2Idx      int
+	outputIdx    int
+	nullableArgs bool
 }
 
 // {{define "projOp"}}
@@ -122,7 +123,23 @@ func (p _OP_NAME) Next() coldata.Batch {
 		// of a projection is Null.
 		// */}}
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		// {{/*
+		// If nullableArgs is true, the function’s definition can handle null
+		// arguments. We would still want to perform the projection, and there is no
+		// need to call projVec.SetNulls(). The behaviour will just be the same as
+		// _HAS_NULLS is false. Since currently only ConcatDatumDatum needs this
+		// nullableArgs == true behaviour, logic for nullableArgs is only added to
+		// the if statement for function with Datum, Datum. If we later introduce
+		// another projection operation that has nullableArgs == true, we should
+		// update this code accordingly.
+		// */}}
+		// {{if and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum")}}
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		// {{else}}
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		// {{end}}
+		if hasNullsAndNotNullable {
 			_SET_PROJECTION(true)
 		} else {
 			_SET_PROJECTION(false)
@@ -245,6 +262,7 @@ func GetProjectionOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projOpBase := projOpBase{
@@ -253,6 +271,7 @@ func GetProjectionOperator(
 		col1Idx:        col1Idx,
 		col2Idx:        col2Idx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 
 	leftType, rightType := inputTypes[col1Idx], inputTypes[col2Idx]

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -115,10 +115,12 @@ func (p _OP_NAME) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1._L_TYP()
 		col2 := vec2._R_TYP()
+		// {{/*
 		// Some operators can result in NULL with non-NULL inputs, like the JSON
 		// fetch value operator, ->. Therefore, _outNulls is defined to allow
 		// updating the output Nulls from within _ASSIGN functions when the result
 		// of a projection is Null.
+		// */}}
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			_SET_PROJECTION(true)
@@ -154,11 +156,13 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS, false)
 		}
 	}
+	// {{/*
 	// _outNulls has been updated from within the _ASSIGN function to include
 	// any NULLs that resulted from the projection.
 	// If _HAS_NULLS is true, union _outNulls with the set of input Nulls.
 	// If _HAS_NULLS is false, then there are no input Nulls. _outNulls is
 	// projVec.Nulls() so there is no need to call projVec.SetNulls().
+	// */}}
 	// {{if _HAS_NULLS}}
 	projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 	// {{end}}

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -211,9 +211,10 @@ func TestGetProjectionOperator(t *testing.T) {
 	inputTypes[col1Idx] = typ
 	inputTypes[col2Idx] = typ
 	outputIdx := 9
+	nullableArgs := false
 	op, err := GetProjectionOperator(
 		testAllocator, inputTypes, types.Int2, binOp, input, col1Idx, col2Idx,
-		outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil, /* cmpExpr */
+		outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
 	)
 	if err != nil {
 		t.Error(err)
@@ -225,6 +226,7 @@ func TestGetProjectionOperator(t *testing.T) {
 			col1Idx:        col1Idx,
 			col2Idx:        col2Idx,
 			outputIdx:      outputIdx,
+			nullableArgs:   nullableArgs,
 		},
 	}
 	if !reflect.DeepEqual(op, expected) {

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -65,10 +65,6 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -97,11 +93,6 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -123,11 +114,6 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -153,10 +139,6 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -185,11 +167,6 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -211,11 +188,6 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -241,10 +213,6 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -273,11 +241,6 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -299,11 +262,6 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -329,10 +287,6 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -361,11 +315,6 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -387,11 +336,6 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -417,10 +361,6 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -449,11 +389,6 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -475,11 +410,6 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -505,10 +435,6 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -537,11 +463,6 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -563,11 +484,6 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -593,10 +509,6 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -625,11 +537,6 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -651,11 +558,6 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -681,10 +583,6 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -713,11 +611,6 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -739,11 +632,6 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -769,10 +657,6 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -801,11 +685,6 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -827,11 +706,6 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -859,10 +733,6 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -904,11 +774,6 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -943,11 +808,6 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -973,10 +833,6 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1005,11 +861,6 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1031,11 +882,6 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1061,10 +907,6 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1093,11 +935,6 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1119,11 +956,6 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1149,10 +981,6 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1181,11 +1009,6 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1207,11 +1030,6 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1237,10 +1055,6 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1269,11 +1083,6 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1295,11 +1104,6 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1325,10 +1129,6 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1357,11 +1157,6 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1383,11 +1178,6 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1413,10 +1203,6 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1445,11 +1231,6 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1471,11 +1252,6 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1501,10 +1277,6 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1533,11 +1305,6 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1559,11 +1326,6 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1589,10 +1351,6 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1621,11 +1379,6 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1647,11 +1400,6 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1677,10 +1425,6 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1709,11 +1453,6 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1735,11 +1474,6 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1767,10 +1501,6 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1812,11 +1542,6 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1851,11 +1576,6 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1881,10 +1601,6 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1913,11 +1629,6 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1939,11 +1650,6 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1969,10 +1675,6 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2001,11 +1703,6 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2027,11 +1724,6 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2057,10 +1749,6 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2089,11 +1777,6 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2115,11 +1798,6 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2145,10 +1823,6 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2177,11 +1851,6 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2203,11 +1872,6 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2233,10 +1897,6 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2265,11 +1925,6 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2291,11 +1946,6 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2321,10 +1971,6 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2353,11 +1999,6 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2379,11 +2020,6 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2409,10 +2045,6 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2441,11 +2073,6 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2467,11 +2094,6 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2497,10 +2119,6 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2529,11 +2147,6 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2555,11 +2168,6 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2585,10 +2193,6 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2617,11 +2221,6 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2643,11 +2242,6 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2675,10 +2269,6 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2720,11 +2310,6 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2759,11 +2344,6 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2789,10 +2369,6 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2835,11 +2411,6 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2875,11 +2446,6 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2905,10 +2471,6 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2951,11 +2513,6 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2991,11 +2548,6 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3021,10 +2573,6 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3067,11 +2615,6 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3107,11 +2650,6 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3137,10 +2675,6 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3181,11 +2715,6 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3219,11 +2748,6 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3249,10 +2773,6 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3293,11 +2813,6 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3331,11 +2846,6 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3361,10 +2871,6 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3405,11 +2911,6 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3443,11 +2944,6 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3473,10 +2969,6 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3517,11 +3009,6 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3555,11 +3042,6 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3585,10 +3067,6 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3633,11 +3111,6 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3675,11 +3148,6 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3707,10 +3175,6 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3761,11 +3225,6 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3809,11 +3268,6 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3839,10 +3293,6 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3883,11 +3333,6 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3921,11 +3366,6 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3951,10 +3391,6 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3995,11 +3431,6 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4033,11 +3464,6 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4063,10 +3489,6 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4107,11 +3529,6 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4145,11 +3562,6 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4175,10 +3587,6 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4223,11 +3631,6 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4265,11 +3668,6 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4297,10 +3695,6 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4351,11 +3745,6 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4399,11 +3788,6 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4429,10 +3813,6 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4473,11 +3853,6 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4511,11 +3886,6 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4541,10 +3911,6 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4585,11 +3951,6 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4623,11 +3984,6 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4653,10 +4009,6 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4697,11 +4049,6 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4735,11 +4082,6 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4765,10 +4107,6 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4813,11 +4151,6 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4855,11 +4188,6 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4887,10 +4215,6 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4941,11 +4265,6 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4989,11 +4308,6 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5019,10 +4333,6 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5057,11 +4367,6 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5089,11 +4394,6 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5119,10 +4419,6 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5157,11 +4453,6 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5189,11 +4480,6 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5219,10 +4505,6 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5257,11 +4539,6 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5289,11 +4566,6 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5319,10 +4591,6 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5347,11 +4615,6 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5369,11 +4632,6 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Add(arg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5401,10 +4659,6 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5455,11 +4709,6 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5503,11 +4752,6 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5535,10 +4779,6 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5588,11 +4828,6 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5635,11 +4870,6 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5667,10 +4897,6 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5720,11 +4946,6 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5767,11 +4988,6 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5799,10 +5015,6 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5852,11 +5064,6 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5899,11 +5106,6 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5931,10 +5133,6 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5984,11 +5182,6 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6031,11 +5224,6 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6061,10 +5249,6 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6107,11 +5291,6 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6147,11 +5326,6 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6177,10 +5351,6 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6223,11 +5393,6 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6263,11 +5428,6 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6293,10 +5453,6 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6339,11 +5495,6 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6379,11 +5530,6 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6409,10 +5555,6 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6453,11 +5595,6 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6491,11 +5628,6 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6521,10 +5653,6 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6565,11 +5693,6 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6603,11 +5726,6 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6633,10 +5751,6 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6677,11 +5791,6 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6715,11 +5824,6 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6745,10 +5849,6 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6789,11 +5889,6 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6827,11 +5922,6 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6857,10 +5947,6 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6905,11 +5991,6 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6947,11 +6028,6 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6979,10 +6055,6 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7033,11 +6105,6 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7081,11 +6148,6 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7111,10 +6173,6 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7155,11 +6213,6 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7193,11 +6246,6 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7223,10 +6271,6 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7267,11 +6311,6 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7305,11 +6344,6 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7335,10 +6369,6 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7379,11 +6409,6 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7417,11 +6442,6 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7447,10 +6467,6 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7495,11 +6511,6 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7537,11 +6548,6 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7569,10 +6575,6 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7623,11 +6625,6 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7671,11 +6668,6 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7701,10 +6693,6 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7745,11 +6733,6 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7783,11 +6766,6 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7813,10 +6791,6 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7857,11 +6831,6 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7895,11 +6864,6 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7925,10 +6889,6 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7969,11 +6929,6 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8007,11 +6962,6 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8037,10 +6987,6 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8085,11 +7031,6 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8127,11 +7068,6 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8159,10 +7095,6 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8213,11 +7145,6 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8261,11 +7188,6 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8291,10 +7213,6 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8329,11 +7247,6 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8361,11 +7274,6 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8391,10 +7299,6 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8425,11 +7329,6 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8453,11 +7352,6 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8483,10 +7377,6 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8521,11 +7411,6 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8553,11 +7438,6 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8583,10 +7463,6 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8611,11 +7487,6 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8633,11 +7504,6 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Sub(arg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8665,10 +7531,6 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8719,11 +7581,6 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8767,11 +7624,6 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8797,10 +7649,6 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8842,11 +7690,6 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8881,11 +7724,6 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8911,10 +7749,6 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8948,11 +7782,6 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8979,11 +7808,6 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9009,10 +7833,6 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9046,11 +7866,6 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9077,11 +7892,6 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9107,10 +7917,6 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9144,11 +7950,6 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9175,11 +7976,6 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9207,10 +8003,6 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9252,11 +8044,6 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9291,11 +8078,6 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9323,10 +8105,6 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9376,11 +8154,6 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9423,11 +8196,6 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9455,10 +8223,6 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9508,11 +8272,6 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9555,11 +8314,6 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9587,10 +8341,6 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9640,11 +8390,6 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9687,11 +8432,6 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9719,10 +8459,6 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9772,11 +8508,6 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9819,11 +8550,6 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9851,10 +8577,6 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9904,11 +8626,6 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9951,11 +8668,6 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9981,10 +8693,6 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10027,11 +8735,6 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10067,11 +8770,6 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10097,10 +8795,6 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10143,11 +8837,6 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10183,11 +8872,6 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10213,10 +8897,6 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10259,11 +8939,6 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10299,11 +8974,6 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10329,10 +8999,6 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10373,11 +9039,6 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10411,11 +9072,6 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10441,10 +9097,6 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10479,11 +9131,6 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10511,11 +9158,6 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10541,10 +9183,6 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10601,11 +9239,6 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10655,11 +9288,6 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10685,10 +9313,6 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10745,11 +9369,6 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10799,11 +9418,6 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10829,10 +9443,6 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10889,11 +9499,6 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10943,11 +9548,6 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10973,10 +9573,6 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11021,11 +9617,6 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11063,11 +9654,6 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11093,10 +9679,6 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11121,11 +9703,6 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11143,11 +9720,6 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11173,10 +9745,6 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11233,11 +9801,6 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11287,11 +9850,6 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11317,10 +9875,6 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11377,11 +9931,6 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11431,11 +9980,6 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11461,10 +10005,6 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11521,11 +10061,6 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11575,11 +10110,6 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11605,10 +10135,6 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11653,11 +10179,6 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11695,11 +10216,6 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11725,10 +10241,6 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11753,11 +10265,6 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11775,11 +10282,6 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11805,10 +10307,6 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11865,11 +10363,6 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11919,11 +10412,6 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11949,10 +10437,6 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12009,11 +10493,6 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12063,11 +10542,6 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12093,10 +10567,6 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12153,11 +10623,6 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12207,11 +10672,6 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12237,10 +10697,6 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12285,11 +10741,6 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12327,11 +10778,6 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12357,10 +10803,6 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12385,11 +10827,6 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12407,11 +10844,6 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12437,10 +10869,6 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12475,11 +10903,6 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12507,11 +10930,6 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12537,10 +10955,6 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12565,11 +10979,6 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12587,11 +10996,6 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12617,10 +11021,6 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12645,11 +11045,6 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12667,11 +11062,6 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12697,10 +11087,6 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12725,11 +11111,6 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12747,11 +11128,6 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12777,10 +11153,6 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12805,11 +11177,6 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12827,11 +11194,6 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12857,10 +11219,6 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12885,11 +11243,6 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12907,11 +11260,6 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12937,10 +11285,6 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12975,11 +11319,6 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13007,11 +11346,6 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13037,10 +11371,6 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13091,11 +11421,6 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13139,11 +11464,6 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13169,10 +11489,6 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13223,11 +11539,6 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13271,11 +11582,6 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13301,10 +11607,6 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13355,11 +11657,6 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13403,11 +11700,6 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13433,10 +11725,6 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13485,11 +11773,6 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13531,11 +11814,6 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13561,10 +11839,6 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13613,11 +11887,6 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13659,11 +11928,6 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13689,10 +11953,6 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13741,11 +12001,6 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13787,11 +12042,6 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13817,10 +12067,6 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13869,11 +12115,6 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13915,11 +12156,6 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13945,10 +12181,6 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14001,11 +12233,6 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14051,11 +12278,6 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14081,10 +12303,6 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14133,11 +12351,6 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14179,11 +12392,6 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14209,10 +12417,6 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14261,11 +12465,6 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14307,11 +12506,6 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14337,10 +12531,6 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14389,11 +12579,6 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14435,11 +12620,6 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14465,10 +12645,6 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14521,11 +12697,6 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14571,11 +12742,6 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14601,10 +12767,6 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14653,11 +12815,6 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14699,11 +12856,6 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14729,10 +12881,6 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14781,11 +12929,6 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14827,11 +12970,6 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14857,10 +12995,6 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14909,11 +13043,6 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14955,11 +13084,6 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14985,10 +13109,6 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15041,11 +13161,6 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15091,11 +13206,6 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15121,10 +13231,6 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15167,11 +13273,6 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15207,11 +13308,6 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15237,10 +13333,6 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15273,11 +13365,6 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15303,11 +13390,6 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Div(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15333,10 +13415,6 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15369,11 +13447,6 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15399,11 +13472,6 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Div(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15429,10 +13497,6 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15465,11 +13529,6 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15495,11 +13554,6 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Div(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15525,10 +13579,6 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15561,11 +13611,6 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15591,11 +13636,6 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.DivFloat(float64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15621,10 +13661,6 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15675,11 +13711,6 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15723,11 +13754,6 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15753,10 +13779,6 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15807,11 +13829,6 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15855,11 +13872,6 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15885,10 +13897,6 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15939,11 +13947,6 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15987,11 +13990,6 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16017,10 +14015,6 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16069,11 +14063,6 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16115,11 +14104,6 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16145,10 +14129,6 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16187,11 +14167,6 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16223,11 +14198,6 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16253,10 +14223,6 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16295,11 +14261,6 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16331,11 +14292,6 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16361,10 +14317,6 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16403,11 +14355,6 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16439,11 +14386,6 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16469,10 +14411,6 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16525,11 +14463,6 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16575,11 +14508,6 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16605,10 +14533,6 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16647,11 +14571,6 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16683,11 +14602,6 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16713,10 +14627,6 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16755,11 +14665,6 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16791,11 +14696,6 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16821,10 +14721,6 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16863,11 +14759,6 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16899,11 +14790,6 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16929,10 +14815,6 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16985,11 +14867,6 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17035,11 +14912,6 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17065,10 +14937,6 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17107,11 +14975,6 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17143,11 +15006,6 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17173,10 +15031,6 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17215,11 +15069,6 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17251,11 +15100,6 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17281,10 +15125,6 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17323,11 +15163,6 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17359,11 +15194,6 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17389,10 +15219,6 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17445,11 +15271,6 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17495,11 +15316,6 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17525,10 +15341,6 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17571,11 +15383,6 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17611,11 +15418,6 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17641,10 +15443,6 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17695,11 +15493,6 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17743,11 +15536,6 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17773,10 +15561,6 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17827,11 +15611,6 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17875,11 +15654,6 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17905,10 +15679,6 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17959,11 +15729,6 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18007,11 +15772,6 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18037,10 +15797,6 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18089,11 +15845,6 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18135,11 +15886,6 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18165,10 +15911,6 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18207,11 +15949,6 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18243,11 +15980,6 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18273,10 +16005,6 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18315,11 +16043,6 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18351,11 +16074,6 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18381,10 +16099,6 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18423,11 +16137,6 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18459,11 +16168,6 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18489,10 +16193,6 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18545,11 +16245,6 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18595,11 +16290,6 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18625,10 +16315,6 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18667,11 +16353,6 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18703,11 +16384,6 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18733,10 +16409,6 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18775,11 +16447,6 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18811,11 +16478,6 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18841,10 +16503,6 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18883,11 +16541,6 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18919,11 +16572,6 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18949,10 +16597,6 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19005,11 +16649,6 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19055,11 +16694,6 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19085,10 +16719,6 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19127,11 +16757,6 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19163,11 +16788,6 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19193,10 +16813,6 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19235,11 +16851,6 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19271,11 +16882,6 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19301,10 +16907,6 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19343,11 +16945,6 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19379,11 +16976,6 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19409,10 +17001,6 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19465,11 +17053,6 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19515,11 +17098,6 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19545,10 +17123,6 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19591,11 +17165,6 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19631,11 +17200,6 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19661,10 +17225,6 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19707,11 +17267,6 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19747,11 +17302,6 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19777,10 +17327,6 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19823,11 +17369,6 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19863,11 +17404,6 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19893,10 +17429,6 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19939,11 +17471,6 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19979,11 +17506,6 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20009,10 +17531,6 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20053,11 +17571,6 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20091,11 +17604,6 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20121,10 +17629,6 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20177,11 +17681,6 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20227,11 +17726,6 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20257,10 +17751,6 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20313,11 +17803,6 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20363,11 +17848,6 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20393,10 +17873,6 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20449,11 +17925,6 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20499,11 +17970,6 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20529,10 +17995,6 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20577,11 +18039,6 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20619,11 +18076,6 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20649,10 +18101,6 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20705,11 +18153,6 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20755,11 +18198,6 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20785,10 +18223,6 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20841,11 +18275,6 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20891,11 +18320,6 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20921,10 +18345,6 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20977,11 +18397,6 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21027,11 +18442,6 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21057,10 +18467,6 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21105,11 +18511,6 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21147,11 +18548,6 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21177,10 +18573,6 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21233,11 +18625,6 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21283,11 +18670,6 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21313,10 +18695,6 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21369,11 +18747,6 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21419,11 +18792,6 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21449,10 +18817,6 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21505,11 +18869,6 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21555,11 +18914,6 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21585,10 +18939,6 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21633,11 +18983,6 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21675,11 +19020,6 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21705,10 +19045,6 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21743,11 +19079,6 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21775,11 +19106,6 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21805,10 +19131,6 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21846,11 +19168,6 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21881,11 +19198,6 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21911,10 +19223,6 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21950,11 +19258,6 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21983,11 +19286,6 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22015,10 +19313,6 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22060,11 +19354,6 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22099,11 +19388,6 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22129,10 +19413,6 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22173,11 +19453,6 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22211,11 +19486,6 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22241,10 +19511,6 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22285,11 +19551,6 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22323,11 +19584,6 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22353,10 +19609,6 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22397,11 +19649,6 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22435,11 +19682,6 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22465,10 +19707,6 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22509,11 +19747,6 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22547,11 +19780,6 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22577,10 +19805,6 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22621,11 +19845,6 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22659,11 +19878,6 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22689,10 +19903,6 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22733,11 +19943,6 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22771,11 +19976,6 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22801,10 +20001,6 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22845,11 +20041,6 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22883,11 +20074,6 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22913,10 +20099,6 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22957,11 +20139,6 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22995,11 +20172,6 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23025,10 +20197,6 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23069,11 +20237,6 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23107,11 +20270,6 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23139,10 +20297,6 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23192,11 +20346,6 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23239,11 +20388,6 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23271,10 +20415,6 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23324,11 +20464,6 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23371,11 +20506,6 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23403,10 +20533,6 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23456,11 +20582,6 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23503,11 +20624,6 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23533,10 +20649,6 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23577,11 +20689,6 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23615,11 +20722,6 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23645,10 +20747,6 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23689,11 +20787,6 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23727,11 +20820,6 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23757,10 +20845,6 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23801,11 +20885,6 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23839,11 +20918,6 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23869,10 +20943,6 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23913,11 +20983,6 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23951,11 +21016,6 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23981,10 +21041,6 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24025,11 +21081,6 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24063,11 +21114,6 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24093,10 +21139,6 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24137,11 +21179,6 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24175,11 +21212,6 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24205,10 +21237,6 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24249,11 +21277,6 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24287,11 +21310,6 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24317,10 +21335,6 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24361,11 +21375,6 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24399,11 +21408,6 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24429,10 +21433,6 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24473,11 +21473,6 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24511,11 +21506,6 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24543,10 +21533,6 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24596,11 +21582,6 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24643,11 +21624,6 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24675,10 +21651,6 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24728,11 +21700,6 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24775,11 +21742,6 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24807,10 +21769,6 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24860,11 +21818,6 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24907,11 +21860,6 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24937,10 +21885,6 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24988,11 +21932,6 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25033,11 +21972,6 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25063,10 +21997,6 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25108,11 +22038,6 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25147,11 +22072,6 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25177,10 +22097,6 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25222,11 +22138,6 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25261,11 +22172,6 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25291,10 +22197,6 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25336,11 +22238,6 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25375,11 +22272,6 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25405,10 +22297,6 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25474,11 +22362,6 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25537,11 +22420,6 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25567,10 +22445,6 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25630,11 +22504,6 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25687,11 +22556,6 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25717,10 +22581,6 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25780,11 +22640,6 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25837,11 +22692,6 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25867,10 +22717,6 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25930,11 +22776,6 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25987,11 +22828,6 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26017,10 +22853,6 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26062,11 +22894,6 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26101,11 +22928,6 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26131,10 +22953,6 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26196,11 +23014,6 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26255,11 +23068,6 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -66,7 +66,9 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -140,7 +142,9 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -214,7 +218,9 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -288,7 +294,9 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -362,7 +370,9 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -436,7 +446,9 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -510,7 +522,9 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -584,7 +598,9 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -658,7 +674,9 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -734,7 +752,9 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -834,7 +854,9 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -908,7 +930,9 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -982,7 +1006,9 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1056,7 +1082,9 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1130,7 +1158,9 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1204,7 +1234,9 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1278,7 +1310,9 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1352,7 +1386,9 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1426,7 +1462,9 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1502,7 +1540,9 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1602,7 +1642,9 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1676,7 +1718,9 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1750,7 +1794,9 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1824,7 +1870,9 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1898,7 +1946,9 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1972,7 +2022,9 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2046,7 +2098,9 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2120,7 +2174,9 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2194,7 +2250,9 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2270,7 +2328,9 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2370,7 +2430,9 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2472,7 +2534,9 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2574,7 +2638,9 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2676,7 +2742,9 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2774,7 +2842,9 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2872,7 +2942,9 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2970,7 +3042,9 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3068,7 +3142,9 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3176,7 +3252,9 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3294,7 +3372,9 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3392,7 +3472,9 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3490,7 +3572,9 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3588,7 +3672,9 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3696,7 +3782,9 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3814,7 +3902,9 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3912,7 +4002,9 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4010,7 +4102,9 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4108,7 +4202,9 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4216,7 +4312,9 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4334,7 +4432,9 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4420,7 +4520,9 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4506,7 +4608,9 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4592,7 +4696,9 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4660,7 +4766,9 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4780,7 +4888,9 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4898,7 +5008,9 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5016,7 +5128,9 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5134,7 +5248,9 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5250,7 +5366,9 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5352,7 +5470,9 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5454,7 +5574,9 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5556,7 +5678,9 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5654,7 +5778,9 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5752,7 +5878,9 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5850,7 +5978,9 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5948,7 +6078,9 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6056,7 +6188,9 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6174,7 +6308,9 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6272,7 +6408,9 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6370,7 +6508,9 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6468,7 +6608,9 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6576,7 +6718,9 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6694,7 +6838,9 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6792,7 +6938,9 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6890,7 +7038,9 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6988,7 +7138,9 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7096,7 +7248,9 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7214,7 +7368,9 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7300,7 +7456,9 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7378,7 +7536,9 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7464,7 +7624,9 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7532,7 +7694,9 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7650,7 +7814,9 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7750,7 +7916,9 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7834,7 +8002,9 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7918,7 +8088,9 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8004,7 +8176,9 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8106,7 +8280,9 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8224,7 +8400,9 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8342,7 +8520,9 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8460,7 +8640,9 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8578,7 +8760,9 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8694,7 +8878,9 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8796,7 +8982,9 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8898,7 +9086,9 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9000,7 +9190,9 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9098,7 +9290,9 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9184,7 +9378,9 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9314,7 +9510,9 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9444,7 +9642,9 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9574,7 +9774,9 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9680,7 +9882,9 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9746,7 +9950,9 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9876,7 +10082,9 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10006,7 +10214,9 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10136,7 +10346,9 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10242,7 +10454,9 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10308,7 +10522,9 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10438,7 +10654,9 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10568,7 +10786,9 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10698,7 +10918,9 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10804,7 +11026,9 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10870,7 +11094,9 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10956,7 +11182,9 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11022,7 +11250,9 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11088,7 +11318,9 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11154,7 +11386,9 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11220,7 +11454,9 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11286,7 +11522,9 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11372,7 +11610,9 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11490,7 +11730,9 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11608,7 +11850,9 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11726,7 +11970,9 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11840,7 +12086,9 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11954,7 +12202,9 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12068,7 +12318,9 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12182,7 +12434,9 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12304,7 +12558,9 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12418,7 +12674,9 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12532,7 +12790,9 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12646,7 +12906,9 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12768,7 +13030,9 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12882,7 +13146,9 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12996,7 +13262,9 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13110,7 +13378,9 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13232,7 +13502,9 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13334,7 +13606,9 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13416,7 +13690,9 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13498,7 +13774,9 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13580,7 +13858,9 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13662,7 +13942,9 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13780,7 +14062,9 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13898,7 +14182,9 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14016,7 +14302,9 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14130,7 +14418,9 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14224,7 +14514,9 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14318,7 +14610,9 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14412,7 +14706,9 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14534,7 +14830,9 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14628,7 +14926,9 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14722,7 +15022,9 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14816,7 +15118,9 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14938,7 +15242,9 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15032,7 +15338,9 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15126,7 +15434,9 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15220,7 +15530,9 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15342,7 +15654,9 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15444,7 +15758,9 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15562,7 +15878,9 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15680,7 +15998,9 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15798,7 +16118,9 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15912,7 +16234,9 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16006,7 +16330,9 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16100,7 +16426,9 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16194,7 +16522,9 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16316,7 +16646,9 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16410,7 +16742,9 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16504,7 +16838,9 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16598,7 +16934,9 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16720,7 +17058,9 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16814,7 +17154,9 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16908,7 +17250,9 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17002,7 +17346,9 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17124,7 +17470,9 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17226,7 +17574,9 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17328,7 +17678,9 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17430,7 +17782,9 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17532,7 +17886,9 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17630,7 +17986,9 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17752,7 +18110,9 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17874,7 +18234,9 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17996,7 +18358,9 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18102,7 +18466,9 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18224,7 +18590,9 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18346,7 +18714,9 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18468,7 +18838,9 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18574,7 +18946,9 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18696,7 +19070,9 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18818,7 +19194,9 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18940,7 +19318,9 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19046,7 +19426,9 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19132,7 +19514,9 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19224,7 +19608,9 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19314,7 +19700,9 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19414,7 +19802,9 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19512,7 +19902,9 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19610,7 +20002,9 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19708,7 +20102,9 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19806,7 +20202,9 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19904,7 +20302,9 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20002,7 +20402,9 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20100,7 +20502,9 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20198,7 +20602,9 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20298,7 +20704,9 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20416,7 +20824,9 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20534,7 +20944,9 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20650,7 +21062,9 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20748,7 +21162,9 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20846,7 +21262,9 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20944,7 +21362,9 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21042,7 +21462,9 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21140,7 +21562,9 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21238,7 +21662,9 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21336,7 +21762,9 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21434,7 +21862,9 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21534,7 +21964,9 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21652,7 +22084,9 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21770,7 +22204,9 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21886,7 +22322,9 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21998,7 +22436,9 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22098,7 +22538,9 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22198,7 +22640,9 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22298,7 +22742,9 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22446,7 +22892,9 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22582,7 +23030,9 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22718,7 +23168,9 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22854,7 +23306,9 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22954,7 +23408,9 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23088,6 +23544,7 @@ func GetProjectionLConstOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
@@ -23095,6 +23552,7 @@ func GetProjectionLConstOperator(
 		allocator:      allocator,
 		colIdx:         colIdx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	leftType, rightType := constType, inputTypes[colIdx]

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_base.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_base.go
@@ -19,7 +19,8 @@ import (
 // except for the constant itself.
 type projConstOpBase struct {
 	colexecop.OneInputHelper
-	allocator *colmem.Allocator
-	colIdx    int
-	outputIdx int
+	allocator    *colmem.Allocator
+	colIdx       int
+	outputIdx    int
+	nullableArgs bool
 }

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
@@ -122,10 +122,12 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec._RET_TYP()
+		// {{/*
 		// Some operators can result in NULL with non-NULL inputs, like the JSON
 		// fetch value operator, ->. Therefore, _outNulls is defined to allow
 		// updating the output Nulls from within _ASSIGN functions when the result
 		// of a projection is Null.
+		// */}}
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			_SET_PROJECTION(true)
@@ -159,11 +161,13 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS, false)
 		}
 	}
+	// {{/*
 	// _outNulls has been updated from within the _ASSIGN function to include
 	// any NULLs that resulted from the projection.
 	// If _HAS_NULLS is true, union _outNulls with the set of input Nulls.
 	// If _HAS_NULLS is false, then there are no input Nulls. _outNulls is
 	// projVec.Nulls() so there is no need to call projVec.SetNulls().
+	// */}}
 	// {{if _HAS_NULLS}}
 	projVec.SetNulls(_outNulls.Or(*colNulls))
 	// {{end}}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
@@ -129,7 +129,23 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 		// of a projection is Null.
 		// */}}
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		// {{/*
+		// If nullableArgs is true, the function’s definition can handle null
+		// arguments. We would still want to perform the projection, and there is no
+		// need to call projVec.SetNulls(). The behaviour will just be the same as
+		// _HAS_NULLS is false. Since currently only ConcatDatumDatum needs this
+		// nullableArgs == true behaviour, logic for nullableArgs is only added to
+		// the if statement for function with Datum, Datum. If we later introduce
+		// another projection operation that has nullableArgs == true, we should
+		// update this code accordingly.
+		// */}}
+		// {{if and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum")}}
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		// {{else}}
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		// {{end}}
+		if hasNullsAndNotNullable {
 			_SET_PROJECTION(true)
 		} else {
 			_SET_PROJECTION(false)
@@ -265,6 +281,7 @@ func GetProjection_CONST_SIDEConstOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
@@ -272,6 +289,7 @@ func GetProjection_CONST_SIDEConstOperator(
 		allocator:      allocator,
 		colIdx:         colIdx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	// {{if _IS_CONST_LEFT}}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -69,7 +69,9 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -143,7 +145,9 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -217,7 +221,9 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -291,7 +297,9 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -365,7 +373,9 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -439,7 +449,9 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -513,7 +525,9 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -587,7 +601,9 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -661,7 +677,9 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -737,7 +755,9 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -837,7 +857,9 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -911,7 +933,9 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -985,7 +1009,9 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1059,7 +1085,9 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1133,7 +1161,9 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1207,7 +1237,9 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1281,7 +1313,9 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1355,7 +1389,9 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1429,7 +1465,9 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1505,7 +1543,9 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1605,7 +1645,9 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1679,7 +1721,9 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1753,7 +1797,9 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1827,7 +1873,9 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1901,7 +1949,9 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1975,7 +2025,9 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2049,7 +2101,9 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2123,7 +2177,9 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2197,7 +2253,9 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2273,7 +2331,9 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2373,7 +2433,9 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2475,7 +2537,9 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2577,7 +2641,9 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2679,7 +2745,9 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2777,7 +2845,9 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2875,7 +2945,9 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2973,7 +3045,9 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3071,7 +3145,9 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3179,7 +3255,9 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3295,7 +3373,9 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3393,7 +3473,9 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3491,7 +3573,9 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3589,7 +3673,9 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3697,7 +3783,9 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3813,7 +3901,9 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3911,7 +4001,9 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4009,7 +4101,9 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4107,7 +4201,9 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4215,7 +4311,9 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4331,7 +4429,9 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4417,7 +4517,9 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4503,7 +4605,9 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4589,7 +4693,9 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4657,7 +4763,9 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4775,7 +4883,9 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4895,7 +5005,9 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5015,7 +5127,9 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5135,7 +5249,9 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5253,7 +5369,9 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5355,7 +5473,9 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5457,7 +5577,9 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5559,7 +5681,9 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5657,7 +5781,9 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5755,7 +5881,9 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5853,7 +5981,9 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5951,7 +6081,9 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6059,7 +6191,9 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6175,7 +6309,9 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6273,7 +6409,9 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6371,7 +6509,9 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6469,7 +6609,9 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6577,7 +6719,9 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6693,7 +6837,9 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6791,7 +6937,9 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6889,7 +7037,9 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6987,7 +7137,9 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7095,7 +7247,9 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7211,7 +7365,9 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7297,7 +7453,9 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7375,7 +7533,9 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7461,7 +7621,9 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7529,7 +7691,9 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7645,7 +7809,9 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7745,7 +7911,9 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7831,7 +7999,9 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7917,7 +8087,9 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8005,7 +8177,9 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8107,7 +8281,9 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8227,7 +8403,9 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8345,7 +8523,9 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8465,7 +8645,9 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8585,7 +8767,9 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8703,7 +8887,9 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8805,7 +8991,9 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8907,7 +9095,9 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9009,7 +9199,9 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9107,7 +9299,9 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9193,7 +9387,9 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9323,7 +9519,9 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9453,7 +9651,9 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9583,7 +9783,9 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9689,7 +9891,9 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9755,7 +9959,9 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9885,7 +10091,9 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10015,7 +10223,9 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10145,7 +10355,9 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10251,7 +10463,9 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10317,7 +10531,9 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10447,7 +10663,9 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10577,7 +10795,9 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10707,7 +10927,9 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10813,7 +11035,9 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10879,7 +11103,9 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10965,7 +11191,9 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11031,7 +11259,9 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11097,7 +11327,9 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11163,7 +11395,9 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11229,7 +11463,9 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11295,7 +11531,9 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11381,7 +11619,9 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11499,7 +11739,9 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11617,7 +11859,9 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11735,7 +11979,9 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11849,7 +12095,9 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11963,7 +12211,9 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12077,7 +12327,9 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12191,7 +12443,9 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12313,7 +12567,9 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12427,7 +12683,9 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12541,7 +12799,9 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12655,7 +12915,9 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12777,7 +13039,9 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12891,7 +13155,9 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13005,7 +13271,9 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13119,7 +13387,9 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13241,7 +13511,9 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13343,7 +13615,9 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13425,7 +13699,9 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13507,7 +13783,9 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13589,7 +13867,9 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13671,7 +13951,9 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13789,7 +14071,9 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13907,7 +14191,9 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14025,7 +14311,9 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14139,7 +14427,9 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14233,7 +14523,9 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14327,7 +14619,9 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14421,7 +14715,9 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14543,7 +14839,9 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14637,7 +14935,9 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14731,7 +15031,9 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14825,7 +15127,9 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14947,7 +15251,9 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15041,7 +15347,9 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15135,7 +15443,9 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15229,7 +15539,9 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15351,7 +15663,9 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15453,7 +15767,9 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15571,7 +15887,9 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15689,7 +16007,9 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15807,7 +16127,9 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15921,7 +16243,9 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16015,7 +16339,9 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16109,7 +16435,9 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16203,7 +16531,9 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16325,7 +16655,9 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16419,7 +16751,9 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16513,7 +16847,9 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16607,7 +16943,9 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16729,7 +17067,9 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16823,7 +17163,9 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16917,7 +17259,9 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17011,7 +17355,9 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17133,7 +17479,9 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17235,7 +17583,9 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17337,7 +17687,9 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17439,7 +17791,9 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17541,7 +17895,9 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17639,7 +17995,9 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17761,7 +18119,9 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17883,7 +18243,9 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18005,7 +18367,9 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18111,7 +18475,9 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18233,7 +18599,9 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18355,7 +18723,9 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18477,7 +18847,9 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18583,7 +18955,9 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18705,7 +19079,9 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18827,7 +19203,9 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18949,7 +19327,9 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19055,7 +19435,9 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19141,7 +19523,9 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19233,7 +19617,9 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19323,7 +19709,9 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19423,7 +19811,9 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19521,7 +19911,9 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19619,7 +20011,9 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19717,7 +20111,9 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19815,7 +20211,9 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19913,7 +20311,9 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20011,7 +20411,9 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20109,7 +20511,9 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20207,7 +20611,9 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20307,7 +20713,9 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20427,7 +20835,9 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20547,7 +20957,9 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20665,7 +21077,9 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20763,7 +21177,9 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20861,7 +21277,9 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20959,7 +21377,9 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21057,7 +21477,9 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21155,7 +21577,9 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21253,7 +21677,9 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21351,7 +21777,9 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21449,7 +21877,9 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21549,7 +21979,9 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21669,7 +22101,9 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21789,7 +22223,9 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21907,7 +22343,9 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22019,7 +22457,9 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22121,7 +22561,9 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22223,7 +22665,9 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22325,7 +22769,9 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22473,7 +22919,9 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22611,7 +23059,9 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22749,7 +23199,9 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22887,7 +23339,9 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22987,7 +23441,9 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23127,7 +23583,9 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23249,7 +23707,9 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23337,7 +23797,9 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23451,7 +23913,9 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23565,7 +24029,9 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23679,7 +24145,9 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23801,7 +24269,9 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23891,7 +24361,9 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24025,7 +24497,9 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24159,7 +24633,9 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24293,7 +24769,9 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24459,7 +24937,9 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24573,7 +25053,9 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24707,7 +25189,9 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24841,7 +25325,9 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24975,7 +25461,9 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25141,7 +25629,9 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25255,7 +25745,9 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25389,7 +25881,9 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25523,7 +26017,9 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25657,7 +26153,9 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25823,7 +26321,9 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25937,7 +26437,9 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26103,7 +26605,9 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26269,7 +26773,9 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26435,7 +26941,9 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26601,7 +27109,9 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26723,7 +27233,9 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26841,7 +27353,9 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26931,7 +27445,9 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27043,7 +27559,9 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27139,7 +27657,9 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27261,7 +27781,9 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27349,7 +27871,9 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27463,7 +27987,9 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27577,7 +28103,9 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27691,7 +28219,9 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27813,7 +28343,9 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27903,7 +28435,9 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28037,7 +28571,9 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28171,7 +28707,9 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28305,7 +28843,9 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28471,7 +29011,9 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28585,7 +29127,9 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28719,7 +29263,9 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28853,7 +29399,9 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28987,7 +29535,9 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29153,7 +29703,9 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29267,7 +29819,9 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29401,7 +29955,9 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29535,7 +30091,9 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29669,7 +30227,9 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29835,7 +30395,9 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29949,7 +30511,9 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30115,7 +30679,9 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30281,7 +30847,9 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30447,7 +31015,9 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30613,7 +31183,9 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30735,7 +31307,9 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30853,7 +31427,9 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30943,7 +31519,9 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31055,7 +31633,9 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31151,7 +31731,9 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31273,7 +31855,9 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31361,7 +31945,9 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31475,7 +32061,9 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31589,7 +32177,9 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31703,7 +32293,9 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31825,7 +32417,9 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31915,7 +32509,9 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32049,7 +32645,9 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32183,7 +32781,9 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32317,7 +32917,9 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32483,7 +33085,9 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32597,7 +33201,9 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32731,7 +33337,9 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32865,7 +33473,9 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32999,7 +33609,9 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33165,7 +33777,9 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33279,7 +33893,9 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33413,7 +34029,9 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33547,7 +34165,9 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33681,7 +34301,9 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33847,7 +34469,9 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33961,7 +34585,9 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34127,7 +34753,9 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34293,7 +34921,9 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34459,7 +35089,9 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34625,7 +35257,9 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34747,7 +35381,9 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34865,7 +35501,9 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34955,7 +35593,9 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35067,7 +35707,9 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35163,7 +35805,9 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35285,7 +35929,9 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35373,7 +36019,9 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35487,7 +36135,9 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35601,7 +36251,9 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35715,7 +36367,9 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35837,7 +36491,9 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35927,7 +36583,9 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36061,7 +36719,9 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36195,7 +36855,9 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36329,7 +36991,9 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36495,7 +37159,9 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36609,7 +37275,9 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36743,7 +37411,9 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36877,7 +37547,9 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37011,7 +37683,9 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37177,7 +37851,9 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37291,7 +37967,9 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37425,7 +38103,9 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37559,7 +38239,9 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37693,7 +38375,9 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37859,7 +38543,9 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37973,7 +38659,9 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38139,7 +38827,9 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38305,7 +38995,9 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38471,7 +39163,9 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38637,7 +39331,9 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38759,7 +39455,9 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38877,7 +39575,9 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38967,7 +39667,9 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39079,7 +39781,9 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39175,7 +39879,9 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39297,7 +40003,9 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39385,7 +40093,9 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39499,7 +40209,9 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39613,7 +40325,9 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39727,7 +40441,9 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39849,7 +40565,9 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39939,7 +40657,9 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40073,7 +40793,9 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40207,7 +40929,9 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40341,7 +41065,9 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40507,7 +41233,9 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40621,7 +41349,9 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40755,7 +41485,9 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40889,7 +41621,9 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41023,7 +41757,9 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41189,7 +41925,9 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41303,7 +42041,9 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41437,7 +42177,9 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41571,7 +42313,9 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41705,7 +42449,9 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41871,7 +42617,9 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41985,7 +42733,9 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42151,7 +42901,9 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42317,7 +43069,9 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42483,7 +43237,9 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42649,7 +43405,9 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42771,7 +43529,9 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42889,7 +43649,9 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42979,7 +43741,9 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43091,7 +43855,9 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43187,7 +43953,9 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43309,7 +44077,9 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43397,7 +44167,9 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43511,7 +44283,9 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43625,7 +44399,9 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43739,7 +44515,9 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43861,7 +44639,9 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43951,7 +44731,9 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44085,7 +44867,9 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44219,7 +45003,9 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44353,7 +45139,9 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44519,7 +45307,9 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44633,7 +45423,9 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44767,7 +45559,9 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44901,7 +45695,9 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45035,7 +45831,9 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45201,7 +45999,9 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45315,7 +46115,9 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45449,7 +46251,9 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45583,7 +46387,9 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45717,7 +46523,9 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45883,7 +46691,9 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45997,7 +46807,9 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46163,7 +46975,9 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46329,7 +47143,9 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46495,7 +47311,9 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46661,7 +47479,9 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46783,7 +47603,9 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46901,7 +47723,9 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46991,7 +47815,9 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47103,7 +47929,9 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47193,6 +48021,7 @@ func GetProjectionRConstOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
@@ -47200,6 +48029,7 @@ func GetProjectionRConstOperator(
 		allocator:      allocator,
 		colIdx:         colIdx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	leftType, rightType := inputTypes[colIdx], constType

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -68,10 +68,6 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -100,11 +96,6 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -126,11 +117,6 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -156,10 +142,6 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -188,11 +170,6 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -214,11 +191,6 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -244,10 +216,6 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -276,11 +244,6 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -302,11 +265,6 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -332,10 +290,6 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -364,11 +318,6 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -390,11 +339,6 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -420,10 +364,6 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -452,11 +392,6 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -478,11 +413,6 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -508,10 +438,6 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -540,11 +466,6 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -566,11 +487,6 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -596,10 +512,6 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -628,11 +540,6 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -654,11 +561,6 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -684,10 +586,6 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -716,11 +614,6 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -742,11 +635,6 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -772,10 +660,6 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -804,11 +688,6 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -830,11 +709,6 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -862,10 +736,6 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -907,11 +777,6 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -946,11 +811,6 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -976,10 +836,6 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1008,11 +864,6 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1034,11 +885,6 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1064,10 +910,6 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1096,11 +938,6 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1122,11 +959,6 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1152,10 +984,6 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1184,11 +1012,6 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1210,11 +1033,6 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1240,10 +1058,6 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1272,11 +1086,6 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1298,11 +1107,6 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1328,10 +1132,6 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1360,11 +1160,6 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1386,11 +1181,6 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1416,10 +1206,6 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1448,11 +1234,6 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1474,11 +1255,6 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1504,10 +1280,6 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1536,11 +1308,6 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1562,11 +1329,6 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1592,10 +1354,6 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1624,11 +1382,6 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1650,11 +1403,6 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1680,10 +1428,6 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1712,11 +1456,6 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1738,11 +1477,6 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1770,10 +1504,6 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1815,11 +1545,6 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1854,11 +1579,6 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1884,10 +1604,6 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1916,11 +1632,6 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1942,11 +1653,6 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1972,10 +1678,6 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2004,11 +1706,6 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2030,11 +1727,6 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2060,10 +1752,6 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2092,11 +1780,6 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2118,11 +1801,6 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2148,10 +1826,6 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2180,11 +1854,6 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2206,11 +1875,6 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2236,10 +1900,6 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2268,11 +1928,6 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2294,11 +1949,6 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2324,10 +1974,6 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2356,11 +2002,6 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2382,11 +2023,6 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2412,10 +2048,6 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2444,11 +2076,6 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2470,11 +2097,6 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2500,10 +2122,6 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2532,11 +2150,6 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2558,11 +2171,6 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2588,10 +2196,6 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2620,11 +2224,6 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2646,11 +2245,6 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2678,10 +2272,6 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2723,11 +2313,6 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2762,11 +2347,6 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2792,10 +2372,6 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2838,11 +2414,6 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2878,11 +2449,6 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2908,10 +2474,6 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2954,11 +2516,6 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2994,11 +2551,6 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3024,10 +2576,6 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3070,11 +2618,6 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3110,11 +2653,6 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3140,10 +2678,6 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3184,11 +2718,6 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3222,11 +2751,6 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3252,10 +2776,6 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3296,11 +2816,6 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3334,11 +2849,6 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3364,10 +2874,6 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3408,11 +2914,6 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3446,11 +2947,6 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3476,10 +2972,6 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3520,11 +3012,6 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3558,11 +3045,6 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3588,10 +3070,6 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3636,11 +3114,6 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3678,11 +3151,6 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3710,10 +3178,6 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3763,11 +3227,6 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3810,11 +3269,6 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3840,10 +3294,6 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3884,11 +3334,6 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3922,11 +3367,6 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3952,10 +3392,6 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3996,11 +3432,6 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4034,11 +3465,6 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4064,10 +3490,6 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4108,11 +3530,6 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4146,11 +3563,6 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4176,10 +3588,6 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4224,11 +3632,6 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4266,11 +3669,6 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4298,10 +3696,6 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4351,11 +3745,6 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4398,11 +3787,6 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4428,10 +3812,6 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4472,11 +3852,6 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4510,11 +3885,6 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4540,10 +3910,6 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4584,11 +3950,6 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4622,11 +3983,6 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4652,10 +4008,6 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4696,11 +4048,6 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4734,11 +4081,6 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4764,10 +4106,6 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4812,11 +4150,6 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4854,11 +4187,6 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4886,10 +4214,6 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4939,11 +4263,6 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4986,11 +4305,6 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5016,10 +4330,6 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5054,11 +4364,6 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5086,11 +4391,6 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5116,10 +4416,6 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5154,11 +4450,6 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5186,11 +4477,6 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5216,10 +4502,6 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5254,11 +4536,6 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5286,11 +4563,6 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5316,10 +4588,6 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5344,11 +4612,6 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5366,11 +4629,6 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Add(p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5398,10 +4656,6 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5451,11 +4705,6 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5498,11 +4747,6 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5530,10 +4774,6 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5584,11 +4824,6 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5632,11 +4867,6 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5664,10 +4894,6 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5718,11 +4944,6 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5766,11 +4987,6 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5798,10 +5014,6 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5852,11 +5064,6 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5900,11 +5107,6 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5932,10 +5134,6 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5986,11 +5184,6 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6034,11 +5227,6 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6064,10 +5252,6 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6110,11 +5294,6 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6150,11 +5329,6 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6180,10 +5354,6 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6226,11 +5396,6 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6266,11 +5431,6 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6296,10 +5456,6 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6342,11 +5498,6 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6382,11 +5533,6 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6412,10 +5558,6 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6456,11 +5598,6 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6494,11 +5631,6 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6524,10 +5656,6 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6568,11 +5696,6 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6606,11 +5729,6 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6636,10 +5754,6 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6680,11 +5794,6 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6718,11 +5827,6 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6748,10 +5852,6 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6792,11 +5892,6 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6830,11 +5925,6 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6860,10 +5950,6 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6908,11 +5994,6 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6950,11 +6031,6 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6982,10 +6058,6 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7035,11 +6107,6 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7082,11 +6149,6 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7112,10 +6174,6 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7156,11 +6214,6 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7194,11 +6247,6 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7224,10 +6272,6 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7268,11 +6312,6 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7306,11 +6345,6 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7336,10 +6370,6 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7380,11 +6410,6 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7418,11 +6443,6 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7448,10 +6468,6 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7496,11 +6512,6 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7538,11 +6549,6 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7570,10 +6576,6 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7623,11 +6625,6 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7670,11 +6667,6 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7700,10 +6692,6 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7744,11 +6732,6 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7782,11 +6765,6 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7812,10 +6790,6 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7856,11 +6830,6 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7894,11 +6863,6 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7924,10 +6888,6 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7968,11 +6928,6 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8006,11 +6961,6 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8036,10 +6986,6 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8084,11 +7030,6 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8126,11 +7067,6 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8158,10 +7094,6 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8211,11 +7143,6 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8258,11 +7185,6 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8288,10 +7210,6 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8326,11 +7244,6 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8358,11 +7271,6 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8388,10 +7296,6 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8422,11 +7326,6 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8450,11 +7349,6 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8480,10 +7374,6 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8518,11 +7408,6 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8550,11 +7435,6 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8580,10 +7460,6 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8608,11 +7484,6 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8630,11 +7501,6 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Sub(p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8662,10 +7528,6 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8715,11 +7577,6 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8762,11 +7619,6 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8792,10 +7644,6 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8837,11 +7685,6 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8876,11 +7719,6 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8906,10 +7744,6 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8944,11 +7778,6 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8976,11 +7805,6 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9006,10 +7830,6 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9044,11 +7864,6 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9076,11 +7891,6 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9106,10 +7916,6 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9144,11 +7950,6 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9176,11 +7977,6 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9208,10 +8004,6 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9253,11 +8045,6 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9292,11 +8079,6 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9324,10 +8106,6 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9378,11 +8156,6 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9426,11 +8199,6 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9458,10 +8226,6 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9511,11 +8275,6 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9558,11 +8317,6 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9590,10 +8344,6 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9644,11 +8394,6 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9692,11 +8437,6 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9724,10 +8464,6 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9778,11 +8514,6 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9826,11 +8557,6 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9858,10 +8584,6 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9912,11 +8634,6 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9960,11 +8677,6 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9990,10 +8702,6 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10036,11 +8744,6 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10076,11 +8779,6 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10106,10 +8804,6 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10152,11 +8846,6 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10192,11 +8881,6 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10222,10 +8906,6 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10268,11 +8948,6 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10308,11 +8983,6 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10338,10 +9008,6 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10382,11 +9048,6 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10420,11 +9081,6 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10450,10 +9106,6 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10488,11 +9140,6 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10520,11 +9167,6 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10550,10 +9192,6 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10610,11 +9248,6 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10664,11 +9297,6 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10694,10 +9322,6 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10754,11 +9378,6 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10808,11 +9427,6 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10838,10 +9452,6 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10898,11 +9508,6 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10952,11 +9557,6 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10982,10 +9582,6 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11030,11 +9626,6 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11072,11 +9663,6 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11102,10 +9688,6 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11130,11 +9712,6 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11152,11 +9729,6 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11182,10 +9754,6 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11242,11 +9810,6 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11296,11 +9859,6 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11326,10 +9884,6 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11386,11 +9940,6 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11440,11 +9989,6 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11470,10 +10014,6 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11530,11 +10070,6 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11584,11 +10119,6 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11614,10 +10144,6 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11662,11 +10188,6 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11704,11 +10225,6 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11734,10 +10250,6 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11762,11 +10274,6 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11784,11 +10291,6 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11814,10 +10316,6 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11874,11 +10372,6 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11928,11 +10421,6 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11958,10 +10446,6 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12018,11 +10502,6 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12072,11 +10551,6 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12102,10 +10576,6 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12162,11 +10632,6 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12216,11 +10681,6 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12246,10 +10706,6 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12294,11 +10750,6 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12336,11 +10787,6 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12366,10 +10812,6 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12394,11 +10836,6 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12416,11 +10853,6 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12446,10 +10878,6 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12484,11 +10912,6 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12516,11 +10939,6 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12546,10 +10964,6 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12574,11 +10988,6 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12596,11 +11005,6 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12626,10 +11030,6 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12654,11 +11054,6 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12676,11 +11071,6 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12706,10 +11096,6 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12734,11 +11120,6 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12756,11 +11137,6 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12786,10 +11162,6 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12814,11 +11186,6 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12836,11 +11203,6 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12866,10 +11228,6 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12894,11 +11252,6 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12916,11 +11269,6 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12946,10 +11294,6 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12984,11 +11328,6 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13016,11 +11355,6 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 					projCol[i] = arg.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13046,10 +11380,6 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13100,11 +11430,6 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13148,11 +11473,6 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13178,10 +11498,6 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13232,11 +11548,6 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13280,11 +11591,6 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13310,10 +11616,6 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13364,11 +11666,6 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13412,11 +11709,6 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13442,10 +11734,6 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13494,11 +11782,6 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13540,11 +11823,6 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13570,10 +11848,6 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13622,11 +11896,6 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13668,11 +11937,6 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13698,10 +11962,6 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13750,11 +12010,6 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13796,11 +12051,6 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13826,10 +12076,6 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13878,11 +12124,6 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13924,11 +12165,6 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13954,10 +12190,6 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14010,11 +12242,6 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14060,11 +12287,6 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14090,10 +12312,6 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14142,11 +12360,6 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14188,11 +12401,6 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14218,10 +12426,6 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14270,11 +12474,6 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14316,11 +12515,6 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14346,10 +12540,6 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14398,11 +12588,6 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14444,11 +12629,6 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14474,10 +12654,6 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14530,11 +12706,6 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14580,11 +12751,6 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14610,10 +12776,6 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14662,11 +12824,6 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14708,11 +12865,6 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14738,10 +12890,6 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14790,11 +12938,6 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14836,11 +12979,6 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14866,10 +13004,6 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14918,11 +13052,6 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14964,11 +13093,6 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14994,10 +13118,6 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15050,11 +13170,6 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15100,11 +13215,6 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15130,10 +13240,6 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15176,11 +13282,6 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15216,11 +13317,6 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15246,10 +13342,6 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15282,11 +13374,6 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15312,11 +13399,6 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Div(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15342,10 +13424,6 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15378,11 +13456,6 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15408,11 +13481,6 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Div(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15438,10 +13506,6 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15474,11 +13538,6 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15504,11 +13563,6 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Div(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15534,10 +13588,6 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15570,11 +13620,6 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15600,11 +13645,6 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.DivFloat(float64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15630,10 +13670,6 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15684,11 +13720,6 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15732,11 +13763,6 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15762,10 +13788,6 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15816,11 +13838,6 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15864,11 +13881,6 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15894,10 +13906,6 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15948,11 +13956,6 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15996,11 +13999,6 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16026,10 +14024,6 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16078,11 +14072,6 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16124,11 +14113,6 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16154,10 +14138,6 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16196,11 +14176,6 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16232,11 +14207,6 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16262,10 +14232,6 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16304,11 +14270,6 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16340,11 +14301,6 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16370,10 +14326,6 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16412,11 +14364,6 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16448,11 +14395,6 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16478,10 +14420,6 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16534,11 +14472,6 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16584,11 +14517,6 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16614,10 +14542,6 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16656,11 +14580,6 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16692,11 +14611,6 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16722,10 +14636,6 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16764,11 +14674,6 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16800,11 +14705,6 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16830,10 +14730,6 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16872,11 +14768,6 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16908,11 +14799,6 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16938,10 +14824,6 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16994,11 +14876,6 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17044,11 +14921,6 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17074,10 +14946,6 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17116,11 +14984,6 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17152,11 +15015,6 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17182,10 +15040,6 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17224,11 +15078,6 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17260,11 +15109,6 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17290,10 +15134,6 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17332,11 +15172,6 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17368,11 +15203,6 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17398,10 +15228,6 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17454,11 +15280,6 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17504,11 +15325,6 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17534,10 +15350,6 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17580,11 +15392,6 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17620,11 +15427,6 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17650,10 +15452,6 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17704,11 +15502,6 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17752,11 +15545,6 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17782,10 +15570,6 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17836,11 +15620,6 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17884,11 +15663,6 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17914,10 +15688,6 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17968,11 +15738,6 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18016,11 +15781,6 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18046,10 +15806,6 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18098,11 +15854,6 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18144,11 +15895,6 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18174,10 +15920,6 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18216,11 +15958,6 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18252,11 +15989,6 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18282,10 +16014,6 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18324,11 +16052,6 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18360,11 +16083,6 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18390,10 +16108,6 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18432,11 +16146,6 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18468,11 +16177,6 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18498,10 +16202,6 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18554,11 +16254,6 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18604,11 +16299,6 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18634,10 +16324,6 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18676,11 +16362,6 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18712,11 +16393,6 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18742,10 +16418,6 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18784,11 +16456,6 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18820,11 +16487,6 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18850,10 +16512,6 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18892,11 +16550,6 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18928,11 +16581,6 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18958,10 +16606,6 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19014,11 +16658,6 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19064,11 +16703,6 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19094,10 +16728,6 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19136,11 +16766,6 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19172,11 +16797,6 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19202,10 +16822,6 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19244,11 +16860,6 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19280,11 +16891,6 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19310,10 +16916,6 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19352,11 +16954,6 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19388,11 +16985,6 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19418,10 +17010,6 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19474,11 +17062,6 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19524,11 +17107,6 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19554,10 +17132,6 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19600,11 +17174,6 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19640,11 +17209,6 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19670,10 +17234,6 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19716,11 +17276,6 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19756,11 +17311,6 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19786,10 +17336,6 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19832,11 +17378,6 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19872,11 +17413,6 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19902,10 +17438,6 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19948,11 +17480,6 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19988,11 +17515,6 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20018,10 +17540,6 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20062,11 +17580,6 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20100,11 +17613,6 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20130,10 +17638,6 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20186,11 +17690,6 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20236,11 +17735,6 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20266,10 +17760,6 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20322,11 +17812,6 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20372,11 +17857,6 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20402,10 +17882,6 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20458,11 +17934,6 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20508,11 +17979,6 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20538,10 +18004,6 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20586,11 +18048,6 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20628,11 +18085,6 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20658,10 +18110,6 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20714,11 +18162,6 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20764,11 +18207,6 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20794,10 +18232,6 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20850,11 +18284,6 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20900,11 +18329,6 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20930,10 +18354,6 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20986,11 +18406,6 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21036,11 +18451,6 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21066,10 +18476,6 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21114,11 +18520,6 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21156,11 +18557,6 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21186,10 +18582,6 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21242,11 +18634,6 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21292,11 +18679,6 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21322,10 +18704,6 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21378,11 +18756,6 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21428,11 +18801,6 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21458,10 +18826,6 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21514,11 +18878,6 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21564,11 +18923,6 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21594,10 +18948,6 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21642,11 +18992,6 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21684,11 +19029,6 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21714,10 +19054,6 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21752,11 +19088,6 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21784,11 +19115,6 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21814,10 +19140,6 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21855,11 +19177,6 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21890,11 +19207,6 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21920,10 +19232,6 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21959,11 +19267,6 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21992,11 +19295,6 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22024,10 +19322,6 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22069,11 +19363,6 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22108,11 +19397,6 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22138,10 +19422,6 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22182,11 +19462,6 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22220,11 +19495,6 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22250,10 +19520,6 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22294,11 +19560,6 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22332,11 +19593,6 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22362,10 +19618,6 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22406,11 +19658,6 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22444,11 +19691,6 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22474,10 +19716,6 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22518,11 +19756,6 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22556,11 +19789,6 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22586,10 +19814,6 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22630,11 +19854,6 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22668,11 +19887,6 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22698,10 +19912,6 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22742,11 +19952,6 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22780,11 +19985,6 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22810,10 +20010,6 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22854,11 +20050,6 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22892,11 +20083,6 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22922,10 +20108,6 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22966,11 +20148,6 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23004,11 +20181,6 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23034,10 +20206,6 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23078,11 +20246,6 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23116,11 +20279,6 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23148,10 +20306,6 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23202,11 +20356,6 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23250,11 +20399,6 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23282,10 +20426,6 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23336,11 +20476,6 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23384,11 +20519,6 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23416,10 +20546,6 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23470,11 +20596,6 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23518,11 +20639,6 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23548,10 +20664,6 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23592,11 +20704,6 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23630,11 +20737,6 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23660,10 +20762,6 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23704,11 +20802,6 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23742,11 +20835,6 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23772,10 +20860,6 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23816,11 +20900,6 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23854,11 +20933,6 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23884,10 +20958,6 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23928,11 +20998,6 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23966,11 +21031,6 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23996,10 +21056,6 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24040,11 +21096,6 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24078,11 +21129,6 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24108,10 +21154,6 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24152,11 +21194,6 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24190,11 +21227,6 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24220,10 +21252,6 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24264,11 +21292,6 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24302,11 +21325,6 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24332,10 +21350,6 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24376,11 +21390,6 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24414,11 +21423,6 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24444,10 +21448,6 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24488,11 +21488,6 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24526,11 +21521,6 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24558,10 +21548,6 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24612,11 +21598,6 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24660,11 +21641,6 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24692,10 +21668,6 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24746,11 +21718,6 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24794,11 +21761,6 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24826,10 +21788,6 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24880,11 +21838,6 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24928,11 +21881,6 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24958,10 +21906,6 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25009,11 +21953,6 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25054,11 +21993,6 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25084,10 +22018,6 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25130,11 +22060,6 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25170,11 +22095,6 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25200,10 +22120,6 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25246,11 +22162,6 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25286,11 +22197,6 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25316,10 +22222,6 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25362,11 +22264,6 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25402,11 +22299,6 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25432,10 +22324,6 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25501,11 +22389,6 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25564,11 +22447,6 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25594,10 +22472,6 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25658,11 +22532,6 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25716,11 +22585,6 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25746,10 +22610,6 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25810,11 +22670,6 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25868,11 +22723,6 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25898,10 +22748,6 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25962,11 +22808,6 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26020,11 +22861,6 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26050,10 +22886,6 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26095,11 +22927,6 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26134,11 +22961,6 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26164,10 +22986,6 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26229,11 +23047,6 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26288,11 +23101,6 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26318,10 +23126,6 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26374,11 +23178,6 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26424,11 +23223,6 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26454,10 +23248,6 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26493,11 +23283,6 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26526,11 +23311,6 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26556,10 +23336,6 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26608,11 +23384,6 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26654,11 +23425,6 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26684,10 +23450,6 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26736,11 +23498,6 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26782,11 +23539,6 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26812,10 +23564,6 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26864,11 +23612,6 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26910,11 +23653,6 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26940,10 +23678,6 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26996,11 +23730,6 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27046,11 +23775,6 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27076,10 +23800,6 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27116,11 +23836,6 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27150,11 +23865,6 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27180,10 +23890,6 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27242,11 +23948,6 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27298,11 +23999,6 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27328,10 +24024,6 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27390,11 +24082,6 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27446,11 +24133,6 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27476,10 +24158,6 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27538,11 +24216,6 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27594,11 +24267,6 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27624,10 +24292,6 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27702,11 +24366,6 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27774,11 +24433,6 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27804,10 +24458,6 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27856,11 +24506,6 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27902,11 +24547,6 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27932,10 +24572,6 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27994,11 +24630,6 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28050,11 +24681,6 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28080,10 +24706,6 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28142,11 +24764,6 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28198,11 +24815,6 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28228,10 +24840,6 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28290,11 +24898,6 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28346,11 +24949,6 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28376,10 +24974,6 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28454,11 +25048,6 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28526,11 +25115,6 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28556,10 +25140,6 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28608,11 +25188,6 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28654,11 +25229,6 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28684,10 +25254,6 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28746,11 +25312,6 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28802,11 +25363,6 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28832,10 +25388,6 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28894,11 +25446,6 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28950,11 +25497,6 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28980,10 +25522,6 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29042,11 +25580,6 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29098,11 +25631,6 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29128,10 +25656,6 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29206,11 +25730,6 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29278,11 +25797,6 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29308,10 +25822,6 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29360,11 +25870,6 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29406,11 +25911,6 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29436,10 +25936,6 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29514,11 +26010,6 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29586,11 +26077,6 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29616,10 +26102,6 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29694,11 +26176,6 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29766,11 +26243,6 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29796,10 +26268,6 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29874,11 +26342,6 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29946,11 +26409,6 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29976,10 +26434,6 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30054,11 +26508,6 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30126,11 +26575,6 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30156,10 +26600,6 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30212,11 +26652,6 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30262,11 +26697,6 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30292,10 +26722,6 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30346,11 +26772,6 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30394,11 +26815,6 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30424,10 +26840,6 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30464,11 +26876,6 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30498,11 +26905,6 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30528,10 +26930,6 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30579,11 +26977,6 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30624,11 +27017,6 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30654,10 +27042,6 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30697,11 +27081,6 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30734,11 +27113,6 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30764,10 +27138,6 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30820,11 +27190,6 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30870,11 +27235,6 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30900,10 +27260,6 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30939,11 +27295,6 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30972,11 +27323,6 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31002,10 +27348,6 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31054,11 +27396,6 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31100,11 +27437,6 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31130,10 +27462,6 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31182,11 +27510,6 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31228,11 +27551,6 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31258,10 +27576,6 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31310,11 +27624,6 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31356,11 +27665,6 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31386,10 +27690,6 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31442,11 +27742,6 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31492,11 +27787,6 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31522,10 +27812,6 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31562,11 +27848,6 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31596,11 +27877,6 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31626,10 +27902,6 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31688,11 +27960,6 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31744,11 +28011,6 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31774,10 +28036,6 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31836,11 +28094,6 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31892,11 +28145,6 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31922,10 +28170,6 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31984,11 +28228,6 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32040,11 +28279,6 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32070,10 +28304,6 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32148,11 +28378,6 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32220,11 +28445,6 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32250,10 +28470,6 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32302,11 +28518,6 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32348,11 +28559,6 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32378,10 +28584,6 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32440,11 +28642,6 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32496,11 +28693,6 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32526,10 +28718,6 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32588,11 +28776,6 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32644,11 +28827,6 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32674,10 +28852,6 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32736,11 +28910,6 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32792,11 +28961,6 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32822,10 +28986,6 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32900,11 +29060,6 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32972,11 +29127,6 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33002,10 +29152,6 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33054,11 +29200,6 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33100,11 +29241,6 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33130,10 +29266,6 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33192,11 +29324,6 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33248,11 +29375,6 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33278,10 +29400,6 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33340,11 +29458,6 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33396,11 +29509,6 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33426,10 +29534,6 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33488,11 +29592,6 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33544,11 +29643,6 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33574,10 +29668,6 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33652,11 +29742,6 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33724,11 +29809,6 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33754,10 +29834,6 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33806,11 +29882,6 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33852,11 +29923,6 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33882,10 +29948,6 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33960,11 +30022,6 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34032,11 +30089,6 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34062,10 +30114,6 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34140,11 +30188,6 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34212,11 +30255,6 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34242,10 +30280,6 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34320,11 +30354,6 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34392,11 +30421,6 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34422,10 +30446,6 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34500,11 +30520,6 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34572,11 +30587,6 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34602,10 +30612,6 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34658,11 +30664,6 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34708,11 +30709,6 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34738,10 +30734,6 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34792,11 +30784,6 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34840,11 +30827,6 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34870,10 +30852,6 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34910,11 +30888,6 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34944,11 +30917,6 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34974,10 +30942,6 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35025,11 +30989,6 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35070,11 +31029,6 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35100,10 +31054,6 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35143,11 +31093,6 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35180,11 +31125,6 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35210,10 +31150,6 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35266,11 +31202,6 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35316,11 +31247,6 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35346,10 +31272,6 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35385,11 +31307,6 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35418,11 +31335,6 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35448,10 +31360,6 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35500,11 +31408,6 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35546,11 +31449,6 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35576,10 +31474,6 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35628,11 +31522,6 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35674,11 +31563,6 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35704,10 +31588,6 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35756,11 +31636,6 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35802,11 +31677,6 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35832,10 +31702,6 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35888,11 +31754,6 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35938,11 +31799,6 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35968,10 +31824,6 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36008,11 +31860,6 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36042,11 +31889,6 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36072,10 +31914,6 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36134,11 +31972,6 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36190,11 +32023,6 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36220,10 +32048,6 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36282,11 +32106,6 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36338,11 +32157,6 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36368,10 +32182,6 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36430,11 +32240,6 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36486,11 +32291,6 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36516,10 +32316,6 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36594,11 +32390,6 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36666,11 +32457,6 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36696,10 +32482,6 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36748,11 +32530,6 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36794,11 +32571,6 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36824,10 +32596,6 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36886,11 +32654,6 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36942,11 +32705,6 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36972,10 +32730,6 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37034,11 +32788,6 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37090,11 +32839,6 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37120,10 +32864,6 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37182,11 +32922,6 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37238,11 +32973,6 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37268,10 +32998,6 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37346,11 +33072,6 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37418,11 +33139,6 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37448,10 +33164,6 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37500,11 +33212,6 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37546,11 +33253,6 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37576,10 +33278,6 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37638,11 +33336,6 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37694,11 +33387,6 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37724,10 +33412,6 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37786,11 +33470,6 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37842,11 +33521,6 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37872,10 +33546,6 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37934,11 +33604,6 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37990,11 +33655,6 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38020,10 +33680,6 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38098,11 +33754,6 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38170,11 +33821,6 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38200,10 +33846,6 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38252,11 +33894,6 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38298,11 +33935,6 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38328,10 +33960,6 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38406,11 +34034,6 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38478,11 +34101,6 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38508,10 +34126,6 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38586,11 +34200,6 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38658,11 +34267,6 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38688,10 +34292,6 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38766,11 +34366,6 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38838,11 +34433,6 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38868,10 +34458,6 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38946,11 +34532,6 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39018,11 +34599,6 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39048,10 +34624,6 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39104,11 +34676,6 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39154,11 +34721,6 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39184,10 +34746,6 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39238,11 +34796,6 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39286,11 +34839,6 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39316,10 +34864,6 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39356,11 +34900,6 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39390,11 +34929,6 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39420,10 +34954,6 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39471,11 +35001,6 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39516,11 +35041,6 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39546,10 +35066,6 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39589,11 +35105,6 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39626,11 +35137,6 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39656,10 +35162,6 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39712,11 +35214,6 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39762,11 +35259,6 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39792,10 +35284,6 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39831,11 +35319,6 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39864,11 +35347,6 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39894,10 +35372,6 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39946,11 +35420,6 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39992,11 +35461,6 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40022,10 +35486,6 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40074,11 +35534,6 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40120,11 +35575,6 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40150,10 +35600,6 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40202,11 +35648,6 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40248,11 +35689,6 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40278,10 +35714,6 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40334,11 +35766,6 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40384,11 +35811,6 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40414,10 +35836,6 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40454,11 +35872,6 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40488,11 +35901,6 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40518,10 +35926,6 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40580,11 +35984,6 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40636,11 +36035,6 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40666,10 +36060,6 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40728,11 +36118,6 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40784,11 +36169,6 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40814,10 +36194,6 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40876,11 +36252,6 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40932,11 +36303,6 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40962,10 +36328,6 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41040,11 +36402,6 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41112,11 +36469,6 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41142,10 +36494,6 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41194,11 +36542,6 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41240,11 +36583,6 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41270,10 +36608,6 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41332,11 +36666,6 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41388,11 +36717,6 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41418,10 +36742,6 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41480,11 +36800,6 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41536,11 +36851,6 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41566,10 +36876,6 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41628,11 +36934,6 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41684,11 +36985,6 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41714,10 +37010,6 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41792,11 +37084,6 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41864,11 +37151,6 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41894,10 +37176,6 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41946,11 +37224,6 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41992,11 +37265,6 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42022,10 +37290,6 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42084,11 +37348,6 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42140,11 +37399,6 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42170,10 +37424,6 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42232,11 +37482,6 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42288,11 +37533,6 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42318,10 +37558,6 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42380,11 +37616,6 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42436,11 +37667,6 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42466,10 +37692,6 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42544,11 +37766,6 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42616,11 +37833,6 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42646,10 +37858,6 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42698,11 +37906,6 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42744,11 +37947,6 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42774,10 +37972,6 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42852,11 +38046,6 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42924,11 +38113,6 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42954,10 +38138,6 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43032,11 +38212,6 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43104,11 +38279,6 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43134,10 +38304,6 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43212,11 +38378,6 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43284,11 +38445,6 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43314,10 +38470,6 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43392,11 +38544,6 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43464,11 +38611,6 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43494,10 +38636,6 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43550,11 +38688,6 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43600,11 +38733,6 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43630,10 +38758,6 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43684,11 +38808,6 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43732,11 +38851,6 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43762,10 +38876,6 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43802,11 +38912,6 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43836,11 +38941,6 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43866,10 +38966,6 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43917,11 +39013,6 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43962,11 +39053,6 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43992,10 +39078,6 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44035,11 +39117,6 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44072,11 +39149,6 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44102,10 +39174,6 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44158,11 +39226,6 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44208,11 +39271,6 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44238,10 +39296,6 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44277,11 +39331,6 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44310,11 +39359,6 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44340,10 +39384,6 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44392,11 +39432,6 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44438,11 +39473,6 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44468,10 +39498,6 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44520,11 +39546,6 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44566,11 +39587,6 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44596,10 +39612,6 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44648,11 +39660,6 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44694,11 +39701,6 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44724,10 +39726,6 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44780,11 +39778,6 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44830,11 +39823,6 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44860,10 +39848,6 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44900,11 +39884,6 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44934,11 +39913,6 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44964,10 +39938,6 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45026,11 +39996,6 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45082,11 +40047,6 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45112,10 +40072,6 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45174,11 +40130,6 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45230,11 +40181,6 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45260,10 +40206,6 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45322,11 +40264,6 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45378,11 +40315,6 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45408,10 +40340,6 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45486,11 +40414,6 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45558,11 +40481,6 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45588,10 +40506,6 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45640,11 +40554,6 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45686,11 +40595,6 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45716,10 +40620,6 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45778,11 +40678,6 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45834,11 +40729,6 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45864,10 +40754,6 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45926,11 +40812,6 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45982,11 +40863,6 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46012,10 +40888,6 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46074,11 +40946,6 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46130,11 +40997,6 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46160,10 +41022,6 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46238,11 +41096,6 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46310,11 +41163,6 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46340,10 +41188,6 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46392,11 +41236,6 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46438,11 +41277,6 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46468,10 +41302,6 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46530,11 +41360,6 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46586,11 +41411,6 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46616,10 +41436,6 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46678,11 +41494,6 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46734,11 +41545,6 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46764,10 +41570,6 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46826,11 +41628,6 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46882,11 +41679,6 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46912,10 +41704,6 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46990,11 +41778,6 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47062,11 +41845,6 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47092,10 +41870,6 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47144,11 +41918,6 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47190,11 +41959,6 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47220,10 +41984,6 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47298,11 +42058,6 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47370,11 +42125,6 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47400,10 +42150,6 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47478,11 +42224,6 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47550,11 +42291,6 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47580,10 +42316,6 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47658,11 +42390,6 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47730,11 +42457,6 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47760,10 +42482,6 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47838,11 +42556,6 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47910,11 +42623,6 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47940,10 +42648,6 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47996,11 +42700,6 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48046,11 +42745,6 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48076,10 +42770,6 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48130,11 +42820,6 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48178,11 +42863,6 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48208,10 +42888,6 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48248,11 +42924,6 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48282,11 +42953,6 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48312,10 +42978,6 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48363,11 +43025,6 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48408,11 +43065,6 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48438,10 +43090,6 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48481,11 +43129,6 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48518,11 +43161,6 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48548,10 +43186,6 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48604,11 +43238,6 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48654,11 +43283,6 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48684,10 +43308,6 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48723,11 +43343,6 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48756,11 +43371,6 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48786,10 +43396,6 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48838,11 +43444,6 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48884,11 +43485,6 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48914,10 +43510,6 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48966,11 +43558,6 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49012,11 +43599,6 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49042,10 +43624,6 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49094,11 +43672,6 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49140,11 +43713,6 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49170,10 +43738,6 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49226,11 +43790,6 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49276,11 +43835,6 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49306,10 +43860,6 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49346,11 +43896,6 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49380,11 +43925,6 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49410,10 +43950,6 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49472,11 +44008,6 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49528,11 +44059,6 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49558,10 +44084,6 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49620,11 +44142,6 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49676,11 +44193,6 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49706,10 +44218,6 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49768,11 +44276,6 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49824,11 +44327,6 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49854,10 +44352,6 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49932,11 +44426,6 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50004,11 +44493,6 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50034,10 +44518,6 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50086,11 +44566,6 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50132,11 +44607,6 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50162,10 +44632,6 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50224,11 +44690,6 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50280,11 +44741,6 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50310,10 +44766,6 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50372,11 +44824,6 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50428,11 +44875,6 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50458,10 +44900,6 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50520,11 +44958,6 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50576,11 +45009,6 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50606,10 +45034,6 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50684,11 +45108,6 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50756,11 +45175,6 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50786,10 +45200,6 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50838,11 +45248,6 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50884,11 +45289,6 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50914,10 +45314,6 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50976,11 +45372,6 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51032,11 +45423,6 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51062,10 +45448,6 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51124,11 +45506,6 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51180,11 +45557,6 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51210,10 +45582,6 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51272,11 +45640,6 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51328,11 +45691,6 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51358,10 +45716,6 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51436,11 +45790,6 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51508,11 +45857,6 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51538,10 +45882,6 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51590,11 +45930,6 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51636,11 +45971,6 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51666,10 +45996,6 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51744,11 +46070,6 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51816,11 +46137,6 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51846,10 +46162,6 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51924,11 +46236,6 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51996,11 +46303,6 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52026,10 +46328,6 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52104,11 +46402,6 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52176,11 +46469,6 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52206,10 +46494,6 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52284,11 +46568,6 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52356,11 +46635,6 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52386,10 +46660,6 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52442,11 +46712,6 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52492,11 +46757,6 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52522,10 +46782,6 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52576,11 +46832,6 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52624,11 +46875,6 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52654,10 +46900,6 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52694,11 +46936,6 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52728,11 +46965,6 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52758,10 +46990,6 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52809,11 +47037,6 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52854,11 +47077,6 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52884,10 +47102,6 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52927,11 +47141,6 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52964,11 +47173,6 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch

--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -37,10 +37,6 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -64,11 +60,6 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -85,11 +76,6 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = bytes.HasPrefix(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -115,10 +101,6 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -142,11 +124,6 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -163,11 +140,6 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = bytes.HasSuffix(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -193,10 +165,6 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -220,11 +188,6 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -241,11 +204,6 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = bytes.Contains(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -271,10 +229,6 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -322,11 +276,6 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -367,11 +316,6 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -397,10 +341,6 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -424,11 +364,6 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -445,11 +380,6 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Match(arg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -475,10 +405,6 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -502,11 +428,6 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -523,11 +444,6 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = !bytes.HasPrefix(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -553,10 +469,6 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -580,11 +492,6 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -601,11 +508,6 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = !bytes.HasSuffix(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -631,10 +533,6 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -658,11 +556,6 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -679,11 +572,6 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = !bytes.Contains(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -709,10 +597,6 @@ func (p projNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -760,11 +644,6 @@ func (p projNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -805,11 +684,6 @@ func (p projNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -835,10 +709,6 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 		// https://github.com/golang/go/issues/39756
 		col := col
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -862,11 +732,6 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -883,11 +748,6 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = !p.constArg.Match(arg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch

--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -38,7 +38,9 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -102,7 +104,9 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -166,7 +170,9 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -230,7 +236,9 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -342,7 +350,9 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -406,7 +416,9 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -470,7 +482,9 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -534,7 +548,9 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -598,7 +614,9 @@ func (p projNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -710,7 +728,9 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]

--- a/pkg/sql/colexec/colexecprojconst/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecprojconst/projection_ops_test.go
@@ -34,9 +34,10 @@ func TestGetProjectionConstOperator(t *testing.T) {
 	constVal := 31.37
 	constArg := tree.NewDFloat(tree.DFloat(constVal))
 	outputIdx := 5
+	nullableArgs := false
 	op, err := GetProjectionRConstOperator(
 		nil /* allocator */, inputTypes, types.Float, types.Float, binOp, input, colIdx,
-		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil, /* cmpExpr */
+		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
 	)
 	if err != nil {
 		t.Error(err)
@@ -46,6 +47,7 @@ func TestGetProjectionConstOperator(t *testing.T) {
 			OneInputHelper: colexecop.MakeOneInputHelper(op.(*projMultFloat64Float64ConstOp).Input),
 			colIdx:         colIdx,
 			outputIdx:      outputIdx,
+			nullableArgs:   nullableArgs,
 		},
 		constArg: constVal,
 	}
@@ -65,9 +67,10 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 	constVal := int16(31)
 	constArg := tree.NewDInt(tree.DInt(constVal))
 	outputIdx := 5
+	nullableArgs := false
 	op, err := GetProjectionRConstOperator(
 		nil /* allocator */, inputTypes, types.Int2, types.Int, cmpOp, input, colIdx,
-		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil, /* cmpExpr */
+		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
 	)
 	if err != nil {
 		t.Error(err)
@@ -77,6 +80,7 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 			OneInputHelper: colexecop.MakeOneInputHelper(op.(*projGEInt64Int16ConstOp).Input),
 			colIdx:         colIdx,
 			outputIdx:      outputIdx,
+			nullableArgs:   nullableArgs,
 		},
 		constArg: constVal,
 	}

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -983,6 +983,25 @@ SELECT NULL::INT[] || NULL::INT[]
 ----
 NULL
 
+# The following test check for projection operators that can handle nullable arguments.
+statement ok
+CREATE TABLE t_bool (b BOOL[]);
+
+query T
+SELECT b || NULL FROM t_bool;
+----
+
+statement ok
+INSERT INTO t_bool VALUES (Array[]);
+
+query T
+SELECT b || NULL FROM t_bool;
+----
+{}
+
+statement ok
+DROP TABLE t_bool;
+
 # Array equality
 
 query B


### PR DESCRIPTION
Previously, the `Concat` projection operators on arrays directly copy nulls into
the output without performing the actual projection whenever either argument was
null. This is incorrect because `Concat` operator can actually handle null arguments,
and we want the actual projection result instead. Since currently the only
projection operator that needs `nullableArgs == true` behaviour is
`ConcatDatumDatum`, this PR fixed this by adding a boolean field `nullableArgs`
to the logic for operators with `Datum`, `Datum`. If we later introduce another
projection operation that has nullableArgs == true, we should update this code
accordingly.

Fixes: https://github.com/cockroachdb/cockroach/issues/83091

Release note (bug fix): Fixed a bug in `Concat` projection operators on arrays
that gave output of nulls when the projection operator can actually handle null
arguments and may result in a non-null output.