### PR TITLE
release-21.2: sql: make sure to stop the internal SQL executor's monitor

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1608,6 +1608,7 @@ func revalidateIndexes(
 	var runner sql.HistoricalInternalExecTxnRunner = func(ctx context.Context, fn sql.InternalExecFn) error {
 		return execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData(execCfg.SV())).(*sql.InternalExecutor)
+			defer ie.Close(ctx)
 			return fn(ctx, txn, ie)
 		})
 	}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -296,6 +296,10 @@ func (tf *schemaFeed) primeInitialTableDescs(ctx context.Context) error {
 		return err
 	}
 
+	// We no longer need the internal executor.
+	tf.ie.Close(ctx)
+	tf.ie = nil
+
 	tf.mu.Lock()
 	// Register all types used by the initial set of tables.
 	for _, desc := range initialDescs {

--- a/pkg/ccl/importccl/import_stmt.go
+++ b/pkg/ccl/importccl/import_stmt.go
@@ -2327,6 +2327,7 @@ func (*importResumer) checkVirtualConstraints(
 
 		if err := execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			ie := job.MakeSessionBoundInternalExecutor(ctx, sql.NewFakeSessionData(execCfg.SV()))
+			defer ie.Close(ctx)
 			return ie.WithSyntheticDescriptors([]catalog.Descriptor{desc}, func() error {
 				return sql.RevalidateUniqueConstraintsInTable(ctx, txn, ie, desc)
 			})

--- a/pkg/ccl/serverccl/role_authentication_test.go
+++ b/pkg/ccl/serverccl/role_authentication_test.go
@@ -41,6 +41,7 @@ func TestVerifyPassword(t *testing.T) {
 		sql.MemoryMetrics{},
 		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 	)
+	defer ie.Close(ctx)
 
 	if util.RaceEnabled {
 		// The default bcrypt cost makes this test approximately 30s slower when the

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -797,6 +797,8 @@ func (ie *wrappedInternalExecutor) WithSyntheticDescriptors(
 	panic("not implemented")
 }
 
+func (ie *wrappedInternalExecutor) Close(context.Context) {}
+
 func (ie *wrappedInternalExecutor) getErrFunc() func(statement string) error {
 	ie.mu.RLock()
 	defer ie.mu.RUnlock()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1262,6 +1262,9 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// Initialize the external storage builders configuration params now that the
 	// engines have been created. The object can be used to create ExternalStorage
 	// objects hereafter.
+	//
+	// Note that we don't need to close this internal executor since it is a
+	// singleton and is alive throughout the lifetime of the Server.
 	fileTableInternalExecutor := sql.MakeInternalExecutor(ctx, s.PGServer().SQLServer, sql.MemoryMetrics{}, s.st)
 	s.externalStorageBuilder.init(s.cfg.ExternalIODirConfig, s.st,
 		blobs.NewBlobClientFactory(s.nodeIDContainer.Get(),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -361,6 +361,8 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 	telemetryLoggingMetrics.Knobs = cfg.TelemetryLoggingTestingKnobs
 	s.TelemetryLoggingMetrics = telemetryLoggingMetrics
 
+	// Note that we don't need to close this internal executor since it is a
+	// singleton and is alive throughout the lifetime of the Server.
 	sqlStatsInternalExecutor := MakeInternalExecutor(context.Background(), s, MemoryMetrics{}, cfg.Settings)
 	persistedSQLStats := persistedsqlstats.New(&persistedsqlstats.Config{
 		Settings:         s.cfg.Settings,
@@ -1004,6 +1006,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 
 	if ex.hasCreatedTemporarySchema && !ex.server.cfg.TestingKnobs.DisableTempObjectsCleanupOnSessionExit {
 		ie := MakeInternalExecutor(ctx, ex.server, MemoryMetrics{}, ex.server.cfg.Settings)
+		defer ie.Close(ctx)
 		err := cleanupSessionTempObjects(
 			ctx,
 			ex.server.cfg.Settings,
@@ -1049,6 +1052,10 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	// is not called.
 	ex.mu.IdleInSessionTimeout.Stop()
 	ex.mu.IdleInTransactionSessionTimeout.Stop()
+
+	if ie := ex.planner.extendedEvalCtx.InternalExecutor; ie != nil {
+		ie.Close(ctx)
+	}
 
 	if closeType != panicClose {
 		ex.state.mon.Stop(ctx)
@@ -2155,6 +2162,9 @@ func (ex *connExecutor) execCopyIn(
 		// going through the state machine.
 		ex.state.sqlTimestamp = txnTS
 		ex.statsCollector.Reset(ex.applicationStats, ex.phaseTimes)
+		// Note that we might be creating a new internal SQL executor in
+		// initPlanner(), but the lifetime of it is unclear, and since COPY is
+		// like an edge case, we choose to not think too hard about this one.
 		ex.initPlanner(ctx, p)
 		ex.resetPlanner(ctx, p, txn, stmtTS)
 	}
@@ -2411,6 +2421,10 @@ func (ex *connExecutor) asOfClauseWithSessionDefault(expr tree.AsOfClause) tree.
 // same across multiple statements. resetEvalCtx must also be called before each
 // statement, to reinitialize other fields.
 func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalContext, p *planner) {
+	if evalCtx != nil && evalCtx.InternalExecutor != nil {
+		evalCtx.InternalExecutor.Close(ctx)
+		evalCtx.InternalExecutor = nil
+	}
 	ie := MakeInternalExecutor(
 		ctx,
 		ex.server,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1351,6 +1351,9 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		// concurrently.
 		var factoryEvalCtx extendedEvalContext
 		ex.initEvalCtx(ctx, &factoryEvalCtx, planner)
+		defer func() {
+			factoryEvalCtx.InternalExecutor.Close(ctx)
+		}()
 		evalCtxFactory = func() *extendedEvalContext {
 			ex.resetEvalCtx(&factoryEvalCtx, planner.txn, planner.ExtendedEvalContext().StmtTimestamp)
 			factoryEvalCtx.Placeholders = &planner.semaCtx.Placeholders

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -94,7 +94,8 @@ func (ie *InternalExecutor) WithSyntheticDescriptors(
 	return run()
 }
 
-// MakeInternalExecutor creates an InternalExecutor.
+// MakeInternalExecutor creates an InternalExecutor which must be closed once no
+// longer in use.
 func MakeInternalExecutor(
 	ctx context.Context, s *Server, memMetrics MemoryMetrics, settings *cluster.Settings,
 ) InternalExecutor {
@@ -113,6 +114,11 @@ func MakeInternalExecutor(
 		mon:        monitor,
 		memMetrics: memMetrics,
 	}
+}
+
+// Close closes the internal executor.
+func (ie *InternalExecutor) Close(ctx context.Context) {
+	ie.mon.Stop(ctx)
 }
 
 // SetSessionData binds the session variables that will be used by queries

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -155,6 +155,7 @@ func TestInternalFullTableScan(t *testing.T) {
 		sql.MemoryMetrics{},
 		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 	)
+	defer ie.Close(context.Background())
 	ie.SetSessionData(
 		&sessiondata.SessionData{
 			SessionData: sessiondatapb.SessionData{
@@ -195,6 +196,7 @@ func TestInternalStmtFingerprintLimit(t *testing.T) {
 		sql.MemoryMetrics{},
 		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 	)
+	defer ie.Close(context.Background())
 
 	_, err = ie.Exec(ctx, "stmt-exceeds-fingerprint-limit", nil, "SELECT 1")
 	require.NoError(t, err)
@@ -328,6 +330,7 @@ func TestSessionBoundInternalExecutor(t *testing.T) {
 		sql.MemoryMetrics{},
 		s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 	)
+	defer ie.Close(context.Background())
 	ie.SetSessionData(
 		&sessiondata.SessionData{
 			SessionData: sessiondatapb.SessionData{
@@ -396,6 +399,7 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 			sql.MemoryMetrics{},
 			s.ExecutorConfig().(sql.ExecutorConfig).Settings,
 		)
+		defer ie.Close(context.Background())
 		ie.SetSessionData(
 			&sessiondata.SessionData{
 				SessionData: sessiondatapb.SessionData{
@@ -421,6 +425,7 @@ type testInternalExecutor interface {
 	Exec(
 		ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
 	) (int, error)
+	Close(context.Context)
 }
 
 func testInternalExecutorAppNameInitialization(

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3302,6 +3302,7 @@ type InternalExecutor interface {
 	QueryRow(
 		ctx context.Context, opName string, txn *kv.Txn, stmt string, qargs ...interface{},
 	) (Datums, error)
+	Close(context.Context)
 }
 
 // PrivilegedAccessor gives access to certain queries that would otherwise

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -146,6 +146,9 @@ type InternalExecutor interface {
 
 	// WithSyntheticDescriptors sets synthetic descriptors. See implementation.
 	WithSyntheticDescriptors(descs []catalog.Descriptor, run func() error) error
+
+	// Close closes the InternalExecutor.
+	Close(context.Context)
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -584,6 +584,7 @@ func (c *TemporaryObjectCleaner) doTemporaryObjectCleanup(
 
 	// Clean up temporary data for inactive sessions.
 	ie := c.makeSessionBoundInternalExecutor(ctx, &sessiondata.SessionData{})
+	defer ie.Close(ctx)
 	for sessionID := range sessionIDs {
 		if _, ok := activeSessions[sessionID.Uint128]; !ok {
 			log.Eventf(ctx, "cleaning up temporary object for session %q", sessionID)


### PR DESCRIPTION
This commit audits all places where we create the internal executors and
makes sure that all of them are closed unless their lifetime matches
that of the Server. The only exception where I'm not sure about the
lifetime is when evaluating COPY, but that doesn't seem important, so no
change is made there.

This commit is a "backport" of #83678 in spirit (in a sense that it fixes the
same bug but in a different way because a lot of the code has changed
during 22.1 cycle). In 22.1 we removed many of the factories that are still
present on 21.2 branch, so I chose to go with the approach of explicitly
closing the internal executor rather than having a global singleton
executor. Please review with care.

Fixes: #77465.

Release note (bug fix): Fixed a "fake" memory accounting leak that in
rare cases could result in "memory budget exceeded" errors even if the
actual RAM usage is within `--max-sql-memory` limit.

Release justification: bug fix.