### PR TITLE
multi-tenant: Use unrestricted blob client for MT tests

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2056,12 +2056,7 @@ func TestChangefeedAuthorization(t *testing.T) {
 		},
 		{name: `cloud`,
 			statement: `CREATE CHANGEFEED FOR d.table_a INTO 'nodelocal://12/nope/'`,
-			// Ideally, this should be returning "connecting to node 12", but
-			// since (with #76582) we're using a local-only blob client by
-			// default for tenants, we get a different error message. This
-			// error message should be reverted when we generalize the blob
-			// client creation in tenants. Tracked with #76378.
-			errMsg: `connecting to remote node not supported`,
+			errMsg:    `connecting to node 12`,
 		},
 		{name: `sinkless`,
 			statement: `EXPERIMENTAL CHANGEFEED FOR d.table_a WITH resolved='1'`,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -817,11 +817,14 @@ func (ts *TestServer) StartTenant(
 	baseCfg.HeapProfileDirName = params.HeapProfileDirName
 	baseCfg.GoroutineDumpDirName = params.GoroutineDumpDirName
 
-	// TODO(ajstorm): Temporarily use a local-only blob client to get things
-	//  working for the common multi-tenant case. Will need to revisit this
-	//  to enable tests which require remote blob access. Tracked with #76378.
+	localNodeIDContainer := &base.NodeIDContainer{}
+	localNodeIDContainer.Set(ctx, ts.NodeID())
+	blobClientFactory := blobs.NewBlobClientFactory(
+		localNodeIDContainer,
+		ts.Server.nodeDialer,
+		params.ExternalIODir,
+	)
 	tk := &baseCfg.TestingKnobs
-	blobClientFactory := blobs.NewLocalOnlyBlobClientFactory(params.ExternalIODir)
 	if serverKnobs, ok := tk.Server.(*TestingKnobs); ok {
 		serverKnobs.BlobClientFactory = blobClientFactory
 	} else {


### PR DESCRIPTION
See individual commits for details.

Informs #76378.

Release note: None.