### PR TITLE
sql: Add database ID to sampled query log

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2463,6 +2463,7 @@ contains common SQL event/execution details.
 | `Database` | Name of the database that initiated the query. | no |
 | `StatementID` | Statement ID of the query. | no |
 | `TransactionID` | Transaction ID of the query. | no |
+| `DatabaseID` | Database ID of the query. | no |
 
 
 #### Common fields

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -12,9 +12,11 @@ package sql
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -94,10 +96,14 @@ func TestTelemetryLogging(t *testing.T) {
 
 	var sessionID string
 	var databaseName string
+	var dbID uint32
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
+	conn := db.DB.(*gosql.DB)
+
 	db.QueryRow(t, `SHOW session_id`).Scan(&sessionID)
 	db.QueryRow(t, `SHOW database`).Scan(&databaseName)
+	dbID = sqlutils.QueryDatabaseID(t, conn, databaseName)
 	db.Exec(t, `SET application_name = 'telemetry-logging-test'`)
 	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
 	db.Exec(t, "CREATE TABLE t();")
@@ -267,6 +273,9 @@ func TestTelemetryLogging(t *testing.T) {
 				}
 				if !strings.Contains(e.Message, "\"Database\":\""+databaseName+"\"") {
 					t.Errorf("expected to find Database: %s", databaseName)
+				}
+				if !strings.Contains(e.Message, "\"DatabaseID\":"+strconv.Itoa(int(dbID))) {
+					t.Errorf("expected to find DatabaseID: %v", dbID)
 				}
 			}
 		}

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3335,6 +3335,15 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, '"')
 	}
 
+	if m.DatabaseID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DatabaseID\":"...)
+		b = strconv.AppendUint(b, uint64(m.DatabaseID), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -58,6 +58,9 @@ message SampledQuery {
 
   // Transaction ID of the query.
   string transaction_id = 11 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Database ID of the query.
+  uint32 database_id = 12 [(gogoproto.customname) = "DatabaseID", (gogoproto.jsontag) = ",omitempty"];
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
This change adds a database ID field to the sampled query telemetry log.

Release note (sql change): Sampled query telemetry log includes new
database ID field.