### PR TITLE
sql/logictest: fix flake in crdb_internal/max_retry_counter

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -773,6 +773,11 @@ start_pretty    end_pretty
 /Table/112/2/2  /Table/112/2/3
 /Table/112/2/3  /Max
 
+# The cleanup we expect in the following truncate requires that the GCJob runs.
+# To avoid this taking 30 seconds, we lower the job adoption interval.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '1s'
+
 statement ok
 TRUNCATE TABLE foo
 
@@ -782,7 +787,7 @@ TRUNCATE TABLE foo
 query TT retry
 SELECT start_pretty, end_pretty FROM crdb_internal.ranges
 WHERE split_enforced_until IS NOT NULL
-AND (start_pretty LIKE '/Table/58/1%' OR start_pretty LIKE '/Table/58/2%')
+AND (start_pretty LIKE '/Table/112/1%' OR start_pretty LIKE '/Table/112/2%')
 ----
 
 statement ok
@@ -795,12 +800,6 @@ query TT colnames,retry
 SELECT start_pretty, end_pretty FROM crdb_internal.ranges WHERE split_enforced_until IS NOT NULL
 ----
 start_pretty    end_pretty
-/Table/112/1/1  /Table/112/1/2
-/Table/112/1/2  /Table/112/1/3
-/Table/112/1/3  /Table/112/2/1
-/Table/112/2/1  /Table/112/2/2
-/Table/112/2/2  /Table/112/2/3
-/Table/112/2/3  /Table/112/3/1
 /Table/112/3/1  /Table/112/3/2
 /Table/112/3/2  /Table/112/3/3
 /Table/112/3/3  /Table/112/4/1


### PR DESCRIPTION
The test creates splits points, truncates the table, and then creates
new split points.

In 7780e1e085d the table IDs in this test changed. This change was
reflected in the expectations, but not in one of queries that waited
for the truncate to clean up the splits.

This was likely hidden by the fact that the `retry` option eventually
allowed the following assertions that depended on the cleanup to
succeed.

Then, in subsequent changes, we rewrote the test assertions to expect
that the cleanup _didn't_ happen. This was also fine most of the time
because the cleanup only happens in a job and the job adoption
interval is rather long by default.

But, every so often, we get unlucky and the job runs quickly.

This change updates the query we use to wait for the TRUNCATE cleanup,
updates the subsequent expectations to require that the cleanup has
happened, and lowers the job adoption interval so that the test
doesn't take so long.

Release note: None