### PR TITLE
tracing: delete old field

### DIFF
--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -121,7 +121,6 @@ func TestRedactRecordingForTenant(t *testing.T) {
 			TagGroups         []tracingpb.TagGroup
 			StartTime         time.Time
 			Duration          time.Duration
-			RedactableLogs    bool
 			Logs              []tracingpb.LogRecord
 			Verbose           bool
 			RecordingMode     tracingpb.RecordingMode

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -834,16 +834,15 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 	recordingType tracingpb.RecordingType, finishing bool,
 ) tracingpb.RecordedSpan {
 	rs := tracingpb.RecordedSpan{
-		TraceID:        s.traceID,
-		SpanID:         s.spanID,
-		ParentSpanID:   s.parentSpanID,
-		GoroutineID:    s.mu.goroutineID,
-		Operation:      s.operation,
-		StartTime:      s.startTime,
-		Duration:       s.mu.duration,
-		RedactableLogs: true,
-		Verbose:        s.recordingType() == tracingpb.RecordingVerbose,
-		RecordingMode:  s.recordingType().ToProto(),
+		TraceID:       s.traceID,
+		SpanID:        s.spanID,
+		ParentSpanID:  s.parentSpanID,
+		GoroutineID:   s.mu.goroutineID,
+		Operation:     s.operation,
+		StartTime:     s.startTime,
+		Duration:      s.mu.duration,
+		Verbose:       s.recordingType() == tracingpb.RecordingVerbose,
+		RecordingMode: s.recordingType().ToProto(),
 	}
 
 	if rs.Duration == -1 {

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -101,10 +101,6 @@ message RecordedSpan {
   google.protobuf.Duration duration = 8 [(gogoproto.nullable) = false,
                                          (gogoproto.stdduration) = true];
 
-  // RedactableLogs determines whether the verbose log messages are redactable.
-  // This field was introduced in the 22.1 release. It can be removed in the 22.2
-  // release. On 22.1 this is always set to `true`.
-  bool redactable_logs = 15;
   // Events logged in the span.
   repeated LogRecord logs = 9 [(gogoproto.nullable) = false];
   // verbose indicates whether the span was recording in verbose mode at the
@@ -141,7 +137,7 @@ message RecordedSpan {
   // view of the various operations that are being traced as part of a span.
   map<string, OperationMetadata> children_metadata = 19 [(gogoproto.nullable) = false];
 
-  reserved 5,10,11;
+  reserved 5,10,11,15;
 }
 
 message TagGroup {


### PR DESCRIPTION
The RecordedSpan.RedactableLogs. This field was unused since 22.1.

Release note: None