### PR TITLE
ui: fix sorting of explain plans

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -18,12 +18,19 @@ import {
 } from "./plansTable";
 import { Button } from "../../button";
 import { SqlBox, SqlBoxSize } from "../../sql";
+import { SortSetting } from "../../sortedtable";
 
 interface PlanDetailsProps {
   plans: PlanHashStats[];
+  sortSetting: SortSetting;
+  onChangeSortSetting: (ss: SortSetting) => void;
 }
 
-export function PlanDetails({ plans }: PlanDetailsProps): React.ReactElement {
+export function PlanDetails({
+  plans,
+  sortSetting,
+  onChangeSortSetting,
+}: PlanDetailsProps): React.ReactElement {
   const [plan, setPlan] = useState<PlanHashStats | null>(null);
   const handleDetails = (plan: PlanHashStats): void => {
     setPlan(plan);
@@ -35,13 +42,20 @@ export function PlanDetails({ plans }: PlanDetailsProps): React.ReactElement {
   if (plan) {
     return renderExplainPlan(plan, backToPlanTable);
   } else {
-    return renderPlanTable(plans, handleDetails);
+    return renderPlanTable(
+      plans,
+      handleDetails,
+      sortSetting,
+      onChangeSortSetting,
+    );
   }
 }
 
 function renderPlanTable(
   plans: PlanHashStats[],
   handleDetails: (plan: PlanHashStats) => void,
+  sortSetting: SortSetting,
+  onChangeSortSetting: (ss: SortSetting) => void,
 ): React.ReactElement {
   const columns = makeExplainPlanColumns(handleDetails);
   return (
@@ -49,6 +63,8 @@ function renderPlanTable(
       columns={columns}
       data={plans}
       className="statements-table"
+      sortSetting={sortSetting}
+      onChangeSortSetting={onChangeSortSetting}
     />
   );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -88,7 +88,7 @@ export type StatementDetailsProps = StatementDetailsOwnProps &
   RouteComponentProps<{ implicitTxn: string; statement: string }>;
 
 export interface StatementDetailsState {
-  sortSetting: SortSetting;
+  plansSortSetting: SortSetting;
   currentTab?: string;
 }
 
@@ -210,10 +210,9 @@ export class StatementDetails extends React.Component<
     super(props);
     const searchParams = new URLSearchParams(props.history.location.search);
     this.state = {
-      sortSetting: {
-        // Latency
+      plansSortSetting: {
         ascending: false,
-        columnTitle: "statementTime",
+        columnTitle: "lastExecTime",
       },
       currentTab: searchParams.get("tab") || "overview",
     };
@@ -345,6 +344,12 @@ export class StatementDetails extends React.Component<
     if (this.props.onBackToStatementsClick) {
       this.props.onBackToStatementsClick();
     }
+  };
+
+  onChangePlansSortSetting = (ss: SortSetting): void => {
+    this.setState({
+      plansSortSetting: ss,
+    });
   };
 
   render(): React.ReactElement {
@@ -733,7 +738,11 @@ export class StatementDetails extends React.Component<
             </Col>
           </Row>
           <p className={summaryCardStylesCx("summary--card__divider")} />
-          <PlanDetails plans={statement_statistics_per_plan_hash} />
+          <PlanDetails
+            plans={statement_statistics_per_plan_hash}
+            sortSetting={this.state.plansSortSetting}
+            onChangeSortSetting={this.onChangePlansSortSetting}
+          />
         </section>
       </>
     );


### PR DESCRIPTION
Previously, the sorting on the plans on the
Explain Plans tab on Statement Details wasn't working.
This commit adds the missing code required to sort
that table.

Fixes #84079

https://www.loom.com/share/0f0ed0e1a8d04fc88def3b2460d617e6

Release note (bug fix): Sorting on the plans table inside the
Statement Details page is now properly working.