### PR TITLE
roachtest: fix nan error coefvar

### DIFF
--- a/pkg/cmd/roachtest/clusterstats/BUILD.bazel
+++ b/pkg/cmd/roachtest/clusterstats/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",
         "@com_github_golang_mock//gomock",
+        "@com_github_montanaflynn_stats//:stats",
         "@com_github_prometheus_client_golang//api/prometheus/v1:prometheus",
         "@com_github_prometheus_common//model",
         "@com_github_stretchr_testify//require",

--- a/pkg/cmd/roachtest/clusterstats/exporter.go
+++ b/pkg/cmd/roachtest/clusterstats/exporter.go
@@ -221,6 +221,12 @@ func (cs *clusterStatCollector) getStatSummary(
 
 	trimmedTaggedSeries, n, trimmedInterval := TrimTaggedSeries(ctx, l, taggedSeries)
 
+	// When there are no values returned in the trimmed interval, return an
+	// error, to log and skip this summary.
+	if n == 0 {
+		return ret, errors.Errorf("No timeseries values found")
+	}
+
 	// We are unable to find the label name requested in the returned time
 	// series.
 	if _, ok := trimmedTaggedSeries[summaryQuery.Stat.LabelName]; !ok {

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -33,7 +33,7 @@ import (
 
 // The duration of no rebalancing actions taken before we assume the
 // configuration is in a steady state and assess balance.
-const allocatorStableSeconds = 10
+const allocatorStableSeconds = 120
 
 func registerAllocator(r registry.Registry) {
 	runAllocator := func(ctx context.Context, t test.Test, c cluster.Cluster, start int, maxStdDev float64) {
@@ -51,7 +51,7 @@ func registerAllocator(r registry.Registry) {
 		m.Go(func(ctx context.Context) error {
 			t.Status("loading fixture")
 			if err := c.RunE(
-				ctx, c.Node(1), "./cockroach", "workload", "fixtures", "import", "tpch", "--scale-factor", "1",
+				ctx, c.Node(1), "./cockroach", "workload", "fixtures", "import", "tpch", "--scale-factor", "10",
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/tests/rebalance_stats.go
+++ b/pkg/cmd/roachtest/tests/rebalance_stats.go
@@ -83,9 +83,19 @@ func applyToSeries(timeseries [][]float64, aggFn func(vals []float64) float64) [
 	return ret
 }
 
+// coefficientOfVariation returns the standard deviation over the mean. No mean
+// or standard deviation can be computed when there are no samples, in which
+// case we return 0. When the sample mean is 0, the coefficient of variation
+// cannot be calculated, we return 0.
 func coefficientOfVariation(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
 	stdev, _ := stats.StandardDeviationSample(vals)
 	mean, _ := stats.Mean(vals)
+	if mean == 0 {
+		return 0
+	}
 	return stdev / mean
 }
 


### PR DESCRIPTION
When calculating the coefficient of variation previously,
`roactest/tests/rebalance_stats.go` would swallow errors that
occurred when calculating mean/var on an array of length 0. This
would produce a `NaN` value.

This patch returns 0 instead, when there are no values in the input 
or the sample mean is 0.

This patch also resets the TPCH import back to 10gb and 120s rebalance
stable seconds.

resolves: #84133

Release note: None