### PR TITLE
sql/tests: skip crdb_internal.request_statement_bundle in test

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -299,7 +299,9 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					// Some spatial function are slow and testing them here
 					// is not worth it.
 					continue
-				case "crdb_internal.reset_sql_stats", "crdb_internal.check_consistency":
+				case "crdb_internal.reset_sql_stats",
+					"crdb_internal.check_consistency",
+					"crdb_internal.request_statement_bundle":
 					// Skipped due to long execution time.
 					continue
 				}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/82971

This isn't useful to test and confuses the randomized test.

Release note: None