### PR TITLE
streamingccl: prioritize cutover on job resumption

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -90,6 +90,7 @@ type tenantStreamingClusters struct {
 	srcTenantSQL    *sqlutils.SQLRunner
 	srcTenantServer serverutils.TestTenantInterface
 	srcURL          url.URL
+	srcCleanup      func()
 
 	destCluster   *testcluster.TestCluster
 	destSysServer serverutils.TestServerInterface
@@ -250,6 +251,7 @@ func createTenantStreamingClusters(
 		srcTenantSQL:    sqlutils.MakeSQLRunner(srcTenantConn),
 		srcSysServer:    srcCluster.Server(0),
 		srcURL:          srcURL,
+		srcCleanup:      srcCleanup,
 		destCluster:     destCluster,
 		destSysSQL:      sqlutils.MakeSQLRunner(destCluster.ServerConn(0)),
 		destSysServer:   destCluster.Server(0),
@@ -782,4 +784,41 @@ func TestTenantStreamingUnavailableStreamAddress(t *testing.T) {
 	alternateCompareResult("SELECT * FROM d.t2")
 	alternateCompareResult("SELECT * FROM d.x")
 	alternateCompareResult("SELECT * FROM d.scattered")
+}
+
+func TestTenantStreamingCutoverOnSourceFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRaceWithIssue(t, 83867)
+
+	ctx := context.Background()
+	args := defaultTenantStreamingClustersArgs
+	c, cleanup := createTenantStreamingClusters(ctx, t, args)
+	defer cleanup()
+
+	producerJobID, ingestionJobID := c.startStreamReplication()
+
+	jobutils.WaitForJobToRun(c.t, c.srcSysSQL, jobspb.JobID(producerJobID))
+	jobutils.WaitForJobToRun(c.t, c.destSysSQL, jobspb.JobID(ingestionJobID))
+
+	c.srcTenantSQL.Exec(t, "INSERT INTO d.t2 VALUES (3);")
+
+	cutoverTime := c.srcCluster.Server(0).Clock().Now()
+	c.waitUntilHighWatermark(cutoverTime, jobspb.JobID(ingestionJobID))
+
+	// Pause ingestion.
+	c.destSysSQL.Exec(t, fmt.Sprintf("PAUSE JOB %d", ingestionJobID))
+	jobutils.WaitForJobToPause(t, c.destSysSQL, jobspb.JobID(ingestionJobID))
+
+	// Destroy the source cluster
+	c.srcCleanup()
+
+	c.destSysSQL.Exec(c.t, `SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`, ingestionJobID, cutoverTime.GoTime())
+
+	// Resume ingestion.
+	c.destSysSQL.Exec(t, fmt.Sprintf("RESUME JOB %d", ingestionJobID))
+
+	// Ingestion job should succeed despite source failure due to the successful cutover
+	jobutils.WaitForJobToSucceed(t, c.destSysSQL, jobspb.JobID(ingestionJobID))
 }


### PR DESCRIPTION
Resolves #84008 

During a disaster, cutover is the most important task required to bring
the backup cluster online and ready to receive requests.  Previously if
unrelated errors happened such as a planning error we would be unable to
cutover.  This change checks for a cutover time prior to the highwater
as soon as the job resumes and completes the cutover if required.

Release note (bug fix): streaming cutover no longer relies on successful
job planning