### PR TITLE
Makefile: add deprecation warning and alternate suggestions

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=41
+DEV_VERSION=42
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/README.md
+++ b/pkg/cmd/dev/README.md
@@ -1,12 +1,11 @@
-WARNING: The migration to Bazel at Cockroach is still in-progress.
-Proceed at your own risk :)
+`dev` is the general-purpose dev tool for working on cockroachdb/cockroach; it's
+powered by Bazel underneath the hood. With it you can:
 
-`dev` is a general-purpose tool for folks working on `cockroach`. Unlike
-builds and tests performed w/ `make`, everything `dev` does is driven by
-Bazel as a build system.
+- build various binaries (cockroach, roachprod, optgen, ...)
+- run arbitrary tests (unit tests, logic tests, ...) under various configurations (stress, race, ...)
+- generate code (bazel files, docs, protos, ...)
 
-You can use the script `./dev` at top-level instead of building `dev`
-ahead of time. This script just builds `dev` and immediately runs it
-with the supplied arguments.
-
-Run `./dev help` to see what `dev` can do!
+You can use the top-level `./dev` script instead of building a `dev` binary
+ahead of time. This script just does it for you whatever version is checked out
+and immediately runs it with the supplied arguments. Run `dev --help` to see
+what it can do!

--- a/pkg/cmd/dev/io/os/os.go
+++ b/pkg/cmd/dev/io/os/os.go
@@ -315,6 +315,20 @@ func (o *OS) CopyFile(src, dst string) error {
 	return err
 }
 
+// Symlink wraps around os.Symlink, creating a symbolic link to and from the
+// named paths.
+func (o *OS) Symlink(to, from string) error {
+	command := fmt.Sprintf("ln -s %s %s", to, from)
+	if !o.knobs.silent {
+		o.logger.Print(command)
+	}
+
+	_, err := o.Next(command, func() (output string, err error) {
+		return "", os.Symlink(to, from)
+	})
+	return err
+}
+
 // CopyAll recursively copies a directory from one location to another.
 // Uses OS.ListFilesWithSuffix, OS.MkdirAll, and OS.CopyFile to discover files, create directories,
 // and move files, respectively


### PR DESCRIPTION
**dev: symlink githooks/ into .git/hooks**

Fixes https://github.com/cockroachdb/cockroach/issues/84362, doing something the Makefile previously did.

---

**Makefile: add deprecation warning and alternate suggestions**

Closes #75734. We now shout the following at the very top:
```
  [WARNING] Makefile is deprecated and will be removed shortly.
```
For common subcommands, we provide best-effort hints for the dev alternatives:
```
  $ make build
  [WARNING] Use `dev build cockroach` instead.

  $ make buildshort
  [WARNING] Use `dev build cockroach-short` instead.

  $ make test PKG=./pkg/sql TESTS='TestCascadingZoneConfig' TESTFLAGS=-v
  [WARNING] Use `dev test pkg/sql --filter TestCascadingZoneConfig --test-args "-v"` instead.

  $ make stressrace PKG=./pkg/spanconfig/spanconfigmanager TESTS=TestManagerCheckJobConditions TESTFLAGS='-v -show-logs'
  [WARNING] Use `dev test --stress --race pkg/spanconfig/spanconfigmanager --filter TestManagerCheckJobConditions --test-args "-v -show-logs" --timeout 45m` instead.

  $ make testccllogic FILES='zone_config'
  [WARNING] Use `dev test pkg/ccl/logictestccl  --filter Test(CCL|Tenant)Logic//^zone_config$/ --test-args "-test.v -show-sql "` instead.

  $ make bench PKG=./pkg/spanconfig/spanconfigkvsubscriber BENCHES='BenchmarkSpanConfigDecoder' TESTFLAGS='-v -count 2 -benchtime=10x'
  [WARNING] Use `dev bench pkg/spanconfig/spanconfigkvsubscriber --filter BenchmarkSpanConfigDecoder --timeout 5m --test-args "-v -count 2 -benchtime=10x"` instead.

  $ make lint TESTS=TestLint/CODEOWNERS
  [WARNING] Use `dev lint  --filter TestLint/CODEOWNERS --timeout 30m` instead.

  $ make lintshort TESTS=TestGolint
  [WARNING] Use `dev lint --filter TestGolint --timeout 30m` instead.

  $ make acceptance TESTS=TestDockerC PKG=./pkg/acceptance TESTFLAGS=-v
  [WARNING] Use `dev acceptance pkg/acceptance --filter TestDockerC --timeout 30m --test-args "-v"` instead.

  $ make generate
  [WARNING] Use `dev generate protobuf` instead.
  [WARNING] Use `dev generate` instead.
  [WARNING] Use `dev generate execgen` instead.

  $ make protobuf
  [WARNING] Use `dev generate protobuf` instead.

  $ make bazel-generate
  [WARNING] Use `dev generate bazel` instead.

  $ make ui-maintainer-clean
  [WARNING] Use `dev ui clean` instead.
  [WARNING] Use `dev ui clean --all` instead.
```
Release note: None