### PR TITLE
sql/schemachanger: detect unsupported types for unique indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2664,3 +2664,11 @@ ALTER TABLE t81448 ADD COLUMN b INT PRIMARY KEY
 
 statement ok
 DROP TABLE t81448
+
+subtest add_column_non_indexable_type
+
+statement ok
+CREATE TABLE t1_non_indexable (n INT8);
+
+statement error pq: unimplemented: column x is of type char\[\] and thus is not indexable
+ALTER TABLE t1_non_indexable ADD COLUMN x CHAR(256)[] UNIQUE;

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -30,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
@@ -148,6 +150,16 @@ func alterTableAddColumn(
 				"cross database type references are not supported: %s",
 				typeName.String()))
 		}
+	}
+	// Block unique indexes on unsupported types.
+	if d.Unique.IsUnique &&
+		!d.Unique.WithoutIndex &&
+		!colinfo.ColumnTypeIsIndexable(spec.colType.Type) {
+		typInfo := spec.colType.Type.DebugString()
+		panic(unimplemented.NewWithIssueDetailf(35730, typInfo,
+			"column %s is of type %s and thus is not indexable",
+			d.Name,
+			spec.colType.Type.Name()))
 	}
 	// Block unsupported types.
 	switch spec.colType.Type.Oid() {


### PR DESCRIPTION
Fixes: #84185

Previously, the declarative schema changer when adding
a column with a unique index did not generate the
appropriate error when an unsupported type was encountered.
As a result, we would wait till execution and require a
rollback during execution phase. To address this, this patch
will report the unsupported type directly within the builder.

Release note: None