### PR TITLE
sql: ban inv idx's on columns that are part of pk

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -749,25 +749,47 @@ func addIndexMutationWithSpecificPrimaryKey(
 		return err
 	}
 
-	setKeySuffixColumnIDsFromPrimary(toAdd, primary)
-	if tempIdx := catalog.FindCorrespondingTemporaryIndexByID(table, toAdd.ID); tempIdx != nil {
-		setKeySuffixColumnIDsFromPrimary(tempIdx.IndexDesc(), primary)
+	if err := setKeySuffixColumnIDsFromPrimary(table, toAdd, primary); err != nil {
+		return err
 	}
-
+	if tempIdx := catalog.FindCorrespondingTemporaryIndexByID(table, toAdd.ID); tempIdx != nil {
+		if err := setKeySuffixColumnIDsFromPrimary(table, tempIdx.IndexDesc(), primary); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
 // setKeySuffixColumnIDsFromPrimary uses the columns in the given
 // primary index to construct this toAdd's KeySuffixColumnIDs list.
 func setKeySuffixColumnIDsFromPrimary(
-	toAdd *descpb.IndexDescriptor, primary *descpb.IndexDescriptor,
-) {
+	table *tabledesc.Mutable, toAdd *descpb.IndexDescriptor, primary *descpb.IndexDescriptor,
+) error {
 	presentColIDs := catalog.MakeTableColSet(toAdd.KeyColumnIDs...)
 	presentColIDs.UnionWith(catalog.MakeTableColSet(toAdd.StoreColumnIDs...))
 	toAdd.KeySuffixColumnIDs = nil
+	invIdx := toAdd.Type == descpb.IndexDescriptor_INVERTED
 	for _, colID := range primary.KeyColumnIDs {
 		if !presentColIDs.Contains(colID) {
 			toAdd.KeySuffixColumnIDs = append(toAdd.KeySuffixColumnIDs, colID)
+		} else if invIdx && colID == toAdd.InvertedColumnID() {
+			// In an inverted index, the inverted column's value is not equal to the
+			// actual data in the row for that column. As a result, if the inverted
+			// column happens to also be in the primary key, it's crucial that
+			// the index key still be suffixed with that full primary key value to
+			// preserve the index semantics.
+			// toAdd.KeySuffixColumnIDs = append(toAdd.KeySuffixColumnIDs, colID)
+			// However, this functionality is not supported by the execution engine,
+			// so prevent it by returning an error.
+			col, err := table.FindColumnWithID(colID)
+			if err != nil {
+				return err
+			}
+			return unimplemented.NewWithIssuef(84405,
+				"primary key column %s cannot be present in an inverted index",
+				col.GetName(),
+			)
 		}
 	}
+	return nil
 }

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/sql/rowenc",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/sem/catconstants",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/volatility",

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -750,13 +751,35 @@ func (desc *Mutable) allocateIndexIDs(columnNames map[string]descpb.ColumnID) er
 
 		// KeySuffixColumnIDs is only populated for indexes using the secondary
 		// index encoding. It is the set difference of the primary key minus the
-		// index's key.
+		// non-inverted columns in the index's key.
 		colIDs := idx.CollectKeyColumnIDs()
+		isInverted := idx.GetType() == descpb.IndexDescriptor_INVERTED
+		invID := catid.ColumnID(0)
+		if isInverted {
+			invID = idx.InvertedColumnID()
+		}
 		var extraColumnIDs []descpb.ColumnID
 		for _, primaryColID := range desc.PrimaryIndex.KeyColumnIDs {
 			if !colIDs.Contains(primaryColID) {
 				extraColumnIDs = append(extraColumnIDs, primaryColID)
 				colIDs.Add(primaryColID)
+			} else if invID == primaryColID {
+				// In an inverted index, the inverted column's value is not equal to the
+				// actual data in the row for that column. As a result, if the inverted
+				// column happens to also be in the primary key, it's crucial that
+				// the index key still be suffixed with that full primary key value to
+				// preserve the index semantics.
+				// extraColumnIDs = append(extraColumnIDs, primaryColID)
+				// However, this functionality is not supported by the execution engine,
+				// so prevent it by returning an error.
+				col, err := desc.FindColumnWithID(primaryColID)
+				if err != nil {
+					return err
+				}
+				return unimplemented.NewWithIssuef(84405,
+					"primary key column %s cannot be present in an inverted index",
+					col.GetName(),
+				)
 			}
 		}
 		if idx.GetEncodingType() == descpb.SecondaryIndexEncoding {

--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -123,3 +123,23 @@ SELECT * FROM a@a_t_idx WHERE t = 'foozoopa' OR t = 'Foo' ORDER BY a
 ----
 1  foozoopa
 2  Foo
+
+# Ensure that it's not possible to create a trigram index on a column that is also
+# part of the primary key.
+
+statement ok
+CREATE TABLE pkt (a TEXT PRIMARY KEY); INSERT INTO pkt VALUES ('abcd'), ('bcde')
+
+statement error primary key column a cannot be present in an inverted index
+CREATE INVERTED INDEX ON pkt(a gin_trgm_ops)
+
+# Ensure that it's not possible to ALTER PRIMARY KEY to a column that's already
+# inverted indexed.
+
+statement ok
+DROP TABLE pkt;
+CREATE TABLE pkt (a INT PRIMARY KEY, b TEXT NOT NULL, INVERTED INDEX(b gin_trgm_ops));
+INSERT INTO pkt VALUES (1, 'abcd'), (2, 'bcde')
+
+statement error primary key column b cannot be present in an inverted index
+ALTER TABLE pkt ALTER PRIMARY KEY USING COLUMNS (b)


### PR DESCRIPTION
Updates #84405

This commit adds an explicit error if a user tries to create an inverted
index on a column that's part of a primary key, or if a user tries to
alter a primary key to include a column that's already participating in
an inverted index.

This limitation is added to avoid buggy behavior, but it could be lifted
at a future time.

Release note: None