### PR TITLE
ci: build roachprod binary

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -24,5 +24,6 @@ bazel build //pkg/cmd/bazci --config=ci
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --compilation_mode opt \
 		       --config "$CONFIG" --config ci --config with_ui \
 		       build //pkg/cmd/cockroach-short //pkg/cmd/cockroach \
-               //pkg/cmd/cockroach-sql \
+		       //pkg/cmd/cockroach-sql \
+		       //pkg/cmd/roachprod \
 		       //pkg/cmd/cockroach-oss //c-deps:libgeos $EXTRA_TARGETS


### PR DESCRIPTION
Previously, roachprod binary was not built by CI.
As of a recent refactoring, roachprod binary is no longer
required to execute roachtests [1]. However, roachprod
is used internally by many teams including those outside
of the Engineering org. This change adds the roachprod
binary build artifact to the existing CI Build jobs.

[1] https://github.com/cockroachdb/cockroach/pull/74218

Release note: None