### PR TITLE
release-21.2: sql: ensure revalidate_unique_constraint* builtins respect privileges

### DIFF
--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -2145,7 +2145,7 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 	}
 
-	if err := r.checkVirtualConstraints(ctx, p.ExecCfg(), r.job); err != nil {
+	if err := r.checkVirtualConstraints(ctx, p.ExecCfg(), r.job, p.User()); err != nil {
 		return err
 	}
 
@@ -2311,7 +2311,7 @@ func (r *importResumer) publishSchemas(ctx context.Context, execCfg *sql.Executo
 // checkVirtualConstraints checks constraints that are enforced via runtime
 // checks, such as uniqueness checks that are not directly backed by an index.
 func (*importResumer) checkVirtualConstraints(
-	ctx context.Context, execCfg *sql.ExecutorConfig, job *jobs.Job,
+	ctx context.Context, execCfg *sql.ExecutorConfig, job *jobs.Job, user security.SQLUsername,
 ) error {
 	for _, tbl := range job.Details().(jobspb.ImportDetails).Tables {
 		desc := tabledesc.NewBuilder(tbl.Desc).BuildExistingMutableTable()
@@ -2328,7 +2328,7 @@ func (*importResumer) checkVirtualConstraints(
 		if err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData(execCfg.SV()))
 			return ie.WithSyntheticDescriptors([]catalog.Descriptor{desc}, func() error {
-				return sql.RevalidateUniqueConstraintsInTable(ctx, txn, ie, desc)
+				return sql.RevalidateUniqueConstraintsInTable(ctx, txn, user, ie, desc)
 			})
 		}); err != nil {
 			return err

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
@@ -223,3 +223,50 @@ user testuser
 statement ok
 ALTER DATABASE repartition_privs ADD REGION "ap-southeast-2";
 ALTER DATABASE repartition_privs DROP REGION "us-east-1"
+
+subtest revalidate_privs
+
+user root
+
+statement ok
+CREATE DATABASE revalidate_privs PRIMARY REGION "ca-central-1" REGIONS "us-east-1"
+
+statement ok
+CREATE TABLE revalidate_privs.rbr () LOCALITY REGIONAL BY ROW
+
+user testuser
+
+statement ok
+USE revalidate_privs
+
+# Check that revalidate_unique_constraint* builtins respect privileges.
+query error user testuser does not have SELECT privilege on relation rbr
+SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()
+
+query error user testuser does not have SELECT privilege on relation rbr
+SELECT crdb_internal.revalidate_unique_constraints_in_table('revalidate_privs.rbr')
+
+query error user testuser does not have SELECT privilege on relation rbr
+SELECT crdb_internal.revalidate_unique_constraint('revalidate_privs.rbr', 'primary')
+
+user root
+
+statement ok
+GRANT SELECT ON revalidate_privs.rbr TO testuser
+
+user testuser
+
+query B
+SELECT crdb_internal.revalidate_unique_constraints_in_all_tables()
+----
+true
+
+query B
+SELECT crdb_internal.revalidate_unique_constraints_in_table('repartition_privs.rbr')
+----
+true
+
+query B
+SELECT crdb_internal.revalidate_unique_constraint('repartition_privs.rbr', 'primary')
+----
+true

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -865,7 +865,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 							"constraint %q in the middle of being added, try again later", t.Constraint)
 					}
 					if err := validateUniqueWithoutIndexConstraintInTxn(
-						params.ctx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, name,
+						params.ctx, params.EvalContext(), n.tableDesc, params.EvalContext().Txn, params.p.User(), name,
 					); err != nil {
 						return err
 					}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -740,7 +741,9 @@ func (sc *SchemaChanger) validateConstraints(
 						return err
 					}
 				} else if c.IsUniqueWithoutIndex() {
-					if err := validateUniqueWithoutIndexConstraintInTxn(ctx, &evalCtx.EvalContext, desc, txn, c.GetName()); err != nil {
+					if err := validateUniqueWithoutIndexConstraintInTxn(
+						ctx, &evalCtx.EvalContext, desc, txn, evalCtx.SessionData().User(), c.GetName(),
+					); err != nil {
 						return err
 					}
 				} else if c.IsNotNull() {
@@ -1825,6 +1828,7 @@ func ValidateForwardIndexes(
 							idx.GetPredicate(),
 							ie,
 							txn,
+							security.NodeUserName(),
 							false, /* preExisting */
 						); err != nil {
 							return err
@@ -2255,7 +2259,7 @@ func runSchemaChangesInTxn(
 			uwi := &c.ConstraintToUpdateDesc().UniqueWithoutIndexConstraint
 			if uwi.Validity == descpb.ConstraintValidity_Validating {
 				if err := validateUniqueWithoutIndexConstraintInTxn(
-					ctx, planner.EvalContext(), tableDesc, planner.txn, c.GetName(),
+					ctx, planner.EvalContext(), tableDesc, planner.txn, planner.User(), c.GetName(),
 				); err != nil {
 					return err
 				}
@@ -2403,6 +2407,7 @@ func validateUniqueWithoutIndexConstraintInTxn(
 	evalCtx *tree.EvalContext,
 	tableDesc *tabledesc.Mutable,
 	txn *kv.Txn,
+	user security.SQLUsername,
 	constraintName string,
 ) error {
 	ie := evalCtx.InternalExecutor.(*InternalExecutor)
@@ -2425,7 +2430,15 @@ func validateUniqueWithoutIndexConstraintInTxn(
 
 	return ie.WithSyntheticDescriptors(syntheticDescs, func() error {
 		return validateUniqueConstraint(
-			ctx, tableDesc, uc.Name, uc.ColumnIDs, uc.Predicate, ie, txn, false, /* preExisting */
+			ctx,
+			tableDesc,
+			uc.Name,
+			uc.ColumnIDs,
+			uc.Predicate,
+			ie,
+			txn,
+			user,
+			false, /* preExisting */
 		)
 	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #83959.

/cc @cockroachdb/release

Release justification: Fix builtin function to respect privileges

---

This commit updates the builtins
`crdb_internal.revalidate_unique_constraints_in_all_tables`,
`crdb_internal.revalidate_unique_constraints_in_table`,
and `crdb_internal.revalidate_unique_constraint` to ensure that the correct
user is passed to the internal executor when running the validation query.
This ensures that privileges will be respected.

Release note (bug fix): Fixed the following builtins so that users can only
run them if they have `SELECT` privileges on the relevant tables:
`crdb_internal.revalidate_unique_constraints_in_all_tables`,
`crdb_internal.revalidate_unique_constraints_in_table`,
and `crdb_internal.revalidate_unique_constraint`.
