### PR TITLE
ccl: upgrade by-name sequence reference to by-ID during restore

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -256,6 +256,7 @@ ALL_TESTS = [
     "//pkg/sql/catalog/seqexpr:seqexpr_disallowed_imports_test",
     "//pkg/sql/catalog/seqexpr:seqexpr_test",
     "//pkg/sql/catalog/systemschema_test:systemschema_test_test",
+    "//pkg/sql/catalog/tabledesc:tabledesc_disallowed_imports_test",
     "//pkg/sql/catalog/tabledesc:tabledesc_test",
     "//pkg/sql/catalog/typedesc:typedesc_test",
     "//pkg/sql/catalog:catalog_disallowed_imports_test",

--- a/pkg/ccl/backupccl/restore_old_sequences_test.go
+++ b/pkg/ccl/backupccl/restore_old_sequences_test.go
@@ -79,35 +79,29 @@ func restoreOldSequencesTest(exportDir string) func(t *testing.T) {
 			t.Fatalf("expected %d rows, got %d", totalRows, importedRows)
 		}
 
-		// Verify that sequences created in older versions cannot be renamed, nor can the
-		// database they are referencing.
-		sqlDB.ExpectErr(t,
-			`pq: cannot rename relation "test.public.s" because view "t1" depends on it`,
-			`ALTER SEQUENCE test.s RENAME TO test.s2`)
-		sqlDB.ExpectErr(t,
-			`pq: cannot rename relation "test.public.t1_i_seq" because view "t1" depends on it`,
-			`ALTER SEQUENCE test.t1_i_seq RENAME TO test.t1_i_seq_new`)
-		sqlDB.ExpectErr(t,
-			`pq: cannot rename database because relation "test.public.t1" depends on relation "test.public.s"`,
-			`ALTER DATABASE test RENAME TO new_test`)
+		// Verify that restored sequences are now referenced by ID.
+		var createTable string
+		sqlDB.QueryRow(t, `SHOW CREATE test.t1`).Scan(&unused, &createTable)
+		require.Contains(t, createTable, "i INT8 NOT NULL DEFAULT nextval('test.public.t1_i_seq'::REGCLASS)")
+		require.Contains(t, createTable, "j INT8 NOT NULL DEFAULT nextval('test.public.s'::REGCLASS)")
+		sqlDB.QueryRow(t, `SHOW CREATE test.v`).Scan(&unused, &createTable)
+		require.Contains(t, createTable, "SELECT nextval('test.public.s2'::REGCLASS)")
+		sqlDB.QueryRow(t, `SHOW CREATE test.v2`).Scan(&unused, &createTable)
+		require.Contains(t, createTable, "SELECT nextval('test.public.s2'::REGCLASS) AS k")
 
-		sequenceResults := [][]string{
+		// Verify that, as a result, all sequences can now be renamed.
+		sqlDB.Exec(t, `ALTER SEQUENCE test.t1_i_seq RENAME TO test.t1_i_seq_new`)
+		sqlDB.Exec(t, `ALTER SEQUENCE test.s RENAME TO test.s_new`)
+		sqlDB.Exec(t, `ALTER SEQUENCE test.s2 RENAME TO test.s2_new`)
+
+		// Finally, verify that sequences are correctly restored and can be used in tables/views.
+		sqlDB.Exec(t, `INSERT INTO test.t1 VALUES (default, default)`)
+		expectedRows := [][]string{
 			{"1", "1"},
 			{"2", "2"},
 		}
-
-		// Verify that tables with old sequences aren't corrupted.
-		sqlDB.Exec(t, `SET database = test; INSERT INTO test.t1 VALUES (default, default)`)
-		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t1 ORDER BY i`, sequenceResults)
-
-		// Verify that the views are okay, and the sequences it depends on cannot be renamed.
-		sqlDB.CheckQueryResults(t, `SET database = test; SELECT * FROM test.v`, [][]string{{"1"}})
-		sqlDB.CheckQueryResults(t, `SET database = test; SELECT * FROM test.v2`, [][]string{{"2"}})
-		sqlDB.ExpectErr(t,
-			`pq: cannot rename relation "s2" because view "v" depends on it`,
-			`ALTER SEQUENCE s2 RENAME TO s3`)
-		sqlDB.CheckQueryResults(t, `SET database = test; SHOW CREATE VIEW test.v`, [][]string{{
-			"test.public.v", "CREATE VIEW public.v (\n\tnextval\n) AS (SELECT nextval('s2':::STRING))",
-		}})
+		sqlDB.CheckQueryResults(t, `SELECT * FROM test.t1 ORDER BY i`, expectedRows)
+		sqlDB.CheckQueryResults(t, `SELECT * FROM test.v`, [][]string{{"1"}})
+		sqlDB.CheckQueryResults(t, `SELECT * FROM test.v2`, [][]string{{"2"}})
 	}
 }

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/rewrite"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
@@ -863,6 +864,12 @@ func resolveTargetDB(
 // the set provided are omitted during the upgrade, instead of causing an error
 // to be returned.
 func maybeUpgradeDescriptors(descs []catalog.Descriptor, skipFKsWithNoMatchingTable bool) error {
+	// A data structure for efficient descriptor lookup by ID or by name.
+	descCatalog := &nstree.MutableCatalog{}
+	for _, d := range descs {
+		descCatalog.UpsertDescriptorEntry(d)
+	}
+
 	for j, desc := range descs {
 		var b catalog.DescriptorBuilder
 		if tableDesc, isTable := desc.(catalog.TableDescriptor); isTable {
@@ -873,14 +880,7 @@ func maybeUpgradeDescriptors(descs []catalog.Descriptor, skipFKsWithNoMatchingTa
 		if err := b.RunPostDeserializationChanges(); err != nil {
 			return errors.NewAssertionErrorWithWrappedErrf(err, "error during RunPostDeserializationChanges")
 		}
-		err := b.RunRestoreChanges(func(id descpb.ID) catalog.Descriptor {
-			for _, d := range descs {
-				if d.GetID() == id {
-					return d
-				}
-			}
-			return nil
-		})
+		err := b.RunRestoreChanges(descCatalog.LookupDescriptorEntry)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "descriptor.go",
         "descriptor_id_set.go",
         "errors.go",
-        "post_derserialization_changes.go",
+        "post_deserialization_changes.go",
         "privilege_object.go",
         "schema.go",
         "synthetic_privilege.go",

--- a/pkg/sql/catalog/post_deserialization_changes.go
+++ b/pkg/sql/catalog/post_deserialization_changes.go
@@ -86,4 +86,8 @@ const (
 	// dropping a schema, we'd mark the database itself as though it was the
 	// schema which was dropped.
 	RemovedSelfEntryInSchemas
+
+	// UpgradedSequenceReference indicates that the table/view had upgraded
+	// their sequence references, if any, from by-name to by-ID, if not already.
+	UpgradedSequenceReference
 )

--- a/pkg/sql/catalog/seqexpr/BUILD.bazel
+++ b/pkg/sql/catalog/seqexpr/BUILD.bazel
@@ -8,11 +8,14 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/seqexpr",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/catalog/descpb",
+        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/builtins/builtinconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -21,11 +24,13 @@ go_test(
     srcs = ["sequence_test.go"],
     deps = [
         ":seqexpr",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/parser",
         "//pkg/sql/sem/builtins",
         "//pkg/sql/sem/builtins/builtinsregistry",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/sql/catalog/seqexpr/sequence_test.go
+++ b/pkg/sql/catalog/seqexpr/sequence_test.go
@@ -15,12 +15,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/seqexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins" // register all builtins in builtins:init() for seqexpr package
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetSequenceFromFunc(t *testing.T) {
@@ -122,7 +124,7 @@ func TestGetUsedSequences(t *testing.T) {
 }
 
 func TestReplaceSequenceNamesWithIDs(t *testing.T) {
-	namesToID := map[string]int64{
+	namesToID := map[string]descpb.ID{
 		"seq": 123,
 	}
 
@@ -157,4 +159,127 @@ func TestReplaceSequenceNamesWithIDs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpgradeSequenceReferenceInExpr(t *testing.T) {
+	t.Run("test name-matching -- fully resolved candidate names", func(t *testing.T) {
+		usedSequenceIDsToNames := make(map[descpb.ID]*tree.TableName)
+		tbl1 := tree.MakeTableNameWithSchema("testdb", "sc1", "t")
+		tbl2 := tree.MakeTableNameWithSchema("testdb", "sc2", "t")
+		usedSequenceIDsToNames[1] = &tbl1
+		usedSequenceIDsToNames[2] = &tbl2
+		expr := "nextval('testdb.sc1.t') + nextval('sc1.t')"
+		hasUpgraded, err := seqexpr.UpgradeSequenceReferenceInExpr(&expr, usedSequenceIDsToNames, builtinsregistry.GetBuiltinProperties)
+		require.NoError(t, err)
+		require.True(t, hasUpgraded)
+		require.Equal(t,
+			"nextval(1:::REGCLASS) + nextval(1:::REGCLASS)",
+			expr)
+	})
+
+	t.Run("test name-matching -- partially resolved candidate names", func(t *testing.T) {
+		usedSequenceIDsToNames := make(map[descpb.ID]*tree.TableName)
+		tbl1 := tree.MakeTableNameWithSchema("", "sc1", "t")
+		tbl2 := tree.MakeTableNameWithSchema("testdb", "sc2", "t")
+		usedSequenceIDsToNames[1] = &tbl1
+		usedSequenceIDsToNames[2] = &tbl2
+		expr := "nextval('testdb.sc1.t') + nextval('sc1.t')"
+		hasUpgraded, err := seqexpr.UpgradeSequenceReferenceInExpr(&expr, usedSequenceIDsToNames, builtinsregistry.GetBuiltinProperties)
+		require.NoError(t, err)
+		require.True(t, hasUpgraded)
+		require.Equal(t,
+			"nextval(1:::REGCLASS) + nextval(1:::REGCLASS)",
+			expr)
+	})
+
+	t.Run("test name-matching -- public schema will be assumed when it's missing in candidate names",
+		func(t *testing.T) {
+			usedSequenceIDsToNames := make(map[descpb.ID]*tree.TableName)
+			tbl1 := tree.MakeTableNameWithSchema("testdb", "", "t")
+			tbl2 := tree.MakeTableNameWithSchema("", "sc2", "t")
+			usedSequenceIDsToNames[1] = &tbl1
+			usedSequenceIDsToNames[2] = &tbl2
+			expr := "nextval('testdb.public.t') + nextval('testdb.t')"
+			hasUpgraded, err := seqexpr.UpgradeSequenceReferenceInExpr(&expr, usedSequenceIDsToNames, builtinsregistry.GetBuiltinProperties)
+			require.NoError(t, err)
+			require.True(t, hasUpgraded)
+			require.Equal(t,
+				"nextval(1:::REGCLASS) + nextval(1:::REGCLASS)",
+				expr)
+		})
+
+	t.Run("test name-matching -- ambiguous name matching, >1 candidates", func(t *testing.T) {
+		usedSequenceIDsToNames := make(map[descpb.ID]*tree.TableName)
+		tbl1 := tree.MakeTableNameWithSchema("", "sc1", "t")
+		tbl2 := tree.MakeTableNameWithSchema("", "sc2", "t")
+		usedSequenceIDsToNames[1] = &tbl1
+		usedSequenceIDsToNames[2] = &tbl2
+		expr := "nextval('t')"
+		_, err := seqexpr.UpgradeSequenceReferenceInExpr(&expr, usedSequenceIDsToNames, builtinsregistry.GetBuiltinProperties)
+		require.Error(t, err, "ambiguous name matching for 't'; both 'sc1.t' and 'sc2.t' match it.")
+		require.Equal(t, "more than 1 matches found for \"t\"", err.Error())
+	})
+
+	t.Run("test name-matching -- no matching name, 0 candidate", func(t *testing.T) {
+		usedSequenceIDsToNames := make(map[descpb.ID]*tree.TableName)
+		tbl1 := tree.MakeTableNameWithSchema("", "sc1", "t")
+		tbl2 := tree.MakeTableNameWithSchema("", "sc2", "t")
+		usedSequenceIDsToNames[1] = &tbl1
+		usedSequenceIDsToNames[2] = &tbl2
+		expr := "nextval('t2')"
+		_, err := seqexpr.UpgradeSequenceReferenceInExpr(&expr, usedSequenceIDsToNames, builtinsregistry.GetBuiltinProperties)
+		require.Error(t, err, "no matching name for 't2'; neither 'sc1.t' nor 'sc2.t' match it.")
+		require.Equal(t, "no table name found to match input \"t2\"", err.Error())
+	})
+
+	t.Run("all seq references are by-ID (no upgrades)", func(t *testing.T) {
+		usedSequenceIDsToNames := make(map[descpb.ID]*tree.TableName)
+		tbl1 := tree.MakeTableNameWithSchema("testdb", "public", "s1")
+		tbl2 := tree.MakeTableNameWithSchema("testdb", "public", "s2")
+		tbl3 := tree.MakeTableNameWithSchema("testdb", "sc1", "s3")
+		usedSequenceIDsToNames[1] = &tbl1
+		usedSequenceIDsToNames[2] = &tbl2
+		usedSequenceIDsToNames[3] = &tbl3
+		expr := "((nextval(1::REGCLASS) + nextval(2::REGCLASS)) + currval(3::REGCLASS)) + nextval(3::REGCLASS)"
+		hasUpgraded, err := seqexpr.UpgradeSequenceReferenceInExpr(&expr, usedSequenceIDsToNames, builtinsregistry.GetBuiltinProperties)
+		require.NoError(t, err)
+		require.False(t, hasUpgraded)
+		require.Equal(t,
+			"((nextval(1::REGCLASS) + nextval(2::REGCLASS)) + currval(3::REGCLASS)) + nextval(3::REGCLASS)",
+			expr)
+	})
+
+	t.Run("all seq references are by-name", func(t *testing.T) {
+		usedSequenceIDsToNames := make(map[descpb.ID]*tree.TableName)
+		tbl1 := tree.MakeTableNameWithSchema("testdb", "public", "s1")
+		tbl2 := tree.MakeTableNameWithSchema("testdb", "public", "s2")
+		tbl3 := tree.MakeTableNameWithSchema("testdb", "sc1", "s3")
+		usedSequenceIDsToNames[1] = &tbl1
+		usedSequenceIDsToNames[2] = &tbl2
+		usedSequenceIDsToNames[3] = &tbl3
+		expr := "nextval('testdb.public.s1') + nextval('testdb.public.s2') + currval('testdb.sc1.s3') + nextval('testdb.sc1.s3')"
+		hasUpgraded, err := seqexpr.UpgradeSequenceReferenceInExpr(&expr, usedSequenceIDsToNames, builtinsregistry.GetBuiltinProperties)
+		require.NoError(t, err)
+		require.True(t, hasUpgraded)
+		require.Equal(t,
+			"((nextval(1:::REGCLASS) + nextval(2:::REGCLASS)) + currval(3:::REGCLASS)) + nextval(3:::REGCLASS)",
+			expr)
+	})
+
+	t.Run("mixed by-name and by-ID seq references", func(t *testing.T) {
+		usedSequenceIDsToNames := make(map[descpb.ID]*tree.TableName)
+		tbl1 := tree.MakeTableNameWithSchema("testdb", "public", "s1")
+		tbl2 := tree.MakeTableNameWithSchema("testdb", "public", "s2")
+		tbl3 := tree.MakeTableNameWithSchema("testdb", "sc1", "s3")
+		usedSequenceIDsToNames[1] = &tbl1
+		usedSequenceIDsToNames[2] = &tbl2
+		usedSequenceIDsToNames[3] = &tbl3
+		expr := "nextval('testdb.public.s1') + nextval(2::REGCLASS) + currval('testdb.sc1.s3') + nextval('testdb.sc1.s3')"
+		hasUpgraded, err := seqexpr.UpgradeSequenceReferenceInExpr(&expr, usedSequenceIDsToNames, builtinsregistry.GetBuiltinProperties)
+		require.NoError(t, err)
+		require.True(t, hasUpgraded)
+		require.Equal(t,
+			"((nextval(1:::REGCLASS) + nextval(2::REGCLASS)) + currval(3:::REGCLASS)) + nextval(3:::REGCLASS)",
+			expr)
+	})
 }

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//build/bazelutil/unused_checker:unused.bzl", "get_x_data")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "tabledesc",
@@ -33,6 +34,7 @@ go_library(
         "//pkg/sql/catalog/internal/validate",
         "//pkg/sql/catalog/multiregion",
         "//pkg/sql/catalog/schemaexpr",
+        "//pkg/sql/catalog/seqexpr",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/lexbase",
         "//pkg/sql/parser",
@@ -41,6 +43,7 @@ go_library(
         "//pkg/sql/privilege",
         "//pkg/sql/rowenc",
         "//pkg/sql/schemachanger/scpb",
+        "//pkg/sql/sem/builtins/builtinsregistry",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
@@ -112,6 +115,13 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_google_protobuf//proto",
+    ],
+)
+
+disallowed_imports_test(
+    "tabledesc",
+    disallowed_list = [
+        "//pkg/sql/sem/builtins",
     ],
 )
 

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -15,8 +15,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/seqexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
@@ -113,14 +117,28 @@ func (tdb *tableDescriptorBuilder) RunPostDeserializationChanges() error {
 func (tdb *tableDescriptorBuilder) RunRestoreChanges(
 	descLookupFn func(id descpb.ID) catalog.Descriptor,
 ) (err error) {
+	// Upgrade FK representation
 	upgradedFK, err := maybeUpgradeForeignKeyRepresentation(
 		descLookupFn,
 		tdb.skipFKsWithNoMatchingTable,
 		tdb.maybeModified,
 	)
+	if err != nil {
+		return err
+	}
 	if upgradedFK {
 		tdb.changes.Add(catalog.UpgradedForeignKeyRepresentation)
 	}
+
+	// Upgrade sequence reference
+	upgradedSequenceReference, err := maybeUpgradeSequenceReference(descLookupFn, tdb.maybeModified)
+	if err != nil {
+		return err
+	}
+	if upgradedSequenceReference {
+		tdb.changes.Add(catalog.UpgradedSequenceReference)
+	}
+
 	return err
 }
 
@@ -771,4 +789,186 @@ func maybeAddConstraintIDs(desc *descpb.TableDescriptor) (hasChanged bool) {
 
 	}
 	return desc.NextConstraintID != initialConstraintID
+}
+
+// maybeUpgradeSequenceReference attempts to upgrade by-name sequence references.
+// If `rel` is a table: upgrade seq reference in each column;
+// If `rel` is a view: upgrade seq reference in its view query;
+// If `rel` is a sequence: upgrade its back-references to relations as "ByID".
+// All these attempts are on a best-effort basis.
+func maybeUpgradeSequenceReference(
+	descLookupFn func(id descpb.ID) catalog.Descriptor, rel *descpb.TableDescriptor,
+) (hasUpgraded bool, err error) {
+	if rel.IsTable() {
+		hasUpgraded, err = maybeUpgradeSequenceReferenceForTable(descLookupFn, rel)
+		if err != nil {
+			return hasUpgraded, err
+		}
+	} else if rel.IsView() {
+		hasUpgraded, err = maybeUpgradeSequenceReferenceForView(descLookupFn, rel)
+		if err != nil {
+			return hasUpgraded, err
+		}
+	} else if rel.IsSequence() {
+		// Upgrade all references to this sequence to "by-ID".
+		for i, ref := range rel.DependedOnBy {
+			if ref.ID != descpb.InvalidID && !ref.ByID {
+				rel.DependedOnBy[i].ByID = true
+				hasUpgraded = true
+			}
+		}
+	} else {
+		return hasUpgraded, errors.AssertionFailedf("table descriptor %v (%d) is not a "+
+			"table, view, or sequence.", rel.Name, rel.ID)
+	}
+
+	return hasUpgraded, err
+}
+
+// maybeUpgradeSequenceReferenceForTable upgrades all by-name sequence references
+// in `tableDesc` to by-ID.
+func maybeUpgradeSequenceReferenceForTable(
+	descLookupFn func(id descpb.ID) catalog.Descriptor, tableDesc *descpb.TableDescriptor,
+) (hasUpgraded bool, err error) {
+	if !tableDesc.IsTable() {
+		return hasUpgraded, nil
+	}
+
+	for _, col := range tableDesc.Columns {
+		// Find sequence names for all sequences used in this column.
+		usedSequenceIDToNames, err := resolveTableNamesForIDs(descLookupFn, col.UsesSequenceIds)
+		if err != nil {
+			return hasUpgraded, err
+		}
+
+		// Upgrade sequence reference in DEFAULT expression, if any.
+		if col.HasDefault() {
+			hasUpgradedInDefault, err := seqexpr.UpgradeSequenceReferenceInExpr(col.DefaultExpr, usedSequenceIDToNames, builtinsregistry.GetBuiltinProperties)
+			if err != nil {
+				return hasUpgraded, err
+			}
+			hasUpgraded = hasUpgraded || hasUpgradedInDefault
+		}
+
+		// Upgrade sequence reference in ON UPDATE expression, if any.
+		if col.HasOnUpdate() {
+			hasUpgradedInOnUpdate, err := seqexpr.UpgradeSequenceReferenceInExpr(col.OnUpdateExpr, usedSequenceIDToNames, builtinsregistry.GetBuiltinProperties)
+			if err != nil {
+				return hasUpgraded, err
+			}
+			hasUpgraded = hasUpgraded || hasUpgradedInOnUpdate
+		}
+	}
+
+	return hasUpgraded, nil
+}
+
+// maybeUpgradeSequenceReferenceForView similarily upgrades all by-name sequence references
+// in `viewDesc` to by-ID.
+func maybeUpgradeSequenceReferenceForView(
+	descLookupFn func(id descpb.ID) catalog.Descriptor, viewDesc *descpb.TableDescriptor,
+) (hasUpgraded bool, err error) {
+	if !viewDesc.IsView() {
+		return hasUpgraded, err
+	}
+
+	// Find sequence names for all those used sequences.
+	usedSequenceIDToNames, err := resolveTableNamesForIDs(descLookupFn, viewDesc.DependsOn)
+	if err != nil {
+		return hasUpgraded, err
+	}
+
+	// A function that looks at an expression and replace any by-name sequence reference with
+	// by-ID reference. It, of course, also append replaced sequence IDs to `upgradedSeqIDs`.
+	replaceSeqFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		newExprStr := expr.String()
+		hasUpgradedInExpr, err := seqexpr.UpgradeSequenceReferenceInExpr(&newExprStr, usedSequenceIDToNames, builtinsregistry.GetBuiltinProperties)
+		if err != nil {
+			return false, expr, err
+		}
+		newExpr, err = parser.ParseExpr(newExprStr)
+		if err != nil {
+			return false, expr, err
+		}
+
+		hasUpgraded = hasUpgraded || hasUpgradedInExpr
+		return false, newExpr, err
+	}
+
+	stmt, err := parser.ParseOne(viewDesc.GetViewQuery())
+	if err != nil {
+		return hasUpgraded, err
+	}
+
+	newStmt, err := tree.SimpleStmtVisit(stmt.AST, replaceSeqFunc)
+	if err != nil {
+		return hasUpgraded, err
+	}
+
+	viewDesc.ViewQuery = newStmt.String()
+
+	return hasUpgraded, err
+}
+
+// Attempt to fully resolve table names for `ids` from a list of descriptors.
+// IDs that do not exist or do not identify a table descriptor will be skipped.
+//
+// This is done on a best-effort basis, meaning if we cannot find a table's
+// schema or database name from `descLookupFn`, they will be set to empty.
+// Consumers of the return of this function should hence expect non-fully resolved
+// table names.
+func resolveTableNamesForIDs(
+	descLookupFn func(id descpb.ID) catalog.Descriptor, ids []descpb.ID,
+) (map[descpb.ID]*tree.TableName, error) {
+	result := make(map[descpb.ID]*tree.TableName)
+
+	for _, id := range ids {
+		if _, exists := result[id]; exists {
+			continue
+		}
+
+		// Attempt to retrieve the table descriptor for `id`; Skip if it does not exist or it does not
+		// identify a table descriptor.
+		d := descLookupFn(id)
+		tableDesc, ok := d.(catalog.TableDescriptor)
+		if !ok {
+			continue
+		}
+
+		// Attempt to get its database and schema name on a best-effort basis.
+		dbName := ""
+		d = descLookupFn(tableDesc.GetParentID())
+		if dbDesc, ok := d.(catalog.DatabaseDescriptor); ok {
+			dbName = dbDesc.GetName()
+		}
+
+		scName := ""
+		d = descLookupFn(tableDesc.GetParentSchemaID())
+		if d != nil {
+			if scDesc, ok := d.(catalog.SchemaDescriptor); ok {
+				scName = scDesc.GetName()
+			}
+		} else {
+			if tableDesc.GetParentSchemaID() == keys.PublicSchemaIDForBackup {
+				// For backups created in 21.2 and prior, the "public" schema is descriptorless,
+				// and always uses the const `keys.PublicSchemaIDForBackUp` as the "public"
+				// schema ID.
+				scName = tree.PublicSchema
+			}
+		}
+
+		result[id] = tree.NewTableNameWithSchema(
+			tree.Name(dbName),
+			tree.Name(scName),
+			tree.Name(tableDesc.GetName()),
+		)
+		if dbName == "" {
+			result[id].ExplicitCatalog = false
+		}
+		if scName == "" {
+			result[id].ExplicitSchema = false
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -439,13 +439,13 @@ func replaceSeqNamesWithIDs(
 		if err != nil {
 			return false, expr, err
 		}
-		seqNameToID := make(map[string]int64)
+		seqNameToID := make(map[string]descpb.ID)
 		for _, seqIdentifier := range seqIdentifiers {
 			seqDesc, err := GetSequenceDescFromIdentifier(ctx, sc, seqIdentifier)
 			if err != nil {
 				return false, expr, err
 			}
-			seqNameToID[seqIdentifier.SeqName] = int64(seqDesc.ID)
+			seqNameToID[seqIdentifier.SeqName] = seqDesc.ID
 		}
 		newExpr, err = seqexpr.ReplaceSequenceNamesWithIDs(expr, seqNameToID, builtinsregistry.GetBuiltinProperties)
 		if err != nil {

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -415,7 +415,7 @@ func (b *builderState) WrapExpression(parentID catid.DescID, expr tree.Expr) *sc
 		if err != nil {
 			panic(err)
 		}
-		seqNameToID := make(map[string]int64)
+		seqNameToID := make(map[string]descpb.ID)
 		for _, seqIdentifier := range seqIdentifiers {
 			if seqIdentifier.IsByID() {
 				seqIDs.Add(catid.DescID(seqIdentifier.SeqID))
@@ -430,7 +430,7 @@ func (b *builderState) WrapExpression(parentID catid.DescID, expr tree.Expr) *sc
 				RequiredPrivilege:   privilege.SELECT,
 			})
 			_, _, seq := scpb.FindSequence(elts)
-			seqNameToID[seqIdentifier.SeqName] = int64(seq.SequenceID)
+			seqNameToID[seqIdentifier.SeqName] = seq.SequenceID
 			seqIDs.Add(seq.SequenceID)
 		}
 		if len(seqNameToID) > 0 {

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -833,7 +833,7 @@ func maybeAddSequenceDependencies(
 	}
 
 	var seqDescs []*tabledesc.Mutable
-	seqNameToID := make(map[string]int64)
+	seqNameToID := make(map[string]descpb.ID)
 	for _, seqIdentifier := range seqIdentifiers {
 		seqDesc, err := GetSequenceDescFromIdentifier(ctx, sc, seqIdentifier)
 		if err != nil {
@@ -850,7 +850,7 @@ func maybeAddSequenceDependencies(
 			)
 
 		}
-		seqNameToID[seqIdentifier.SeqName] = int64(seqDesc.ID)
+		seqNameToID[seqIdentifier.SeqName] = seqDesc.ID
 
 		// If we had already modified this Sequence as part of this transaction,
 		// we only want to modify a single instance of it instead of overwriting it.

--- a/pkg/upgrade/upgrades/upgrade_sequence_to_be_referenced_by_ID.go
+++ b/pkg/upgrade/upgrades/upgrade_sequence_to_be_referenced_by_ID.go
@@ -283,8 +283,8 @@ func maybeUpdateBackRefsAndBuildMap(
 	t *tabledesc.Mutable,
 	seqIdentifiers []seqexpr.SeqIdentifier,
 	changedSeqDescs *[]*tabledesc.Mutable,
-) (map[string]int64, error) {
-	seqNameToID := make(map[string]int64)
+) (map[string]descpb.ID, error) {
+	seqNameToID := make(map[string]descpb.ID)
 	for _, seqIdentifier := range seqIdentifiers {
 		seqDesc, err := sql.GetSequenceDescFromIdentifier(ctx, sc, seqIdentifier)
 		if err != nil {
@@ -309,7 +309,7 @@ func maybeUpdateBackRefsAndBuildMap(
 				*changedSeqDescs = append(*changedSeqDescs, seqDesc)
 			}
 		}
-		seqNameToID[seqDesc.GetName()] = int64(seqDesc.ID)
+		seqNameToID[seqDesc.GetName()] = seqDesc.ID
 	}
 
 	return seqNameToID, nil


### PR DESCRIPTION
In 20.2 and prior, sequences are referenced by-name. It was later
changed to reference-by-ID to enable things like
`ALTER SEQUENCE ... RENAME ...`.

But if a backup is taken in 20.2 and prior, and then the backup is
restored in a newer binary version (where sequence references should
be by-ID), we will need to also be able to upgrade those sequence
references from by-name to by-ID.

Release note: None