### PR TITLE
opt: don't panic on negated geospatial comparison operator

### DIFF
--- a/pkg/sql/opt/norm/bool_funcs.go
+++ b/pkg/sql/opt/norm/bool_funcs.go
@@ -37,6 +37,12 @@ func (c *CustomFuncs) NegateComparison(
 	return c.f.DynamicConstruct(negate, left, right).(opt.ScalarExpr)
 }
 
+// CanNegateComparison returns whether the given comparison op can be negated.
+func (c *CustomFuncs) CanNegateComparison(cmp opt.Operator) bool {
+	_, ok := opt.NegateOpMap[cmp]
+	return ok
+}
+
 // FindRedundantConjunct takes the left and right operands of an Or operator as
 // input. It examines each conjunct from the left expression and determines
 // whether it appears as a conjunct in the right expression. If so, it returns

--- a/pkg/sql/opt/norm/rules/bool.opt
+++ b/pkg/sql/opt/norm/rules/bool.opt
@@ -110,16 +110,14 @@ $input
 
 # NegateComparison inverts eligible comparison operators when they are negated
 # by the Not operator. For example, Eq maps to Ne, and Gt maps to Le. All
-# comparisons can be negated except for the JSON comparisons.
+# comparisons can be negated except for the JSON and Geospatial comparisons.
 [NegateComparison, Normalize]
 (Not
     $input:(Comparison $left:* $right:*) &
-        ^(Contains | ContainedBy | JsonExists | JsonSomeExists
-                | JsonAllExists | Overlaps
-        )
+        (CanNegateComparison $op:(OpName $input))
 )
 =>
-(NegateComparison (OpName $input) $left $right)
+(NegateComparison $op $left $right)
 
 # EliminateNot discards a doubled Not operator.
 [EliminateNot, Normalize]

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -424,6 +424,39 @@ select
       ├── NOT (j:5 ?& ARRAY['foo']) [outer=(5), immutable]
       └── NOT (ARRAY[i:2] && ARRAY[1]) [outer=(2), immutable]
 
+# Regression test for #84476 - don't panic when encountering a negated
+# geospatial comparison operator.
+norm expect-not=NegateComparison
+SELECT
+	NULL, t.g
+FROM
+	(VALUES (NULL::GEOMETRY)) AS t (g)
+WHERE
+	(NOT (t.g ~ t.g));
+----
+project
+ ├── columns: "?column?":2 g:1
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── select
+ │    ├── columns: column1:1
+ │    ├── cardinality: [0 - 1]
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── values
+ │    │    ├── columns: column1:1
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (NULL,)
+ │    └── filters
+ │         └── NOT (CAST(NULL AS GEOMETRY) ~ CAST(NULL AS GEOMETRY)) [immutable]
+ └── projections
+      └── NULL [as="?column?":2]
+
 # --------------------------------------------------
 # EliminateNot
 # --------------------------------------------------


### PR DESCRIPTION
Previously, the `NegateComparison` rule could match geospatial
comparison operators like `~`. This would lead to a panic when the
rule attempted to construct the negated version of the expression,
since there is no negation for `~` and other geospatial comparisons.

This patch modifies `NegateComparison` to directly check
`opt.NegateOpMap` to ensure that a comparison can be negated before
matching the expression.

Fixes #84476

Release note (bug fix): Fixed a bug introduced in 20.2 that could
cause a panic when an expression contained a geospatial comparison
like `~` that was negated.