### PR TITLE
cli,sdnotify: improve the handling of unix socket directories

### DIFF
--- a/pkg/cli/interactive_tests/test_socket_name.tcl
+++ b/pkg/cli/interactive_tests/test_socket_name.tcl
@@ -1,0 +1,65 @@
+#! /usr/bin/env expect -f
+#
+source [file join [file dirname $argv0] common.tcl]
+
+set longname "this-is-a-very-long-directory-name-the-point-is-to-be-more-than-one-hundred-and-twenty-three-characters/and-we-also-need-to-break-it-into-two-parts"
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+send "mkdir -p $longname\r"
+eexpect ":/# "
+
+start_test "Check that the socket-dir flag checks the length of the directory."
+send "$argv start-single-node --insecure --socket-dir=$longname\r"
+eexpect "value of --socket-dir is too long"
+eexpect "socket directory name must be shorter"
+eexpect ":/# "
+end_test
+
+set crdb [file normalize $argv]
+send "export BASEDIR=\$PWD\r"
+eexpect ":/# "
+send "export PREVTMP=\$TMPDIR\r"
+eexpect ":/# "
+
+start_test "Check that --background complains about the directory name if there is no default."
+send "cd $longname\r"
+eexpect ":/# "
+send "export TMPDIR=\$PWD\r"
+eexpect ":/# "
+send "$crdb start-single-node --insecure --background\r"
+eexpect "no suitable directory found for the --background notify socket"
+eexpect "use a shorter directory name"
+eexpect ":/# "
+end_test
+
+start_test "Check that --background can use --socket-name if specified and set to sane default."
+send "$crdb start-single-node --insecure --background --socket-dir=\$BASEDIR --pid-file=\$BASEDIR/server_pid\r"
+eexpect ":/# "
+# check the server is running.
+system "$crdb sql --insecure -e 'select 1'"
+stop_server $crdb
+end_test
+
+start_test "Check that --background can use TMPDIR if specified and set to sane default."
+# NB: we use a single-command override of TMPDIR (as opposed to using 'export') so that
+# the following test below can reuse the value set above.
+send "TMPDIR=\$PREVTMP $crdb start-single-node --insecure --background --pid-file=\$BASEDIR/server_pid\r"
+eexpect ":/# "
+# check the server is running.
+system "$crdb sql --insecure -e 'select 1'"
+stop_server $crdb
+end_test
+
+start_test "Check that --background can use cwd if TMPDIR is invalid."
+# NB: at this point TMPDIR is still long, as per previous test.
+send "cd \$BASEDIR\r"
+eexpect ":/# "
+send "$crdb start-single-node --insecure --background --pid-file=server_pid\r"
+eexpect ":/# "
+# check the server is running.
+system "$crdb sql --insecure -e 'select 1'"
+stop_server $crdb
+end_test

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -758,8 +758,10 @@ func waitForShutdown(
 				// INFO because a single interrupt is rather innocuous.
 				severity.INFO,
 			)
-			msgDouble := "Note: a second interrupt will skip graceful shutdown and terminate forcefully"
-			fmt.Fprintln(os.Stdout, msgDouble)
+			if !startCtx.inBackground {
+				msgDouble := "Note: a second interrupt will skip graceful shutdown and terminate forcefully"
+				fmt.Fprintln(os.Stdout, msgDouble)
+			}
 		}
 
 		// Start the draining process in a separate goroutine so that it
