### PR TITLE
toolchains: update toolchains to consume new kernel, glibc version

### DIFF
--- a/build/toolchains/REPOSITORIES.bzl
+++ b/build/toolchains/REPOSITORIES.bzl
@@ -17,48 +17,48 @@ def toolchain_dependencies():
         name = "toolchain_cross_aarch64-unknown-linux-gnu",
         host = "x86_64",
         target = "aarch64-unknown-linux-gnu",
-        tarball_sha256 = "76efd6ee539a0a358c03a6405c95c2f758935bbe70572e030fad86fb328b7d7b",
+        tarball_sha256 = "58407f1f3ed490bd0a0a500b23b88503fbcc25f0f69a0b7f8a3e8e7b9237341b",
     )
     _crosstool_toolchain_repo(
         name = "toolchain_cross_s390x-ibm-linux-gnu",
         host = "x86_64",
         target = "s390x-ibm-linux-gnu",
-        tarball_sha256 = "3917b7ba50b30d4907d05a3060e79e931e541cb7096913285e4fc0b06ccc98fe",
+        tarball_sha256 = "c1e82a3cd7f0989abbb7228d21b217c235b79559e4460ef255a76b7a813240ce",
     )
     _crosstool_toolchain_repo(
         name = "toolchain_cross_x86_64-unknown-linux-gnu",
         host = "x86_64",
         target = "x86_64-unknown-linux-gnu",
-        tarball_sha256 = "267331e9c9cefdcb079a1487b346014f956e6b95332286fadb43d41b6cdd8ce0",
+        tarball_sha256 = "8b0c246c3ebd02aceeb48bb3d70c779a1503db3e99be332ac256d4f3f1c22d47",
     )
     _crosstool_toolchain_repo(
         name = "toolchain_cross_x86_64-w64-mingw32",
         host = "x86_64",
         target = "x86_64-w64-mingw32",
-        tarball_sha256 = "6b2a41d551f91d43b00ce086c60bb589e0ae95da2b14cc3fc6e2f2bf4494b21d",
+        tarball_sha256 = "b87814aaeed8c68679852029de70cee28f96c352ed31c4c520e7bee55999b1c6",
     )
     _crosstool_toolchain_repo(
         name = "armtoolchain_cross_aarch64-unknown-linux-gnu",
         host = "aarch64",
         target = "aarch64-unknown-linux-gnu",
-        tarball_sha256 = "8e8455a9f5cec46aa6f8a7ffa53b6fb470f98ae169c49a8fe65ed2fbeb83e82f",
+        tarball_sha256 = "1e7e5ccc142a528ea4e79a002824af8c15225393d42e452259ed4e99ea45eabe",
     )
     _crosstool_toolchain_repo(
         name = "armtoolchain_cross_s390x-ibm-linux-gnu",
         host = "aarch64",
         target = "s390x-ibm-linux-gnu",
-        tarball_sha256 = "013e7ad3294b7f77b4937e988e0766bd0eb02186876c9e12f51314af38a43597",
+        tarball_sha256 = "76ede410bba820ff9e5e10d68802abc8cf809720fc035a93b1e16f40e987bfd4",
     )
     _crosstool_toolchain_repo(
         name = "armtoolchain_cross_x86_64-unknown-linux-gnu",
         host = "aarch64",
         target = "x86_64-unknown-linux-gnu",
-        tarball_sha256 = "a74aa2fb685b23e32a099f4c0bd32618640fc6f1070237edfd3f0c7f613ea983",
+        tarball_sha256 = "7b6101ec5b55e8d10004734823bca221b54b6163e0b500df25ede38f1cc27d2e",
     )
     _crosstool_toolchain_repo(
         name = "armtoolchain_cross_x86_64-w64-mingw32",
         host = "aarch64",
         target = "x86_64-w64-mingw32",
-        tarball_sha256 = "6baff5e7658215aabfbc6d37374f4fcdd1b62269828d55ebef841248a99373cc",
+        tarball_sha256 = "1bca59b5aac70bdbbb17499141f2f261dbfeb4accb14cd9a3f699579b5372dc4",
     )
     _macos_toolchain_repos()

--- a/build/toolchains/crosstool-ng/toolchain.bzl
+++ b/build/toolchains/crosstool-ng/toolchain.bzl
@@ -1,8 +1,8 @@
 def _impl(rctx):
     if rctx.attr.host == "x86_64":
-        url = "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/{}/20220317-191459/{}.tar.gz".format(rctx.attr.host, rctx.attr.target)
+        url = "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/{}/20220711-205918/{}.tar.gz".format(rctx.attr.host, rctx.attr.target)
     elif rctx.attr.host == "aarch64":
-        url = "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/{}/20220316-165237/{}.tar.gz".format(rctx.attr.host, rctx.attr.target)
+        url = "https://storage.googleapis.com/public-bazel-artifacts/toolchains/crosstool-ng/{}/20220711-204538/{}.tar.gz".format(rctx.attr.host, rctx.attr.target)
     rctx.download_and_extract(
         url = [url],
         sha256 = rctx.attr.tarball_sha256,


### PR DESCRIPTION
Consume `5cfb5178d9c0ad8c9a868807ffa306aac1f948cf` for new toolchains.

Release note (general change): Update new minimum supported kernel and
glibc versions on Linux to 3.10.108 and 2.25 respectively.