### PR TITLE
rowexec: use OutOfOrder mode of streamer for lookup joins with ordering

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -504,7 +504,10 @@ func TestStreamerMultiRangeScan(t *testing.T) {
 	// The crux of the test - run a query that performs a lookup join when
 	// ordering needs to be maintained and then confirm that the results of the
 	// parallel lookups are served in the right order.
-	r := db.QueryRow("SELECT array_agg(s) FROM small INNER LOOKUP JOIN large ON small.n = large.n GROUP BY small.n ORDER BY small.n")
+	// TODO(yuzefovich): remove ORDER BY clause inside array_agg when the lookup
+	// joins use the InOrder mode of the streamer when ordering needs to be
+	// maintained.
+	r := db.QueryRow("SELECT array_agg(s ORDER BY s) FROM small INNER LOOKUP JOIN large ON small.n = large.n GROUP BY small.n ORDER BY small.n")
 	var result string
 	err = r.Scan(&result)
 	require.NoError(t, err)


### PR DESCRIPTION
Currently, the join reader always restores the required order for lookup
joins on its own since all looked up rows are buffered before any output
row is emitted. This observation allows us to use the OutOfOrder mode of
the streamer in such scenarios, so this commit makes such a change.
Previously, we would effectively maintain the order twice - both in the
streamer and in the join reader, and the former is redundant. This will
change in the future, but for now we can use the more-efficient mode.

```
name                                                  old time/op    new time/op    delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24             6.64ms ± 1%    6.48ms ± 1%  -2.34%  (p=0.000 n=10+10)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24    7.89ms ± 1%    7.75ms ± 1%  -1.80%  (p=0.000 n=10+10)
LookupJoinOrdering/Cockroach-24                         9.01ms ± 3%    8.88ms ± 4%    ~     (p=0.218 n=10+10)
LookupJoinOrdering/MultinodeCockroach-24                12.1ms ± 4%    12.0ms ± 3%    ~     (p=0.393 n=10+10)

name                                                  old alloc/op   new alloc/op   delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24             1.68MB ± 1%    1.60MB ± 1%  -4.93%  (p=0.000 n=10+10)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24    2.37MB ± 2%    2.29MB ± 2%  -3.11%  (p=0.000 n=10+10)
LookupJoinOrdering/Cockroach-24                         1.75MB ± 1%    1.66MB ± 1%  -5.01%  (p=0.000 n=10+9)
LookupJoinOrdering/MultinodeCockroach-24                2.36MB ± 1%    2.25MB ± 1%  -4.68%  (p=0.000 n=8+10)

name                                                  old allocs/op  new allocs/op  delta
LookupJoinEqColsAreKeyOrdering/Cockroach-24              10.0k ± 1%     10.0k ± 1%    ~     (p=0.278 n=10+9)
LookupJoinEqColsAreKeyOrdering/MultinodeCockroach-24     14.3k ± 1%     14.3k ± 1%    ~     (p=0.470 n=10+10)
LookupJoinOrdering/Cockroach-24                          12.4k ± 1%     12.5k ± 1%    ~     (p=0.780 n=10+10)
LookupJoinOrdering/MultinodeCockroach-24                 17.1k ± 1%     17.0k ± 1%    ~     (p=0.494 n=10+10)
```

Addresses: #82159.

Release note: None