### PR TITLE
release-22.1: server: remove TLS cert data retrieval over HTTP

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -50,7 +50,6 @@ Support status: [reserved](#support-status)
 | ----- | ---- | ----- | ----------- | -------------- |
 | type | [CertificateDetails.CertificateType](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.CertificateType) |  |  | [reserved](#support-status) |
 | error_message | [string](#cockroach.server.serverpb.CertificatesResponse-string) |  | "error_message" and "data" are mutually exclusive. | [reserved](#support-status) |
-| data | [bytes](#cockroach.server.serverpb.CertificatesResponse-bytes) |  | data is the raw file contents of the certificate. This means PEM-encoded DER data. | [reserved](#support-status) |
 | fields | [CertificateDetails.Fields](#cockroach.server.serverpb.CertificatesResponse-cockroach.server.serverpb.CertificateDetails.Fields) | repeated |  | [reserved](#support-status) |
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -75,9 +75,7 @@ message CertificateDetails {
   CertificateType type = 1;
   // "error_message" and "data" are mutually exclusive.
   string error_message = 2;
-  // data is the raw file contents of the certificate. This means PEM-encoded
-  // DER data.
-  bytes data = 3;
+  reserved 3;
   repeated Fields fields = 4 [ (gogoproto.nullable) = false ];
 }
 

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -900,8 +900,7 @@ func (s *statusServer) Certificates(
 		}
 
 		if cert.Error == nil {
-			details.Data = cert.FileContents
-			if err := extractCertFields(details.Data, &details); err != nil {
+			if err := extractCertFields(cert.FileContents, &details); err != nil {
 				details.ErrorMessage = err.Error()
 			}
 		} else {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics/diagnosticspb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
@@ -1445,28 +1444,12 @@ func TestCertificatesResponse(t *testing.T) {
 		t.Errorf("expected %d certificates, found %d", e, a)
 	}
 
-	// Read the certificates from the embedded assets.
-	caPath := filepath.Join(security.EmbeddedCertsDir, security.EmbeddedCACert)
-	nodePath := filepath.Join(security.EmbeddedCertsDir, security.EmbeddedNodeCert)
-
-	caFile, err := securitytest.EmbeddedAssets.ReadFile(caPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	nodeFile, err := securitytest.EmbeddedAssets.ReadFile(nodePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// The response is ordered: CA cert followed by node cert.
 	cert := response.Certificates[0]
 	if a, e := cert.Type, serverpb.CertificateDetails_CA; a != e {
 		t.Errorf("wrong type %s, expected %s", a, e)
 	} else if cert.ErrorMessage != "" {
 		t.Errorf("expected cert without error, got %v", cert.ErrorMessage)
-	} else if a, e := cert.Data, caFile; !bytes.Equal(a, e) {
-		t.Errorf("mismatched contents: %s vs %s", a, e)
 	}
 
 	cert = response.Certificates[1]
@@ -1474,8 +1457,6 @@ func TestCertificatesResponse(t *testing.T) {
 		t.Errorf("wrong type %s, expected %s", a, e)
 	} else if cert.ErrorMessage != "" {
 		t.Errorf("expected cert without error, got %v", cert.ErrorMessage)
-	} else if a, e := cert.Data, nodeFile; !bytes.Equal(a, e) {
-		t.Errorf("mismatched contents: %s vs %s", a, e)
 	}
 }
 


### PR DESCRIPTION
Backporting 1/1 commit from #83902.

cc @cockroachdb/release 

Release justification: security fix to a non-published API