### PR TITLE
release-22.1: sql: fixes around accounting of prepared statements

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -153,9 +153,6 @@ func (ex *connExecutor) prepare(
 		createdAt: timeutil.Now(),
 		origin:    origin,
 	}
-	// NB: if we start caching the plan, we'll want to keep around the memory
-	// account used for the plan, rather than clearing it.
-	defer prepared.memAcc.Clear(ctx)
 
 	if stmt.AST == nil {
 		return prepared, nil

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -105,12 +105,14 @@ func (ex *connExecutor) addPreparedStmt(
 	}
 
 	if len(prepared.TypeHints) > pgwirebase.MaxPreparedStatementArgs {
+		prepared.memAcc.Close(ctx)
 		return nil, pgwirebase.NewProtocolViolationErrorf(
 			"more than %d arguments to prepared statement: %d",
 			pgwirebase.MaxPreparedStatementArgs, len(prepared.TypeHints))
 	}
 
 	if err := prepared.memAcc.Grow(ctx, int64(len(name))); err != nil {
+		prepared.memAcc.Close(ctx)
 		return nil, err
 	}
 	ex.extraTxnState.prepStmtsNamespace.prepStmts[name] = prepared
@@ -135,16 +137,13 @@ func (ex *connExecutor) addPreparedStmt(
 //
 // placeholderHints may contain partial type information for placeholders.
 // prepare will populate the missing types. It can be nil.
-//
-// The PreparedStatement is returned (or nil if there are no results). The
-// returned PreparedStatement needs to be close()d once its no longer in use.
 func (ex *connExecutor) prepare(
 	ctx context.Context,
 	stmt Statement,
 	placeholderHints tree.PlaceholderTypes,
 	rawTypeHints []oid.Oid,
 	origin PreparedStatementOrigin,
-) (*PreparedStatement, error) {
+) (_ *PreparedStatement, retErr error) {
 
 	prepared := &PreparedStatement{
 		memAcc:   ex.sessionMon.MakeBoundAccount(),
@@ -153,6 +152,12 @@ func (ex *connExecutor) prepare(
 		createdAt: timeutil.Now(),
 		origin:    origin,
 	}
+	defer func() {
+		// Make sure to close the memory account if an error is returned.
+		if retErr != nil {
+			prepared.memAcc.Close(ctx)
+		}
+	}()
 
 	if stmt.AST == nil {
 		return prepared, nil

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -157,8 +157,12 @@ func (ex *connExecutor) makePreparedPortal(
 func (p PreparedPortal) accountForCopy(
 	ctx context.Context, prepStmtsNamespaceMemAcc *mon.BoundAccount, portalName string,
 ) error {
+	if err := prepStmtsNamespaceMemAcc.Grow(ctx, p.size(portalName)); err != nil {
+		return err
+	}
+	// Only increment the reference if we're going to keep it.
 	p.Stmt.incRef(ctx)
-	return prepStmtsNamespaceMemAcc.Grow(ctx, p.size(portalName))
+	return nil
 }
 
 // close closes this portal.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: don't clear the memory account of the prepared stmt" (#83615)
  * 2/2 commits from "sql: fix memory accounting of prepared statements and portals in error cases" (#84049)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: bug fixes.