### PR TITLE
sql: filter internal queries from recording index usage reads

### DIFF
--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -616,7 +616,7 @@ func (ef *execFactory) ConstructIndexJoin(
 	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
 	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
-	if !ef.isExplain {
+	if !ef.isExplain && !ef.planner.isInternalPlanner {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tabDesc.GetID()),
 			IndexID: roachpb.IndexID(idx.GetID()),
@@ -676,7 +676,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
 	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
-	if !ef.isExplain {
+	if !ef.isExplain && !ef.planner.isInternalPlanner {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tabDesc.GetID()),
 			IndexID: roachpb.IndexID(idx.GetID()),
@@ -809,7 +809,7 @@ func (ef *execFactory) ConstructInvertedJoin(
 	tableScan.lockingStrength = descpb.ToScanLockingStrength(locking.Strength)
 	tableScan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(locking.WaitPolicy)
 
-	if !ef.isExplain {
+	if !ef.isExplain && !ef.planner.isInternalPlanner {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tabDesc.GetID()),
 			IndexID: roachpb.IndexID(idx.GetID()),
@@ -878,7 +878,7 @@ func (ef *execFactory) constructScanForZigzag(
 		return nil, nil, err
 	}
 
-	if !ef.isExplain {
+	if !ef.isExplain && !ef.planner.isInternalPlanner {
 		idxUsageKey := roachpb.IndexUsageKey{
 			TableID: roachpb.TableID(tableDesc.GetID()),
 			IndexID: roachpb.IndexID(idxDesc.GetID()),


### PR DESCRIPTION
Resolves: #84454

Previously, we were recording index reads in instances where an internal
query could be causing the read. However, we would like our recorded
index usage statistics to reflect how our users' workloads make use (or
lack of use) of their indexes. By filtering our internal queries, we
reflect user workloads more accurately, and can offer index
recommendations (i.e. drop unused indexes).

Release note: None