### PR TITLE
gc: fix NumKeysAffected counting more than collected

### DIFF
--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -379,6 +379,10 @@ func processReplicatedKeyRange(
 		}
 		if affected := isNewest && (sentBatchForThisKey || haveGarbageForThisKey); affected {
 			info.NumKeysAffected++
+			// If we reached newest timestamp for the key then we should reset sent
+			// batch to ensure subsequent keys are not included in affected keys if
+			// they don't have garbage.
+			sentBatchForThisKey = false
 		}
 		shouldSendBatch := batchGCKeysBytes >= KeyVersionChunkBytes
 		if shouldSendBatch || isNewest && haveGarbageForThisKey {


### PR DESCRIPTION
Previously if key is not collected after a GC batch is sent out
it would still be included as affected in GC stats.
Those stats are mostly used for logging and tests, the unfortunate
effect is that randomized test could fail.
This commit fixes the bug.

Release note: None

Fixes #84164