### PR TITLE
sql/schemachanger: implemented ALTER PRIMARY KEY for vanilla case 

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -568,18 +568,14 @@ func (p *planner) AlterPrimaryKey(
 
 	// Send a notice to users about how this job is asynchronous.
 	// TODO(knz): Mention the job ID in the client notice.
-	noticeStr := "primary key changes are finalized asynchronously"
 	if alterPrimaryKeyLocalitySwap != nil {
-		noticeStr = "LOCALITY changes will be finalized asynchronously"
+		p.BufferClientNotice(
+			ctx,
+			pgnotice.Newf(
+				"LOCALITY changes will be finalized asynchronously; "+
+					"further schema changes on this table may be restricted until the job completes"),
+		)
 	}
-	p.BufferClientNotice(
-		ctx,
-		pgnotice.Newf(
-			"%s; further schema changes on this table may be restricted "+
-				"until the job completes",
-			noticeStr,
-		),
-	)
 
 	return nil
 }

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -111,7 +111,7 @@ func (desc *wrapper) GetParentSchemaID() descpb.ID {
 
 // IndexKeysPerRow implements the TableDescriptor interface.
 func (desc *wrapper) IndexKeysPerRow(idx catalog.Index) int {
-	if desc.PrimaryIndex.ID == idx.GetID() {
+	if desc.PrimaryIndex.ID == idx.GetID() || idx.GetEncodingType() == descpb.PrimaryIndexEncoding {
 		return len(desc.Families)
 	}
 	if idx.NumSecondaryStoredColumns() == 0 || len(desc.Families) == 1 {

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1706,3 +1706,14 @@ t_pkey      i            ASC
 t_pkey      j            N/A
 t_j_key     j            ASC
 t_j_key     i            ASC
+
+
+subtest alter_primary_key_with_more_than_one_column_families
+statement ok
+CREATE TABLE t_multiple_cf (i INT PRIMARY KEY, j INT NOT NULL, FAMILY (i), FAMILY (j))
+
+statement ok
+INSERT INTO t_multiple_cf VALUES (23, 24)
+
+statement ok
+ALTER TABLE t_multiple_cf ALTER PRIMARY KEY USING COLUMNS (j)

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -4,10 +4,8 @@ CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, w INT, INDEX 
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 
-query T noticetrace
+statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y, z)
-----
-NOTICE: primary key changes are finalized asynchronously; further schema changes on this table may be restricted until the job completes
 
 query IIII rowsort
 SELECT * FROM t@t_pkey

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "alter_table.go",
         "alter_table_add_column.go",
+        "alter_table_alter_primary_key.go",
         "alter_table_drop_column.go",
         "comment_on.go",
         "create_index.go",
@@ -24,6 +25,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt",
     visibility = ["//pkg/sql/schemachanger/scbuild:__subpackages__"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
@@ -35,6 +37,7 @@ go_library(
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/decodeusername",
+        "//pkg/sql/paramparse",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -28,8 +28,9 @@ import (
 // declarative schema  changer. Operations marked as non-fully supported can
 // only be with the use_declarative_schema_changer session variable.
 var supportedAlterTableStatements = map[reflect.Type]supportedStatement{
-	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):  {alterTableAddColumn, true},
-	reflect.TypeOf((*tree.AlterTableDropColumn)(nil)): {alterTableDropColumn, true},
+	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):       {alterTableAddColumn, true},
+	reflect.TypeOf((*tree.AlterTableDropColumn)(nil)):      {alterTableDropColumn, true},
+	reflect.TypeOf((*tree.AlterTableAlterPrimaryKey)(nil)): {alterTableAlterPrimaryKey, false},
 }
 
 func init() {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -30,7 +30,7 @@ import (
 var supportedAlterTableStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):       {alterTableAddColumn, true},
 	reflect.TypeOf((*tree.AlterTableDropColumn)(nil)):      {alterTableDropColumn, true},
-	reflect.TypeOf((*tree.AlterTableAlterPrimaryKey)(nil)): {alterTableAlterPrimaryKey, false},
+	reflect.TypeOf((*tree.AlterTableAlterPrimaryKey)(nil)): {alterTableAlterPrimaryKey, true},
 }
 
 func init() {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -1,0 +1,766 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scbuildstmt
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+func alterTableAlterPrimaryKey(
+	b BuildCtx, tn *tree.TableName, tbl *scpb.Table, t *tree.AlterTableAlterPrimaryKey,
+) {
+	// Panic on certain forbidden `ALTER PRIMARY KEY` cases (e.g. one of
+	// the new primary key column is a virtual column). See the comments
+	// for a full list of preconditions we check.
+	checkForEarlyExit(b, tbl, t)
+
+	// Nothing to do if the requested new pk is the same as the old one.
+	if isNewPrimaryKeySameAsOldPrimaryKey(b, tbl, t) {
+		return
+	}
+
+	// TODO (xiang): This section contains all fall-back cases and need to
+	// be removed to fully support `ALTER PRIMARY KEY`.
+	fallBackIfConcurrentSchemaChange(b, tbl.TableID)
+	fallBackIfRequestToBeSharded(t)
+	fallBackIfSecondaryIndexExists(b, tbl.TableID)
+	fallBackIfRegionalByRowTable(b, tbl.TableID)
+	fallBackIfDescColInRowLevelTTLTables(b, tbl.TableID, t)
+
+	// Retrieve old primary index and its name elements.
+	oldPrimaryIndexElem, newPrimaryIndexElem := getPrimaryIndexes(b, tbl.TableID)
+	if newPrimaryIndexElem != nil {
+		// TODO (xiang): some other DDL stmt preceded this `ALTER PRIMARY KEY` and
+		// thus a new primary index has already been created. We'd like
+		// to support this use case one day
+		// (e.g. `ALTER TABLE t ADD COLUMN ..., ALTER PRIMARY KEY ...;`).
+		// Note that such scenarios should be caught above in
+		// `fallBackIfConcurrentSchemaChange` and an unimplemented error
+		// should be returned, so, here we panic with an programming error.
+		panic(errors.AssertionFailedf("programming error: new primary index has already existed."))
+	}
+	newPrimaryIndexElem = createNewPrimaryIndex(b, tbl, oldPrimaryIndexElem, func(
+		b BuildCtx, newPrimaryIndex *scpb.PrimaryIndex, _ []*scpb.IndexColumn,
+	) (newColumns []*scpb.IndexColumn) {
+		allColumns := getSortedAllColumnIDsInTable(b, tbl.TableID)
+
+		// Get all KEY columns from t.Columns
+		allColumnsNameToIDMapping := getAllColumnsNameToIDMapping(b, tbl.TableID)
+		allKeyColumnIDs := make(map[catid.ColumnID]bool)
+		for i, col := range t.Columns {
+			if colID, exist := allColumnsNameToIDMapping[string(col.Column)]; !exist {
+				panic(fmt.Sprintf("table %v does not have a column named %v", tn.String(), col.Column))
+			} else {
+				ic := &scpb.IndexColumn{
+					TableID:       tbl.TableID,
+					IndexID:       newPrimaryIndex.IndexID,
+					ColumnID:      colID,
+					OrdinalInKind: uint32(i),
+					Kind:          scpb.IndexColumn_KEY,
+					Direction:     indexColumnDirection(col.Direction),
+				}
+				b.Add(ic)
+				newColumns = append(newColumns, ic)
+				allKeyColumnIDs[colID] = true
+			}
+		}
+
+		// What's left are STORED columns, excluding virtual columns and system columns
+		i := 0
+		for _, colID := range allColumns {
+			if _, isKeyCol := allKeyColumnIDs[colID]; isKeyCol ||
+				mustRetrieveColumnTypeElem(b, tbl.TableID, colID).IsVirtual ||
+				colinfo.IsColIDSystemColumn(colID) {
+				continue
+			}
+			ic := &scpb.IndexColumn{
+				TableID:       tbl.TableID,
+				IndexID:       newPrimaryIndex.IndexID,
+				ColumnID:      colID,
+				OrdinalInKind: uint32(i),
+				Kind:          scpb.IndexColumn_STORED,
+			}
+			b.Add(ic)
+			newColumns = append(newColumns, ic)
+			i++
+		}
+
+		return newColumns
+	})
+	newPrimaryIndexElem.Sharding = makeShardedDescriptor(b, t)
+
+	// Construct and add elements for a unique secondary index created on
+	// the old primary key columns.
+	// This is a CRDB unique feature that exists in the legacy schema changer.
+	maybeAddUniqueIndexForOldPrimaryKey(b, tn, tbl, t, oldPrimaryIndexElem, newPrimaryIndexElem)
+}
+
+// checkForEarlyExit asserts several precondition for a
+// `ALTER PRIMARY KEY`, including
+//   1. no expression columns allowed;
+//   2. no columns that are in `DROPPED` state;
+//   3. no inaccessible columns;
+//   4. no nullable columns;
+//   5. no virtual columns (starting from v22.1);
+//   6. add more here
+// Panic if any precondition is found unmet.
+func checkForEarlyExit(b BuildCtx, tbl *scpb.Table, t *tree.AlterTableAlterPrimaryKey) {
+	if err := paramparse.ValidateUniqueConstraintParams(
+		t.StorageParams,
+		paramparse.UniqueConstraintParamContext{
+			IsPrimaryKey: true,
+			IsSharded:    t.Sharded != nil,
+		},
+	); err != nil {
+		panic(err)
+	}
+
+	for _, col := range t.Columns {
+		if col.Column == "" && col.Expr != nil {
+			panic(errors.WithHint(
+				pgerror.Newf(
+					pgcode.InvalidColumnDefinition,
+					"expressions such as %q are not allowed in primary index definition",
+					col.Expr.String(),
+				),
+				"use columns instead",
+			))
+		}
+
+		colElems := b.ResolveColumn(tbl.TableID, col.Column, ResolveParams{
+			IsExistenceOptional: false,
+			RequiredPrivilege:   privilege.CREATE,
+		})
+
+		colCurrentStatus, _, colElem := scpb.FindColumn(colElems)
+		if colElem == nil {
+			panic(errors.AssertionFailedf("programming error: resolving column %v does not give a "+
+				"Column element.", col.Column))
+		}
+		if colCurrentStatus == scpb.Status_DROPPED || colCurrentStatus == scpb.Status_ABSENT {
+			panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"column %q is being dropped", col.Column))
+		}
+		if colElem.IsInaccessible {
+			panic(pgerror.Newf(pgcode.InvalidSchemaDefinition, "cannot use inaccessible "+
+				"column %q in primary key", col.Column))
+		}
+		_, _, colTypeElem := scpb.FindColumnType(colElems)
+		if colTypeElem == nil {
+			panic(errors.AssertionFailedf("programming error: resolving column %v does not give a "+
+				"ColumnType element.", col.Column))
+		}
+		if colTypeElem.IsNullable {
+			panic(pgerror.Newf(pgcode.InvalidSchemaDefinition, "cannot use nullable column "+
+				"%q in primary key", col.Column))
+		}
+
+		if !b.EvalCtx().Settings.Version.IsActive(b, clusterversion.Start22_1) {
+			if colTypeElem.IsVirtual {
+				panic(pgerror.Newf(pgcode.FeatureNotSupported, "cannot use virtual column %q "+
+					"in primary key", col.Column))
+			}
+		}
+	}
+}
+
+// isNewPrimaryKeySameAsOldPrimaryKey returns whether the requested new
+// primary key is the same as the old primary key.
+func isNewPrimaryKeySameAsOldPrimaryKey(
+	b BuildCtx, tbl *scpb.Table, t *tree.AlterTableAlterPrimaryKey,
+) bool {
+	oldPrimaryIndexElem := mustRetrievePrimaryIndexElement(b, tbl.TableID)
+	oldPrimaryIndexKeyColumns := mustRetrieveKeyIndexColumns(b, tbl.TableID, oldPrimaryIndexElem.IndexID)
+
+	// Check whether they have the same number of key columns.
+	if len(oldPrimaryIndexKeyColumns) != len(t.Columns) {
+		return false
+	}
+
+	// Check whether they are both sharded or both not sharded.
+	if (oldPrimaryIndexElem.Sharding == nil) != (t.Sharded == nil) {
+		return false
+	}
+
+	// Check whether all key columns (ID and directions) are the same.
+	for i, col := range t.Columns {
+		colElems := b.ResolveColumn(tbl.TableID, col.Column, ResolveParams{
+			IsExistenceOptional: false,
+			RequiredPrivilege:   privilege.CREATE,
+		})
+		_, _, colElem := scpb.FindColumn(colElems)
+		if (oldPrimaryIndexKeyColumns[i].ColumnID != colElem.ColumnID) ||
+			oldPrimaryIndexKeyColumns[i].Direction != indexColumnDirection(col.Direction) {
+			return false
+		}
+	}
+
+	// If both are sharded, check whether they have the same bucket count.
+	if oldPrimaryIndexElem.Sharding != nil {
+		shardBucketsInNewPrimaryIndex, err := tabledesc.EvalShardBucketCount(b, b.SemaCtx(), b.EvalCtx(),
+			t.Sharded.ShardBuckets, t.StorageParams)
+		if err != nil {
+			panic(err)
+		}
+		if oldPrimaryIndexElem.Sharding.ShardBuckets != shardBucketsInNewPrimaryIndex {
+			return false
+		}
+	}
+
+	return true
+}
+
+// fallBackIfConcurrentSchemaChange panics with an unimplemented error if
+// there are any other concurrent schema change on this table. This is determined
+// by searching for any element that is currently not in its terminal status.
+func fallBackIfConcurrentSchemaChange(b BuildCtx, tableID catid.DescID) {
+	b.QueryByID(tableID).ForEachElementStatus(func(current scpb.Status, target scpb.TargetStatus, e scpb.Element) {
+		if current != target.Status() {
+			_, _, ns := scpb.FindNamespace(b.QueryByID(tableID))
+			if ns == nil {
+				panic(errors.AssertionFailedf("programming error: resolving table %v does not "+
+					"give a Namespace element", tableID))
+			}
+			panic(scerrors.NotImplementedErrorf(
+				nil,
+				"cannot perform a primary key change on %v with other schema changes on %v in the same transaction",
+				ns.Name, ns.Name))
+		}
+	})
+}
+
+// fallBackIfRequestToBeSharded panics with an unimplemented error
+// if it is requested to be hash-sharded.
+func fallBackIfRequestToBeSharded(t *tree.AlterTableAlterPrimaryKey) {
+	if t.Sharded != nil {
+		panic(scerrors.NotImplementedErrorf(nil, "ALTER PRIMARY KEY USING HASH is not yet supported."))
+	}
+}
+
+// fallBackIfSecondaryIndexExists panics with an unimplemented
+// error if there exists secondary indexes on the table, which might
+// need to be rewritten.
+func fallBackIfSecondaryIndexExists(b BuildCtx, tableID catid.DescID) {
+	_, _, sie := scpb.FindSecondaryIndex(b.QueryByID(tableID))
+	if sie != nil {
+		panic(scerrors.NotImplementedErrorf(nil, "ALTER PRIMARY KEY on a table with secondary index"+
+			"is not yet supported because they might need to be rewritten."))
+	}
+}
+
+// fallBackIfRegionalByRowTable panics with an unimplemented
+// error if it's a REGIONAL BY ROW table because we need to
+// include the implicit REGION column when constructing the
+// new primary key.
+func fallBackIfRegionalByRowTable(b BuildCtx, tableID catid.DescID) {
+	_, _, rbrElem := scpb.FindTableLocalityRegionalByRow(b.QueryByID(tableID))
+	if rbrElem != nil {
+		panic(scerrors.NotImplementedErrorf(nil, "ALTER PRIMARY KEY on a REGIONAL BY ROW table "+
+			"is not yet supported."))
+	}
+}
+
+// fallBackIfDescColInRowLevelTTLTables panics with an unimplemented
+// error if the table is a (row-level-ttl table && (it has a descending
+// key column || it has any inbound/outbound FK constraint)).
+func fallBackIfDescColInRowLevelTTLTables(
+	b BuildCtx, tableID catid.DescID, t *tree.AlterTableAlterPrimaryKey,
+) {
+	_, _, rowLevelTTLElem := scpb.FindRowLevelTTL(b.QueryByID(tableID))
+	if rowLevelTTLElem == nil {
+		return
+	}
+
+	// It's a row-level-ttl table. Ensure it has no non-descending
+	// key columns, and there is no inbound/outbound foreign keys.
+	for _, col := range t.Columns {
+		if indexColumnDirection(col.Direction) != catpb.IndexColumn_ASC {
+			panic(scerrors.NotImplementedErrorf(nil, "non-ascending ordering on PRIMARY KEYs are not supported"))
+		}
+	}
+
+	_, _, ns := scpb.FindNamespace(b.QueryByID(tableID))
+	hasFKConstraintError := scerrors.NotImplementedErrorf(nil, fmt.Sprintf(`foreign keys to/from 
+table with TTL "%s" are not permitted`, ns.Name))
+	// Panic if there is any inbound/outbound FK constraints.
+	_, _, inboundFKElem := scpb.FindForeignKeyConstraint(b.BackReferences(tableID))
+	if inboundFKElem != nil {
+		panic(hasFKConstraintError)
+	}
+	scpb.ForEachForeignKeyConstraint(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.ForeignKeyConstraint,
+	) {
+		panic(hasFKConstraintError)
+	})
+}
+
+func mustRetrievePrimaryIndexElement(b BuildCtx, tableID catid.DescID) (res *scpb.PrimaryIndex) {
+	scpb.ForEachPrimaryIndex(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.PrimaryIndex,
+	) {
+		// TODO (xiang): for now, we assume there is one primary index, which
+		// will not be true when there are DDL stmts (e.g. ADD/DROP COLUMN)
+		// before this `ALTER PRIMARY KEY`.
+		if current == scpb.Status_PUBLIC {
+			res = e
+		}
+	})
+	if res == nil {
+		panic(errors.AssertionFailedf("programming error: resolving table %v does not give "+
+			"a PrimaryIndex element", tableID))
+	}
+	return res
+}
+
+func mustRetrieveColumnElem(
+	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID,
+) (column *scpb.Column) {
+	scpb.ForEachColumn(b.QueryByID(tableID), func(current scpb.Status, target scpb.TargetStatus, e *scpb.Column) {
+		if e.ColumnID == columnID {
+			column = e
+		}
+	})
+	if column == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find a Column element for column ID %v", columnID))
+	}
+	return column
+}
+
+func mustRetrieveColumnNameElem(
+	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID,
+) (columnName *scpb.ColumnName) {
+	scpb.ForEachColumnName(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.ColumnName,
+	) {
+		if e.ColumnID == columnID {
+			columnName = e
+		}
+	})
+	if columnName == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find a ColumnName element for column ID %v", columnID))
+	}
+	return columnName
+}
+
+func mustRetrieveColumnTypeElem(
+	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID,
+) (columnType *scpb.ColumnType) {
+	scpb.ForEachColumnType(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.ColumnType,
+	) {
+		if e.ColumnID == columnID {
+			columnType = e
+		}
+	})
+	if columnType == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find a ColumnType element for column ID %v", columnID))
+	}
+	return columnType
+}
+
+func mustRetrieveIndexElement(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
+) (indexElem *scpb.Index) {
+	scpb.ForEachSecondaryIndex(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.SecondaryIndex,
+	) {
+		if e.IndexID == indexID {
+			indexElem = &e.Index
+		}
+	})
+	scpb.ForEachPrimaryIndex(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.PrimaryIndex,
+	) {
+		if e.IndexID == indexID {
+			indexElem = &e.Index
+		}
+	})
+	if indexElem == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find an index with ID %v from table %v",
+			indexID, tableID))
+	}
+	return indexElem
+}
+
+func mustRetrieveKeyIndexColumns(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
+) (indexColumns []*scpb.IndexColumn) {
+	scpb.ForEachIndexColumn(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.IndexColumn,
+	) {
+		if e.IndexID == indexID && e.Kind == scpb.IndexColumn_KEY {
+			indexColumns = append(indexColumns, e)
+		}
+	})
+	if indexColumns == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find any KEY index columns in "+
+			"index %v from table %v", indexID, tableID))
+	}
+	return indexColumns
+}
+
+// makeShardedDescriptor construct a sharded descriptor for the new primary key.
+// Return nil if the new primary key is not hash-sharded.
+func makeShardedDescriptor(b BuildCtx, t *tree.AlterTableAlterPrimaryKey) *catpb.ShardedDescriptor {
+	if t.Sharded == nil {
+		return nil
+	}
+
+	shardBuckets, err := tabledesc.EvalShardBucketCount(b, b.SemaCtx(), b.EvalCtx(),
+		t.Sharded.ShardBuckets, t.StorageParams)
+	if err != nil {
+		panic(err)
+	}
+	columnNames := make([]string, len(t.Columns))
+	for i, col := range t.Columns {
+		columnNames[i] = col.Column.String()
+	}
+
+	return &catpb.ShardedDescriptor{
+		IsSharded:    true,
+		Name:         tabledesc.GetShardColumnName(columnNames, shardBuckets),
+		ShardBuckets: shardBuckets,
+		ColumnNames:  columnNames,
+	}
+}
+
+// maybeAddUniqueIndexForOldPrimaryKey constructs and adds all necessary elements
+// for a unique index on the old primary key columns, if certain conditions are
+// met (see comments of shouldCreateUniqueIndexOnOldPrimaryKeyColumns for details).
+// Namely, it includes
+//     1. a SecondaryIndex element;
+//     2. a set of IndexColumn elements for the secondary index;
+//     3. a TemporaryIndex elements;
+//     4. a set of IndexColumn elements for the temporary index;
+//     5. a IndexName element;
+// This is a CRDB unique feature that helps optimize the performance of
+// queries that still filter on old primary key columns.
+func maybeAddUniqueIndexForOldPrimaryKey(
+	b BuildCtx,
+	tn *tree.TableName,
+	tbl *scpb.Table,
+	t *tree.AlterTableAlterPrimaryKey,
+	oldPrimaryIndex, newPrimaryIndex *scpb.PrimaryIndex,
+) {
+	if shouldCreateUniqueIndexOnOldPrimaryKeyColumns(b, tn, tbl, t,
+		oldPrimaryIndex.IndexID, newPrimaryIndex.IndexID) {
+		newUniqueSecondaryIndex, tempIndex := addNewUniqueSecondaryIndexAndTempIndex(b, tn, tbl, oldPrimaryIndex)
+		addIndexColumnsForNewUniqueSecondaryIndexAndTempIndex(b, tn, tbl, t,
+			oldPrimaryIndex.IndexID, newUniqueSecondaryIndex.IndexID, tempIndex.IndexID)
+		addIndexNameForNewUniqueSecondaryIndex(b, tbl, newUniqueSecondaryIndex.IndexID)
+	}
+}
+
+// addNewUniqueSecondaryIndexAndTempIndex constructs and adds elements for
+// a new secondary index and its associated temporary index.
+func addNewUniqueSecondaryIndexAndTempIndex(
+	b BuildCtx, tn *tree.TableName, tbl *scpb.Table, oldPrimaryIndexElem *scpb.PrimaryIndex,
+) (*scpb.SecondaryIndex, *scpb.TemporaryIndex) {
+	newSecondaryIndexElem := &scpb.SecondaryIndex{Index: scpb.Index{
+		TableID:             tbl.TableID,
+		IndexID:             nextRelationIndexID(b, tbl),
+		IsUnique:            true,
+		IsInverted:          oldPrimaryIndexElem.IsInverted,
+		Sharding:            oldPrimaryIndexElem.Sharding,
+		IsCreatedExplicitly: false,
+		SourceIndexID:       oldPrimaryIndexElem.IndexID,
+		TemporaryIndexID:    0,
+	}}
+	b.Add(newSecondaryIndexElem)
+
+	temporaryIndexElemForNewSecondaryIndex := &scpb.TemporaryIndex{
+		Index:                    protoutil.Clone(newSecondaryIndexElem).(*scpb.SecondaryIndex).Index,
+		IsUsingSecondaryEncoding: true,
+	}
+	b.AddTransient(temporaryIndexElemForNewSecondaryIndex)
+
+	temporaryIndexElemForNewSecondaryIndex.IndexID = nextRelationIndexID(b, tbl)
+	newSecondaryIndexElem.TemporaryIndexID = temporaryIndexElemForNewSecondaryIndex.IndexID
+
+	return newSecondaryIndexElem, temporaryIndexElemForNewSecondaryIndex
+}
+
+// addIndexColumnsForNewUniqueSecondaryIndexAndTempIndex constructs and adds IndexColumn
+// elements for the new primary index and its associated temporary index.
+func addIndexColumnsForNewUniqueSecondaryIndexAndTempIndex(
+	b BuildCtx,
+	tn *tree.TableName,
+	tbl *scpb.Table,
+	t *tree.AlterTableAlterPrimaryKey,
+	oldPrimaryIndexID catid.IndexID,
+	newUniqueSecondaryIndexID catid.IndexID,
+	temporaryIndexIDForNewUniqueSecondaryIndex catid.IndexID,
+) {
+	// KEY columns = old primary key columns
+	oldPrimaryIndexKeyColumns := mustRetrieveKeyIndexColumns(b, tbl.TableID, oldPrimaryIndexID)
+	oldPrimaryIndexKeyColumnIDs := make([]catid.ColumnID, len(oldPrimaryIndexKeyColumns))
+	for i, keyIndexCol := range oldPrimaryIndexKeyColumns {
+		oldPrimaryIndexKeyColumnIDs[i] = keyIndexCol.ColumnID
+	}
+
+	for _, keyIndexColumn := range oldPrimaryIndexKeyColumns {
+		b.Add(&scpb.IndexColumn{
+			TableID:       tbl.TableID,
+			IndexID:       newUniqueSecondaryIndexID,
+			ColumnID:      keyIndexColumn.ColumnID,
+			OrdinalInKind: keyIndexColumn.OrdinalInKind,
+			Kind:          scpb.IndexColumn_KEY,
+			Direction:     keyIndexColumn.Direction,
+		})
+		b.Add(&scpb.IndexColumn{
+			TableID:       tbl.TableID,
+			IndexID:       temporaryIndexIDForNewUniqueSecondaryIndex,
+			ColumnID:      keyIndexColumn.ColumnID,
+			OrdinalInKind: keyIndexColumn.OrdinalInKind,
+			Kind:          scpb.IndexColumn_KEY,
+			Direction:     keyIndexColumn.Direction,
+		})
+	}
+
+	// SUFFIX_KEY columns = new primary index columns - old primary key columns
+	// First find column IDs and dirs by their names, as specified in t.Columns.
+	newPrimaryIndexKeyColumnIDs := make([]catid.ColumnID, len(t.Columns))
+	newPrimaryIndexKeyColumnDirs := make([]catpb.IndexColumn_Direction, len(t.Columns))
+	allColumnsNameToIDMapping := getAllColumnsNameToIDMapping(b, tbl.TableID)
+	for i, col := range t.Columns {
+		if colID, exist := allColumnsNameToIDMapping[string(col.Column)]; !exist {
+			panic(fmt.Sprintf("table %v does not have a column named %v", tn.String(), col.Column))
+		} else {
+			newPrimaryIndexKeyColumnIDs[i] = colID
+			newPrimaryIndexKeyColumnDirs[i] = indexColumnDirection(col.Direction)
+		}
+	}
+
+	// Add each column that is not in the old primary key as a SUFFIX_KEY column.
+	for i, keyColIDInNewPrimaryIndex := range newPrimaryIndexKeyColumnIDs {
+		if !descpb.ColumnIDs(oldPrimaryIndexKeyColumnIDs).Contains(keyColIDInNewPrimaryIndex) {
+			b.Add(&scpb.IndexColumn{
+				TableID:       tbl.TableID,
+				IndexID:       newUniqueSecondaryIndexID,
+				ColumnID:      keyColIDInNewPrimaryIndex,
+				OrdinalInKind: uint32(i),
+				Kind:          scpb.IndexColumn_KEY_SUFFIX,
+				Direction:     newPrimaryIndexKeyColumnDirs[i],
+			})
+			b.Add(&scpb.IndexColumn{
+				TableID:       tbl.TableID,
+				IndexID:       temporaryIndexIDForNewUniqueSecondaryIndex,
+				ColumnID:      keyColIDInNewPrimaryIndex,
+				OrdinalInKind: uint32(i),
+				Kind:          scpb.IndexColumn_KEY_SUFFIX,
+				Direction:     newPrimaryIndexKeyColumnDirs[i],
+			})
+		}
+	}
+}
+
+// addIndexNameForNewUniqueSecondaryIndex constructs and adds an IndexName
+// element for the new, unique secondary index on the old primary key.
+func addIndexNameForNewUniqueSecondaryIndex(b BuildCtx, tbl *scpb.Table, indexID catid.IndexID) {
+	indexName := getImplicitSecondaryIndexName(b, tbl, indexID, 0 /* numImplicitColumns */)
+	b.Add(&scpb.IndexName{
+		TableID: tbl.TableID,
+		IndexID: indexID,
+		Name:    indexName,
+	})
+}
+
+// We only recreate the old primary key of the table as a unique secondary
+// index if:
+// * The table has a primary key (no DROP PRIMARY KEY statements have
+//   been executed).
+// * The primary key is not the default rowid primary key.
+// * The new primary key isn't the same set of columns and directions
+//   other than hash sharding.
+// * There is no partitioning change.
+// * There is no existing secondary index on the old primary key columns.
+func shouldCreateUniqueIndexOnOldPrimaryKeyColumns(
+	b BuildCtx,
+	tn *tree.TableName,
+	tbl *scpb.Table,
+	t *tree.AlterTableAlterPrimaryKey,
+	oldPrimaryIndexID catid.IndexID,
+	newPrimaryIndexID catid.IndexID,
+) bool {
+	// A function that retrieves all KEY columns of this index.
+	// If excludeShardedCol, sharded column is excluded, if any.
+	keyColumnIDsAndDirsOfIndex := func(
+		b BuildCtx, tableID catid.DescID, indexID catid.IndexID, excludeShardedCol bool,
+	) (
+		columnIDs descpb.ColumnIDs,
+		columnDirs []catpb.IndexColumn_Direction,
+	) {
+		sharding := mustRetrieveIndexElement(b, tableID, indexID).Sharding
+		allKeyIndexColumns := mustRetrieveKeyIndexColumns(b, tableID, indexID)
+		for _, keyIndexCol := range allKeyIndexColumns {
+			if !excludeShardedCol || sharding == nil ||
+				mustRetrieveColumnNameElem(b, tableID, keyIndexCol.ColumnID).Name != sharding.Name {
+				columnIDs = append(columnIDs, keyIndexCol.ColumnID)
+				columnDirs = append(columnDirs, keyIndexCol.Direction)
+			}
+		}
+		return columnIDs, columnDirs
+	}
+
+	// A function that checks whether two indexes have matching columns and directions,
+	// excluding shard column if specified.
+	keyColumnIDsAndDirsMatch := func(
+		b BuildCtx, tableID catid.DescID, oldIndexID, newIndexID catid.IndexID, excludeShardedCol bool,
+	) bool {
+		oldIDs, oldDirs := keyColumnIDsAndDirsOfIndex(b, tableID, oldIndexID, excludeShardedCol)
+		newIDs, newDirs := keyColumnIDsAndDirsOfIndex(b, tableID, newIndexID, excludeShardedCol)
+		if !oldIDs.Equals(newIDs) {
+			return false
+		}
+		for i := range oldDirs {
+			if oldDirs[i] != newDirs[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// A function that checks whether there exists a secondary index
+	// that is "identical" to the old primary index.
+	// It is used to avoid creating duplicate secondary index during
+	// `ALTER PRIMARY KEY`.
+	alreadyHasSecondaryIndexOnPKColumns := func(
+		b BuildCtx, tableID catid.DescID, oldPrimaryIndexID catid.IndexID,
+	) (found bool) {
+		scpb.ForEachSecondaryIndex(b.QueryByID(tableID), func(
+			current scpb.Status, target scpb.TargetStatus, candidate *scpb.SecondaryIndex,
+		) {
+			if !mustRetrieveIndexElement(b, tableID, candidate.IndexID).IsUnique {
+				return
+			}
+			if !keyColumnIDsAndDirsMatch(b, tableID, oldPrimaryIndexID,
+				candidate.IndexID, false /* excludeShardedCol */) {
+				return
+			}
+			// This secondary index is non-partial, unique, and has exactly the same
+			// key columns (and same directions) as the old primary index!
+			found = true
+		})
+		return found
+	}
+
+	return !isPrimaryIndexDefaultRowID(b, tbl.TableID, oldPrimaryIndexID) &&
+		!keyColumnIDsAndDirsMatch(b, tbl.TableID, oldPrimaryIndexID, newPrimaryIndexID, true /* excludeShardedCol */) &&
+		!alreadyHasSecondaryIndexOnPKColumns(b, tbl.TableID, oldPrimaryIndexID)
+}
+
+// isPrimaryIndexDefaultRowID checks whether the index is on the
+// implicitly created, hidden column 'rowid'.
+func isPrimaryIndexDefaultRowID(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
+) (res bool) {
+	// Sanity check: input `indexID` should really be the index of
+	// a primary index.
+	var primaryIndex *scpb.PrimaryIndex
+	scpb.ForEachPrimaryIndex(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.PrimaryIndex,
+	) {
+		if current == scpb.Status_PUBLIC && e.IndexID == indexID {
+			primaryIndex = e
+		}
+	})
+	if primaryIndex == nil {
+		panic(fmt.Sprintf("internal error: input indexID %v is not the primary index of table %v", indexID, tableID))
+	}
+
+	// This primary index should have only one column.
+	indexColumns := mustRetrieveKeyIndexColumns(b, tableID, indexID)
+	if len(indexColumns) != 1 {
+		return false
+	}
+
+	columnID := indexColumns[0].ColumnID
+
+	// That one column should be hidden.
+	column := mustRetrieveColumnElem(b, tableID, columnID)
+	if !column.IsHidden {
+		return false
+	}
+
+	// That one column's name should be 'rowid' or prefixed by 'rowid'.
+	columnName := mustRetrieveColumnNameElem(b, tableID, columnID)
+	if !strings.HasPrefix(columnName.Name, "rowid") {
+		return false
+	}
+
+	// That column should be of type INT.
+	columnType := mustRetrieveColumnTypeElem(b, tableID, columnID)
+	if !columnType.Type.Equal(types.Int) {
+		return false
+	}
+
+	// That column should have default expression that is equal to "unique_rowid()".
+	var columnDefaultExpression *scpb.ColumnDefaultExpression
+	scpb.ForEachColumnDefaultExpression(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.ColumnDefaultExpression,
+	) {
+		if e.ColumnID == column.ColumnID {
+			columnDefaultExpression = e
+		}
+	})
+	if columnDefaultExpression == nil || columnDefaultExpression.Expr != "unique_rowid()" {
+		return false
+	}
+
+	// All checks are satisfied, return true!
+	return true
+}
+
+// getAllColumnsNameToIDMapping constructs a name to ID mapping
+// for all non-system columns.
+func getAllColumnsNameToIDMapping(
+	b BuildCtx, tableID catid.DescID,
+) (res map[string]catid.ColumnID) {
+	res = make(map[string]catid.ColumnID)
+	scpb.ForEachColumnName(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.ColumnName,
+	) {
+		res[e.Name] = e.ColumnID
+	})
+	return res
+}
+
+// getSortedAllColumnIDsInTable returns sorted IDs of all columns in table.
+func getSortedAllColumnIDsInTable(b BuildCtx, tableID catid.DescID) (res []catid.ColumnID) {
+	scpb.ForEachColumn(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.Column,
+	) {
+		res = append(res, e.ColumnID)
+	})
+	sort.Slice(res, func(i, j int) bool {
+		return res[i] < res[j]
+	})
+	return res
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
 
