### PR TITLE
sql: make setup of leaf txn for streamer more bullet-proof

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
-	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -477,7 +476,7 @@ func (dsp *DistSQLPlanner) Run(
 			// given a LeafTxn. In order for that LeafTxn to be created later,
 			// during the flow setup, we need to populate leafInputState below,
 			// so we tell the localState that there is concurrency.
-			if row.CanUseStreamer(ctx, dsp.st) {
+			if execinfra.CanUseStreamer(dsp.st) {
 				for _, proc := range plan.Processors {
 					if jr := proc.Spec.Core.JoinReader; jr != nil {
 						// Both index and lookup joins, with and without

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -16,29 +16,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvstreamer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
-)
-
-// CanUseStreamer returns whether the kvstreamer.Streamer API should be used.
-func CanUseStreamer(ctx context.Context, settings *cluster.Settings) bool {
-	return useStreamerEnabled.Get(&settings.SV)
-}
-
-// useStreamerEnabled determines whether the Streamer API should be used.
-// TODO(yuzefovich): remove this in 23.1.
-var useStreamerEnabled = settings.RegisterBoolSetting(
-	settings.TenantReadOnly,
-	"sql.distsql.use_streamer.enabled",
-	"determines whether the usage of the Streamer API is allowed. "+
-		"Enabling this will increase the speed of lookup/index joins "+
-		"while adhering to memory limits.",
-	true,
 )
 
 // txnKVStreamer handles retrieval of key/values.


### PR DESCRIPTION
This commit makes sure that we try to use the streamer API only if we
can actually create a non-nil `LeafTxn`. In some edge cases it appears
that all the previous checks were insufficient, and this commit should
take care of that. Note that I couldn't reproduce those edge cases
manually, so there is no regression test.

Fixes: #84239.

Release note: None