### PR TITLE
ui: update time picker options

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.tsx
@@ -78,7 +78,7 @@ export const TimeFrameControls = ({
       </ButtonGroup>
       <Tooltip
         placement="bottom"
-        title="past 1 day"
+        title="past day"
         mouseEnterDelay={delay}
         mouseLeaveDelay={delay}
       >

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
@@ -205,7 +205,7 @@ describe("<TimeScaleDropdown> component", function () {
     // When a preset option is selected, the dropdown should open to other preset options.
     userEvent.click(getByText("Past 10 Minutes"));
     getByText("Past 30 Minutes");
-    getByText("Past 1 Hour");
+    getByText("Past Hour");
 
     // Change to a custom selection
     userEvent.click(
@@ -227,7 +227,7 @@ describe("<TimeScaleDropdown> component", function () {
     // Clicking "Preset time intervals" should bring the dropdown back to the preset options.
     userEvent.click(getByText("Preset time intervals"));
     getByText("Past 30 Minutes");
-    getByText("Past 1 Hour");
+    getByText("Past Hour");
   });
 });
 
@@ -235,7 +235,7 @@ const initialEntries = [
   "#/metrics/overview/cluster", // Past 10 minutes
   `#/metrics/overview/cluster/cluster?start=${moment()
     .subtract(1, "hour")
-    .format("X")}&end=${moment().format("X")}`, // Past 1 hour
+    .format("X")}&end=${moment().format("X")}`, // Past hour
   `#/metrics/overview/cluster/cluster?start=${moment()
     .subtract(6, "hours")
     .format("X")}&end=${moment().format("X")}`, // Past 6 hours

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
@@ -18,7 +18,7 @@ import React from "react";
  * selected by the user.
  */
 export const timeScale1hMinOptions: TimeScaleOptions = {
-  "Past 1 Hour": {
+  "Past Hour": {
     windowSize: moment.duration(1, "hour"),
     windowValid: moment.duration(1, "minute"),
     sampleSize: moment.duration(30, "seconds"),
@@ -28,7 +28,7 @@ export const timeScale1hMinOptions: TimeScaleOptions = {
     windowValid: moment.duration(5, "minutes"),
     sampleSize: moment.duration(1, "minutes"),
   },
-  "Past 1 Day": {
+  "Past Day": {
     windowSize: moment.duration(1, "day"),
     windowValid: moment.duration(10, "minutes"),
     sampleSize: moment.duration(5, "minutes"),
@@ -84,8 +84,8 @@ export const defaultTimeScaleOptions: TimeScaleOptions = {
 };
 
 export const defaultTimeScaleSelected: TimeScale = {
-  ...defaultTimeScaleOptions["Past 1 Hour"],
-  key: "Past 1 Hour",
+  ...defaultTimeScaleOptions["Past Hour"],
+  key: "Past Hour",
   fixedWindowEnd: false,
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/keyVizualizer/timeWindow.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/keyVizualizer/timeWindow.tsx
@@ -25,7 +25,7 @@ export const KeyVizualizerTimeWindow = () => {
       windowValid: moment.duration(15, "minutes"),
       sampleSize: moment.duration(30, "seconds"),
     },
-    "Past 1 Hour": {
+    "Past Hour": {
       windowSize: moment.duration(1, "hour"),
       windowValid: moment.duration(15, "minutes"),
       sampleSize: moment.duration(30, "seconds"),
@@ -35,7 +35,7 @@ export const KeyVizualizerTimeWindow = () => {
       windowValid: moment.duration(15, "minutes"),
       sampleSize: moment.duration(1, "minutes"),
     },
-    "Past 1 Day": {
+    "Past Day": {
       windowSize: moment.duration(1, "day"),
       windowValid: moment.duration(15, "minutes"),
       sampleSize: moment.duration(5, "minutes"),


### PR DESCRIPTION
Previously we were using "Past 1" for hour and day,
but just "Past" for week and month.
This commit removes the "1" from the hour and day options,
to align with the week and month options.

<img width="452" alt="Screen Shot 2022-07-15 at 5 38 48 PM" src="https://user-images.githubusercontent.com/1017486/179314970-39022fae-a9e6-4f4c-b8c2-169d899b929a.png">



Release note (ui change): Update time picker options to remove
"1" on the hour and day options.