### PR TITLE
ui: update empty results message on SQL Activity

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/emptyStatementsPlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/emptyStatementsPlaceholder.tsx
@@ -50,10 +50,8 @@ function getMessage(type: StatementViewType): EmptyTableProps {
     case StatementViewType.FINGERPRINTS:
     default:
       return {
-        title: "No SQL statements since this page was last cleared",
+        title: "No SQL statements in the selected time interval",
         icon: emptyTableResultsImg,
-        message:
-          "Statements are cleared every hour by default, or according to your configuration.",
         footer,
       };
   }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/emptyTransactionsPlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/emptyTransactionsPlaceholder.tsx
@@ -51,10 +51,8 @@ function getMessage(type: TransactionViewType): EmptyTableProps {
     case TransactionViewType.FINGERPRINTS:
     default:
       return {
-        title: "No transactions since this page was last cleared",
+        title: "No transactions in the selected time interval",
         icon: emptyTableResultsImg,
-        message:
-          "Transactions are cleared every hour by default, or according to your configuration.",
         footer,
       };
   }


### PR DESCRIPTION
Previously, when there was no data on the time interval
selected, we were displaying a message still referencing
our previous behaviour of only saving info for 1h.
This commit updates the message to remove that reference
and point out there are no data on the selected time
interval.

Before
<img width="718" alt="Screen Shot 2022-07-15 at 12 00 01 PM" src="https://user-images.githubusercontent.com/1017486/179263425-5646544e-be30-46f8-8de8-570183187e4b.png">
<img width="688" alt="Screen Shot 2022-07-15 at 12 03 16 PM" src="https://user-images.githubusercontent.com/1017486/179263449-5fea490d-3f84-49c1-ad75-f03aa3df0bd2.png">


After
<img width="571" alt="Screen Shot 2022-07-15 at 2 10 58 PM" src="https://user-images.githubusercontent.com/1017486/179285422-547d0d73-5030-47a8-9550-7c184c902c07.png">
<img width="555" alt="Screen Shot 2022-07-15 at 2 11 05 PM" src="https://user-images.githubusercontent.com/1017486/179285440-d12da261-c144-435b-93a7-0a3a5e59e325.png">


Release note (ui change): Update the message when there is no
data on the selected time interval on Statement and Transaction
pages.