### PR TITLE
release-21.2: roachtest: update gorm support tag

### DIFF
--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -22,7 +22,7 @@ import (
 )
 
 var gormReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var gormSupportedTag = "v1.23.1"
+var gormSupportedTag = "v1.23.8"
 
 func registerGORM(r registry.Registry) {
 	runGORM := func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
Backport 1/1 commits from #84188 on behalf of @ZhouXing19.

/cc @cockroachdb/release

fixes #83794
fixes #83797
fixes #83885

Release note: None

Release justification: fix roachtest with gorm