### PR TITLE
release-22.1: sql: ensure revalidate_unique_constraint* builtins respect privileges

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
@@ -268,3 +268,50 @@ user testuser
 statement ok
 ALTER DATABASE repartition_privs ADD REGION "ap-southeast-2";
 ALTER DATABASE repartition_privs DROP REGION "us-east-1"
+
+subtest revalidate_privs
+
+user root
+
+statement ok
+CREATE DATABASE revalidate_privs PRIMARY REGION "ca-central-1" REGIONS "us-east-1"
+
+statement ok
+CREATE TABLE revalidate_privs.rbr () LOCALITY REGIONAL BY ROW
+
+user testuser
+
+statement ok
+USE revalidate_privs
+
+# Check that revalidate_unique_constraint* builtins respect privileges.
+query error user testuser does not have SELECT privilege on relation rbr
+SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()
+
+query error user testuser does not have SELECT privilege on relation rbr
+SELECT crdb_internal.revalidate_unique_constraints_in_table('revalidate_privs.rbr')
+
+query error user testuser does not have SELECT privilege on relation rbr
+SELECT crdb_internal.revalidate_unique_constraint('revalidate_privs.rbr', 'rbr_pkey')
+
+user root
+
+statement ok
+GRANT SELECT ON revalidate_privs.rbr TO testuser
+
+user testuser
+
+query T
+SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()
+----
+·
+
+query T
+SELECT crdb_internal.revalidate_unique_constraints_in_table('repartition_privs.rbr')
+----
+·
+
+query T
+SELECT crdb_internal.revalidate_unique_constraint('repartition_privs.rbr', 'rbr_pkey')
+----
+·

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -599,7 +599,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 					if err := validateUniqueWithoutIndexConstraintInTxn(
 						params.ctx, params.ExecCfg().InternalExecutorFactory(
 							params.ctx, params.SessionData(),
-						), n.tableDesc, params.EvalContext().Txn, name,
+						), n.tableDesc, params.EvalContext().Txn, params.p.User(), name,
 					); err != nil {
 						return err
 					}


### PR DESCRIPTION
Backport 1/1 commits from #83959.

/cc @cockroachdb/release

Release justification: Fix builtin function to respect privileges

---

This commit updates the builtins
`crdb_internal.revalidate_unique_constraints_in_all_tables`,
`crdb_internal.revalidate_unique_constraints_in_table`,
and `crdb_internal.revalidate_unique_constraint` to ensure that the correct
user is passed to the internal executor when running the validation query.
This ensures that privileges will be respected.

Release note (bug fix): Fixed the following builtins so that users can only
run them if they have `SELECT` privileges on the relevant tables:
`crdb_internal.revalidate_unique_constraints_in_all_tables`,
`crdb_internal.revalidate_unique_constraints_in_table`,
and `crdb_internal.revalidate_unique_constraint`.
