### PR TITLE
backupccl: disable `restore_at_current_time` until 22.1 finalization

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -125,7 +125,7 @@ var numRestoreWorkers = settings.RegisterIntSetting(
 var restoreAtNow = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"bulkio.restore_at_current_time.enabled",
-	"write restored data at the current timestamp",
+	"write restored data at the current timestamp (ignored until 22.1 finalization)",
 	true,
 )
 
@@ -404,12 +404,8 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	iter := sst.iter
 	defer sst.cleanup()
 
-	writeAtBatchTS := restoreAtNow.Get(&evalCtx.Settings.SV)
-	if writeAtBatchTS && !evalCtx.Settings.Version.IsActive(ctx, clusterversion.MVCCAddSSTable) {
-		return roachpb.BulkOpSummary{}, errors.Newf(
-			"cannot use %s until version %s", restoreAtNow.Key(), clusterversion.MVCCAddSSTable.String(),
-		)
-	}
+	writeAtBatchTS := restoreAtNow.Get(&evalCtx.Settings.SV) &&
+		evalCtx.Settings.Version.IsActive(ctx, clusterversion.MVCCAddSSTable)
 
 	// If the system tenant is restoring a guest tenant span, we don't want to
 	// forward all the restored data to now, as there may be importing tables in


### PR DESCRIPTION
In 22.1, the setting `bulkio.restore_at_current_time.enabled` was
introduced to write the restored data at the current timestamp, for MVCC
compliance. The setting defaults to `true`.

However, the version gate `MVCCAddSSTable` was required for this to
work, since it relied on new `AddSSTable` APIs added in 22.1. If the
cluster wasn't yet upgraded to this version, then restores with the
above default-true setting would fail with:

```
cannot use bulkio.restore_at_current_time.enabled until version MVCCAddSSTable
```

Given that the setting defaults to true, this patch instead falls back
to the 21.2 behavior if the cluster is not yet upgraded, rather than
erroring. The cluster setting description has been updated to reflect
this.

Release note (bug fix): Backup restores on mixed-version clusters that
had not yet finalized the upgrade to 22.1 could fail with `cannot use
bulkio.restore_at_current_time.enabled until version MVCCAddSSTable`.
Restores now fall back to the 21.2 behavior instead of erroring in this
scenario.