### PR TITLE
ui: update Jobs Details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -20,7 +20,7 @@ import { JobRequest, JobResponse } from "src/api/jobsApi";
 import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox } from "src/sql";
-import { SummaryCard } from "src/summaryCard";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import { TimestampToMoment } from "src/util";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { getMatchParamByName } from "src/util/query";
@@ -72,65 +72,66 @@ export class JobDetails extends React.Component<JobDetailsProps> {
     this.refresh();
   }
 
-  prevPage = () => this.props.history.goBack();
+  prevPage = (): void => this.props.history.goBack();
 
-  renderContent = () => {
+  renderContent = (): React.ReactElement => {
     const job = this.props.job;
     return (
-      <Row gutter={16}>
-        <Col className={commonStyles("gutter-row")} span={16}>
-          <SqlBox value={job.description} />
-          <SummaryCard>
-            <h3 className={cardCx("summary--card__status--title")}>Status</h3>
-            <JobStatusCell job={job} lineWidth={1.5} />
-          </SummaryCard>
-        </Col>
-        <Col className={commonStyles("gutter-row")} span={8}>
-          <SummaryCard>
-            <Row>
-              <Col span={24}>
-                <div className={cardCx("summary--card__counting")}>
-                  <h3 className={cardCx("summary--card__counting--value")}>
-                    {TimestampToMoment(job.created).format(DATE_FORMAT_24_UTC)}
-                  </h3>
-                  <p className={cardCx("summary--card__counting--label")}>
-                    Creation time
-                  </p>
-                </div>
-              </Col>
-              <Col span={24}>
-                <div className={cardCx("summary--card__counting")}>
-                  <h3 className={cardCx("summary--card__counting--value")}>
-                    {job.username}
-                  </h3>
-                  <p className={cardCx("summary--card__counting--label")}>
-                    Users
-                  </p>
-                </div>
-              </Col>
-              {job.highwater_timestamp ? (
-                <Col span={24}>
-                  <div className={cardCx("summary--card__counting")}>
-                    <h3 className={cardCx("summary--card__counting--value")}>
-                      <HighwaterTimestamp
-                        timestamp={job.highwater_timestamp}
-                        decimalString={job.highwater_decimal}
-                      />
-                    </h3>
-                    <p className={cardCx("summary--card__counting--label")}>
-                      High-water Timestamp
-                    </p>
-                  </div>
-                </Col>
-              ) : null}
-            </Row>
-          </SummaryCard>
-        </Col>
-      </Row>
+      <>
+        <Row gutter={24}>
+          <Col className="gutter-row" span={24}>
+            <SqlBox value={job.description} />
+          </Col>
+        </Row>
+        <Row gutter={24}>
+          <Col className="gutter-row" span={12}>
+            <SummaryCard>
+              <h3 className={jobCx("summary--card--title")}>Status</h3>
+              <JobStatusCell job={job} lineWidth={1.5} hideDuration={true} />
+              <h3 className={jobCx("summary--card--title", "secondary")}>
+                Next Planned Execution Time:
+              </h3>
+              {TimestampToMoment(job.next_run).format(DATE_FORMAT_24_UTC)}
+            </SummaryCard>
+          </Col>
+          <Col className="gutter-row" span={12}>
+            <SummaryCard className={cardCx("summary-card")}>
+              <SummaryCardItem
+                label="Creation Time"
+                value={TimestampToMoment(job.created).format(
+                  DATE_FORMAT_24_UTC,
+                )}
+              />
+              <SummaryCardItem
+                label="Last Execution Time"
+                value={TimestampToMoment(job.last_run).format(
+                  DATE_FORMAT_24_UTC,
+                )}
+              />
+              <SummaryCardItem
+                label="Execution Count"
+                value={String(job.num_runs)}
+              />
+              <SummaryCardItem label="User Name" value={job.username} />
+              {job.highwater_timestamp && (
+                <SummaryCardItem
+                  label="High-water Timestamp"
+                  value={
+                    <HighwaterTimestamp
+                      timestamp={job.highwater_timestamp}
+                      decimalString={job.highwater_decimal}
+                    />
+                  }
+                />
+              )}
+            </SummaryCard>
+          </Col>
+        </Row>
+      </>
     );
   };
 
-  render() {
+  render(): React.ReactElement {
     const isLoading = !this.props.job || this.props.jobLoading;
     const error = this.props.job && this.props.jobError;
     return (

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
@@ -129,14 +129,16 @@
     }
   }
 
-  .summary--card__status {
-    &--title {
-      font-family: $font-family--base;
-      font-size: $font-size--tall;
-      line-height: 1.5;
-      color: $colors--neutral-7;
-      margin-bottom: 15px;
-    }
+  .summary--card--title {
+    font-family: $font-family--base;
+    font-size: $font-size--tall;
+    font-weight: $font-weight--bold;
+    line-height: 1.5;
+    color: $colors--neutral-8;
+    margin-bottom: 15px;
+  }
+  .secondary {
+    margin-top: 15px;
   }
   .page--header__title {
     margin-bottom: 30px;

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobStatus.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobStatus.tsx
@@ -30,12 +30,14 @@ export interface JobStatusProps {
   job: Job;
   lineWidth?: number;
   compact?: boolean;
+  hideDuration?: boolean;
 }
 
 export const JobStatus: React.FC<JobStatusProps> = ({
   job,
   compact,
   lineWidth,
+  hideDuration = false,
 }) => {
   const visualType = jobToVisual(job);
 
@@ -46,7 +48,9 @@ export const JobStatus: React.FC<JobStatusProps> = ({
       return (
         <div>
           <JobStatusBadge jobStatus={job.status} />
-          <Duration job={job} className={cx("jobs-table__duration")} />
+          {!hideDuration && (
+            <Duration job={job} className={cx("jobs-table__duration")} />
+          )}
         </div>
       );
     case JobStatusVisual.ProgressBarWithDuration: {

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobStatusCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobStatusCell.tsx
@@ -22,15 +22,22 @@ export interface JobStatusCellProps {
   job: Job;
   lineWidth?: number;
   compact?: boolean;
+  hideDuration?: boolean;
 }
 
 export const JobStatusCell: React.FC<JobStatusCellProps> = ({
   job,
   lineWidth,
   compact = false,
+  hideDuration = false,
 }) => {
   const jobStatus = (
-    <JobStatus job={job} lineWidth={lineWidth} compact={compact} />
+    <JobStatus
+      job={job}
+      lineWidth={lineWidth}
+      compact={compact}
+      hideDuration={hideDuration}
+    />
   );
   if (isRetrying(job.status)) {
     return (
@@ -39,7 +46,7 @@ export const JobStatusCell: React.FC<JobStatusCellProps> = ({
         style="tableTitle"
         content={
           <>
-            Next Execution Time:
+            Next Planned Execution Time:
             <br />
             {TimestampToMoment(job.next_run).format(DATE_FORMAT_24_UTC)}
           </>

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -8,6 +8,13 @@
   margin-bottom: 15px;
   font-family: $font-family--base;
   font-size: $font-size--medium;
+  h4 {
+    @include text--body-strong;
+    color: $colors--neutral-7;
+  }
+  p {
+    @include text--body;
+  }
   &__divider {
     width: 100%;
     height: 1px;


### PR DESCRIPTION
Update Jobs Details page to most recent design,
aligning with the format from Statement Details page.
New information added for Last Execution Time, Next
Execution Time and Execution Count.

Fixes #83949

Before
<img width="1398" alt="Screen Shot 2022-07-15 at 12 21 44 PM" src="https://user-images.githubusercontent.com/1017486/179284906-08347977-725f-4415-8350-d522d8cca5ad.png">


After
<img width="1380" alt="Screen Shot 2022-07-15 at 2 02 34 PM" src="https://user-images.githubusercontent.com/1017486/179284956-84d9f062-8f4e-43dd-867f-c577d8aa4dd0.png">


Release note (ui change): Update Jobs Details page to new design
and add information about Last Execution Time, Next Execution
Time and Execution Count.