### PR TITLE
sql: fix flakiness with InternalExecutorFactoryMemMonitor closing TestServers

### DIFF
--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -44,9 +44,6 @@ func TestBackendDialTLS(t *testing.T) {
 		defer sql.Stopper().Stop(ctx)
 
 		conn, err := BackendDial(startupMsg, sql.ServingSQLAddr(), tlsConfig)
-		defer func() {
-			_ = conn.Close()
-		}()
 
 		require.NoError(t, err)
 		require.NotNil(t, conn)


### PR DESCRIPTION
Release note: None