### PR TITLE
streamingccl: fix TestTenantStreamingProducerJobTimedOut flaky test

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -59,7 +59,7 @@ func getStreamIngestionStats(
 	evalCtx *eval.Context, txn *kv.Txn, ingestionJobID jobspb.JobID,
 ) (*streampb.StreamIngestionStats, error) {
 	registry := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig).JobRegistry
-	j, err := registry.LoadJob(evalCtx.Ctx(), ingestionJobID)
+	j, err := registry.LoadJobWithTxn(evalCtx.Ctx(), ingestionJobID, txn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -194,7 +194,9 @@ func (s *streamIngestionResultWriter) AddRow(ctx context.Context, row tree.Datum
 		&ingestedHighWatermark); err != nil {
 		return errors.NewAssertionErrorWithWrappedErrf(err, `unmarshalling resolved timestamp`)
 	}
-	return s.registry.UpdateJobWithTxn(ctx, s.jobID, nil /* txn */, false, /* useReadLock */
+	// TODO(casper): currently if this update is without read lock, read may see nil high watermark
+	// when getting a stream ingestion stats. We need to keep investigating why this happens.
+	return s.registry.UpdateJobWithTxn(ctx, s.jobID, nil /* txn */, true, /* useReadLock */
 		func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 			if err := jobs.UpdateHighwaterProgressed(ingestedHighWatermark, md, ju); err != nil {
 				return err

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -325,6 +325,8 @@ func TestTenantStreamingProducerJobTimedOut(t *testing.T) {
 	c.compareResult("SELECT * FROM d.t2")
 
 	stats := streamIngestionStats(t, c.destSysSQL, ingestionJobID)
+
+	require.NotNil(t, stats.ReplicationLagInfo)
 	require.True(t, srcTime.LessEq(stats.ReplicationLagInfo.MinIngestedTimestamp))
 	require.Equal(t, "", stats.ProducerError)
 


### PR DESCRIPTION
streamingccl: fix TestTenantStreamingProducerJobTimedOut flaky test

Fixes a race between job resumer updating the job high watermark
and reading high watermark when getting a stream ingestion stats.

Closes: https://github.com/cockroachdb/cockroach/issues/84332

Release note: None