### PR TITLE
backupccl: correctly restore tables that conflict with system tables

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -20,10 +20,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descidgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -643,6 +648,26 @@ func TestDataDriven(t *testing.T) {
 				}
 				return ""
 
+			case "create-dummy-system-table":
+				db := ds.servers[lastCreatedServer].DB()
+				codec := ds.servers[lastCreatedServer].ExecutorConfig().(sql.ExecutorConfig).Codec
+				dummyTable := systemschema.SettingsTable
+				err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+					id, err := descidgen.GenerateUniqueDescID(ctx, db, codec)
+					if err != nil {
+						return err
+					}
+					mut := dummyTable.NewBuilder().BuildCreatedMutable().(*tabledesc.Mutable)
+					mut.ID = id
+					mut.Name = fmt.Sprintf("dummy_test_table_%d", id)
+					tKey := catalogkeys.EncodeNameKey(codec, mut)
+					b := txn.NewBatch()
+					b.CPut(tKey, mut.GetID(), nil)
+					b.CPut(catalogkeys.MakeDescMetadataKey(codec, mut.GetID()), mut.DescriptorProto(), nil)
+					return txn.Run(ctx, b)
+				})
+				require.NoError(t, err)
+				return ""
 			default:
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2481,7 +2481,7 @@ func (r *restoreResumer) restoreSystemTables(
 
 			if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				if err := systemTable.config.migrationFunc(ctx, r.execCfg, txn,
-					systemTable.stagingTableName); err != nil {
+					systemTable.stagingTableName, details.DescriptorRewrites); err != nil {
 					return err
 				}
 
@@ -2505,7 +2505,7 @@ func (r *restoreResumer) restoreSystemTables(
 			}
 
 			log.Eventf(ctx, "restoring system table %s", systemTable.systemTableName)
-			err := restoreFunc(ctx, r.execCfg, txn, systemTable.systemTableName, systemTable.stagingTableName)
+			err := restoreFunc(ctx, r.execCfg, txn, systemTable.systemTableName, systemTable.stagingTableName, details.DescriptorRewrites)
 			if err != nil {
 				return errors.Wrapf(err, "restoring system table %s", systemTable.systemTableName)
 			}

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -553,6 +553,13 @@ ORDER BY
 			{"non-system", "3"},
 		})
 		sqlDB.CheckQueryResults(t, "SELECT * FROM data.bank", [][]string{{"1"}})
+		// Check that we can select from every known system
+		// table and haven't clobbered any.
+		for systemTableName, config := range systemTableBackupConfiguration {
+			if !config.expectMissingInSystemTenant {
+				sqlDB.Exec(t, fmt.Sprintf("SELECT * FROM system.%s", systemTableName))
+			}
+		}
 	}
 }
 

--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -79,6 +79,11 @@ type systemBackupConfiguration struct {
 	// holds the restore system table data into the given system table. If none
 	// is provided then `defaultRestoreFunc` is used.
 	customRestoreFunc func(ctx context.Context, execCtx *sql.ExecutorConfig, txn *kv.Txn, systemTableName, tempTableName string) error
+
+	// The following fields are for testing.
+
+	// expectMissingInSystemTenant is true for tables that only exist in secondary tenants.
+	expectMissingInSystemTenant bool
 }
 
 // defaultSystemTableRestoreFunc is how system table data is restored. This can
