### PR TITLE
release-22.1: ui: remove link to stmt details on sessions details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -321,27 +321,6 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                   value={TimestampToMoment(stmt.start).format(DATE_FORMAT)}
                   className={cx("details-item")}
                 />
-                <SummaryCardItem
-                  label={
-                    <div className={cx("session-details-link")}>
-                      <Link
-                        to={StatementLinkTarget({
-                          statementFingerprintID: stmt.id,
-                          statementNoConstants: stmt.sql_no_constants,
-                          implicitTxn: session.active_txn?.implicit,
-                        })}
-                        onClick={() =>
-                          this.props.onStatementClick &&
-                          this.props.onStatementClick()
-                        }
-                      >
-                        View Statement Details
-                      </Link>
-                    </div>
-                  }
-                  value={""}
-                  className={cx("details-item")}
-                />
               </Col>
               <Col className="gutter-row" span={4} />
               <Col className="gutter-row" span={10}>


### PR DESCRIPTION
Backport 1/1 commits from #84485.

/cc @cockroachdb/release

---

Previously, when a statment was active, it would show
on the Sessions page with a link to view its details,
but since the statement was not yet saved/persisted,
clicking the link it would crash the Statement Details
page.
This commit removes this link.

Fixes #84462

Release note (ui change): Removal of `View Statement Details`
link inside the Sessions Details page.

---
Release justification: Category 2, bug fix
