### PR TITLE
colexechash: improve memory accounting in the hash table

### DIFF
--- a/pkg/sql/colexec/colexecdisk/external_distinct.go
+++ b/pkg/sql/colexec/colexecdisk/external_distinct.go
@@ -158,7 +158,7 @@ func (f *unorderedDistinctFilterer) Next() coldata.Batch {
 			//
 			// See https://github.com/cockroachdb/cockroach/pull/58006#pullrequestreview-565859919
 			// for all the gory details.
-			f.ud.Ht.MaybeRepairAfterDistinctBuild()
+			f.ud.Ht.RepairAfterDistinctBuild()
 			f.ud.MaybeEmitErrorOnDup(f.ud.LastInputBatchOrigLen, batch.Length())
 			f.seenBatch = true
 			return batch

--- a/pkg/sql/colexec/colexecjoin/BUILD.bazel
+++ b/pkg/sql/colexec/colexecjoin/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra/execopnode",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/memsize",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",  # keep
         "//pkg/sql/types",

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -431,6 +431,12 @@ func (op *hashAggregator) onlineAgg(b coldata.Batch) {
 }
 
 func (op *hashAggregator) ExportBuffered(input colexecop.Operator) coldata.Batch {
+	if op.ht != nil {
+		// This is the first call to ExportBuffered - release the hash table
+		// since we no longer need it.
+		op.ht.Release()
+		op.ht = nil
+	}
 	if !op.inputTrackingState.zeroBatchEnqueued {
 		// Per the contract of the spilling queue, we need to append a
 		// zero-length batch.

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -33,7 +33,7 @@ func NewUnorderedDistinct(
 ) colexecop.ResettableOperator {
 	return &UnorderedDistinct{
 		OneInputNode:         colexecop.NewOneInputNode(input),
-		allocator:            allocator,
+		hashTableAllocator:   allocator,
 		distinctCols:         distinctCols,
 		typs:                 typs,
 		nullsAreDistinct:     nullsAreDistinct,
@@ -50,10 +50,10 @@ type UnorderedDistinct struct {
 	colexecop.OneInputNode
 	colexecbase.UpsertDistinctHelper
 
-	allocator        *colmem.Allocator
-	distinctCols     []uint32
-	typs             []*types.T
-	nullsAreDistinct bool
+	hashTableAllocator *colmem.Allocator
+	distinctCols       []uint32
+	typs               []*types.T
+	nullsAreDistinct   bool
 
 	Ht *colexechash.HashTable
 	// lastInputBatch tracks the last input batch read from the input and not
@@ -80,7 +80,7 @@ func (op *UnorderedDistinct) Init(ctx context.Context) {
 	const hashTableNumBuckets = 128
 	op.Ht = colexechash.NewHashTable(
 		op.Ctx,
-		op.allocator,
+		op.hashTableAllocator,
 		hashTableLoadFactor,
 		hashTableNumBuckets,
 		op.typs,


### PR DESCRIPTION
This commit improves the memory accounting in the hash table to be more
precise in the case when the `distsql_workmem` limit is exhausted.
Previously, we would allocate large slices first only to perform the
memory accounting after the fact, possibly running out of budget which
would result in a error being thrown. We'd end up in a situation where
the hash table is still referencing larger newly-allocated slices while
only the previous memory usage is accounted for. This commit makes it so
that we account for the needed capacity upfront, then perform the
allocation, and then reconcile the accounting if necessary. This way
we're much more likely to encounter the budget error before making the
large allocations.

Additionally, this commit accounts for some internal slices in the hash
table used only in the hash joiner case.

Also, now both the hash aggregator and the hash joiner eagerly release
references to these internal slices of the hash table when the spilling
to disk occurs (we cannot do the same for the unordered distinct because
there the hash table is actually used after the spilling too).

This required a minor change to the way the unordered distinct spills to
disk. Previously, the memory error could only occur in two spots (and
one of those would leave the hash table in an inconsistent state and we
were "smart" in how we repaired that). However, now the memory error
could occur in more spots (and we could have several different
inconsistent states), so this commit chooses a slight performance
regression of simply rebuilding the hash table from scratch, once, when
the unordered distinct spills to disk.

Addresses: #60022.
Addresses: #64906.

Release note: None