### PR TITLE
server: fix conversion error on jobs

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -108,6 +108,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/security/username",
         "//pkg/server",
+        "//pkg/server/serverpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2057,7 +2057,7 @@ func (s *adminServer) jobsHelper(
               when ` + retryRevertingCondition + ` then 'retry-reverting' 
               else status
             end as status, running_status, created, started, finished, modified, fraction_completed,
-            high_water_timestamp, error, last_run, next_run, num_runs, execution_events::string::bytes,
+            high_water_timestamp, error, last_run, next_run, num_runs, execution_events::string,
             coordinator_id
         FROM crdb_internal.jobs
        WHERE true
@@ -2143,7 +2143,7 @@ func scanRowIntoJob(scanner resultScanner, row tree.Datums, job *serverpb.JobRes
 	var fractionCompletedOrNil *float32
 	var highwaterOrNil *apd.Decimal
 	var runningStatusOrNil *string
-	var executionFailures []byte
+	var executionFailuresOrNil *string
 	var coordinatorOrNil *int64
 	if err := scanner.ScanAll(
 		row,
@@ -2165,7 +2165,7 @@ func scanRowIntoJob(scanner resultScanner, row tree.Datums, job *serverpb.JobRes
 		&job.LastRun,
 		&job.NextRun,
 		&job.NumRuns,
-		&executionFailures,
+		&executionFailuresOrNil,
 		&coordinatorOrNil,
 	); err != nil {
 		return errors.Wrap(err, "scan")
@@ -2185,8 +2185,8 @@ func scanRowIntoJob(scanner resultScanner, row tree.Datums, job *serverpb.JobRes
 	if runningStatusOrNil != nil {
 		job.RunningStatus = *runningStatusOrNil
 	}
-	{
-		failures, err := jobs.ParseRetriableExecutionErrorLogFromJSON(executionFailures)
+	if executionFailuresOrNil != nil {
+		failures, err := jobs.ParseRetriableExecutionErrorLogFromJSON([]byte(*executionFailuresOrNil))
 		if err != nil {
 			return errors.Wrap(err, "parse")
 		}
@@ -2233,7 +2233,7 @@ func (s *adminServer) jobHelper(
 	        SELECT job_id, job_type, description, statement, user_name, descriptor_ids, status,
 	  						 running_status, created, started, finished, modified,
 	  						 fraction_completed, high_water_timestamp, error, last_run,
-								 next_run, num_runs, execution_events::string::bytes,
+								 next_run, num_runs, execution_events::string,
                  coordinator_id
 	          FROM crdb_internal.jobs
 	         WHERE job_id = $1`


### PR DESCRIPTION
Previously, if a job contained \" on its execution events value, it would cause
an error on conversion into BYTEA. This commit removes that cast and properly
decodes the json string.

Fixes #84139

Release note (bug fix): Fixed a bug which could result in 500 errors when loading the jobs details page when the job had encountered an error containing an escape sequence or quotation.