### PR TITLE
opt: mark SimplifyRootOrdering as an essential rule

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -980,6 +980,10 @@ func (o *Optimizer) disableRules(probability float64) {
 		// supports distinct on an empty column set.
 		int(opt.EliminateDistinctNoColumns),
 		int(opt.EliminateEnsureDistinctNoColumns),
+		// TODO(#84191): Needed to remove the same column and direction
+		// appearing consecutively in ordering columns, which can cause
+		// incorrect results until #84191 is addressed.
+		int(opt.SimplifyRootOrdering),
 	)
 
 	for i := opt.RuleName(1); i < opt.NumRuleNames; i++ {


### PR DESCRIPTION
The unoptimized query oracle, which disables rules, found a bug in the
execution engine that is only possible to hit if the
`SimplifyRootOrdering` rule is disabled (see #84191). Until the bug is
fixed, we mark the rule as essential so that it is not disabled by these
tests.

Fixes #84067

Release note: None