### PR TITLE
release-22.1: backupccl: fix mixed-version CREATE SCHEDULE bug

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -923,9 +923,13 @@ func backupPlanHook(
 				return err
 			}
 
-			if err := writeLockOnBackupLocation(ctx, p.ExecCfg(), backupDest.defaultURI, nodeID,
-				p.User()); err != nil {
-				return err
+			// We only want to write a BACKUP-LOCK file if this is not a dry-run
+			// backup that is going to be rolled back.
+			if !backupStmt.IsDryRun {
+				if err := writeLockOnBackupLocation(ctx, p.ExecCfg(), backupDest.defaultURI, nodeID,
+					p.User()); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -1003,10 +1007,14 @@ func backupPlanHook(
 				return err
 			}
 
-			if err := writeBackupManifestCheckpoint(
-				ctx, backupDetails.URI, backupDetails.EncryptionOptions, &backupManifest, p.ExecCfg(), p.User(),
-			); err != nil {
-				return err
+			// We only want to write a BACKUP-CHECKPOINT file if this is not a dry-run
+			// backup that is going to be rolled back.
+			if !backupStmt.IsDryRun {
+				if err := writeBackupManifestCheckpoint(
+					ctx, backupDetails.URI, backupDetails.EncryptionOptions, &backupManifest, p.ExecCfg(), p.User(),
+				); err != nil {
+					return err
+				}
 			}
 
 			resultsCh <- tree.Datums{tree.NewDInt(tree.DInt(jobID))}
@@ -1030,10 +1038,14 @@ func backupPlanHook(
 				return err
 			}
 
-			if err := writeBackupManifestCheckpoint(
-				ctx, backupDetails.URI, backupDetails.EncryptionOptions, &backupManifest, p.ExecCfg(), p.User(),
-			); err != nil {
-				return err
+			// We only want to write a BACKUP-CHECKPOINT file if this is not a dry-run
+			// backup that is going to be rolled back.
+			if !backupStmt.IsDryRun {
+				if err := writeBackupManifestCheckpoint(
+					ctx, backupDetails.URI, backupDetails.EncryptionOptions, &backupManifest, p.ExecCfg(), p.User(),
+				); err != nil {
+					return err
+				}
 			}
 
 			// We commit the transaction here so that the job can be started. This

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -689,6 +689,9 @@ func dryRunBackup(ctx context.Context, p sql.PlanHookState, backupNode *tree.Bac
 }
 
 func dryRunInvokeBackup(ctx context.Context, p sql.PlanHookState, backupNode *tree.Backup) error {
+	// IsDryRun prevents the backup planning from performing operations that
+	// cannot be rolled back.
+	backupNode.IsDryRun = true
 	backupFn, err := planBackup(ctx, p, backupNode)
 	if err != nil {
 		return err

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -72,6 +72,11 @@ type Backup struct {
 	// explicitly specified by the user, then this will be set during BACKUP
 	// planning once the destination has been resolved.
 	Subdir Expr
+
+	// IsDryRun is set to true if the caller wants to plan a backup but not
+	// persist and run it as a job. This field is for internal use and is only
+	// used on the creation of a backup schedule.
+	IsDryRun bool
 }
 
 var _ Statement = &Backup{}


### PR DESCRIPTION
In a 21.2, 22.1 mixed-version state, backup checks for concurrent backups
running to the same bucket during the planning phase. If it sees a
`BACKUP-LOCK-<nodeID>` file that was not written as part of its planning then
it fails the backup statement. During the execution of a `CREATE SCHEDULE` we
run a dry-run backup that executes the planning phase of the backup statement
and then rolls the txn back. Prior to the fix, this dry run phase would write
a `BACKUP-LOCK-<nodeID>` file and not delete it. If another node were to then
schedule the backup job to actually run, it would see the `BACKUP-LOCK` file
written during the dry-run and incorrectly assume that a concurrent backup is
running to the same bucket, therefore causing the scheduled job to fail.

As a rule of thumb we should not be performing any operations during
planning that cannot be rolled back on txn rollback, this will be the
case in a non-mixed version state since all these operation have been moved
to job execution. As a workaround we make certain operations such as
writing the lock file, and writing the checkpoint file conditional
on the backup not being part of a dry run.

Informs: https://github.com/cockroachlabs/support/issues/1694

Release note (bug fix): A `CREATE SCHEDULE` in a mixed version
cluster could prevent the scheduled job from actually running because
of incorrectly writing a lock file.

Release justification: bug fix for an issue that could cause scheduled jobs to fail in a mixed version state