### PR TITLE
sql: add statement fingerprint ID to sampled query

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2464,6 +2464,7 @@ contains common SQL event/execution details.
 | `StatementID` | Statement ID of the query. | no |
 | `TransactionID` | Transaction ID of the query. | no |
 | `DatabaseID` | Database ID of the query. | no |
+| `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
 
 
 #### Common fields

--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -19,16 +19,6 @@ import (
 // StmtFingerprintID is the type of a Statement's fingerprint ID.
 type StmtFingerprintID uint64
 
-// FingerprintID returns the FingerprintID of the StatementStatisticsKey.
-func (m *StatementStatisticsKey) FingerprintID() StmtFingerprintID {
-	return ConstructStatementFingerprintID(
-		m.Query,
-		m.Failed,
-		m.ImplicitTxn,
-		m.Database,
-	)
-}
-
 // ConstructStatementFingerprintID constructs an ID by hashing an anonymized query, its database
 // and failure status, and if it was part of an implicit txn. At the time of writing,
 // these are the axis' we use to bucket queries for stats collection

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1365,7 +1365,6 @@ type connExecutor struct {
 			savepoints       savepointStack
 			sessionDataStack *sessiondata.Stack
 		}
-
 		// transactionStatementFingerprintIDs tracks all statement IDs that make up the current
 		// transaction. It's length is bound by the TxnStatsNumStmtFingerprintIDsToRecord
 		// cluster setting.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1061,6 +1061,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		res.DisableBuffering()
 	}
 
+	var stmtFingerprintID roachpb.StmtFingerprintID
 	defer func() {
 		planner.maybeLogStatement(
 			ctx,
@@ -1072,6 +1073,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
+			stmtFingerprintID,
 		)
 	}()
 
@@ -1185,7 +1187,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	// Record the statement summary. This also closes the plan if the
 	// plan has not been closed earlier.
-	ex.recordStatementSummary(
+	stmtFingerprintID = ex.recordStatementSummary(
 		ctx, planner,
 		int(ex.state.mu.autoRetryCounter), res.RowsAffected(), res.Err(), stats,
 	)

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -116,7 +116,7 @@ func (ex *connExecutor) recordStatementSummary(
 	rowsAffected int,
 	stmtErr error,
 	stats topLevelQueryStats,
-) {
+) roachpb.StmtFingerprintID {
 	phaseTimes := ex.statsCollector.PhaseTimes()
 
 	// Collect the statistics.
@@ -235,6 +235,7 @@ func (ex *connExecutor) recordStatementSummary(
 			sessionAge,
 		)
 	}
+	return stmtFingerprintID
 }
 
 func (ex *connExecutor) updateOptCounters(planFlags planFlags) {

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3344,6 +3344,15 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = strconv.AppendUint(b, uint64(m.DatabaseID), 10)
 	}
 
+	if m.StatementFingerprintID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatementFingerprintID\":"...)
+		b = strconv.AppendUint(b, uint64(m.StatementFingerprintID), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -61,6 +61,9 @@ message SampledQuery {
 
   // Database ID of the query.
   uint32 database_id = 12 [(gogoproto.customname) = "DatabaseID", (gogoproto.jsontag) = ",omitempty"];
+
+  // Statement fingerprint ID of the query.
+  uint64 statement_fingerprint_id = 13 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty'];
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
Partially addresses: #71328

This change adds the statement fingerprint ID to the sampled query log,
allowing us to measure the uniqueness of a workload.

Release note (sql change): Sampled query telemetry log now includes the
statement's fingerprint ID.