### PR TITLE
descs: don't invalidate kvDescriptors cache

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/base",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/sql",
+        "//pkg/sql/parser",
         "//pkg/testutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/bench/rttanalysis/rtt_analysis_bench.go
+++ b/pkg/bench/rttanalysis/rtt_analysis_bench.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -117,32 +118,51 @@ func executeRoundTripTest(b testingB, tc RoundTripBenchTestCase, cc ClusterConst
 	b.StopTimer()
 	var r tracingpb.Recording
 
+	// The statement trace records individual statements, but we may want to
+	// execute multiple SQL statements. Note that multi-statement traces won't
+	// count round trips correctly if there are duplicate statements.
+	statements, err := parser.Parse(tc.Stmt)
+	if err != nil {
+		panic(err)
+	}
+
 	// Do an extra iteration and don't record it in order to deal with effects of
 	// running it the first time.
 	for i := 0; i < b.N()+1; i++ {
 		sql.Exec(b, "CREATE DATABASE bench;")
 		sql.Exec(b, tc.Setup)
-		cluster.clearStatementTrace(tc.Stmt)
+		for _, statement := range statements {
+			cluster.clearStatementTrace(statement.SQL)
+		}
 
 		b.StartTimer()
 		sql.Exec(b, tc.Stmt)
 		b.StopTimer()
 		var ok bool
-		r, ok = cluster.getStatementTrace(tc.Stmt)
-		if !ok {
-			b.Fatalf(
-				"could not find number of round trips for statement: %s",
-				tc.Stmt,
-			)
-		}
 
-		// If there's a retry error then we're just going to throw away this
-		// run.
-		rt, hasRetry := countKvBatchRequestsInRecording(r)
-		if hasRetry {
-			i--
-		} else if i > 0 { // skip the initial iteration
-			roundTrips += rt
+		total := 0
+		for _, statement := range statements {
+			r, ok = cluster.getStatementTrace(statement.SQL)
+			if !ok {
+				b.Fatalf(
+					"could not find number of round trips for statement: %s",
+					statement.SQL,
+				)
+			}
+
+			// If there's a retry error then we're just going to throw away this
+			// run.
+			rt, hasRetry := countKvBatchRequestsInRecording(r)
+			if hasRetry {
+				i--
+				ok = false
+				break
+			} else if i > 0 { // skip the initial iteration
+				total += rt
+			}
+		}
+		if ok {
+			roundTrips += total
 		}
 
 		sql.Exec(b, "DROP DATABASE bench;")

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -90,5 +90,6 @@ exp,benchmark
 18,Truncate/truncate_2_column_0_rows
 18,Truncate/truncate_2_column_1_rows
 18,Truncate/truncate_2_column_2_rows
+19,VirtualTableQueries/virtual_table_cache
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk

--- a/pkg/bench/rttanalysis/virtual_table_bench_test.go
+++ b/pkg/bench/rttanalysis/virtual_table_bench_test.go
@@ -35,5 +35,20 @@ CREATE TABLE t2 (i INT PRIMARY KEY, j INT REFERENCES t1(i));
 `,
 			Stmt: `SELECT * FROM "".crdb_internal.invalid_objects`,
 		},
+		// This checks that descriptors are still cached after they are written. We
+		// expect the second and third selects not to go to KV because the
+		// descriptors were cached after the first lookup.
+		{
+			Name: "virtual table cache",
+			Setup: `
+CREATE TABLE t1 (i INT PRIMARY KEY);
+CREATE TABLE t2 (i INT PRIMARY KEY, j INT);`,
+			Stmt: `
+SELECT * FROM crdb_internal.tables;
+ALTER TABLE t1 ADD COLUMN j INT;
+SELECT * FROM crdb_internal.table_columns;
+CREATE INDEX idx ON t2 (j);
+SELECT * FROM crdb_internal.index_columns;`,
+		},
 	})
 }

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -664,3 +664,123 @@ func TestKVDescriptorsProperlyUsesMemoryMonitoring(t *testing.T) {
 	require.Equal(t, int64(0), monitor.AllocBytes())
 	monitor.Stop(ctx)
 }
+
+// TestDescriptorCache ensures that when descriptors are modified, a batch
+// lookup on the Collection views the latest changes.
+func TestDescriptorCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	tdb.Exec(t, `CREATE DATABASE db`)
+	tdb.Exec(t, `USE db`)
+	tdb.Exec(t, `CREATE SCHEMA schema`)
+	tdb.Exec(t, `CREATE TABLE db.schema.table()`)
+
+	s0 := tc.Server(0)
+	execCfg := s0.ExecutorConfig().(sql.ExecutorConfig)
+	t.Run("all descriptors", func(t *testing.T) {
+		require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+		) error {
+			// Warm up cache.
+			_, err := descriptors.GetAllDescriptors(ctx, txn)
+			if err != nil {
+				return err
+			}
+			// Modify table descriptor.
+			tn := tree.MakeTableNameWithSchema("db", "schema", "table")
+			flags := tree.ObjectLookupFlagsWithRequired()
+			flags.RequireMutable = true
+			_, mut, err := descriptors.GetMutableTableByName(ctx, txn, &tn, flags)
+			if err != nil {
+				return err
+			}
+			require.NotNil(t, mut)
+			mut.Name = "new_name"
+			err = descriptors.AddUncommittedDescriptor(mut)
+			if err != nil {
+				return err
+			}
+			// The collection's all descriptors should include the modification.
+			cat, err := descriptors.GetAllDescriptors(ctx, txn)
+			if err != nil {
+				return err
+			}
+			found := cat.LookupDescriptorEntry(mut.ID)
+			require.NotEmpty(t, found)
+			require.Equal(t, found, mut.ImmutableCopy())
+			return nil
+		}))
+	})
+	t.Run("all db descriptors", func(t *testing.T) {
+		require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+		) error {
+			// Warm up cache.
+			_, err := descriptors.GetAllDatabaseDescriptors(ctx, txn)
+			if err != nil {
+				return err
+			}
+			// Modify database descriptor.
+			flags := tree.DatabaseLookupFlags{}
+			flags.RequireMutable = true
+			mut, err := descriptors.GetMutableDatabaseByName(ctx, txn, "db", flags)
+			if err != nil {
+				return err
+			}
+			require.NotNil(t, mut)
+			mut.Version += 1
+			err = descriptors.AddUncommittedDescriptor(mut)
+			if err != nil {
+				return err
+			}
+			// The collection's all database descriptors should reflect the
+			// modification.
+			dbDescs, err := descriptors.GetAllDatabaseDescriptors(ctx, txn)
+			if err != nil {
+				return err
+			}
+			require.Len(t, dbDescs, 4)
+			require.Equal(t, dbDescs[0], mut.ImmutableCopy())
+			return nil
+		}))
+	})
+	t.Run("schemas for database", func(t *testing.T) {
+		require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+		) error {
+			// Warm up cache.
+			dbDesc, err := descriptors.GetDatabaseDesc(ctx, txn, "db", tree.DatabaseLookupFlags{})
+			if err != nil {
+				return err
+			}
+			_, err = descriptors.GetSchemasForDatabase(ctx, txn, dbDesc)
+			if err != nil {
+				return err
+			}
+			// Modify schema name.
+			schemaDesc, err := descriptors.GetMutableSchemaByName(ctx, txn, dbDesc, "schema", tree.SchemaLookupFlags{Required: true})
+			if err != nil {
+				return err
+			}
+			schemaDesc.SchemaDesc().Name = "new_name"
+			err = descriptors.AddUncommittedDescriptor(schemaDesc.(catalog.MutableDescriptor))
+			if err != nil {
+				return err
+			}
+			// The collection's schemas for database should reflect the modification.
+			schemas, err := descriptors.GetSchemasForDatabase(ctx, txn, dbDesc)
+			if err != nil {
+				return err
+			}
+			require.Len(t, schemas, 2)
+			require.Equal(t, schemas[schemaDesc.GetID()], schemaDesc.GetName())
+			return nil
+		}))
+	})
+}

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -253,7 +253,7 @@ func (q *byIDLookupContext) lookupLeased(id descpb.ID) (catalog.Descriptor, erro
 	//
 	// TODO(ajwerner): More generally leverage this set of kv descriptors on
 	// the resolution path.
-	if q.tc.kv.idDefinitelyDoesNotExist(id) {
+	if q.tc.idDefinitelyDoesNotExist(id) {
 		return nil, catalog.ErrDescriptorNotFound
 	}
 	desc, shouldReadFromStore, err := q.tc.leased.getByID(q.ctx, q.tc.deadlineHolder(q.txn), id)


### PR DESCRIPTION
Previously, the collection invalidated its view of descriptors read from
KV after a descriptor was modified. This was necessary because the
collection does not fully buffer writes to descriptors, so the
descriptors stored in KV may change. This is problematic, because users
of the `kvDescriptors` (virtual tables) must perform a round trip to
refresh their descriptors cache after schema changes in the same
transaction.

To address this, this commit avoids invalidating the cache. Instead,
when serving lookups that rely on the `kvDescriptors`, we will amend the
cache with the contents of `uncommittedDescriptors` to ensure that a
transaction sees its own modifications.

Relates to #64673

Release note: None