@@ -355,4 +357,16 @@ func getPrimaryIndexes(
 		panic(pgerror.Newf(pgcode.NoPrimaryKey, "missing active primary key"))
 	}
 	return existing, freshlyAdded
+}
+
+// indexColumnDirection converts tree.Direction to catpb.IndexColumn_Direction.
+func indexColumnDirection(d tree.Direction) catpb.IndexColumn_Direction {
+	switch d {
+	case tree.DefaultDirection, tree.Ascending:
+		return catpb.IndexColumn_ASC
+	case tree.Descending:
+		return catpb.IndexColumn_DESC
+	default:
+		panic(errors.AssertionFailedf("unknown direction %s", d))
+	}
 }

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
@@ -145,3 +145,47 @@ ALTER TABLE defaultdb.bar ADD COLUMN b INT;
   {columnId: 3, isNullable: true, tableId: 105, type: {family: IntFamily, oid: 20, width: 64}}
 - [[IndexColumn:{DescID: 105, ColumnID: 3, IndexID: 1}, PUBLIC], ABSENT]
   {columnId: 3, indexId: 1, kind: STORED, ordinalInKind: 1, tableId: 105}
+
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL)
+----
+
+build
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
+----
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 1, indexId: 1, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 2, indexId: 1, kind: STORED, tableId: 106}
+- [[PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC]
+  {constraintId: 1, indexId: 1, isUnique: true, tableId: 106}
+- [[IndexName:{DescID: 106, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC]
+  {indexId: 1, name: t_pkey, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT]
+  {columnId: 2, indexId: 2, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT]
+  {columnId: 1, indexId: 2, kind: STORED, tableId: 106}
+- [[PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT]
+  {constraintId: 1, indexId: 2, isUnique: true, sourceIndexId: 1, tableId: 106, temporaryIndexId: 3}
+- [[IndexName:{DescID: 106, Name: t_pkey, IndexID: 2}, PUBLIC], ABSENT]
+  {indexId: 2, name: t_pkey, tableId: 106}
+- [[TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+  {constraintId: 1, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT]
+  {columnId: 2, indexId: 3, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
+  {columnId: 1, indexId: 3, kind: STORED, tableId: 106}
+- [[SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT]
+  {indexId: 4, isUnique: true, sourceIndexId: 1, tableId: 106, temporaryIndexId: 5}
+- [[TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+  {indexId: 5, isUnique: true, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT]
+  {columnId: 1, indexId: 4, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT]
+  {columnId: 1, indexId: 5, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT]
+  {columnId: 2, indexId: 4, kind: KEY_SUFFIX, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}, PUBLIC], ABSENT]
+  {columnId: 2, indexId: 5, kind: KEY_SUFFIX, tableId: 106}
+- [[IndexName:{DescID: 106, Name: t_i_key, IndexID: 4}, PUBLIC], ABSENT]
+  {indexId: 4, name: t_i_key, tableId: 106}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -33,10 +33,6 @@ ALTER TABLE defaultdb.foo ALTER COLUMN i SET DATA TYPE STRING
 ----
 
 unimplemented
-ALTER TABLE defaultdb.foo ALTER PRIMARY KEY USING COLUMNS (i)
-----
-
-unimplemented
 ALTER TABLE defaultdb.foo DROP COLUMN k
 ----
 

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -1241,3 +1241,321 @@ PostCommitPhase stage 2 of 2 with 7 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
+
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL)
+----
+
+ops
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
+----
+StatementPhase stage 1 of 1 with 12 MutationType ops
+  transitions:
+    [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[TemporaryIndex:{DescID: 108, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[TemporaryIndex:{DescID: 108, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 5}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakeAddedIndexBackfilling
+      Index:
+        ConstraintID: 1
+        IndexID: 2
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 108
+        TemporaryIndexID: 3
+    *scop.MakeAddedTempIndexDeleteOnly
+      Index:
+        ConstraintID: 1
+        IndexID: 3
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 108
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 3
+      TableID: 108
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 3
+      Kind: 2
+      TableID: 108
+    *scop.MakeAddedIndexBackfilling
+      Index:
+        IndexID: 4
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 108
+        TemporaryIndexID: 5
+      IsSecondaryIndex: true
+    *scop.MakeAddedTempIndexDeleteOnly
+      Index:
+        IndexID: 5
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 108
+      IsSecondaryIndex: true
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 4
+      TableID: 108
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 5
+      TableID: 108
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 4
+      Kind: 1
+      TableID: 108
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 5
+      Kind: 1
+      TableID: 108
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 2
+      TableID: 108
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 2
+      Kind: 2
+      TableID: 108
+PreCommitPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+  ops:
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+      Initialize: true
+    *scop.CreateSchemaChangerJob
+      Authorization:
+        UserName: root
+      DescriptorIDs:
+      - 108
+      JobID: 1
+      RunningStatus: PostCommitPhase stage 1 of 7 with 2 MutationType ops pending
+      Statements:
+      - statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
+        redactedstatement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS
+          (‹j›)
+        statementtag: ALTER TABLE
+PostCommitPhase stage 1 of 7 with 4 MutationType ops
+  transitions:
+    [[TemporaryIndex:{DescID: 108, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 108, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+  ops:
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 3
+      TableID: 108
+    *scop.MakeAddedIndexDeleteAndWriteOnly
+      IndexID: 5
+      TableID: 108
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 2 of 7 with 2 BackfillType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+  ops:
+    *scop.BackfillIndex
+      IndexID: 2
+      SourceIndexID: 1
+      TableID: 108
+    *scop.BackfillIndex
+      IndexID: 4
+      SourceIndexID: 1
+      TableID: 108
+PostCommitPhase stage 3 of 7 with 4 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+  ops:
+    *scop.MakeBackfillingIndexDeleteOnly
+      IndexID: 2
+      TableID: 108
+    *scop.MakeBackfillingIndexDeleteOnly
+      IndexID: 4
+      TableID: 108
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 4 of 7 with 4 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+  ops:
+    *scop.MakeBackfilledIndexMerging
+      IndexID: 2
+      TableID: 108
+    *scop.MakeBackfilledIndexMerging
+      IndexID: 4
+      TableID: 108
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 5 of 7 with 2 BackfillType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
+  ops:
+    *scop.MergeIndex
+      BackfilledIndexID: 2
+      TableID: 108
+      TemporaryIndexID: 3
+    *scop.MergeIndex
+      BackfilledIndexID: 4
+      TableID: 108
+      TemporaryIndexID: 5
+PostCommitPhase stage 6 of 7 with 4 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
+  ops:
+    *scop.MakeMergedIndexWriteOnly
+      IndexID: 2
+      TableID: 108
+    *scop.MakeMergedIndexWriteOnly
+      IndexID: 4
+      TableID: 108
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 7 of 7 with 2 ValidationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
+  ops:
+    *scop.ValidateUniqueIndex
+      IndexID: 2
+      TableID: 108
+    *scop.ValidateUniqueIndex
+      IndexID: 4
+      TableID: 108
+PostCommitNonRevertiblePhase stage 1 of 3 with 12 MutationType ops
+  transitions:
+    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 108, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[TemporaryIndex:{DescID: 108, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[IndexName:{DescID: 108, Name: t_i_key, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
+      IndexID: 1
+      TableID: 108
+    *scop.SetIndexName
+      IndexID: 1
+      Name: crdb_internal_index_1_name_placeholder
+      TableID: 108
+    *scop.SetIndexName
+      IndexID: 2
+      Name: t_pkey
+      TableID: 108
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 3
+      TableID: 108
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 5
+      TableID: 108
+    *scop.SetIndexName
+      IndexID: 4
+      Name: t_i_key
+      TableID: 108
+    *scop.RemoveColumnFromIndex
+      ColumnID: 1
+      IndexID: 1
+      TableID: 108
+    *scop.RemoveColumnFromIndex
+      ColumnID: 2
+      IndexID: 1
+      Kind: 2
+      TableID: 108
+    *scop.MakeAddedPrimaryIndexPublic
+      EventBase:
+        Authorization:
+          UserName: root
+        Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+        StatementTag: ALTER TABLE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+      IndexID: 2
+      TableID: 108
+    *scop.MakeAddedSecondaryIndexPublic
+      IndexID: 4
+      TableID: 108
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
+  ops:
+    *scop.MakeDroppedIndexDeleteOnly
+      IndexID: 1
+      TableID: 108
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 3 of 3 with 8 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[TemporaryIndex:{DescID: 108, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 108, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+  ops:
+    *scop.CreateGcJobForIndex
+      IndexID: 3
+      TableID: 108
+    *scop.MakeIndexAbsent
+      IndexID: 3
+      TableID: 108
+    *scop.CreateGcJobForIndex
+      IndexID: 5
+      TableID: 108
+    *scop.MakeIndexAbsent
+      IndexID: 5
+      TableID: 108
+    *scop.CreateGcJobForIndex
+      IndexID: 1
+      StatementForDropJob:
+        Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+      TableID: 108
+    *scop.MakeIndexAbsent
+      EventBase:
+        Authorization:
+          UserName: root
+        Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+        StatementTag: ALTER TABLE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+      IndexID: 1
+      TableID: 108
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 108
+      JobID: 1
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
@@ -1,0 +1,636 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL)
+----
+...
++object {100 101 t} -> 104
+
+
+test
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+## StatementPhase stage 1 of 1 with 12 MutationType ops
+upsert descriptor #104
+  ...
+     formatVersion: 3
+     id: 104
+  -  modificationTime:
+  -    wallTime: "1640995200000000000"
+  +  modificationTime: {}
+  +  mutations:
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      name: crdb_internal_index_2_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      storeColumnNames:
+  +      - i
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      storeColumnNames:
+  +      - i
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 4
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_4_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 5
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_5_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextConstraintId: 6
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 6
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 1 with 2 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY
+  +          USING COLUMNS (‹j›)
+  +        statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     formatVersion: 3
+     id: 104
+  -  modificationTime: {}
+  +  modificationTime:
+  +    wallTime: "1640995200000000001"
+     mutations:
+     - direction: ADD
+  ...
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 7 with 4 MutationType ops
+upsert descriptor #104
+  ...
+     formatVersion: 3
+     id: 104
+  -  modificationTime:
+  -    wallTime: "1640995200000000001"
+  +  modificationTime: {}
+     mutations:
+     - direction: ADD
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: DELETE_AND_WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: DELETE_AND_WRITE_ONLY
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+update progress of schema change job #1: "PostCommitPhase stage 2 of 7 with 2 BackfillType ops pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 7 with 2 BackfillType ops
+backfill indexes [2 4] from index #1 in table #104
+commit transaction #4
+begin transaction #5
+## PostCommitPhase stage 3 of 7 with 4 MutationType ops
+upsert descriptor #104
+  ...
+     formatVersion: 3
+     id: 104
+  -  modificationTime:
+  -    wallTime: "1640995200000000003"
+  +  modificationTime: {}
+     mutations:
+     - direction: ADD
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+update progress of schema change job #1: "PostCommitPhase stage 4 of 7 with 2 MutationType ops pending"
+commit transaction #5
+begin transaction #6
+## PostCommitPhase stage 4 of 7 with 4 MutationType ops
+upsert descriptor #104
+  ...
+     formatVersion: 3
+     id: 104
+  -  modificationTime:
+  -    wallTime: "1640995200000000005"
+  +  modificationTime: {}
+     mutations:
+     - direction: ADD
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+update progress of schema change job #1: "PostCommitPhase stage 5 of 7 with 2 BackfillType ops pending"
+commit transaction #6
+begin transaction #7
+## PostCommitPhase stage 5 of 7 with 2 BackfillType ops
+merge temporary indexes [3 5] into backfilled indexes [2 4] in table #104
+commit transaction #7
+begin transaction #8
+## PostCommitPhase stage 6 of 7 with 4 MutationType ops
+upsert descriptor #104
+  ...
+     formatVersion: 3
+     id: 104
+  -  modificationTime:
+  -    wallTime: "1640995200000000006"
+  +  modificationTime: {}
+     mutations:
+     - direction: ADD
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  +    state: DELETE_AND_WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  +    state: DELETE_AND_WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "5"
+  +  version: "6"
+update progress of schema change job #1: "PostCommitPhase stage 7 of 7 with 2 ValidationType ops pending"
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 7 with 2 ValidationType ops
+validate forward indexes [2] in table #104
+commit transaction #9
+begin transaction #10
+## PostCommitNonRevertiblePhase stage 1 of 3 with 12 MutationType ops
+upsert descriptor #104
+  ...
+           statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
+           statementTag: ALTER TABLE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+     formatVersion: 3
+     id: 104
+  -  modificationTime:
+  -    wallTime: "1640995200000000008"
+  +  indexes:
+  +  - constraintId: 4
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 4
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 1
+  +    keyColumnNames:
+  +    - i
+  +    keySuffixColumnIds:
+  +    - 2
+  +    name: t_i_key
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    unique: true
+  +    version: 4
+  +  modificationTime: {}
+     mutations:
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+  -      constraintId: 2
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - j
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      storeColumnNames:
+  -      - i
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_AND_WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+         constraintId: 3
+         createdExplicitly: true
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_AND_WRITE_ONLY
+  -  - direction: ADD
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
+  -      constraintId: 4
+  +      constraintId: 5
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 4
+  +      id: 5
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keySuffixColumnIds:
+         - 2
+  -      name: crdb_internal_index_4_name_placeholder
+  +      name: crdb_internal_index_5_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnNames: []
+         unique: true
+  +      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  -    state: DELETE_AND_WRITE_ONLY
+  -  - direction: ADD
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+  +      encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 5
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - i
+  -      keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_5_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+         sharded: {}
+  -      storeColumnNames: []
+  +      storeColumnIds:
+  +      - 2
+  +      storeColumnNames:
+  +      - j
+         unique: true
+  -      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 2
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 2
+       interleave: {}
+       keyColumnDirections:
+       - ASC
+       keyColumnIds:
+  -    - 1
+  +    - 2
+       keyColumnNames:
+  -    - i
+  +    - j
+       name: t_pkey
+       partitioning: {}
+       sharded: {}
+       storeColumnIds:
+  -    - 2
+  +    - 1
+       storeColumnNames:
+  -    - j
+  +    - i
+       unique: true
+       version: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "6"
+  +  version: "7"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 1 MutationType op pending"
+set schema change job #1 to non-cancellable
+commit transaction #10
+begin transaction #11
+## PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops
+upsert descriptor #104
+  ...
+       unique: true
+       version: 4
+  -  modificationTime:
+  -    wallTime: "1640995200000000010"
+  +  modificationTime: {}
+     mutations:
+     - direction: DROP
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_AND_WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "7"
+  +  version: "8"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops pending"
+commit transaction #11
+begin transaction #12
+## PostCommitNonRevertiblePhase stage 3 of 3 with 8 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY
+  -          USING COLUMNS (‹j›)
+  -        statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
+  -        statementTag: ALTER TABLE
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+       unique: true
+       version: 4
+  -  modificationTime:
+  -    wallTime: "1640995200000000011"
+  -  mutations:
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 3
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 3
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - j
+  -      name: crdb_internal_index_3_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      storeColumnNames:
+  -      - i
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 5
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - i
+  -      keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_5_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 1
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - i
+  -      name: crdb_internal_index_1_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      storeColumnNames:
+  -      - j
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  +  modificationTime: {}
+  +  mutations: []
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "8"
+  +  version: "9"
+write *eventpb.FinishSchemaChange to event log for descriptor 104
+create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
+  descriptor IDs: [104]
+update progress of schema change job #1: "all stages completed"
+commit transaction #12
+notified job registry to adopt jobs: [2]
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla
@@ -1,0 +1,149 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+EXPLAIN (ddl) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 10 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+ │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+ │         └── 12 Mutation operations
+ │              ├── MakeAddedIndexBackfilling {"Index":{"ConstraintID":1,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
+ │              ├── MakeAddedTempIndexDeleteOnly {"Index":{"ConstraintID":1,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":2,"TableID":104}
+ │              ├── MakeAddedIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── MakeAddedTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":2,"Kind":2,"TableID":104}
+ ├── PreCommitPhase
+ │    └── Stage 1 of 1 in PreCommitPhase
+ │         └── 2 Mutation operations
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":5,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 2 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    └── 2 Backfill operations
+ │    │         ├── BackfillIndex {"IndexID":2,"SourceIndexID":1,"TableID":104}
+ │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":1,"TableID":104}
+ │    ├── Stage 3 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 4 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 5 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    └── 2 Backfill operations
+ │    │         ├── MergeIndex {"BackfilledIndexID":2,"TableID":104,"TemporaryIndexID":3}
+ │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":104,"TemporaryIndexID":5}
+ │    ├── Stage 6 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGED → WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── MERGED → WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 7 of 7 in PostCommitPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+ │         └── 2 Validation operations
+ │              ├── ValidateUniqueIndex {"IndexID":2,"TableID":104}
+ │              └── ValidateUniqueIndex {"IndexID":4,"TableID":104}
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+      │    │    ├── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    └── 12 Mutation operations
+      │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"t_i_key","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── MakeAddedPrimaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeAddedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    └── 3 Mutation operations
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward ABSENT
+           │    └── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+           ├── 2 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           └── 8 Mutation operations
+                ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":1,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_1_of_7
@@ -1,0 +1,43 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+           │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+           └── 19 Mutation operations
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── LogEvent {"TargetStatus":1}
+                ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_2_of_7
@@ -1,0 +1,52 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    └── 17 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           └── 6 Mutation operations
+                ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_3_of_7
@@ -1,0 +1,52 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    └── 17 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           └── 6 Mutation operations
+                ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_4_of_7
@@ -1,0 +1,52 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    └── 17 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           └── 6 Mutation operations
+                ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_5_of_7
@@ -1,0 +1,56 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    └── 14 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           └── 11 Mutation operations
+                ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── LogEvent {"TargetStatus":1}
+                ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_6_of_7
@@ -1,0 +1,56 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    └── 14 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           └── 11 Mutation operations
+                ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── LogEvent {"TargetStatus":1}
+                ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_7_of_7
@@ -1,0 +1,56 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    └── 14 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           └── 11 Mutation operations
+                ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── LogEvent {"TargetStatus":1}
+                ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGcJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
@@ -1,0 +1,612 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+----
+• Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+│
+├── • StatementPhase
+│   │
+│   └── • Stage 1 of 1 in StatementPhase
+│       │
+│       ├── • 10 elements transitioning toward PUBLIC
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │         rule: "index-column added to index after index exists"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │         rule: "index-column added to index after index exists"
+│       │   │
+│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │     ABSENT → BACKFILL_ONLY
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   │         rule: "temp index exists before columns, partitioning, and partial"
+│       │   │         rule: "index-column added to index after temp index exists"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   │         rule: "temp index exists before columns, partitioning, and partial"
+│       │   │         rule: "index-column added to index after temp index exists"
+│       │   │
+│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│       │   │     ABSENT → BACKFILL_ONLY
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│       │   │         rule: "index-column added to index after index exists"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│       │   │         rule: "temp index exists before columns, partitioning, and partial"
+│       │   │         rule: "index-column added to index after temp index exists"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│       │   │         rule: "index-column added to index after index exists"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+│       │       │ ABSENT → PUBLIC
+│       │       │
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│       │             rule: "temp index exists before columns, partitioning, and partial"
+│       │             rule: "index-column added to index after temp index exists"
+│       │
+│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│       │   │
+│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   │     ABSENT → DELETE_ONLY
+│       │   │
+│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│       │         ABSENT → DELETE_ONLY
+│       │
+│       └── • 12 Mutation operations
+│           │
+│           ├── • MakeAddedIndexBackfilling
+│           │     Index:
+│           │       ConstraintID: 1
+│           │       IndexID: 2
+│           │       IsUnique: true
+│           │       SourceIndexID: 1
+│           │       TableID: 104
+│           │       TemporaryIndexID: 3
+│           │
+│           ├── • MakeAddedTempIndexDeleteOnly
+│           │     Index:
+│           │       ConstraintID: 1
+│           │       IndexID: 3
+│           │       IsUnique: true
+│           │       SourceIndexID: 1
+│           │       TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 2
+│           │     IndexID: 3
+│           │     TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 3
+│           │     Kind: 2
+│           │     TableID: 104
+│           │
+│           ├── • MakeAddedIndexBackfilling
+│           │     Index:
+│           │       IndexID: 4
+│           │       IsUnique: true
+│           │       SourceIndexID: 1
+│           │       TableID: 104
+│           │       TemporaryIndexID: 5
+│           │     IsSecondaryIndex: true
+│           │
+│           ├── • MakeAddedTempIndexDeleteOnly
+│           │     Index:
+│           │       IndexID: 5
+│           │       IsUnique: true
+│           │       SourceIndexID: 1
+│           │       TableID: 104
+│           │     IsSecondaryIndex: true
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 4
+│           │     TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 5
+│           │     TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 2
+│           │     IndexID: 4
+│           │     Kind: 1
+│           │     TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 2
+│           │     IndexID: 5
+│           │     Kind: 1
+│           │     TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 2
+│           │     IndexID: 2
+│           │     TableID: 104
+│           │
+│           └── • AddColumnToIndex
+│                 ColumnID: 1
+│                 IndexID: 2
+│                 Kind: 2
+│                 TableID: 104
+│
+├── • PreCommitPhase
+│   │
+│   └── • Stage 1 of 1 in PreCommitPhase
+│       │
+│       └── • 2 Mutation operations
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 104
+│           │     Initialize: true
+│           │
+│           └── • CreateSchemaChangerJob
+│                 Authorization:
+│                   UserName: root
+│                 DescriptorIDs:
+│                 - 104
+│                 JobID: 1
+│                 RunningStatus: PostCommitPhase stage 1 of 7 with 2 MutationType ops pending
+│                 Statements:
+│                 - statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
+│                   redactedstatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING
+│                     COLUMNS (‹j›)
+│                   statementtag: ALTER TABLE
+│
+├── • PostCommitPhase
+│   │
+│   ├── • Stage 1 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│   │   │   │
+│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│   │   │   │   │ DELETE_ONLY → WRITE_ONLY
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+│   │   │   │   │     rule: "index-column added to index before temp index receives writes"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│   │   │   │         rule: "index-column added to index before temp index receives writes"
+│   │   │   │
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│   │   │       │ DELETE_ONLY → WRITE_ONLY
+│   │   │       │
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+│   │   │       │     rule: "index-column added to index before temp index receives writes"
+│   │   │       │
+│   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+│   │   │             rule: "index-column added to index before temp index receives writes"
+│   │   │
+│   │   └── • 4 Mutation operations
+│   │       │
+│   │       ├── • MakeAddedIndexDeleteAndWriteOnly
+│   │       │     IndexID: 3
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeAddedIndexDeleteAndWriteOnly
+│   │       │     IndexID: 5
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       └── • UpdateSchemaChangerJob
+│   │             JobID: 1
+│   │             RunningStatus: PostCommitPhase stage 2 of 7 with 2 BackfillType ops pending
+│   │
+│   ├── • Stage 2 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 2 elements transitioning toward PUBLIC
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   │   │ BACKFILL_ONLY → BACKFILLED
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+│   │   │   │   │     rule: "index-column added to index before index is backfilled"
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+│   │   │   │   │     rule: "index-column added to index before index is backfilled"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│   │   │   │         rule: "temp index is WRITE_ONLY before backfill"
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │       │ BACKFILL_ONLY → BACKFILLED
+│   │   │       │
+│   │   │       ├── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│   │   │       │     rule: "temp index is WRITE_ONLY before backfill"
+│   │   │       │
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+│   │   │       │     rule: "index-column added to index before index is backfilled"
+│   │   │       │
+│   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+│   │   │             rule: "index-column added to index before index is backfilled"
+│   │   │
+│   │   └── • 2 Backfill operations
+│   │       │
+│   │       ├── • BackfillIndex
+│   │       │     IndexID: 2
+│   │       │     SourceIndexID: 1
+│   │       │     TableID: 104
+│   │       │
+│   │       └── • BackfillIndex
+│   │             IndexID: 4
+│   │             SourceIndexID: 1
+│   │             TableID: 104
+│   │
+│   ├── • Stage 3 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 2 elements transitioning toward PUBLIC
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   │     BACKFILLED → DELETE_ONLY
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │         BACKFILLED → DELETE_ONLY
+│   │   │
+│   │   └── • 4 Mutation operations
+│   │       │
+│   │       ├── • MakeBackfillingIndexDeleteOnly
+│   │       │     IndexID: 2
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeBackfillingIndexDeleteOnly
+│   │       │     IndexID: 4
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       └── • UpdateSchemaChangerJob
+│   │             JobID: 1
+│   │             RunningStatus: PostCommitPhase stage 4 of 7 with 2 MutationType ops pending
+│   │
+│   ├── • Stage 4 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 2 elements transitioning toward PUBLIC
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   │     DELETE_ONLY → MERGE_ONLY
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │         DELETE_ONLY → MERGE_ONLY
+│   │   │
+│   │   └── • 4 Mutation operations
+│   │       │
+│   │       ├── • MakeBackfilledIndexMerging
+│   │       │     IndexID: 2
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeBackfilledIndexMerging
+│   │       │     IndexID: 4
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       └── • UpdateSchemaChangerJob
+│   │             JobID: 1
+│   │             RunningStatus: PostCommitPhase stage 5 of 7 with 2 BackfillType ops pending
+│   │
+│   ├── • Stage 5 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 2 elements transitioning toward PUBLIC
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   │     MERGE_ONLY → MERGED
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │         MERGE_ONLY → MERGED
+│   │   │
+│   │   └── • 2 Backfill operations
+│   │       │
+│   │       ├── • MergeIndex
+│   │       │     BackfilledIndexID: 2
+│   │       │     TableID: 104
+│   │       │     TemporaryIndexID: 3
+│   │       │
+│   │       └── • MergeIndex
+│   │             BackfilledIndexID: 4
+│   │             TableID: 104
+│   │             TemporaryIndexID: 5
+│   │
+│   ├── • Stage 6 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 2 elements transitioning toward PUBLIC
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   │     MERGED → WRITE_ONLY
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │         MERGED → WRITE_ONLY
+│   │   │
+│   │   └── • 4 Mutation operations
+│   │       │
+│   │       ├── • MakeMergedIndexWriteOnly
+│   │       │     IndexID: 2
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeMergedIndexWriteOnly
+│   │       │     IndexID: 4
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       └── • UpdateSchemaChangerJob
+│   │             JobID: 1
+│   │             RunningStatus: PostCommitPhase stage 7 of 7 with 2 ValidationType ops pending
+│   │
+│   └── • Stage 7 of 7 in PostCommitPhase
+│       │
+│       ├── • 2 elements transitioning toward PUBLIC
+│       │   │
+│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │     WRITE_ONLY → VALIDATED
+│       │   │
+│       │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+│       │         WRITE_ONLY → VALIDATED
+│       │
+│       └── • 2 Validation operations
+│           │
+│           ├── • ValidateUniqueIndex
+│           │     IndexID: 2
+│           │     TableID: 104
+│           │
+│           └── • ValidateUniqueIndex
+│                 IndexID: 4
+│                 TableID: 104
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "index no longer public before dependents removed"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "index no longer public before dependents removed"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │     PUBLIC → WRITE_ONLY
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │             rule: "index no longer public before dependents removed"
+    │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │   │ ABSENT → PUBLIC
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index existence precedes index name and comment"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index name and comment"
+    │   │
+    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │
+    │   └── • 12 Mutation operations
+    │       │
+    │       ├── • MakeDroppedPrimaryIndexDeleteAndWriteOnly
+    │       │     IndexID: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 1
+    │       │     Name: crdb_internal_index_1_name_placeholder
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 2
+    │       │     Name: t_pkey
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 4
+    │       │     Name: t_i_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 1
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeAddedPrimaryIndexPublic
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS
+    │       │         (‹j›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeAddedSecondaryIndexPublic
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 1 MutationType op pending
+    │
+    ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 1 element transitioning toward ABSENT
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
+    │   │
+    │   └── • 3 Mutation operations
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops pending
+    │
+    └── • Stage 3 of 3 in PostCommitNonRevertiblePhase
+        │
+        ├── • 1 element transitioning toward ABSENT
+        │   │
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │       │     rule: "temp indexes reach absent at the same time as other indexes"
+        │       │
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │             rule: "temp indexes reach absent at the same time as other indexes"
+        │
+        ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   │     TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+        │
+        └── • 8 Mutation operations
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 1
+            │     StatementForDropJob:
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS
+            │         (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     IndexID: 1
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_1_of_7
@@ -1,0 +1,207 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
+        │
+        ├── • 12 elements transitioning toward ABSENT
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │     PUBLIC → ABSENT
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │     PUBLIC → ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   │ BACKFILL_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │     PUBLIC → ABSENT
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │     PUBLIC → ABSENT
+        │   │
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   │   │ BACKFILL_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "secondary index columns removed before removing the index"
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+        │   │   │     rule: "secondary index columns removed before removing the index"
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+        │   │     PUBLIC → ABSENT
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+        │   │
+        │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │         PUBLIC → ABSENT
+        │
+        └── • 19 Mutation operations
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 2
+            │     IndexID: 2
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 1
+            │     IndexID: 2
+            │     Kind: 2
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 2
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 1
+            │     IndexID: 3
+            │     Kind: 2
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 1
+            │     IndexID: 4
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 1
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 2
+            │     IndexID: 4
+            │     Kind: 1
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 2
+            │     IndexID: 5
+            │     Kind: 1
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 2
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     IndexID: 2
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • LogEvent
+            │     Element:
+            │       SecondaryIndex:
+            │         indexId: 4
+            │         isUnique: true
+            │         sourceIndexId: 1
+            │         tableId: 104
+            │         temporaryIndexId: 5
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     TargetStatus: 1
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_2_of_7
@@ -1,0 +1,235 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 12 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │     rule: "secondary index columns removed before removing the index"
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │     rule: "secondary index columns removed before removing the index"
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │         PUBLIC → ABSENT
+    │   │
+    │   └── • 17 Mutation operations
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 4
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 5
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGcJobForIndex
+    │       │     IndexID: 2
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         indexId: 4
+    │       │         isUnique: true
+    │       │         sourceIndexId: 1
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 5
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGcJobForIndex
+    │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 2 elements transitioning toward ABSENT
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │             rule: "dependents removed before index"
+        │
+        └── • 6 Mutation operations
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_3_of_7
@@ -1,0 +1,235 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 12 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │     rule: "secondary index columns removed before removing the index"
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │     rule: "secondary index columns removed before removing the index"
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │         PUBLIC → ABSENT
+    │   │
+    │   └── • 17 Mutation operations
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 4
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 5
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGcJobForIndex
+    │       │     IndexID: 2
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         indexId: 4
+    │       │         isUnique: true
+    │       │         sourceIndexId: 1
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 5
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGcJobForIndex
+    │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 2 elements transitioning toward ABSENT
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │             rule: "dependents removed before index"
+        │
+        └── • 6 Mutation operations
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_4_of_7
@@ -1,0 +1,235 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 12 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │     rule: "secondary index columns removed before removing the index"
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │     rule: "secondary index columns removed before removing the index"
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │         PUBLIC → ABSENT
+    │   │
+    │   └── • 17 Mutation operations
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGcJobForIndex
+    │       │     IndexID: 2
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 4
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 5
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         indexId: 4
+    │       │         isUnique: true
+    │       │         sourceIndexId: 1
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 5
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGcJobForIndex
+    │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 2 elements transitioning toward ABSENT
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │             rule: "dependents removed before index"
+        │
+        └── • 6 Mutation operations
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_5_of_7
@@ -1,0 +1,249 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 12 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │         PUBLIC → ABSENT
+    │   │
+    │   └── • 14 Mutation operations
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 5
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 4
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 9 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "secondary index columns removed before removing the index"
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+        │   │   │     rule: "secondary index columns removed before removing the index"
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │             rule: "dependents removed before index"
+        │
+        └── • 11 Mutation operations
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 2
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     IndexID: 2
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • LogEvent
+            │     Element:
+            │       SecondaryIndex:
+            │         indexId: 4
+            │         isUnique: true
+            │         sourceIndexId: 1
+            │         tableId: 104
+            │         temporaryIndexId: 5
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     TargetStatus: 1
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_6_of_7
@@ -1,0 +1,249 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 12 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │         PUBLIC → ABSENT
+    │   │
+    │   └── • 14 Mutation operations
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 5
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 4
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 9 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "secondary index columns removed before removing the index"
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+        │   │   │     rule: "secondary index columns removed before removing the index"
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │             rule: "dependents removed before index"
+        │
+        └── • 11 Mutation operations
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 2
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     IndexID: 2
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • LogEvent
+            │     Element:
+            │       SecondaryIndex:
+            │         indexId: 4
+            │         isUnique: true
+            │         sourceIndexId: 1
+            │         tableId: 104
+            │         temporaryIndexId: 5
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     TargetStatus: 1
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_7_of_7
@@ -1,0 +1,249 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+
+/* test */
+ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 12 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │         PUBLIC → ABSENT
+    │   │
+    │   └── • 14 Mutation operations
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeDroppedIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 1
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 4
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 5
+    │       │     Kind: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 9 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "secondary index columns removed before removing the index"
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
+        │   │   │     rule: "secondary index columns removed before removing the index"
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │             rule: "dependents removed before index"
+        │
+        └── • 11 Mutation operations
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 2
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     IndexID: 2
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • LogEvent
+            │     Element:
+            │       SecondaryIndex:
+            │         indexId: 4
+            │         isUnique: true
+            │         sourceIndexId: 1
+            │         tableId: 104
+            │         temporaryIndexId: 5
+            │     EventBase:
+            │       Authorization:
+            │         UserName: root
+            │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›)
+            │       StatementTag: ALTER TABLE
+            │       TargetMetadata:
+            │         SourceElementID: 1
+            │         SubWorkID: 1
+            │     TargetStatus: 1
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 104
+            │
+            ├── • CreateGcJobForIndex
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 5
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed


### PR DESCRIPTION
The PR implements `ALTER PRIMARY KEY` under the declarative schema
changer framework that handles the simplest, "vanilla" case like
```
CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL)
ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
```

This is the first of a series PRs where followup PRs will expand its
capabilities to be able to handle more complex cases, including
  1. Allow the requested new primary key to be hash-sharded;
  2. Consider the case where altering primary key requires us to
     modify existing secondary indexes(see the legacy schema change
     about in what cases we should rewrite)
  3. Consider the case where the old primary index is on the implicitly
     created `rowid` column, in which case we also need to drop that
     column;
  5. Consider partitioning and locality (I'm not sure what they are,
     and why they play a role when `ALTER PRIMARY KEY` but I've seen
     them in the old schema changer, so I assume we ought to do
     something about them too here).
  6. Support `ALTER PRIMARY KEY` with concurrent schema change
      statements. E.g.
 ```ALTER TABLE t ADD COLUMN k INT NOT NULL DEFAULT 30, ALTER PRIMARY KEY USING COLUMNS (j);```

related: #83932
Release note: None