### PR TITLE
sql/sqlstats: record QuerySummary when merging stats

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -400,3 +400,19 @@ SELECT * FROM txn_fingerprint_view
 
 statement ok
 COMMIT
+
+statement ok
+BEGIN; SELECT count(1) AS wombat1; COMMIT
+
+query T
+SELECT metadata->>'querySummary' FROM crdb_internal.statement_statistics WHERE metadata->>'query' LIKE '%wombat1%'
+----
+SELECT count(_) AS wom...
+
+statement ok
+SELECT count(1) AS wombat2
+
+query T
+SELECT metadata->>'querySummary' FROM crdb_internal.statement_statistics WHERE metadata->>'query' LIKE '%wombat2%'
+----
+SELECT count(_) AS wom...

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -473,6 +473,7 @@ func (s *stmtStats) mergeStatsLocked(statistics *roachpb.CollectedStatementStati
 	s.mu.distSQLUsed = statistics.Key.DistSQL
 	s.mu.fullScan = statistics.Key.FullScan
 	s.mu.database = statistics.Key.Database
+	s.mu.querySummary = statistics.Key.QuerySummary
 }
 
 // getStatsForStmt retrieves the per-stmt stat object. Regardless of if a valid


### PR DESCRIPTION
During execution of a transaction, all statement statistics are
collected in an struct local to that transaction, and then flushed to
the main ApplicationStats container when the transaction finishes.

Previously, when flushing, we failed to copy the QuerySummary field,
leading to `metadata->'querySummary'` from being empty in most cases.

Prior to ce1b42bd341cc5f87357ecf82027b3dd5a3e88c1 this only affected
statements in an explicit transaction. After that commit, it affected
all statements.

Release note (bug fix): Fix a bug that led to the querySummary field
in crdb_internal.statements_statistics's metadata column being empty.