### PR TITLE
sql/logictests: don't fail parent test when using retry

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3248,9 +3248,11 @@ func (t *logicTest) processSubtest(
 
 				for i := 0; i < repeat; i++ {
 					if query.retry && !*rewriteResultsInTestfiles {
-						testutils.SucceedsSoon(t.rootT, func() error {
+						if err := testutils.SucceedsSoonError(func() error {
 							return t.execQuery(query)
-						})
+						}); err != nil {
+							t.Error(err)
+						}
 					} else {
 						if query.retry && *rewriteResultsInTestfiles {
 							// The presence of the retry flag indicates that we expect this


### PR DESCRIPTION
testutils.SucceedsSoon calls Fatal() on the passed testing.T.  Here,
we were calling SucceedsSoon with the root T, which in the case of a
subtest resulted in this error showing up in our logs

    testing.go:1169: test executed panic(nil) or runtime.Goexit:
    subtest may have called FailNow on a parent test

This moves to using SucceedsSoonError so that we can process errors
using the same formatting that we use elsewhere.

Release note: None