@@ -401,6 +406,7 @@ var systemTableBackupConfiguration = map[string]systemBackupConfiguration{
 	},
 	systemschema.SpanCountTable.GetName(): {
 		shouldIncludeInClusterBackup: optOutOfClusterBackup,
+		expectMissingInSystemTenant:  true,
 	},
 	systemschema.SystemPrivilegeTable.GetName(): {
 		shouldIncludeInClusterBackup: optOutOfClusterBackup,

--- a/pkg/ccl/backupccl/testdata/backup-restore/descriptor-conflicts
+++ b/pkg/ccl/backupccl/testdata/backup-restore/descriptor-conflicts
@@ -1,0 +1,75 @@
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE foo;
+CREATE SCHEMA foo.bar;
+CREATE TYPE foo.bar.baz AS ENUM('a', 'b', 'c');
+CREATE TABLE foo.bar.bat (pk int primary key, b foo.bar.baz);
+INSERT INTO foo.bar.bat VALUES (1, 'a'),(2, 'b'),(3, 'c');
+ALTER TABLE foo.bar.bat CONFIGURE ZONE USING gc.ttlseconds=999;
+COMMENT ON TABLE foo.bar.bat IS 'should survive';
+CREATE ROLE hamburger;
+ALTER ROLE hamburger IN DATABASE foo SET application_name='helper';
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://0/conflicting-descriptors';
+----
+
+new-server name=s2 share-io-dir=s1
+----
+
+# Create 4 dummy system tables that will conflict
+# with the database, schema, table, and type created
+# in s1.
+
+create-dummy-system-table
+----
+
+create-dummy-system-table
+----
+
+create-dummy-system-table
+----
+
+create-dummy-system-table
+----
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://0/conflicting-descriptors';
+----
+
+query-sql
+SELECT * FROM foo.bar.bat;
+----
+1 a
+2 b
+3 c
+
+query-sql
+SELECT count(1) FROM [SHOW TABLES FROM system] WHERE table_name LIKE 'dummy_test_table_%';
+----
+4
+
+query-sql
+SHOW ZONE CONFIGURATION FROM TABLE foo.bar.bat;
+----
+TABLE foo.bar.bat ALTER TABLE foo.bar.bat CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 999,
+	num_replicas = 3,
+	constraints = '[]',
+	lease_preferences = '[]'
+
+query-sql
+SELECT comment FROM [SHOW TABLES FROM foo WITH COMMENT] WHERE table_name = 'bat';
+----
+should survive
+
+query-sql
+select role_name, settings FROM system.database_role_settings AS drs JOIN system.namespace AS ns ON ns.id = drs.database_id WHERE ns.name = 'foo';
+----
+hamburger {application_name=helper}
+


### PR DESCRIPTION
This change fixes a bug in which a restore on 22.1 clusters would
either fail with an error such as

    restoring system table ‹tenant_settings›: deleting data from
    system.‹tenant_settings›: ‹tenant_settings-data-deletion›: relation
    ‹"system.tenant_settings"› does not exist-

Or succeed but overwrite the descriptor for the tenant_settings table.

The descriptor IDs contained in a backup may conflict with the IDs
that already exist in the database. During restore, we look for such
conflicts, allocate new IDs for the objects being restored, and rekey
any KV data that has descriptor IDs embedded in the key while
importing the data.

However, during a _full cluster restore_, we assume that we do not
need to rekey any databases or tables other than system tables that
exist in the backup, because the destination cluster is otherwise
empty.

In previous releases, this was a good assumption. The only tables that
could conflict were system tables. All system tables in the backup are
restored to a temporary database under new IDs; and any system tables
in the existing cluster were at known, reserved IDs that could not
conflict with user data.

However, in 22.1 we removed the arbitrary limit on system tables,
requiring that their IDs are no longer fixed.

In a fresh 22.1 cluster, the tenant_settings table has ID 50. However,
in a cluster that was upgraded from 21.2, ID 50 is likely already
allocated (likely as the database descriptor ID for defaultdb) as it
was previously the first non-reserved ID.  A backup created on such a
cluster thus has descriptors using ID 50 which won't be rekeyed but
which will conflict with the tenant_settings table.

Here we fix this by detecting such conflicts and both (1) preparing
the necessary descriptor rewrites and rekeys and (2) accounting for
system table ID conflicts when setting the id generator key to avoid
leaking too many IDs.

Note that in the case of 22.1 backups, the conflict is likely to occur
on id 50, which means that it is likely that _every_ table in the
backup will be rewritten for users whose clusters started on versions
before 22.1.

Fixes #84359

Release note (bug fix): Fix bug that prevents restoring a backup taken
on 22.1.