### PR TITLE
streamingccl: switch PartitionedStreamClient to use pgx library

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_jackc_pgx_v4//:pgx",
     ],
 )
 
@@ -67,7 +68,6 @@ go_test(
         "//pkg/streaming",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/cancelchecker",
         "//pkg/util/ctxgroup",

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -78,7 +78,7 @@ type Client interface {
 	) (Subscription, error)
 
 	// Close releases all the resources used by this client.
-	Close() error
+	Close(ctx context.Context) error
 
 	// Complete completes a replication stream consumption.
 	Complete(ctx context.Context, streamID streaming.StreamID) error

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -123,7 +123,9 @@ type Subscription interface {
 }
 
 // NewStreamClient creates a new stream client based on the stream address.
-func NewStreamClient(streamAddress streamingccl.StreamAddress) (Client, error) {
+func NewStreamClient(
+	ctx context.Context, streamAddress streamingccl.StreamAddress,
+) (Client, error) {
 	var streamClient Client
 	streamURL, err := streamAddress.URL()
 	if err != nil {
@@ -134,7 +136,7 @@ func NewStreamClient(streamAddress streamingccl.StreamAddress) (Client, error) {
 	case "postgres", "postgresql":
 		// The canonical PostgreSQL URL scheme is "postgresql", however our
 		// own client commands also accept "postgres".
-		return newPartitionedStreamClient(streamURL)
+		return newPartitionedStreamClient(ctx, streamURL)
 	case RandomGenScheme:
 		streamClient, err = newRandomStreamClient(streamURL)
 		if err != nil {

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -10,7 +10,6 @@ package streamclient
 
 import (
 	"context"
-	gosql "database/sql"
 	"net"
 	"net/url"
 
@@ -19,35 +18,43 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/streaming"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgx/v4"
 )
 
 type partitionedStreamClient struct {
-	srcDB          *gosql.DB // DB handle to the source cluster
 	urlPlaceholder url.URL
+	pgxConfig      *pgx.ConnConfig
 
 	mu struct {
 		syncutil.Mutex
 
 		closed              bool
 		activeSubscriptions map[*partitionedStreamSubscription]struct{}
+		srcConn             *pgx.Conn // pgx connection to the source cluster
 	}
 }
 
 func newPartitionedStreamClient(remote *url.URL) (*partitionedStreamClient, error) {
-	db, err := gosql.Open("postgres", remote.String())
+	config, err := pgx.ParseConfig(remote.String())
+	if err != nil {
+		return nil, err
+	}
+	conn, err := pgx.ConnectConfig(context.Background(), config)
 	if err != nil {
 		return nil, err
 	}
 
 	client := &partitionedStreamClient{
-		srcDB:          db,
 		urlPlaceholder: *remote,
+		pgxConfig:      config,
 	}
 	client.mu.activeSubscriptions = make(map[*partitionedStreamSubscription]struct{})
+	client.mu.srcConn = conn
 	return client, nil
 }
 
@@ -60,19 +67,16 @@ func (p *partitionedStreamClient) Create(
 	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.Create")
 	defer sp.Finish()
 
-	streamID := streaming.InvalidStreamID
-
-	conn, err := p.srcDB.Conn(ctx)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var streamID streaming.StreamID
+	row := p.mu.srcConn.QueryRow(ctx, `SELECT crdb_internal.start_replication_stream($1)`, tenantID.ToUint64())
+	err := row.Scan(&streamID)
 	if err != nil {
-		return streamID, err
+		return streaming.InvalidStreamID,
+			errors.Wrapf(err, "error creating replication stream for tenant %s", tenantID.String())
 	}
 
-	row := conn.QueryRowContext(ctx, `SELECT crdb_internal.start_replication_stream($1)`, tenantID.ToUint64())
-	if row.Err() != nil {
-		return streamID, errors.Wrapf(row.Err(), "error creating replication stream for tenant %s", tenantID.String())
-	}
-
-	err = row.Scan(&streamID)
 	return streamID, err
 }
 
@@ -83,21 +87,14 @@ func (p *partitionedStreamClient) Heartbeat(
 	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.Heartbeat")
 	defer sp.Finish()
 
-	conn, err := p.srcDB.Conn(ctx)
-	if err != nil {
-		return streampb.StreamReplicationStatus{}, err
-	}
-
-	row := conn.QueryRowContext(ctx,
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	row := p.mu.srcConn.QueryRow(ctx,
 		`SELECT crdb_internal.replication_stream_progress($1, $2)`, streamID, consumed.String())
-	if row.Err() != nil {
-		return streampb.StreamReplicationStatus{},
-			errors.Wrapf(row.Err(), "error sending heartbeat to replication stream %d", streamID)
-	}
-
 	var rawStatus []byte
 	if err := row.Scan(&rawStatus); err != nil {
-		return streampb.StreamReplicationStatus{}, err
+		return streampb.StreamReplicationStatus{},
+			errors.Wrapf(err, "error sending heartbeat to replication stream %d", streamID)
 	}
 	var status streampb.StreamReplicationStatus
 	if err := protoutil.Unmarshal(rawStatus, &status); err != nil {
@@ -121,23 +118,19 @@ func (p *partitionedStreamClient) postgresURL(servingAddr string) (url.URL, erro
 func (p *partitionedStreamClient) Plan(
 	ctx context.Context, streamID streaming.StreamID,
 ) (Topology, error) {
-	conn, err := p.srcDB.Conn(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	row := conn.QueryRowContext(ctx, `SELECT crdb_internal.replication_stream_spec($1)`, streamID)
-	if row.Err() != nil {
-		return nil, errors.Wrapf(row.Err(), "error planning replication stream %d", streamID)
-	}
-
-	var rawSpec []byte
-	if err := row.Scan(&rawSpec); err != nil {
-		return nil, err
-	}
 	var spec streampb.ReplicationStreamSpec
-	if err := protoutil.Unmarshal(rawSpec, &spec); err != nil {
-		return nil, err
+	{
+		p.mu.Lock()
+		defer p.mu.Unlock()
+
+		row := p.mu.srcConn.QueryRow(ctx, `SELECT crdb_internal.replication_stream_spec($1)`, streamID)
+		var rawSpec []byte
+		if err := row.Scan(&rawSpec); err != nil {
+			return nil, errors.Wrapf(err, "error planning replication stream %d", streamID)
+		}
+		if err := protoutil.Unmarshal(rawSpec, &spec); err != nil {
+			return nil, err
+		}
 	}
 
 	topology := Topology{}
@@ -163,7 +156,7 @@ func (p *partitionedStreamClient) Plan(
 }
 
 // Close implements Client interface.
-func (p *partitionedStreamClient) Close() error {
+func (p *partitionedStreamClient) Close(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -176,7 +169,7 @@ func (p *partitionedStreamClient) Close() error {
 		close(sub.closeChan)
 		delete(p.mu.activeSubscriptions, sub)
 	}
-	return p.srcDB.Close()
+	return p.mu.srcConn.Close(ctx)
 }
 
 // Subscribe implements Client interface.
@@ -198,11 +191,11 @@ func (p *partitionedStreamClient) Subscribe(
 	}
 
 	res := &partitionedStreamSubscription{
-		eventsChan: make(chan streamingccl.Event),
-		db:         p.srcDB,
-		specBytes:  specBytes,
-		streamID:   stream,
-		closeChan:  make(chan struct{}),
+		eventsChan:    make(chan streamingccl.Event),
+		srcConnConfig: p.pgxConfig,
+		specBytes:     specBytes,
+		streamID:      stream,
+		closeChan:     make(chan struct{}),
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -215,21 +208,19 @@ func (p *partitionedStreamClient) Complete(ctx context.Context, streamID streami
 	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.Complete")
 	defer sp.Finish()
 
-	conn, err := p.srcDB.Conn(ctx)
-	if err != nil {
-		return err
-	}
-	row := conn.QueryRowContext(ctx, `SELECT crdb_internal.complete_replication_stream($1)`, streamID)
-	if row.Err() != nil {
-		return errors.Wrapf(row.Err(), "error completing replication stream %d", streamID)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	row := p.mu.srcConn.QueryRow(ctx, `SELECT crdb_internal.complete_replication_stream($1)`, streamID)
+	if err := row.Scan(&streamID); err != nil {
+		return errors.Wrapf(err, "error completing replication stream %d", streamID)
 	}
 	return nil
 }
 
 type partitionedStreamSubscription struct {
-	err        error
-	db         *gosql.DB
-	eventsChan chan streamingccl.Event
+	err           error
+	srcConnConfig *pgx.ConnConfig
+	eventsChan    chan streamingccl.Event
 	// Channel to send signal to close the subscription.
 	closeChan chan struct{}
 
@@ -274,16 +265,23 @@ func (p *partitionedStreamSubscription) Subscribe(ctx context.Context) error {
 	defer sp.Finish()
 
 	defer close(p.eventsChan)
-	conn, err := p.db.Conn(ctx)
+	// Each subscription has its own pgx connection instead of
+	// shares one with other Subscription.
+	srcConn, err := pgx.ConnectConfig(ctx, p.srcConnConfig)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			log.Warningf(ctx, "error when closing subscription connection: %v", err)
+		}
+	}()
 
-	_, err = conn.ExecContext(ctx, `SET avoid_buffering = true`)
+	_, err = srcConn.Exec(ctx, `SET avoid_buffering = true`)
 	if err != nil {
 		return err
 	}
-	rows, err := conn.QueryContext(ctx, `SELECT * FROM crdb_internal.stream_partition($1, $2)`,
+	rows, err := srcConn.Query(ctx, `SELECT * FROM crdb_internal.stream_partition($1, $2)`,
 		p.streamID, p.specBytes)
 	if err != nil {
 		return err

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -39,12 +39,14 @@ type partitionedStreamClient struct {
 	}
 }
 
-func newPartitionedStreamClient(remote *url.URL) (*partitionedStreamClient, error) {
+func newPartitionedStreamClient(
+	ctx context.Context, remote *url.URL,
+) (*partitionedStreamClient, error) {
 	config, err := pgx.ParseConfig(remote.String())
 	if err != nil {
 		return nil, err
 	}
-	conn, err := pgx.ConnectConfig(context.Background(), config)
+	conn, err := pgx.ConnectConfig(ctx, config)
 	if err != nil {
 		return nil, err
 	}
@@ -265,8 +267,7 @@ func (p *partitionedStreamSubscription) Subscribe(ctx context.Context) error {
 	defer sp.Finish()
 
 	defer close(p.eventsChan)
-	// Each subscription has its own pgx connection instead of
-	// shares one with other Subscription.
+	// Each subscription has its own pgx connection.
 	srcConn, err := pgx.ConnectConfig(ctx, p.srcConnConfig)
 	if err != nil {
 		return err

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -88,7 +88,7 @@ INSERT INTO d.t1 (i) VALUES (42);
 INSERT INTO d.t2 VALUES (2);
 `)
 
-	client, err := newPartitionedStreamClient(&h.PGUrl)
+	client, err := newPartitionedStreamClient(ctx, &h.PGUrl)
 	defer func() {
 		require.NoError(t, client.Close(ctx))
 	}()
@@ -164,7 +164,7 @@ INSERT INTO d.t2 VALUES (2);
 	url, err := streamingccl.StreamAddress(top[0].SrcAddr).URL()
 	require.NoError(t, err)
 	// Create a new stream client with the given partition address.
-	subClient, err := newPartitionedStreamClient(url)
+	subClient, err := newPartitionedStreamClient(ctx, url)
 	defer func() {
 		require.NoError(t, subClient.Close(ctx))
 	}()

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/streaming"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -58,7 +57,6 @@ func (f *subscriptionFeedSource) Close(ctx context.Context) {}
 
 func TestPartitionedStreamReplicationClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderRaceWithIssue(t, 83694)
 	defer log.Scope(t).Close(t)
 
 	h, cleanup := streamingtest.NewReplicationHelper(t,
@@ -92,7 +90,7 @@ INSERT INTO d.t2 VALUES (2);
 
 	client, err := newPartitionedStreamClient(&h.PGUrl)
 	defer func() {
-		require.NoError(t, client.Close())
+		require.NoError(t, client.Close(ctx))
 	}()
 	require.NoError(t, err)
 	expectStreamState := func(streamID streaming.StreamID, status jobs.Status) {
@@ -168,7 +166,7 @@ INSERT INTO d.t2 VALUES (2);
 	// Create a new stream client with the given partition address.
 	subClient, err := newPartitionedStreamClient(url)
 	defer func() {
-		require.NoError(t, subClient.Close())
+		require.NoError(t, subClient.Close(ctx))
 	}()
 	require.NoError(t, err)
 	sub, err := subClient.Subscribe(ctx, streamID, encodeSpec("t1"), hlc.Timestamp{})

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -339,7 +339,7 @@ func (m *randomStreamClient) getDescriptorAndNamespaceKVForTableID(
 }
 
 // Close implements the Client interface.
-func (m *randomStreamClient) Close() error {
+func (m *randomStreamClient) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -165,7 +165,9 @@ type heartbeatSender struct {
 func newHeartbeatSender(
 	flowCtx *execinfra.FlowCtx, spec execinfrapb.StreamIngestionFrontierSpec,
 ) (*heartbeatSender, error) {
-	streamClient, err := streamclient.NewStreamClient(streamingccl.StreamAddress(spec.StreamAddress))
+	streamClient, err := streamclient.NewStreamClient(
+		flowCtx.EvalCtx.Ctx(),
+		streamingccl.StreamAddress(spec.StreamAddress))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -234,7 +234,7 @@ func (h *heartbeatSender) startHeartbeatLoop(ctx context.Context) {
 				return streamingccl.NewStreamStatusErr(h.streamID, streamStatus.StreamStatus)
 			}
 		}
-		err := errors.CombineErrors(sendHeartbeats(), h.client.Close())
+		err := errors.CombineErrors(sendHeartbeats(), h.client.Close(ctx))
 		close(h.stoppedChan)
 		return err
 	})

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
@@ -226,7 +226,7 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 				partitionEvents: tc.events,
 			}
 			defer func() {
-				require.NoError(t, sip.forceClientForTests.Close())
+				require.NoError(t, sip.forceClientForTests.Close(ctx))
 			}()
 
 			// Create a frontier processor.

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -91,7 +91,7 @@ func getStreamIngestionStats(
 		stats.ReplicationLagInfo = lagInfo
 	}
 
-	client, err := streamclient.NewStreamClient(streamingccl.StreamAddress(details.StreamAddress))
+	client, err := streamclient.NewStreamClient(evalCtx.Ctx(), streamingccl.StreamAddress(details.StreamAddress))
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.
 	// If there is an existing stream ID, reconnect to it.
 	streamID := streaming.StreamID(details.StreamID)
 	// Initialize a stream client and resolve topology.
-	client, err := streamclient.NewStreamClient(streamAddress)
+	client, err := streamclient.NewStreamClient(ctx, streamAddress)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -101,7 +101,7 @@ func getStreamIngestionStats(
 	} else {
 		stats.ProducerStatus = &streamStatus
 	}
-	return stats, client.Close()
+	return stats, client.Close(evalCtx.Ctx())
 }
 
 type streamIngestionResumer struct {
@@ -220,7 +220,7 @@ func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.
 		// Completes the producer job in the source cluster.
 		return client.Complete(ctx, streamID)
 	}
-	return errors.CombineErrors(ingestWithClient(), client.Close())
+	return errors.CombineErrors(ingestWithClient(), client.Close(ctx))
 }
 
 // Resume is part of the jobs.Resumer interface.

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -127,26 +127,21 @@ func ingestionPlanHook(
 		}
 
 		streamAddress := streamingccl.StreamAddress(from[0])
-		url, err := streamAddress.URL()
+		streamUrl, err := streamAddress.URL()
 		if err != nil {
 			return err
 		}
-		q := url.Query()
+		q := streamUrl.Query()
 
 		// Operator should specify a postgres scheme address with cert authentication.
 		if hasPostgresAuthentication := (q.Get("sslmode") == "verify-full") &&
-			q.Has("sslrootcert") && q.Has("sslkey") && q.Has("sslcert"); (url.Scheme == "postgres") && !hasPostgresAuthentication {
+			q.Has("sslrootcert") && q.Has("sslkey") && q.Has("sslcert"); (streamUrl.Scheme == "postgres") &&
+			!hasPostgresAuthentication {
 			return errors.Errorf(
 				"stream replication address should have cert authentication if in postgres scheme: %s", streamAddress)
 		}
 
-		// Convert this URL into sslinline mode.
-		*url, err = maybeAddInlineSecurityCredentials(*url)
-		if err != nil {
-			return err
-		}
-		streamAddress = streamingccl.StreamAddress(url.String())
-
+		streamAddress = streamingccl.StreamAddress(streamUrl.String())
 		if ingestionStmt.Targets.Databases != nil ||
 			ingestionStmt.Targets.Tables.TablePatterns != nil || ingestionStmt.Targets.Schemas != nil {
 			return errors.Newf("unsupported target in ingestion query, "+
@@ -190,7 +185,7 @@ func ingestionPlanHook(
 		if err != nil {
 			return err
 		}
-		if err := client.Close(); err != nil {
+		if err := client.Close(ctx); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -10,8 +10,6 @@ package streamingest
 
 import (
 	"context"
-	"net/url"
-	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
@@ -37,45 +35,6 @@ func streamIngestionJobDescription(
 ) (string, error) {
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(streamIngestion, ann), nil
-}
-
-// maybeAddInlineSecurityCredentials converts a PG URL into sslinline mode by adding ssl key and
-// certificates inline as ssl parameters. sslinline is postgres driver specific feature
-// (https://github.com/lib/pq/blob/8446d16b8935fdf2b5c0fe333538ac395e3e1e4b/ssl.go#L85).
-func maybeAddInlineSecurityCredentials(pgURL url.URL) (url.URL, error) {
-	options := pgURL.Query()
-	if options.Get("sslinline") == "true" {
-		return pgURL, nil
-	}
-
-	loadPathContentAsOption := func(optionKey string) error {
-		if !options.Has(optionKey) {
-			return nil
-		}
-		content, err := os.ReadFile(options.Get(optionKey))
-		if err != nil {
-			return err
-		}
-		options.Set(optionKey, string(content))
-		return nil
-	}
-
-	if err := loadPathContentAsOption("sslrootcert"); err != nil {
-		return url.URL{}, err
-	}
-	// Convert client certs inline.
-	if options.Get("sslmode") == "verify-full" {
-		if err := loadPathContentAsOption("sslcert"); err != nil {
-			return url.URL{}, err
-		}
-		if err := loadPathContentAsOption("sslkey"); err != nil {
-			return url.URL{}, err
-		}
-	}
-	options.Set("sslinline", "true")
-	res := pgURL
-	res.RawQuery = options.Encode()
-	return res, nil
 }
 
 func ingestionPlanHook(
@@ -127,21 +86,21 @@ func ingestionPlanHook(
 		}
 
 		streamAddress := streamingccl.StreamAddress(from[0])
-		streamUrl, err := streamAddress.URL()
+		streamURL, err := streamAddress.URL()
 		if err != nil {
 			return err
 		}
-		q := streamUrl.Query()
+		q := streamURL.Query()
 
 		// Operator should specify a postgres scheme address with cert authentication.
 		if hasPostgresAuthentication := (q.Get("sslmode") == "verify-full") &&
-			q.Has("sslrootcert") && q.Has("sslkey") && q.Has("sslcert"); (streamUrl.Scheme == "postgres") &&
+			q.Has("sslrootcert") && q.Has("sslkey") && q.Has("sslcert"); (streamURL.Scheme == "postgres") &&
 			!hasPostgresAuthentication {
 			return errors.Errorf(
 				"stream replication address should have cert authentication if in postgres scheme: %s", streamAddress)
 		}
 
-		streamAddress = streamingccl.StreamAddress(streamUrl.String())
+		streamAddress = streamingccl.StreamAddress(streamURL.String())
 		if ingestionStmt.Targets.Databases != nil ||
 			ingestionStmt.Targets.Tables.TablePatterns != nil || ingestionStmt.Targets.Schemas != nil {
 			return errors.Newf("unsupported target in ingestion query, "+
@@ -175,7 +134,7 @@ func ingestionPlanHook(
 		}
 
 		// Create a new stream with stream client.
-		client, err := streamclient.NewStreamClient(streamAddress)
+		client, err := streamclient.NewStreamClient(ctx, streamAddress)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -271,7 +271,7 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 			streamClient = sip.forceClientForTests
 			log.Infof(ctx, "using testing client")
 		} else {
-			streamClient, err = streamclient.NewStreamClient(streamingccl.StreamAddress(addr))
+			streamClient, err = streamclient.NewStreamClient(ctx, streamingccl.StreamAddress(addr))
 			if err != nil {
 				sip.MoveToDraining(errors.Wrapf(err, "creating client for partition spec %q from %q", token, addr))
 				return

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -359,7 +359,7 @@ func (sip *streamIngestionProcessor) close() {
 	}
 
 	for _, client := range sip.streamPartitionClients {
-		_ = client.Close()
+		_ = client.Close(sip.Ctx)
 	}
 	if sip.batcher != nil {
 		sip.batcher.Close(sip.Ctx)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -125,7 +125,7 @@ func (m *mockStreamClient) Subscribe(
 }
 
 // Close implements the Client interface.
-func (m *mockStreamClient) Close() error {
+func (m *mockStreamClient) Close(ctx context.Context) error {
 	return nil
 }
 
@@ -324,7 +324,7 @@ func TestStreamIngestionProcessor(t *testing.T) {
 		sip, out, err := getStreamIngestionProcessor(ctx, t, registry, kvDB,
 			partitions, startTime, []jobspb.ResolvedSpan{} /* checkpoint */, nil /* interceptEvents */, tenantRekey, mockClient, nil /* cutoverProvider */, streamingTestingKnob)
 		defer func() {
-			require.NoError(t, sip.forceClientForTests.Close())
+			require.NoError(t, sip.forceClientForTests.Close(ctx))
 		}()
 		require.NoError(t, err)
 
@@ -592,7 +592,7 @@ func runStreamIngestionProcessor(
 	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}
-	if err := sip.forceClientForTests.Close(); err != nil {
+	if err := sip.forceClientForTests.Close(ctx); err != nil {
 		return nil, err
 	}
 	return out, err

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -482,7 +482,7 @@ func TestRandomClientGeneration(t *testing.T) {
 	streamAddr := getTestRandomClientURI(tenantID)
 
 	// The random client returns system and table data partitions.
-	streamClient, err := streamclient.NewStreamClient(streamingccl.StreamAddress(streamAddr))
+	streamClient, err := streamclient.NewStreamClient(ctx, streamingccl.StreamAddress(streamAddr))
 	require.NoError(t, err)
 	id, err := streamClient.Create(ctx, roachpb.MakeTenantID(tenantID))
 	require.NoError(t, err)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
@@ -99,7 +99,7 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 	registerValidator := registerValidatorWithClient(streamValidator)
 	client := streamclient.GetRandomStreamClientSingletonForTesting()
 	defer func() {
-		require.NoError(t, client.Close())
+		require.NoError(t, client.Close(ctx))
 	}()
 	interceptEvents := []streamclient.InterceptFn{
 		completeJobAfterCheckpoints,


### PR DESCRIPTION
We have been switching to pgx from lib/pq across teams in CRL.
This PR continues this journey and makes PartitionedStreamClient 
 to use pgx and also in a thread-safe way.

To avoid overhead of creating connection, APIs except Subscribe
share the same connection guarded by a mutex, and Subcribe owns
a private connection which makes sense as two Subscribe calls
don't want to share a connection.

Fixes data race we have been seen in the past: 
Closes: https://github.com/cockroachdb/cockroach/issues/83694

Also unskip stream_replication_e2e_test under race.

Release note: None

Addresses https://github.com/cockroachdb/cockroach/issues/83695