### PR TITLE
kvserver: lease transfer in relocate range

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -1102,10 +1102,6 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			)
 
 			require.Len(t, voterTargets, len(tc.expRebalancedVoters))
-			if len(voterTargets) > 0 && voterTargets[0].StoreID != tc.expRebalancedVoters[0] {
-				t.Errorf("chooseRangeToRebalance(existing=%v, qps=%f) chose s%d as leaseholder; want s%v",
-					tc.voters, testingQPS, voterTargets[0], tc.expRebalancedVoters[0])
-			}
 
 			voterStoreIDs := make([]roachpb.StoreID, len(voterTargets))
 			for i, target := range voterTargets {


### PR DESCRIPTION
Previously, the store rebalancer would transfer the lease on a range to
the store with the least qps, when invoking relocate range to rebalance
replicas. This is in addition to lease transfers that occur in the first
part of the store rebalancer loop.

This patch removes the lease transfer that may occur when rebalancing
replicas, using relocate range. Instead, only lease transfers may occur
in the first phase of the rebalance loop.

Release note: None