### PR TITLE
release-22.1: opt: fix nil pointer exception in FK delete cascade fast path

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4102,3 +4102,43 @@ DELETE FROM p76852 WHERE i = 1;
 query B
 SELECT b FROM c76852@idx WHERE b
 ----
+
+# Regression test for #80828. Do not attempt a fast path cascading delete when
+# a descendent is in the process of being added.
+subtest 80828
+
+statement ok
+CREATE TABLE parent80828 (id int primary key);
+CREATE TABLE child80828 (id INT PRIMARY KEY, pid INT NOT NULL REFERENCES parent80828(id) ON DELETE CASCADE, UNIQUE INDEX (pid));
+INSERT INTO parent80828 VALUES (1);
+INSERT INTO child80828 VALUES (1, 1);
+
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.base = .00001;
+
+# Set a pause point so that grandchild stays in the "adding" state.
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec'
+
+statement error job .* was paused before it completed with reason: pause point "schemachanger.before.exec" hit
+CREATE TABLE grandchild80828 (parent_id INT NOT NULL REFERENCES child80828(pid) ON DELETE CASCADE);
+
+statement ok
+DELETE FROM parent80828 WHERE id = 1;
+
+# Clear the pause point.
+statement ok
+RESET CLUSTER SETTING jobs.debug.pausepoints
+
+statement ok
+RESET CLUSTER SETTING jobs.registry.interval.base
+
+query I
+SELECT count(*) FROM parent80828
+----
+0
+
+query I
+SELECT count(*) FROM child80828
+----
+0

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -238,6 +238,13 @@ func tryNewOnDeleteFastCascadeBuilder(
 		default:
 			tab = resolveTable(ctx, catalog, tabID)
 		}
+		// If the table could not be resolved, then we cannot confirm that FK
+		// references form a simple tree, so we return false. This is possible
+		// when resolveTable returns nil above because the table is in the
+		// process of being added.
+		if tab == nil {
+			return false
+		}
 		for i, n := 0, tab.InboundForeignKeyCount(); i < n; i++ {
 			if !checkPaths(tab.InboundForeignKey(i).OriginTableID()) {
 				return false


### PR DESCRIPTION
Backport 1/1 commits from #84219.

/cc @cockroachdb/release

---

Fixes #80828

Release note (bug fix): A bug has been fixed that caused internal errors
in rare cases when performing `DELETE`s on a table that had foreign key
references to it with the `ON DELETE CASCADE` option. For example,
imagine tables `a` and `b` already exist, and `b` has a FK
`ON DELETE CASCADE` column referencing `a`. If table `c` is added with a
FK `ON DELETE CASCADE` column referencing table `b` and a `DELETE`
statement is performed on table `a` in the same transaction, and
internal error could occur. This bug has been present since v21.1.0.
