### PR TITLE
sql: support synthetic privileges with grant option

### DIFF
--- a/docs/generated/sql/bnf/revoke_stmt.bnf
+++ b/docs/generated/sql/bnf/revoke_stmt.bnf
@@ -31,3 +31,6 @@ revoke_stmt ::=
 	| 'REVOKE' 'SYSTEM' 'ALL' 'PRIVILEGES' 'FROM' role_spec_list
 	| 'REVOKE' 'SYSTEM' 'ALL'  'FROM' role_spec_list
 	| 'REVOKE' 'SYSTEM' privilege_list 'FROM' role_spec_list
+	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' 'SYSTEM' 'ALL' 'PRIVILEGES' 'FROM' role_spec_list
+	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' 'SYSTEM' 'ALL'  'FROM' role_spec_list
+	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' 'SYSTEM' privilege_list 'FROM' role_spec_list

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -110,6 +110,7 @@ revoke_stmt ::=
 	| 'REVOKE' privileges 'ON' 'ALL' 'SEQUENCES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' privileges 'ON' 'ALL' 'TABLES' 'IN' 'SCHEMA' schema_name_list 'FROM' role_spec_list
 	| 'REVOKE' 'SYSTEM' privileges 'FROM' role_spec_list
+	| 'REVOKE' 'GRANT' 'OPTION' 'FOR' 'SYSTEM' privileges 'FROM' role_spec_list
 
 savepoint_stmt ::=
 	'SAVEPOINT' name

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -117,7 +117,7 @@ func (p *planner) Revoke(ctx context.Context, n *tree.Revoke) (planNode, error) 
 		return &changeNonDescriptorBackedPrivilegesNode{
 			changePrivilegesNode: changePrivilegesNode{
 				isGrant:         false,
-				withGrantOption: false,
+				withGrantOption: n.GrantOptionFor,
 				grantees:        grantees,
 				desiredprivs:    n.Privileges,
 				grantOn:         grantOn,

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -57,8 +57,7 @@ func (n *changeNonDescriptorBackedPrivilegesNode) startExec(params runParams) er
 	if n.isGrant {
 		// Privileges are valid, write them to the system.privileges table.
 		for _, user := range n.grantees {
-			syntheticPrivDesc.Grant(user, n.desiredprivs, false)
-
+			syntheticPrivDesc.Grant(user, n.desiredprivs, n.withGrantOption)
 			userPrivs, found := syntheticPrivDesc.FindUser(user)
 			if !found {
 				return errors.AssertionFailedf("user %s not found", user)
@@ -84,7 +83,7 @@ func (n *changeNonDescriptorBackedPrivilegesNode) startExec(params runParams) er
 
 	// Handle revoke case.
 	for _, user := range n.grantees {
-		syntheticPrivDesc.Revoke(user, n.desiredprivs, n.grantOn, false)
+		syntheticPrivDesc.Revoke(user, n.desiredprivs, n.grantOn, n.withGrantOption)
 		userPrivs, found := syntheticPrivDesc.FindUser(user)
 
 		// If there are no entries remaining on the PrivilegeDescriptor for the user

--- a/pkg/sql/logictest/testdata/logic_test/system_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/system_privileges
@@ -6,6 +6,9 @@ SELECT * FROM crdb_internal.cluster_settings;
 user root
 
 statement ok
+CREATE USER testuser2
+
+statement ok
 GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser
 
 user testuser
@@ -13,10 +16,14 @@ user testuser
 statement ok
 SELECT * FROM crdb_internal.cluster_settings;
 
+# Without grant option, testuser should not be able to grant to others.
+statement error pq: user testuser missing WITH GRANT OPTION privilege on MODIFYCLUSTERSETTING
+GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser2
+
 user root
 
 query TTTT
-SELECT * FROM system.privileges
+SELECT * FROM system.privileges ORDER BY 1, 2
 ----
 testuser  /global/  {MODIFYCLUSTERSETTING}  {}
 
@@ -31,5 +38,60 @@ SELECT * FROM crdb_internal.cluster_settings;
 user root
 
 query TTTT
-SELECT * FROM system.privileges
+SELECT * FROM system.privileges ORDER BY 1, 2
 ----
+
+user root
+
+statement ok
+GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser
+
+statement ok
+GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser WITH GRANT OPTION
+
+user testuser
+
+statement ok
+GRANT SYSTEM MODIFYCLUSTERSETTING TO root
+
+user root
+
+query TTTT
+SELECT * FROM system.privileges ORDER BY 1, 2
+----
+root      /global/  {MODIFYCLUSTERSETTING}  {}
+testuser  /global/  {MODIFYCLUSTERSETTING}  {MODIFYCLUSTERSETTING}
+
+statement ok
+REVOKE GRANT OPTION FOR SYSTEM MODIFYCLUSTERSETTING FROM testuser
+
+query TTTT
+SELECT * FROM system.privileges ORDER BY 1, 2
+----
+root      /global/  {MODIFYCLUSTERSETTING}  {}
+testuser  /global/  {MODIFYCLUSTERSETTING}  {}
+
+statement ok
+REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
+
+query TTTT
+SELECT * FROM system.privileges ORDER BY 1, 2
+----
+root  /global/  {MODIFYCLUSTERSETTING}  {}
+
+statement ok
+GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser WITH GRANT OPTION
+
+query TTTT
+SELECT * FROM system.privileges ORDER BY 1, 2
+----
+root      /global/  {MODIFYCLUSTERSETTING}  {}
+testuser  /global/  {MODIFYCLUSTERSETTING}  {MODIFYCLUSTERSETTING}
+
+statement ok
+REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
+
+query TTTT
+SELECT * FROM system.privileges ORDER BY 1, 2
+----
+root  /global/  {MODIFYCLUSTERSETTING}  {}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5204,6 +5204,17 @@ revoke_stmt:
       Grantees: $5.roleSpecList(),
     }
   }
+| REVOKE GRANT OPTION FOR SYSTEM privileges FROM role_spec_list
+  {
+    $$.val = &tree.Revoke{
+      Privileges: $6.privilegeList(),
+      Targets: tree.GrantTargetList{
+        System: true,
+      },
+      Grantees: $8.roleSpecList(),
+      GrantOptionFor: true,
+    }
+  }
 | REVOKE privileges ON SEQUENCE error
   {
     return unimplemented(sqllex, "revoke privileges on sequence")

--- a/pkg/upgrade/upgrades/system_privileges_test.go
+++ b/pkg/upgrade/upgrades/system_privileges_test.go
@@ -73,7 +73,7 @@ func TestSystemPrivilegesMigration(t *testing.T) {
 ('user2', 'path/1/user', ARRAY['1', '0'], ARRAY['0']),
 ('user2', 'path/2/user', ARRAY['10'], ARRAY['10'])`)
 
-	tdb.CheckQueryResults(t, `SELECT * FROM system.privileges`, [][]string{
+	tdb.CheckQueryResults(t, `SELECT * FROM system.privileges ORDER BY 1, 2`, [][]string{
 		{"user1", "path/1/user", "{10}", "{10}"},
 		{"user1", "path/2/user", "{0,0}", "{1,0}"},
 		{"user2", "path/1/user", "{1,0}", "{0}"},


### PR DESCRIPTION
Release note (sql change): Synthetic privileges now support grant options.
Previously, GRANT SYSTEM MODIFYCLUSTERSETTING TO foo WITH GRANT OPTION, would
ignore the GRANT OPTION.

Now this is supported, users need GRANT option to be able to grant the privilege.