### PR TITLE
execinfra: allow tenants to disable the streamer

### DIFF
--- a/pkg/sql/execinfra/readerbase.go
+++ b/pkg/sql/execinfra/readerbase.go
@@ -229,7 +229,7 @@ func (flowCtx *FlowCtx) UseStreamer() (bool, *kv.Txn, error) {
 // useStreamerEnabled determines whether the Streamer API should be used.
 // TODO(yuzefovich): remove this in 23.1.
 var useStreamerEnabled = settings.RegisterBoolSetting(
-	settings.TenantReadOnly,
+	settings.TenantWritable,
 	"sql.distsql.use_streamer.enabled",
 	"determines whether the usage of the Streamer API is allowed. "+
 		"Enabling this will increase the speed of lookup/index joins "+


### PR DESCRIPTION
Previously, we marked the setting that controls whether the streamer is
used as `TenantReadOnly` since we were not sure whether the streamer fit
well into the tenant cost model. Recently we revamped the cost model so
that it can now correctly predict the usage of the hardware resources by
the streamer, so at this point it seems safe to mark the setting
`TenantWritable`.

Informs: #82167

Release note: None