### PR TITLE
backupinfo: add tracing spans

### DIFF
--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )


### PR DESCRIPTION
We lost one of the tracing spans we added for checkpointing during a
refactor. While I was here, I added tracing spans to many of the
public methods and a couple of the private methods that are called
repeatedly by public methods.

For public methods, I added spans to methods that did substantial work
with external storage, excluding those that primarily just called
other methods that have had spans added.

Release note: None