### PR TITLE
ui: Add Last Execution Time to Statements

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -17,7 +17,10 @@ import {
   StatementSummary,
   StatementStatistics,
   Count,
+  TimestampToNumber,
+  TimestampToMoment,
 } from "src/util";
+import { DATE_FORMAT } from "src/util/format";
 import {
   countBarChart,
   bytesReadBarChart,
@@ -180,6 +183,15 @@ function makeCommonColumns(
       },
       sort: (stmt: AggregateStatistics) => stmt.regionNodes.sort().join(", "),
       hideIfTenant: true,
+    },
+    {
+      name: "lastExecTimestamp",
+      title: statisticsTableTitles.lastExecTimestamp(statType),
+      cell: (stmt: AggregateStatistics) =>
+        TimestampToMoment(stmt.stats.last_exec_timestamp).format(DATE_FORMAT),
+      sort: (stmt: AggregateStatistics) =>
+        TimestampToNumber(stmt.stats.last_exec_timestamp),
+      showByDefault: false,
     },
   ];
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -57,6 +57,7 @@ export const statisticsColumnLabels = {
   time: "Time",
   transactions: "Transactions",
   workloadPct: "% of All Runtime",
+  lastExecTimestamp: "Last Execution Time (UTC)",
 };
 
 export const contentModifiers = {
@@ -376,6 +377,29 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         content={<p>Database on which the {contentModifier} was executed.</p>}
       >
         {getLabel("database")}
+      </Tooltip>
+    );
+  },
+  lastExecTimestamp: (statType: StatisticType) => {
+    let contentModifier = "";
+    switch (statType) {
+      case "transaction":
+        contentModifier = contentModifiers.transaction;
+        break;
+      case "statement":
+        contentModifier = contentModifiers.statement;
+        break;
+    }
+
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <p>Last time stamp on which the {contentModifier} was executed.</p>
+        }
+      >
+        {getLabel("lastExecTimestamp")}
       </Tooltip>
     );
   },


### PR DESCRIPTION
This adds the Last Execution Timestamp column 
to the SQL Activity Statements overview. This
will allow users to sort by which queries by when 
they were executed. The column is hidden by default.

closes #81913
<img width="616" alt="Screen Shot 2022-07-15 at 2 38 00 PM" src="https://user-images.githubusercontent.com/8868107/179296438-9d1e428c-0d01-42d8-b60c-e7a5794da6ba.png">


<img width="283" alt="Screen Shot 2022-07-15 at 3 17 54 PM" src="https://user-images.githubusercontent.com/8868107/179296412-fc298ea1-ae9b-412a-b16a-aaf3c55d45dd.png">


Release note: (ui change): Adds new Last Execution 
Time to Statements, which is hidden by default.