### PR TITLE
release-21.2: pgwire: use better error for invalid Describe message

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -556,8 +556,10 @@ func (ex *connExecutor) execDescribe(
 			res.SetPortalOutput(ctx, portal.Stmt.Columns, portal.OutFormats)
 		}
 	default:
-		return retErr(errors.AssertionFailedf(
-			"unknown describe type: %s", errors.Safe(descCmd.Type)))
+		return retErr(pgerror.Newf(
+			pgcode.ProtocolViolation,
+			"invalid DESCRIBE message subtype %d", errors.Safe(byte(descCmd.Type)),
+		))
 	}
 	return nil, nil
 }

--- a/pkg/sql/pgwire/testdata/pgtest/portals
+++ b/pkg/sql/pgwire/testdata/pgtest/portals
@@ -998,3 +998,19 @@ ReadyForQuery
 ----
 {"Type":"CommandComplete","CommandTag":"ROLLBACK"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT * FROM generate_series(1, 4)"}
+Describe
+Bind
+Execute
+Sync
+----
+
+until keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"08P01","Message":"invalid DESCRIBE message subtype 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Backport 1/1 commits from #83929.

/cc @cockroachdb/release

Release justification: error message change

---

fixes https://github.com/cockroachdb/cockroach/issues/82785

Release note: None
