### PR TITLE
logictest: temporarily disable workmem randomization in SQLLite tests

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -4617,6 +4617,8 @@ func runSQLLiteLogicTest(t *testing.T, configOverride string, globs ...string) {
 	// limit than other logic tests get.
 	serverArgs := TestServerArgs{
 		maxSQLMemoryLimit: 512 << 20, // 512 MiB
+		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
+		DisableWorkmemRandomization: true,
 	}
 	RunLogicTestWithDefaultConfig(t, serverArgs, configOverride, "", true /* runCCLConfigs */, prefixedGlobs...)
 }


### PR DESCRIPTION
The failure is not really a concerning one, so it's ok to skip until
we figure it out.

Informs: #84022.

Release note: None