@@ -843,7 +845,9 @@ func waitForShutdown(
 
 	const msgDrain = "initiating graceful shutdown of server"
 	log.Ops.Info(shutdownCtx, msgDrain)
-	fmt.Fprintln(os.Stdout, msgDrain)
+	if !startCtx.inBackground {
+		fmt.Fprintln(os.Stdout, msgDrain)
+	}
 
 	// Notify the user every 5 second of the shutdown progress.
 	go func() {
@@ -895,12 +899,16 @@ func waitForShutdown(
 		case <-stopper.IsStopped():
 			const msgDone = "server drained and shutdown completed"
 			log.Ops.Infof(shutdownCtx, msgDone)
-			fmt.Fprintln(os.Stdout, msgDone)
+			if !startCtx.inBackground {
+				fmt.Fprintln(os.Stdout, msgDone)
+			}
 
 		case <-stopWithoutDrain:
 			const msgDone = "too early to drain; used hard shutdown instead"
 			log.Ops.Infof(shutdownCtx, msgDone)
-			fmt.Fprintln(os.Stdout, msgDone)
+			if !startCtx.inBackground {
+				fmt.Fprintln(os.Stdout, msgDone)
+			}
 		}
 		break
 	}

--- a/pkg/util/sdnotify/BUILD.bazel
+++ b/pkg/util/sdnotify/BUILD.bazel
@@ -26,42 +26,55 @@ go_test(
     deps = select({
         "@io_bazel_rules_go//go/platform:aix": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:illumos": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:js": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/util/sdnotify/sdnotify.go
+++ b/pkg/util/sdnotify/sdnotify.go
@@ -29,6 +29,6 @@ func Ready() error {
 // either exited or signaled that it is ready. If the command exits
 // with a non-zero status before signaling readiness, returns an
 // exec.ExitError.
-func Exec(cmd *exec.Cmd) error {
-	return bgExec(cmd)
+func Exec(cmd *exec.Cmd, socketDir string) error {
+	return bgExec(cmd, socketDir)
 }

--- a/pkg/util/sdnotify/sdnotify_unix.go
+++ b/pkg/util/sdnotify/sdnotify_unix.go
@@ -55,8 +55,8 @@ func notify(path, msg string) error {
 	return err
 }
 
-func bgExec(cmd *exec.Cmd) error {
-	l, err := listen()
+func bgExec(cmd *exec.Cmd, socketDir string) error {
+	l, err := listen(socketDir)
 	if err != nil {
 		return err
 	}
@@ -97,8 +97,8 @@ type listener struct {
 	conn    *net.UnixConn
 }
 
-func listen() (listener, error) {
-	dir, err := ioutil.TempDir("", "sdnotify")
+func listen(socketDir string) (listener, error) {
+	dir, err := ioutil.TempDir(socketDir, "sdnotify")
 	if err != nil {
 		return listener{}, err
 	}

--- a/pkg/util/sdnotify/sdnotify_unix_test.go
+++ b/pkg/util/sdnotify/sdnotify_unix_test.go
@@ -18,13 +18,25 @@ import (
 	"testing"
 
 	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
+	"github.com/stretchr/testify/require"
 )
 
 func TestSDNotify(t *testing.T) {
-	l, err := listen(os.TempDir())
-	if err != nil {
-		t.Fatal(err)
+	tmpDir := os.TempDir()
+	// On BSD, binding to a socket is limited to a path length of 104 characters
+	// (including the NUL terminator). In glibc, this limit is 108 characters.
+	// macOS also has a tendency to produce very long temporary directory names.
+	if len(tmpDir) >= 104-1-len("sdnotify/notify.sock")-10 {
+		// Perhaps running inside a sandbox?
+		t.Logf("default temp dir name is too long: %s", tmpDir)
+		t.Logf("forcing use of /tmp instead")
+		// Note: Using /tmp may fail on some systems; this is why we
+		// prefer os.TempDir() by default.
+		tmpDir = "/tmp"
 	}
+
+	l, err := listen(tmpDir)
+	require.NoError(t, err)
 	defer func() { _ = l.close() }()
 
 	ch := make(chan error)

--- a/pkg/util/sdnotify/sdnotify_unix_test.go
+++ b/pkg/util/sdnotify/sdnotify_unix_test.go
@@ -14,13 +14,14 @@
 package sdnotify
 
 import (
+	"os"
 	"testing"
 
 	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
 )
 
 func TestSDNotify(t *testing.T) {
-	l, err := listen()
+	l, err := listen(os.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/sdnotify/sdnotify_windows.go
+++ b/pkg/util/sdnotify/sdnotify_windows.go
@@ -20,6 +20,6 @@ func ready() error {
 	return nil
 }
 
-func bgExec(*exec.Cmd) error {
+func bgExec(*exec.Cmd, string) error {
 	return errors.New("not implemented")
 }


### PR DESCRIPTION
tldr: This patch makes it easier for users to understand when
CockroachDB has a problem using/creating unix sockets, and
what they can do to avert the situation.

Fixes #76904.

Example, before;
```
$ cockroach start-single-node --insecure --background
...
listen unixgram /data/home/kena/cockroach/this-is-a-very-long-directory-name-the-point-is-to-be-more-than-one-hundred-and-twenty-three-characters/sdnotify2139543236/notify.sock: bind: invalid argument
```

Example, after:
```
$ cockroach start-single-node --insecure --background
ERROR: no suitable directory found for the --background notify socket
HINT: Avoid using --background altogether (preferred), or use a
shorter directory name for --socket-dir, TMPDIR or the current directory.
```

**Context:**

CockroachDB uses unix sockets both to handle `--background` and to
create a postgres-compatible SQL client socket via `--socket-dir`. For
`--background`, the logic was previously hardwired to always use
`os.TempDir()`, i.e. either `$TMPDIR` or `/tmp`.

On Unix, socket objects are commonly limited to 128 bytes;
that's e.g. 104 path characters including final NUL on BSD, 108 on glibc.
When the actual length is larger, creating the socket fails with
a confusing error `bind: invalid argument`.

**The problem:**

Users have reported issues in the following circumstances:

- when setting their CWD/$TMPDIR to a long directory name,
  they expected `--socket-dir` to also influence the socket
  name used for `--background`. Instead, `--background`
  failed with a hard-to-understand error. (#76904)

- when running tests inside a container/sandbox with a long
  prefix, they were confused that `--background` / `--socket-dir=.`
  did not work properly.

- they use macOS which has very large directory names in $TMPDIR.

To improve user experience, this patch changes the behavior
as described in the release notes below below.

Release note (cli change): CockroachDB now produces a clearer error
when the path specified via `--socket-dir` is too long.

Release note (cli change): When the flag `--background` is specified,
CockroachDB now makes 3 attempts to find a suitable directory to
create the notification socket: the value of `--socket-dir` if
specified, the value of `$TMPDIR` (or /tmp if the env var is empty),
and the current working directory. If none of these directories has a
name short enough, an explanatory error is printed.