### PR TITLE
server: fix conversion error on jobs

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2002,8 +2002,7 @@ func (s *adminServer) jobsHelper(
               when ` + retryRevertingCondition + ` then 'retry-reverting' 
               else status
             end as status, running_status, created, started, finished, modified, fraction_completed,
-            high_water_timestamp, error, last_run, next_run, num_runs, execution_events::string::bytes,
-            coordinator_id
+            high_water_timestamp, error, last_run, next_run, num_runs, execution_events::string, coordinator_id
         FROM crdb_internal.jobs
        WHERE true
 	`)
@@ -2088,7 +2087,7 @@ func scanRowIntoJob(scanner resultScanner, row tree.Datums, job *serverpb.JobRes
 	var fractionCompletedOrNil *float32
 	var highwaterOrNil *apd.Decimal
 	var runningStatusOrNil *string
-	var executionFailures []byte
+	var executionFailuresOrNil *string
 	var coordinatorOrNil *int64
 	if err := scanner.ScanAll(
 		row,
@@ -2110,7 +2109,7 @@ func scanRowIntoJob(scanner resultScanner, row tree.Datums, job *serverpb.JobRes
 		&job.LastRun,
 		&job.NextRun,
 		&job.NumRuns,
-		&executionFailures,
+		&executionFailuresOrNil,
 		&coordinatorOrNil,
 	); err != nil {
 		return errors.Wrap(err, "scan")
@@ -2130,8 +2129,8 @@ func scanRowIntoJob(scanner resultScanner, row tree.Datums, job *serverpb.JobRes
 	if runningStatusOrNil != nil {
 		job.RunningStatus = *runningStatusOrNil
 	}
-	{
-		failures, err := jobs.ParseRetriableExecutionErrorLogFromJSON(executionFailures)
+	if executionFailuresOrNil != nil {
+		failures, err := jobs.ParseRetriableExecutionErrorLogFromJSON([]byte(*executionFailuresOrNil))
 		if err != nil {
 			return errors.Wrap(err, "parse")
 		}
@@ -2178,7 +2177,7 @@ func (s *adminServer) jobHelper(
 	        SELECT job_id, job_type, description, statement, user_name, descriptor_ids, status,
 	  						 running_status, created, started, finished, modified,
 	  						 fraction_completed, high_water_timestamp, error, last_run,
-								 next_run, num_runs, execution_events::string::bytes,
+								 next_run, num_runs, execution_events::string,
                  coordinator_id
 	          FROM crdb_internal.jobs
 	         WHERE job_id = $1`


### PR DESCRIPTION
Previously, if a job contained quote on its execution events
value, it would cause an error on conversion into `BYTEA`.
This commit removes the BYTEA cast and decode to json string.

Fixes #84139

Release note (bug fix): Fix on conversion on jobs endpoint, so
the Jobs page won't return 500 error when the job contained
an error with quotes.