### PR TITLE
ui: Split out trace details route from snapshot overview route to enable back-button browsing.

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -7085,6 +7085,7 @@ GetTrace represents the response to the GetTrace RPC.
 | trace_id | [uint64](#cockroach.server.serverpb.GetTraceResponse-uint64) |  |  | [reserved](#support-status) |
 | still_exists | [bool](#cockroach.server.serverpb.GetTraceResponse-bool) |  | still_exists is set if any spans from this trace are currently present in the active spans registry.<br><br>If snapshot_id is 0, still_exists is always set. | [reserved](#support-status) |
 | serialized_recording | [string](#cockroach.server.serverpb.GetTraceResponse-string) |  | serialized_recording represents the serialization of trace recording. We return the recording already serialized as formatted string for easy consumption in the browser. | [reserved](#support-status) |
+| operation | [string](#cockroach.server.serverpb.GetTraceResponse-string) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3706,11 +3706,16 @@ func (s *adminServer) GetTrace(
 		return nil, errors.Errorf("Trace %d not found.", traceID)
 	}
 
+	operation := ""
+	if len(recording) > 0 {
+		operation = recording[0].Operation
+	}
 	return &serverpb.GetTraceResponse{
 		SnapshotID:          snapID,
 		TraceID:             traceID,
 		StillExists:         traceStillExists,
 		SerializedRecording: recording.String(),
+		Operation:           operation,
 	}, nil
 }
 

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -1169,6 +1169,7 @@ message GetTraceResponse {
   // return the recording already serialized as formatted string for easy
   // consumption in the browser.
   string serialized_recording = 4;
+  string operation = 5;
 }
 
 // TracingSnapshot represents a snapshot of the active spans registry, including

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -77,7 +77,8 @@ import HotRangesPage from "src/views/hotRanges/index";
 import ActiveStatementDetails from "./views/statements/activeStatementDetailsConnected";
 import ActiveTransactionDetails from "./views/transactions/activeTransactionDetailsConnected";
 import "styl/app.styl";
-import { Tracez } from "src/views/tracez/tracez";
+import { TraceCollection } from "src/views/tracez/traceCollection";
+import { TraceDetails } from "src/views/tracez/traceDetails";
 
 // NOTE: If you are adding a new path to the router, and that path contains any
 // components that are personally identifying information, you MUST update the
@@ -292,7 +293,21 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
 
                 {/* debug pages */}
                 <Route exact path="/debug" component={Debug} />
-                <Route exact path="/debug/tracez" component={Tracez} />
+                <Redirect
+                  exact
+                  from="/debug/tracez"
+                  to={"/debug/tracez/trace_collection/"}
+                />
+                <Route
+                  exact
+                  path="/debug/tracez/trace_collection/:collectionID?"
+                  component={TraceCollection}
+                />
+                <Route
+                  exact
+                  path="/debug/tracez/trace_collection/:collectionID/trace_details/:traceID"
+                  component={TraceDetails}
+                />
                 <Route exact path="/debug/redux" component={ReduxDebug} />
                 <Route exact path="/debug/chart" component={CustomChart} />
                 <Route

--- a/pkg/ui/workspaces/db-console/src/views/tracez/traceCollection.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez/traceCollection.tsx
@@ -29,8 +29,6 @@ import {
 } from "src/views/shared/components/pageconfig";
 import { cockroach, google } from "src/js/protos";
 import {
-  getLiveTrace,
-  getTraceForSnapshot,
   getTracingSnapshot,
   listTracingSnapshots,
   setTraceRecordingType,
@@ -41,11 +39,10 @@ import { Switch } from "antd";
 import ISnapshotInfo = cockroach.server.serverpb.ISnapshotInfo;
 import ITracingSpan = cockroach.server.serverpb.ITracingSpan;
 import GetTracingSnapshotRequest = cockroach.server.serverpb.GetTracingSnapshotRequest;
-import GetTraceRequest = cockroach.server.serverpb.GetTraceRequest;
-import IGetTraceResponse = cockroach.server.serverpb.IGetTraceResponse;
 import ISpanTag = cockroach.server.serverpb.ISpanTag;
 import SetTraceRecordingTypeRequest = cockroach.server.serverpb.SetTraceRecordingTypeRequest;
 import RecordingMode = cockroach.util.tracing.tracingpb.RecordingMode;
+import { RouteComponentProps, useParams } from "react-router-dom";
 
 const TS_FORMAT = "MMMM Do YYYY, H:mm:ss"; // January 28th 2022, 19:12:40;
 
@@ -195,14 +192,14 @@ const TagBadge = ({
 
 const OperationCell = (props: {
   sr: SnapshotRow;
-  setRecording: (trace: cockroach.server.serverpb.ITracingSpan) => void;
+  setRecording: (traceID: Long) => void;
 }) => {
   return (
     <div>
       <Button
         as="a"
         intent="tertiary"
-        onClick={() => props.setRecording(props.sr.span)}
+        onClick={() => props.setRecording(props.sr.span.trace_id)}
       >
         {props.sr.span.operation}
       </Button>
@@ -265,7 +262,7 @@ const TagCell = (props: {
 };
 
 const snapshotColumns = (
-  setRecording: (span: ITracingSpan) => void,
+  setRecording: (traceID: Long) => void,
   setSearch: (s: string) => void,
   setTraceRecordingVerbose: (span: ITracingSpan) => void,
 ): ColumnDescriptor<SnapshotRow>[] => {
@@ -321,7 +318,7 @@ const CurrentSnapshot = ({
 }: {
   snapshot: Snapshot;
   search: string;
-  setRecording: (trace: cockroach.server.serverpb.ITracingSpan) => void;
+  setRecording: (traceID: Long) => void;
   setSearch: (s: string) => void;
   setTraceRecordingVerbose: (span: ITracingSpan) => void;
 }) => {
@@ -352,25 +349,40 @@ interface Snapshot {
   captured_at?: google.protobuf.ITimestamp;
 }
 
-export const Tracez = () => {
+// TODO(benbardin): Move state to Redux to enable caching across pages.
+export const TraceCollection = (props: RouteComponentProps) => {
   // Snapshot state
   const [snapshot, setSnapshot] = useState<Snapshot>({ rows: [] });
   const [search, setSearch] = useState<string>("");
   const [snapshots, setSnapshots] = useState<ISnapshotInfo[]>([]);
 
-  // Recording view state
-  // In the UI when you click on an operation we set the requestedSpan. Then
-  // the effect is triggered to retrieve the trace for that span, once that's
-  // updated the UI is changed.
-  const [requestedSpan, setRequestedSpan] =
-    useState<cockroach.server.serverpb.ITracingSpan>(null);
-  const [currentTrace, setCurrentTrace] = useState<IGetTraceResponse>(null);
-  const [showTrace, setShowTrace] = useState<boolean>(false);
-  const [showLiveTrace, setShowLiveTrace] = useState<boolean>(false);
+  const { history } = props;
+  const { collectionID: collectionIDParam } = useParams<{
+    collectionID: string;
+  }>();
+  const snapshotID = collectionIDParam
+    ? Long.fromString(collectionIDParam)
+    : undefined;
 
   const setSnapshotID = (id: Long) => {
+    if (id === snapshotID) {
+      return;
+    }
+    history.push(`/debug/tracez/trace_collection/${id}`);
+  };
+
+  useEffect(() => {
+    if (snapshots.length && snapshotID === undefined) {
+      setSnapshotID(snapshots[snapshots.length - 1].snapshot_id);
+    }
+  }, [snapshots]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (snapshotID === undefined) {
+      return;
+    }
     const req = new GetTracingSnapshotRequest({
-      snapshot_id: id,
+      snapshot_id: snapshotID,
     });
     getTracingSnapshot(req).then(req => {
       setSnapshot({
@@ -386,7 +398,7 @@ export const Tracez = () => {
         ),
       });
     });
-  };
+  }, [collectionIDParam]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // takeSnapshot takes a snapshot and displays it.
   const takeSnapshot = () => {
@@ -403,33 +415,9 @@ export const Tracez = () => {
     });
   };
 
-  useEffect(refreshTracingSnapshots, []);
-
   useEffect(() => {
-    if (showTrace) {
-      if (showLiveTrace) {
-        getLiveTrace(
-          new GetTraceRequest({
-            trace_id: requestedSpan.trace_id,
-            recording_type: RecordingMode.VERBOSE,
-          }),
-        ).then(resp => {
-          setCurrentTrace(resp);
-          setShowTrace(true);
-        });
-      } else {
-        getTraceForSnapshot(
-          new GetTraceRequest({
-            trace_id: requestedSpan.trace_id,
-            snapshot_id: snapshot.id,
-          }),
-        ).then(resp => {
-          setCurrentTrace(resp);
-          setShowTrace(true);
-        });
-      }
-    }
-  }, [showTrace, snapshot, requestedSpan, showLiveTrace]);
+    refreshTracingSnapshots();
+  }, []);
 
   const setTraceRecordingVerbose = (span: ITracingSpan) => {
     const recMode =
@@ -456,80 +444,20 @@ export const Tracez = () => {
     });
   };
   return (
-    <div>
-      {showTrace && currentTrace ? (
-        <TraceView
-          currentTrace={currentTrace}
-          cancel={() => {
-            setShowTrace(false);
-            setShowLiveTrace(false);
-          }}
-          showLive={() => {
-            setShowLiveTrace(true);
-          }}
-          operation={requestedSpan.operation}
-        />
-      ) : (
-        <SnapshotView
-          takeSnapshot={takeSnapshot}
-          setSnapshotID={setSnapshotID}
-          snapshots={snapshots}
-          snapshot={snapshot}
-          setSearch={setSearch}
-          search={search}
-          setRecording={span => {
-            setRequestedSpan(span);
-            setShowTrace(true);
-          }}
-          setTraceRecordingVerbose={setTraceRecordingVerbose}
-        />
-      )}
-    </div>
-  );
-};
-
-interface TraceViewProps {
-  currentTrace: IGetTraceResponse;
-  cancel: () => void;
-  showLive: () => void;
-  operation: string;
-}
-
-const TraceView = ({
-  currentTrace,
-  cancel,
-  showLive,
-  operation,
-}: TraceViewProps) => {
-  return (
-    <>
-      <h3 className="base-heading">
-        Active Traces{" "}
-        <span>
-          <CaretRight />
-          {currentTrace.snapshot_id.toNumber() === 0
-            ? "Latest"
-            : `Snapshot: ${currentTrace.snapshot_id}`}
-          <CaretRight />
-          {operation}
-        </span>
-      </h3>
-      <PageConfig>
-        <PageConfigItem>
-          <Button as={"button"} onClick={cancel}>
-            Back
-          </Button>
-        </PageConfigItem>
-        <PageConfigItem>
-          <Button as={"button"} onClick={showLive}>
-            Switch to Latest
-          </Button>
-        </PageConfigItem>
-      </PageConfig>
-      <section className="section" style={{ maxWidth: "none" }}>
-        <pre>{currentTrace.serialized_recording}</pre>
-      </section>
-    </>
+    <SnapshotView
+      takeSnapshot={takeSnapshot}
+      setSnapshotID={setSnapshotID}
+      snapshots={snapshots}
+      snapshot={snapshot}
+      setSearch={setSearch}
+      search={search}
+      setRecording={(traceID: Long) => {
+        history.push(
+          `/debug/tracez/trace_collection/${collectionIDParam}/trace_details/${traceID}`,
+        );
+      }}
+      setTraceRecordingVerbose={setTraceRecordingVerbose}
+    />
   );
 };
 
@@ -540,7 +468,7 @@ interface SnapshotViewProps {
   snapshot: Snapshot;
   setSearch: (s: string) => void;
   search: string;
-  setRecording: (s: cockroach.server.serverpb.ITracingSpan) => void;
+  setRecording: (traceID: Long) => void;
   setTraceRecordingVerbose: (span: ITracingSpan) => void;
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/tracez/traceDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez/traceDetails.tsx
@@ -1,0 +1,113 @@
+import { useParams } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import Long from "long";
+import { cockroach } from "src/js/protos";
+import IGetTraceResponse = cockroach.server.serverpb.IGetTraceResponse;
+import { getLiveTrace, getTraceForSnapshot } from "oss/src/util/api";
+import GetTraceRequest = cockroach.server.serverpb.GetTraceRequest;
+import RecordingMode = cockroach.util.tracing.tracingpb.RecordingMode;
+import { CaretRight } from "@cockroachlabs/icons";
+import {
+  PageConfig,
+  PageConfigItem,
+} from "oss/src/views/shared/components/pageconfig";
+import { Button } from "@cockroachlabs/ui-components";
+
+export const TraceDetails = () => {
+  // Recording view state
+  // In the UI when you click on an operation we set the requestedSpan. Then
+  // the effect is triggered to retrieve the trace for that span, once that's
+  // updated the UI is changed.
+  const [currentTrace, setCurrentTrace] = useState<IGetTraceResponse>(null);
+  const [showLiveTrace, setShowLiveTrace] = useState<boolean>(false);
+
+  const { collectionID: collectionIDParam, traceID: traceIDParam } = useParams<{
+    collectionID: string;
+    traceID: string;
+  }>();
+
+  const snapshotID = collectionIDParam
+    ? Long.fromString(collectionIDParam)
+    : undefined;
+  const traceID = traceIDParam ? Long.fromString(traceIDParam) : undefined;
+
+  useEffect(() => {
+    if (!snapshotID || !traceID) {
+      return;
+    }
+    if (showLiveTrace) {
+      getLiveTrace(
+        new GetTraceRequest({
+          trace_id: traceID,
+          recording_type: RecordingMode.VERBOSE,
+        }),
+      ).then(resp => {
+        setCurrentTrace(resp);
+      });
+    } else {
+      getTraceForSnapshot(
+        new GetTraceRequest({
+          trace_id: traceID,
+          snapshot_id: snapshotID,
+        }),
+      ).then(resp => {
+        setCurrentTrace(resp);
+      });
+    }
+  }, [collectionIDParam, traceIDParam, showLiveTrace, setCurrentTrace]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <TraceView
+      currentTrace={currentTrace}
+      cancel={() => {
+        setShowLiveTrace(false);
+        history.back();
+      }}
+      showLive={() => {
+        setShowLiveTrace(true);
+      }}
+    />
+  );
+};
+
+interface TraceViewProps {
+  currentTrace: IGetTraceResponse;
+  cancel: () => void;
+  showLive: () => void;
+}
+
+const TraceView = ({ currentTrace, cancel, showLive }: TraceViewProps) => {
+  if (!currentTrace) {
+    return null;
+  }
+  return (
+    <>
+      <h3 className="base-heading">
+        Active Traces{" "}
+        <span>
+          <CaretRight />
+          {currentTrace.snapshot_id.toNumber() === 0
+            ? "Latest"
+            : `Snapshot: ${currentTrace.snapshot_id}`}
+          <CaretRight />
+          {currentTrace.operation}
+        </span>
+      </h3>
+      <PageConfig>
+        <PageConfigItem>
+          <Button as={"button"} onClick={cancel}>
+            Back
+          </Button>
+        </PageConfigItem>
+        <PageConfigItem>
+          <Button as={"button"} onClick={showLive}>
+            Switch to Latest
+          </Button>
+        </PageConfigItem>
+      </PageConfig>
+      <section className="section" style={{ maxWidth: "none" }}>
+        <pre>{currentTrace.serialized_recording}</pre>
+      </section>
+    </>
+  );
+};


### PR DESCRIPTION
Release note: None