### PR TITLE
kvcoord: account for the span overhead when condensing refresh spans

### DIFF
--- a/pkg/kv/kvclient/kvcoord/condensable_span_set_test.go
+++ b/pkg/kv/kvclient/kvcoord/condensable_span_set_test.go
@@ -27,9 +27,9 @@ func TestCondensableSpanSetMergeContiguousSpans(t *testing.T) {
 	s := condensableSpanSet{}
 	s.insert(roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")})
 	s.insert(roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")})
-	require.Equal(t, int64(4), s.bytes)
+	require.Equal(t, 4+2*roachpb.SpanOverhead, s.bytes)
 	s.mergeAndSort()
-	require.Equal(t, int64(2), s.bytes)
+	require.Equal(t, 2+roachpb.SpanOverhead, s.bytes)
 }
 
 func TestCondensableSpanSetEstimateSize(t *testing.T) {
@@ -51,32 +51,32 @@ func TestCondensableSpanSetEstimateSize(t *testing.T) {
 			name:           "new spans fit without merging",
 			set:            []roachpb.Span{ab, bc},
 			newSpans:       []roachpb.Span{ab},
-			mergeThreshold: 100,
-			expEstimate:    6,
+			mergeThreshold: 100 + 3*roachpb.SpanOverhead,
+			expEstimate:    6 + 3*roachpb.SpanOverhead,
 		},
 		{
 			// The set gets merged, the new spans don't.
 			name:           "set needs merging",
 			set:            []roachpb.Span{ab, bc},
 			newSpans:       []roachpb.Span{ab},
-			mergeThreshold: 5,
-			expEstimate:    4,
+			mergeThreshold: 5 + 2*roachpb.SpanOverhead,
+			expEstimate:    4 + 2*roachpb.SpanOverhead,
 		},
 		{
 			// The set gets merged, and then it gets merged again with the newSpans.
 			name:           "new spans fit without merging",
 			set:            []roachpb.Span{ab, bc},
 			newSpans:       []roachpb.Span{ab, bc},
-			mergeThreshold: 5,
-			expEstimate:    2,
+			mergeThreshold: 5 + 2*roachpb.SpanOverhead,
+			expEstimate:    2 + roachpb.SpanOverhead,
 		},
 		{
 			// Everything gets merged, but it still doesn't fit.
 			name:           "new spans dont fit",
 			set:            []roachpb.Span{ab, bc},
 			newSpans:       []roachpb.Span{ab, bc, largeSpan},
-			mergeThreshold: 5,
-			expEstimate:    12,
+			mergeThreshold: 5 + 2*roachpb.SpanOverhead,
+			expEstimate:    12 + 2*roachpb.SpanOverhead,
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -1068,3 +1068,7 @@ func (a *inFlightWriteAlloc) clear() {
 	}
 	*a = (*a)[:0]
 }
+
+func keySize(k roachpb.Key) int64 {
+	return int64(len(k))
+}


### PR DESCRIPTION
Previously, we would only account for the lengths of the key and the end
key of the span for the purposes of memory estimation while condensing
the refresh spans set. However, each span has non-trivial overhead (48
bytes) of `roachpb.Span` object itself which we previously ignored. As
a result, the actual footprint of the refresh spans could previously
significantly exceed the target size, especially when the keys are
small. For example, when looking at a recently collected core dump,
I saw the refresh spans taking up about 24MB in the heap whereas the
target setting is only 4MiB. This memory currently is not tracked
against the memory accounting system at all, so such over-shots are
quite bad, especially so given the recent bump of the setting from
256KiB to 4MiB.

Addresses: #64906.
Addresses: #81451.

Release note (ops change): The way we track memory against
`kv.transaction.max_intents_bytes` and
`kv.transaction.max_refresh_spans_bytes` has been adjusted to be more
precise (we no longer ignore some of the overhead). As a result, the
stability of CRDB improves (we're less likely to OOM), however, this
change effectively reduces the budgets determined by those cluster
settings. In practice, this means that
- the intents might be tracked more coarsely (due to span coalescing)
which makes the intent resolution less efficient
- the refresh spans become more coarse too making it more likely that
`ReadWithinUncertaintyIntervalError`s are returned to the user rather
than are retried transparently.