### PR TITLE
pgwire: Parse, Describe, and Bind should fail in an aborted txn

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -40,6 +41,10 @@ func (ex *connExecutor) execPrepare(
 	// the Sync message is handled.
 	if _, isNoTxn := ex.machine.CurState().(stateNoTxn); isNoTxn {
 		return ex.beginImplicitTxn(ctx, parseCmd.AST)
+	} else if _, isAbortedTxn := ex.machine.CurState().(stateAborted); isAbortedTxn {
+		if !ex.isAllowedInAbortedTxn(parseCmd.AST) {
+			return retErr(sqlerrors.NewTransactionAbortedError("" /* customMsg */))
+		}
 	}
 
 	ctx, sp := tracing.EnsureChildSpan(ctx, ex.server.cfg.AmbientCtx.Tracer, "prepare stmt")
@@ -305,6 +310,10 @@ func (ex *connExecutor) execBind(
 	// handled separately in conn_executor_exec.
 	if _, isNoTxn := ex.machine.CurState().(stateNoTxn); isNoTxn {
 		return ex.beginImplicitTxn(ctx, ps.AST)
+	} else if _, isAbortedTxn := ex.machine.CurState().(stateAborted); isAbortedTxn {
+		if !ex.isAllowedInAbortedTxn(ps.AST) {
+			return retErr(sqlerrors.NewTransactionAbortedError("" /* customMsg */))
+		}
 	}
 
 	portalName := bindCmd.PortalName
@@ -545,6 +554,7 @@ func (ex *connExecutor) execDescribe(
 	retErr := func(err error) (fsm.Event, fsm.EventPayload) {
 		return eventNonRetriableErr{IsCommit: fsm.False}, eventNonRetriableErrPayload{err: err}
 	}
+	_, isAbortedTxn := ex.machine.CurState().(stateAborted)
 
 	switch descCmd.Type {
 	case pgwirebase.PrepareStatement:
@@ -554,8 +564,6 @@ func (ex *connExecutor) execDescribe(
 				pgcode.InvalidSQLStatementName,
 				"unknown prepared statement %q", descCmd.Name))
 		}
-
-		res.SetInferredTypes(ps.InferredTypes)
 
 		ast := ps.AST
 		if execute, ok := ast.(*tree.Execute); ok {
@@ -570,6 +578,10 @@ func (ex *connExecutor) execDescribe(
 			}
 			ast = innerPs.AST
 		}
+		if isAbortedTxn && !ex.isAllowedInAbortedTxn(ast) {
+			return retErr(sqlerrors.NewTransactionAbortedError("" /* customMsg */))
+		}
+		res.SetInferredTypes(ps.InferredTypes)
 		if stmtHasNoData(ast) {
 			res.SetNoDataRowDescription()
 		} else {
@@ -584,13 +596,20 @@ func (ex *connExecutor) execDescribe(
 				return retErr(pgerror.Newf(
 					pgcode.InvalidCursorName, "unknown portal %q", descCmd.Name))
 			}
+			if isAbortedTxn {
+				return retErr(sqlerrors.NewTransactionAbortedError("" /* customMsg */))
+			}
 			// Sending a nil formatCodes is equivalent to sending all text format
 			// codes.
 			res.SetPortalOutput(ctx, cursor.InternalRows.Types(), nil /* formatCodes */)
 			return nil, nil
 		}
 
-		if stmtHasNoData(portal.Stmt.AST) {
+		ast := portal.Stmt.AST
+		if isAbortedTxn && !ex.isAllowedInAbortedTxn(ast) {
+			return retErr(sqlerrors.NewTransactionAbortedError("" /* customMsg */))
+		}
+		if stmtHasNoData(ast) {
 			res.SetNoDataRowDescription()
 		} else {
 			res.SetPortalOutput(ctx, portal.Stmt.Columns, portal.OutFormats)
@@ -600,4 +619,20 @@ func (ex *connExecutor) execDescribe(
 			"unknown describe type: %s", errors.Safe(descCmd.Type)))
 	}
 	return nil, nil
+}
+
+// isAllowedInAbortedTxn returns true if the statement is allowed to be
+// prepared and executed inside of an aborted transaction.
+func (ex *connExecutor) isAllowedInAbortedTxn(ast tree.Statement) bool {
+	switch s := ast.(type) {
+	case *tree.CommitTransaction, *tree.RollbackTransaction, *tree.RollbackToSavepoint:
+		return true
+	case *tree.Savepoint:
+		if ex.isCommitOnReleaseSavepoint(s.Name) {
+			return true
+		}
+		return false
+	default:
+		return false
+	}
 }

--- a/pkg/sql/pgwire/testdata/pgtest/aborted_txn
+++ b/pkg/sql/pgwire/testdata/pgtest/aborted_txn
@@ -1,0 +1,238 @@
+# Prepare a statement and make sure it works.
+
+send
+Query {"String": "DROP TABLE IF EXISTS drop_cols;"}
+Query {"String": "CREATE TABLE drop_cols (id int PRIMARY KEY NOT NULL, f1 int NOT NULL, f2 int NOT NULL);"}
+Query {"String": "INSERT INTO drop_cols (id, f1, f2) VALUES (1, 1, 2)"}
+Query {"String": "BEGIN"}
+Parse {"Name": "s1", "Query": "SELECT * FROM drop_cols WHERE id = $1"}
+Bind {"PreparedStatement": "s1", "Parameters": [{"text": "1"}]}
+Execute
+Sync
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"1"},{"text":"2"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# Make a schema change that breaks the prepared statement.
+
+send
+Query {"String": "ALTER TABLE drop_cols DROP COLUMN f1"}
+Bind {"PreparedStatement": "s1", "Parameters": [{"text": "1"}]}
+Execute
+Sync
+----
+
+until ignore=BindComplete
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ALTER TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ErrorResponse","Code":"0A000"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+# Parse should fail in an aborted transaction.
+
+send
+Parse {"Name": "s2", "Query": "SELECT * FROM drop_cols WHERE id = $1"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"25P02"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+# Describe should fail in an aborted transaction.
+
+send
+Describe {"Name": "s1", "ObjectType": "S"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"25P02"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+# Flush should *not* fail in an aborted transaction.
+
+send
+Flush
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+# Bind should fail in an aborted transaction.
+
+send
+Bind {"PreparedStatement": "s1", "Parameters": [{"text": "1"}]}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"25P02"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+# Rollback the transaction, and make sure prepared statement works.
+
+send
+Query {"String": "ROLLBACK"}
+Parse {"Name": "s3", "Query": "SELECT * FROM drop_cols WHERE id = $1"}
+Bind {"PreparedStatement": "s3", "Parameters": [{"text": "1"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"1"},{"text":"1"},{"text":"2"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# ROLLBACK in a prepared statement is allowed.
+
+send
+Query {"String": "BEGIN"}
+Query {"String": "SELECT 1/0"}
+Parse {"Name": "rollback_stmt", "Query": "ROLLBACK"}
+Bind {"DestinationPortal": "p3", "PreparedStatement": "rollback_stmt"}
+Describe {"Name": "rollback_stmt", "ObjectType": "S"}
+Describe {"Name": "p3", "ObjectType": "P"}
+Execute {"Portal": "p3"}
+Sync
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ErrorResponse","Code":"22012"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":null}
+{"Type":"NoData"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# ROLLBACK TO SAVEPOINT in a prepared statement is allowed.
+
+send
+Query {"String": "BEGIN"}
+Parse {"Name": "savepoint_stmt", "Query": "SAVEPOINT cockroach_restart"}
+Bind {"DestinationPortal": "p5", "PreparedStatement": "savepoint_stmt"}
+Describe {"Name": "savepoint_stmt", "ObjectType": "S"}
+Describe {"Name": "p5", "ObjectType": "P"}
+Execute {"Portal": "p5"}
+Query {"String": "SELECT 1/0"}
+Parse {"Name": "rollback_savepoint_stmt", "Query": "ROLLBACK TO SAVEPOINT cockroach_restart"}
+Bind {"DestinationPortal": "p6", "PreparedStatement": "rollback_savepoint_stmt"}
+Describe {"Name": "rollback_savepoint_stmt", "ObjectType": "S"}
+Describe {"Name": "p6", "ObjectType": "P"}
+Execute {"Portal": "p6"}
+Sync
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":null}
+{"Type":"NoData"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"SAVEPOINT"}
+{"Type":"ErrorResponse","Code":"22012"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":null}
+{"Type":"NoData"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+# COMMIT in a prepared statement is allowed.
+
+send
+Query {"String": "SELECT 1/0"}
+Parse {"Name": "commit_stmt", "Query": "COMMIT"}
+Bind {"DestinationPortal": "p4", "PreparedStatement": "commit_stmt"}
+Describe {"Name": "commit_stmt", "ObjectType": "S"}
+Describe {"Name": "p4", "ObjectType": "P"}
+Execute {"Portal": "p4"}
+Sync
+----
+
+until ignore=RowDescription
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"22012"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":null}
+{"Type":"NoData"}
+{"Type":"NoData"}
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/84140

Release note (bug fix): The Parse, Bind, and Execute pgwire commands
now return an error if they are used during an aborted transaction.