### PR TITLE
roachtest: lower descriptor lease duration in acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -113,6 +113,16 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 		//
 		// See the comment on createCheckpoints for details on fixtures.
 		uploadAndStartFromCheckpointFixture(c.All(), predecessorVersion),
+
+		// lower descriptor lease duration to 1 minute, working around a
+		// lease leak that can occasionally make this test time out (flake
+		// rate ~3%).
+		//
+		// TODO(renato): remove this call and function definition when
+		// https://github.com/cockroachdb/cockroach/issues/84382 is
+		// closed.
+		lowerLeaseDuration(1),
+
 		uploadAndInitSchemaChangeWorkload(),
 		waitForUpgradeStep(c.All()),
 		testFeaturesStep,
@@ -400,6 +410,18 @@ func enableTracingGloballyStep(ctx context.Context, t test.Test, u *versionUpgra
 	_, err := db.ExecContext(ctx, `SET CLUSTER SETTING trace.debug.enable = $1`, true)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+// lowerLeaseDuration sets the `sql.catalog.descriptor_lease_duration`
+// setting to 1 minute.
+func lowerLeaseDuration(node int) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		db := u.conn(ctx, t, node)
+		_, err := db.ExecContext(ctx, `SET CLUSTER SETTING sql.catalog.descriptor_lease_duration = '1m'`)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
The `acceptance/version-upgrade` test uncovered a descriptor lease
leak that can lead to the test timing out due to waiting a full lease
duration (5 minutes by default), making it flaky.

Once the bug is fixed, we should be able to use the default duration
again.

Relates to #84382.

Release note: None.