### PR TITLE
roachtest: test-eng owns perf tests

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -273,7 +273,7 @@ func registerKV(r registry.Registry) {
 		if opts.tracing {
 			nameParts = append(nameParts, "tracing")
 		}
-		owner := registry.OwnerKV
+		owner := registry.OwnerTestEng
 		if opts.owner != "" {
 			owner = opts.owner
 		}

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -148,7 +148,7 @@ func registerSysbench(r registry.Registry) {
 
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("sysbench/%s/nodes=%d/cpu=%d/conc=%d", w, n, cpus, conc),
-			Owner:   registry.OwnerKV,
+			Owner:   registry.OwnerTestEng,
 			Cluster: r.MakeClusterSpec(n+1, spec.CPU(cpus)),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runSysbench(ctx, t, c, opts)

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -833,6 +833,7 @@ func (l tpccBenchLoadConfig) numLoadNodes(d tpccBenchDistribution) int {
 }
 
 type tpccBenchSpec struct {
+	Owner                    registry.Owner // defaults to Test-Eng
 	Nodes                    int
 	CPUs                     int
 	Chaos                    bool
@@ -885,6 +886,10 @@ func (s tpccBenchSpec) startOpts() (option.StartOpts, install.ClusterSettings) {
 }
 
 func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
+	owner := registry.OwnerTestEng
+	if b.Owner != "" {
+		owner = b.Owner
+	}
 	nameParts := []string{
 		"tpccbench",
 		fmt.Sprintf("nodes=%d", b.Nodes),
@@ -934,7 +939,7 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 
 	r.Add(registry.TestSpec{
 		Name:    name,
-		Owner:   registry.OwnerKV,
+		Owner:   owner,
 		Cluster: nodes,
 		Tags:    b.Tags,
 		// NB: intentionally not enabling encryption-at-rest to produce

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -27,6 +27,7 @@ import (
 
 func registerTPCE(r registry.Registry) {
 	type tpceOptions struct {
+		owner     registry.Owner // defaults to test-eng
 		customers int
 		nodes     int
 		cpus      int
@@ -112,9 +113,13 @@ func registerTPCE(r registry.Registry) {
 		{customers: 100_000, nodes: 5, cpus: 32, ssds: 2, tags: []string{"weekly"}, timeout: 36 * time.Hour},
 	} {
 		opts := opts
+		owner := registry.OwnerTestEng
+		if opts.owner != "" {
+			owner = opts.owner
+		}
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("tpce/c=%d/nodes=%d", opts.customers, opts.nodes),
-			Owner:   registry.OwnerKV,
+			Owner:   owner,
 			Tags:    opts.tags,
 			Timeout: opts.timeout,
 			Cluster: r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds)),

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -95,7 +95,7 @@ func registerYCSB(r registry.Registry) {
 			wl, cpus := wl, cpus
 			r.Add(registry.TestSpec{
 				Name:    name,
-				Owner:   registry.OwnerKV,
+				Owner:   registry.OwnerTestEng,
 				Cluster: r.MakeClusterSpec(4, spec.CPU(cpus)),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus)


### PR DESCRIPTION
As of this PR, the test-eng teams owns its first 60 roachtests. The KV team now
owns ~160, down from ~220 initially. These tests are fairly stable, when they flake
it is mostly due to cloud infrastructure issues.

Touches #82060.

- roachtest: own kv perf tests to test-eng
- roachtest: own sysbench tests to test-eng
- roachtest: own tpccbench to test-eng
- roachtest: own tpc-e to test-eng
- roachtest: own ycsb to test-eng
