### PR TITLE
skip: add WithIssueUntil for time-limited skips

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -449,6 +449,7 @@ ALL_TESTS = [
     "//pkg/testutils/lint/passes/returnerrcheck:returnerrcheck_test",
     "//pkg/testutils/lint/passes/timer:timer_test",
     "//pkg/testutils/lint/passes/unconvert:unconvert_test",
+    "//pkg/testutils/skip:skip_test",
     "//pkg/testutils/sqlutils:sqlutils_test",
     "//pkg/testutils/testcluster:testcluster_test",
     "//pkg/testutils/zerofields:zerofields_test",

--- a/pkg/testutils/skip/BUILD.bazel
+++ b/pkg/testutils/skip/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "skip",
@@ -14,5 +14,15 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/syncutil",
+    ],
+)
+
+go_test(
+    name = "skip_test",
+    srcs = ["skip_test.go"],
+    deps = [
+        ":skip",
+        "//pkg/util/timeutil",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/skip/skip_test.go
+++ b/pkg/testutils/skip/skip_test.go
@@ -1,0 +1,41 @@
+package skip_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpirationTooFarPanics(t *testing.T) {
+	tooFar := timeutil.Now().Add(31 * 24 * time.Hour).Format("2006-01-02")
+	require.Panics(t, func() {
+		skip.WithIssueUntil(t, 0, skip.Expiration(tooFar))
+	})
+}
+
+func TestExpirationBadFormatPanics(t *testing.T) {
+	require.Panics(t, func() {
+		skip.WithIssueUntil(t, 0, skip.Expiration("2006-1-23 5"))
+	})
+}
+
+func TestSkipWithIssueUntilSkips(t *testing.T) {
+	alwaysSkip := timeutil.Now().Add(29 * 24 * time.Hour).Format("2006-01-02")
+	skip.WithIssueUntil(t, 0, skip.Expiration(alwaysSkip))
+	require.True(t, false)
+}
+
+func TestSkipWithIssueUntilRespectsExpiration(t *testing.T) {
+	expired := timeutil.Now().Add(-24 * time.Hour).Format("2006-01-02")
+	shouldFail := true
+	defer func() {
+		if shouldFail {
+			t.Fatal("shouldFail still true despite skip expiration")
+		}
+	}()
+	skip.WithIssueUntil(t, 0, skip.Expiration(expired))
+	shouldFail = false
+}


### PR DESCRIPTION
Flaky tests often need to be skipped to unblock other teams. However,
skipped tests also represent a liability as new problems may be
introduced to that the test doesn't catch because it is skipped.

This adds a WithIssueUntil variant of skip that expires after the
given date.

Release note: None