### PR TITLE
backupccl: cache query results in data driven tests

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -68,7 +68,7 @@ SELECT owner FROM [SHOW TABLES] WHERE table_name = 'testtable_greeting_owner';
 testuser
 
 # Check the expected grants on each of the schema objects created above.
-query-sql
+query-sql save-to-var=testdb
 SHOW GRANTS ON DATABASE testdb;
 ----
 testdb admin ALL true
@@ -159,14 +159,9 @@ exec-sql
 USE testdb
 ----
 
-query-sql
+query-sql equals-var=testdb
 SHOW GRANTS ON DATABASE testdb;
 ----
-testdb admin ALL true
-testdb public CONNECT false
-testdb root ALL true
-testdb testuser ALL true
-testdb user1 ALL true
 
 query-sql
 SHOW GRANTS ON SCHEMA public;


### PR DESCRIPTION
Data driven test writers can now cache query results on a tag, and then compare
the query later in the test. Using this feature has a few benefits
- reduces the amount of text in a data driven test
- makes it a bit easier to reason about longer data driven test that conduct
  many comparisons
- opens the door for randomized testing in datadriven tests

A canonical example:
```
exec-sql tag=foo
SELECT * FROM foo;

[do some backup restore]

query-sql equals=foo
SELECT * FROM restoredFoo
```
Release note: None