### PR TITLE
kvserver: avoid truncating off intermittently overloaded stores

### DIFF
--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -160,7 +160,7 @@ type raftLogQueue struct {
 func newRaftLogQueue(store *Store, db *kv.DB) *raftLogQueue {
 	rlq := &raftLogQueue{
 		db:           db,
-		logSnapshots: util.Every(10 * time.Second),
+		logSnapshots: util.Every(1 * time.Nanosecond), // HACK(tbg)
 	}
 	rlq.baseQueue = newBaseQueue(
 		"raftlog", rlq, store,
@@ -253,6 +253,40 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// efficient to catch up via a snapshot than via applying a long tail of log
 	// entries.
 	targetSize := r.store.cfg.RaftLogTruncationThreshold
+
+	// If we have paused followers, make log truncation lenient until the
+	// log is large enough so that catching up would certainly be slower.
+	// Without this, followers that are paused regularly due to an ongoing
+	// overload situation over time might be cut off from all logs and will
+	// be overloaded via snapshots instead.
+	ioThresholds := r.store.ioOverloadedStores.Load()
+	thresh := pauseReplicationIOThreshold.Get(&r.store.cfg.Settings.SV)
+	if thresh < 1.0 {
+		// We're pausing replication to followers based on `thresh`, but if we delay
+		// log truncations only while above that threshold, the moment we drop below
+		// we'll truncate the log. This is perhaps fine if the recovery is
+		// permanent, but more often than not it will be transient - we're hitting
+		// the store with more load again, so it might overload again. So use a
+		// lower threshold for delaying truncations, i.e. we will delay truncation
+		// for stores before and after they get paused, i.e. carry out the aggressive
+		// truncations only once the store has (hopefully) conclusively dipped below
+		// half the original threshold.
+		thresh /= 2
+	}
+	var maxScore float64
+	if len(r.mu.pausedFollowers) > 0 || (thresh > 0 && len(r.descRLocked().Replicas().Filter(func(rDesc roachpb.ReplicaDescriptor) bool {
+		iot, ok := ioThresholds[rDesc.StoreID]
+		if !ok {
+			return false
+		}
+		sc, _ := iot.Score()
+		if sc > maxScore {
+			maxScore = sc
+		}
+		return sc > thresh
+	}).AsProto()) > 0) {
+		targetSize = r.mu.conf.RangeMaxBytes
+	}
 	if targetSize > r.mu.conf.RangeMaxBytes {
 		targetSize = r.mu.conf.RangeMaxBytes
 	}
@@ -310,6 +344,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 		FirstIndex:           firstIndex,
 		LastIndex:            lastIndex,
 		PendingSnapshotIndex: pendingSnapshotIndex,
+		MaxIOThresholdScore:  maxScore,
 	}
 
 	decision := computeTruncateDecision(input)
@@ -367,6 +402,7 @@ type truncateDecisionInput struct {
 	LogSizeTrusted        bool // false when LogSize might be off
 	FirstIndex, LastIndex uint64
 	PendingSnapshotIndex  uint64
+	MaxIOThresholdScore   float64
 }
 
 func (input truncateDecisionInput) LogTooLarge() bool {
@@ -442,6 +478,9 @@ func (td *truncateDecision) String() string {
 	}
 	if !td.Input.LogSizeTrusted {
 		_, _ = fmt.Fprintf(&buf, "; log size untrusted")
+	}
+	if td.Input.MaxIOThresholdScore > 0 {
+		_, _ = fmt.Fprintf(&buf, "; max I/O overload: %.2f", td.Input.MaxIOThresholdScore)
 	}
 	buf.WriteRune(']')
 


### PR DESCRIPTION
When a follower is in an overload regime primarily caused by
replication, its IOThreshold score is expected to hit the overload
regime, dip below, hit it again, ad infinitum.

Before this commit, in this situation the raft log queue would
over time tend to cut off most replicas subject to intermittent
pausing, so the replication traffic would be replaced by snapshot
traffic in its entirety. At least in my experiments, the overload
seems to stabilize (i.e. despite snapshots, it doesn't go out of
whack) but it's a lot of redundant data transfer and certaintly
hurts the L0 file and sublevel count, so it would be good to avoid.

This commit instructs the raft log queue to use a much more lenient
target size for uncooperative truncations as long as any replica
in the range is within a factor of two of being pausable.

This has a few potential downsides: First, retaining the raft log for
extended periods of time causes higher LSM write amp. I think this is
not a big problem - the old threshold, 8mb of log per replica, is
already large enough to have most log entries flushed to L0, and so the
bulk of the write amplification will be incurred either way. Second,
many large raft logs might run the cluster out of disk; it would be
better to have an explicit trade-off between delaying truncations
and that but at present there is no such mechanism. Third, there
might be a performance penalty on the healthy nodes due to lower
cache efficiencies both in pebble and the raft entry cache. And
fourth, catching up on many very long raft logs at the same time
could known weaknesses in the raft transport related to memory
usage with increased likelihood.

However, there's also the clear upside - snapshots don't by default
undermine the benefit of pausing followers. Besides, the
`admission.kv.pause_replication_io_threshold` can be set to zero and the
defaults for log truncations will take hold immediately, in effect
providing an escape hatch.

Release note: None
