### PR TITLE
sql/tests: TestRandomSyntaxSchemaChangeColumn use a resettable timeout

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -53,7 +53,7 @@ var (
 	flagRSGTime                    = flag.Duration("rsg", 0, "random syntax generator test duration")
 	flagRSGGoRoutines              = flag.Int("rsg-routines", 1, "number of Go routines executing random statements in each RSG test")
 	flagRSGExecTimeout             = flag.Duration("rsg-exec-timeout", 15*time.Second, "timeout duration when executing a statement")
-	flagRSGExecColumnChangeTimeout = flag.Duration("rsg-exec-column-change-timeout", 2*time.Minute, "timeout duration when executing a statement for random column changes")
+	flagRSGExecColumnChangeTimeout = flag.Duration("rsg-exec-column-change-timeout", 20*time.Second, "timeout duration when executing a statement for random column changes")
 )
 
 func verifyFormat(sql string) error {
@@ -83,6 +83,9 @@ type verifyFormatDB struct {
 		syncutil.Mutex
 		// active holds the currently executing statements.
 		active map[string]int
+		// lastCompletedStmt tracks the time when the last statement finished
+		// executing, which will be used for resettable timeouts.
+		lastCompletedStmt time.Time
 	}
 }
 
@@ -98,6 +101,7 @@ func (db *verifyFormatDB) Incr(sql string) func() {
 	return func() {
 		db.mu.Lock()
 		db.mu.active[sql]--
+		db.mu.lastCompletedStmt = timeutil.Now()
 		if db.mu.active[sql] == 0 {
 			delete(db.mu.active, sql)
 		}
@@ -129,6 +133,21 @@ func (db *verifyFormatDB) exec(t *testing.T, ctx context.Context, sql string) er
 func (db *verifyFormatDB) execWithTimeout(
 	t *testing.T, ctx context.Context, sql string, duration time.Duration,
 ) error {
+	return db.execWithResettableTimeout(t,
+		ctx,
+		sql,
+		duration,
+		0 /* no resets allowed */)
+}
+
+// execWithResettableTimeout executes a statement with a timeout, if the type of
+// timeout is resettable then the timeout will be reset everytime a query completes.
+// This specifically is used in cases where multiple things might be serially
+// executed, for example schema changes on the same table. maxResets can be used
+// to guarantee we don't endlessly extend the timeout.
+func (db *verifyFormatDB) execWithResettableTimeout(
+	t *testing.T, ctx context.Context, sql string, duration time.Duration, maxResets int,
+) error {
 	if err := func() (retErr error) {
 		defer func() {
 			if err := recover(); err != nil {
@@ -154,64 +173,98 @@ func (db *verifyFormatDB) execWithTimeout(
 		_, err := db.db.ExecContext(ctx, sql)
 		funcdone <- err
 	}()
-	select {
-	case err := <-funcdone:
-		if err != nil {
-			if pqerr := (*pq.Error)(nil); errors.As(err, &pqerr) {
-				// Output Postgres error code if it's available.
-				if pgcode.MakeCode(string(pqerr.Code)) == pgcode.CrashShutdown {
-					return &crasher{
-						sql:    sql,
-						err:    err,
-						detail: pqerr.Detail,
+	retry := true
+	targetDuration := duration
+	for retry {
+		retry = false
+		err := func() error {
+			select {
+			case err := <-funcdone:
+				if err != nil {
+					if pqerr := (*pq.Error)(nil); errors.As(err, &pqerr) {
+						// Output Postgres error code if it's available.
+						if pgcode.MakeCode(string(pqerr.Code)) == pgcode.CrashShutdown {
+							return &crasher{
+								sql:    sql,
+								err:    err,
+								detail: pqerr.Detail,
+							}
+						}
+					}
+					if es := err.Error(); strings.Contains(es, "internal error") ||
+						strings.Contains(es, "driver: bad connection") ||
+						strings.Contains(es, "unexpected error inside CockroachDB") {
+						return &crasher{
+							sql: sql,
+							err: err,
+						}
+					}
+					return &nonCrasher{sql: sql, err: err}
+				}
+				return nil
+			case <-time.After(targetDuration):
+				db.mu.Lock()
+				defer db.mu.Unlock()
+				// In the resettable mode, we are going to wait for no progress on any
+				// queries before declaring this a hang.
+				if maxResets > 0 {
+					if db.mu.lastCompletedStmt.Add(duration).After(timeutil.Now()) {
+						// Recompute the timeout duration based, so that the timeout is
+						// N seconds after the last queries completion. This is done to
+						// the timeouts between queries more reasonable for long intervals:
+						// (1) => Executes work in 1 second (setting the last completed query)
+						// (2) => Times out after 2 minutes
+						// If we simply wait the duration for (2) then we will incur another
+						// 2 minute wait and miss potential hangs (if the test times out first).
+						// Whereas this approach will wait 2 minutes after the completion of
+						// (1), only waiting an extra second more.
+						targetDuration = duration - db.mu.lastCompletedStmt.Add(duration).Sub(timeutil.Now())
+						// Avoid having super tight spins, wait at least a second.
+						if targetDuration <= time.Second {
+							targetDuration = time.Second
+						}
+						retry = true
+						maxResets -= 1
+						return nil
 					}
 				}
-			}
-			if es := err.Error(); strings.Contains(es, "internal error") ||
-				strings.Contains(es, "driver: bad connection") ||
-				strings.Contains(es, "unexpected error inside CockroachDB") {
+				b := make([]byte, 1024*1024)
+				n := runtime.Stack(b, true)
+				t.Logf("%s\n", b[:n])
+				// Now see if we can execute a SELECT 1. This is useful because sometimes an
+				// exec timeout is because of a slow-executing statement, and other times
+				// it's because the server is completely wedged. This is an automated way
+				// to find out.
+				errch := make(chan error, 1)
+				go func() {
+					rows, err := db.db.Query(`SELECT 1`)
+					if err == nil {
+						rows.Close()
+					}
+					errch <- err
+				}()
+				select {
+				case <-time.After(5 * time.Second):
+					t.Log("SELECT 1 timeout: probably a wedged server")
+				case err := <-errch:
+					if err != nil {
+						t.Log("SELECT 1 execute error:", err)
+					} else {
+						t.Log("SELECT 1 executed successfully: probably a slow statement")
+					}
+				}
 				return &crasher{
-					sql: sql,
-					err: err,
+					sql:    sql,
+					err:    errors.Newf("statement exec timeout"),
+					detail: fmt.Sprintf("timeout: %q. currently executing: %v", sql, db.mu.active),
 				}
 			}
-			return &nonCrasher{sql: sql, err: err}
-		}
-		return nil
-	case <-time.After(duration):
-		db.mu.Lock()
-		defer db.mu.Unlock()
-		b := make([]byte, 1024*1024)
-		n := runtime.Stack(b, true)
-		t.Logf("%s\n", b[:n])
-		// Now see if we can execute a SELECT 1. This is useful because sometimes an
-		// exec timeout is because of a slow-executing statement, and other times
-		// it's because the server is completely wedged. This is an automated way
-		// to find out.
-		errch := make(chan error, 1)
-		go func() {
-			rows, err := db.db.Query(`SELECT 1`)
-			if err == nil {
-				rows.Close()
-			}
-			errch <- err
 		}()
-		select {
-		case <-time.After(5 * time.Second):
-			t.Log("SELECT 1 timeout: probably a wedged server")
-		case err := <-errch:
-			if err != nil {
-				t.Log("SELECT 1 execute error:", err)
-			} else {
-				t.Log("SELECT 1 executed successfully: probably a slow statement")
-			}
-		}
-		return &crasher{
-			sql:    sql,
-			err:    errors.Newf("statement exec timeout"),
-			detail: fmt.Sprintf("timeout: %q. currently executing: %v", sql, db.mu.active),
+		if err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 func TestRandomSyntaxGeneration(t *testing.T) {
@@ -421,7 +474,14 @@ func TestRandomSyntaxSchemaChangeColumn(t *testing.T) {
 	}, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		n := r.Intn(len(roots))
 		s := fmt.Sprintf("ALTER TABLE ident.ident %s", r.Generate(roots[n], 500))
-		return db.execWithTimeout(t, ctx, s, *flagRSGExecColumnChangeTimeout)
+		// Execute with a resettable timeout, where we allow up to N go-routines worth
+		// of resets. This should be the maximum theoretical time we can get
+		// stuck behind other work.
+		return db.execWithResettableTimeout(t,
+			ctx,
+			s,
+			*flagRSGExecColumnChangeTimeout,
+			*flagRSGGoRoutines)
 	})
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/65736

Previously, TestRandomSyntaxSchemaChangeColumn had a fixed
timeout, which meant that if schema change got stuck behind
each other, this timeout may not have been sufficient. Previously,
we tried bumping up this timeout, but this is not the most reliable
for this test. To address this, this patch introduces the concept of
resettable timeouts, which states that the timeout expires only if
no other statements are complete within the given timeout (otherwise,
its recalculated since the completion of the last statement. To avoid
potential starvation there is a limit on the number of resets,
which guarantees eventual expiry if a query is always bypassed.

Release note: None