### PR TITLE
kv: raft closed timestamp is no longer nullable

### DIFF
--- a/pkg/kv/kvserver/below_raft_protos_test.go
+++ b/pkg/kv/kvserver/below_raft_protos_test.go
@@ -77,8 +77,8 @@ var belowRaftGoldenProtos = map[reflect.Type]fixture{
 		populatedConstructor: func(r *rand.Rand) protoutil.Message {
 			return enginepb.NewPopulatedRangeAppliedState(r, false)
 		},
-		emptySum:     615555020845646359,
-		populatedSum: 4888917721712214316,
+		emptySum:     10160370728048384381,
+		populatedSum: 13858955692092952193,
 	},
 	reflect.TypeOf(&raftpb.HardState{}): {
 		populatedConstructor: func(r *rand.Rand) protoutil.Message {

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -184,7 +185,7 @@ func (r *replicaTruncatorTest) writeRaftAppliedIndex(
 	t *testing.T, eng storage.Engine, raftAppliedIndex uint64, flush bool,
 ) {
 	require.NoError(t, r.stateLoader.SetRangeAppliedState(context.Background(), eng,
-		raftAppliedIndex, 0, 0, &enginepb.MVCCStats{}, nil, nil))
+		raftAppliedIndex, 0, 0, &enginepb.MVCCStats{}, hlc.Timestamp{}, nil))
 	// Flush to make it satisfy the contract of OnlyReadGuaranteedDurable in
 	// Pebble.
 	if flush {

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -1041,7 +1041,7 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 	loader := &b.r.raftMu.stateLoader
 	return loader.SetRangeAppliedState(
 		ctx, b.batch, b.state.RaftAppliedIndex, b.state.LeaseAppliedIndex, b.state.RaftAppliedIndexTerm,
-		b.state.Stats, &b.state.RaftClosedTimestamp, &b.asAlloc,
+		b.state.Stats, b.state.RaftClosedTimestamp, &b.asAlloc,
 	)
 }
 

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
-	raft "go.etcd.io/etcd/raft/v3"
+	"go.etcd.io/etcd/raft/v3"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 
@@ -146,7 +146,7 @@ func splitPreApply(
 		initClosedTS = &hlc.Timestamp{}
 	}
 	initClosedTS.Forward(r.GetCurrentClosedTimestamp(ctx))
-	if err := rsl.SetClosedTimestamp(ctx, readWriter, initClosedTS); err != nil {
+	if err := rsl.SetClosedTimestamp(ctx, readWriter, *initClosedTS); err != nil {
 		log.Fatalf(ctx, "%s", err)
 	}
 }

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -258,12 +258,7 @@ message RangeAppliedState {
   // commands that can still apply are writing at higher timestamps.
   // Non-leaseholder replicas are free to serve "follower reads" at or below
   // this timestamp.
-  //
-  // TODO(andrei): Make this field not-nullable in 21.2, once all the ranges
-  // have a closed timestamp applied to their state (this might need a
-  // migration). In 21.1 we cannot write empty timestamp to disk because that
-  // looks like an inconsistency to the consistency-checker.
-  util.hlc.Timestamp raft_closed_timestamp = 4;
+  util.hlc.Timestamp raft_closed_timestamp = 4 [(gogoproto.nullable) = false];
 
   // raft_applied_index_term is the term corresponding to raft_applied_index.
   // The serialized proto will not contain this field until code starts


### PR DESCRIPTION
The Raft protocol closed timestamp is no longer nullable.

This change does not require a per-range migration because other migrations (namely, AddRaftAppliedIndexTermMigration) have already run across all ranges since v21.1 when this field was initially added. Those migrations ensured that all ranges now have a non-nil RaftClosedTimestamp.

Closes #84104.
Jira issue: [CRDB-17462](https://cockroachlabs.atlassian.net/browse/CRDB-17462)