### PR TITLE
sql: add COST as an available column label keyword

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3258,6 +3258,7 @@ family_name ::=
 bare_label_keywords ::=
 	'ATOMIC'
 	| 'CALLED'
+	| 'COST'
 	| 'DEFINER'
 	| 'EXTERNAL'
 	| 'IMMUTABLE'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -14804,6 +14804,7 @@ unreserved_keyword:
 bare_label_keywords:
   ATOMIC
 | CALLED
+| COST
 | DEFINER
 | EXTERNAL
 | IMMUTABLE


### PR DESCRIPTION
Adding cost as an available column label keyword to avoid
breaking user queries with this new keyword.

Release note: None.