### PR TITLE
cmd/reduce: support unoptimized-query-oracle with bin/reduce

### DIFF
--- a/pkg/cmd/reduce/reduce/reduce.go
+++ b/pkg/cmd/reduce/reduce/reduce.go
@@ -329,6 +329,10 @@ func attemptChunkReduction(
 			return "", err
 		}
 
+		if chunkReducer.NumSegments() == 0 {
+			return reduced, nil
+		}
+
 		// Pick two random indexes and remove all statements between them.
 		start := rand.Intn(chunkReducer.NumSegments())
 		end := rand.Intn(chunkReducer.NumSegments()-start) + start + 1


### PR DESCRIPTION
This commit adds support for reducing test failures from the
`unoptimized-query-oracle` roachtest.

Release note: None