### PR TITLE
ui: add insights overview page v1

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -1,0 +1,120 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  executeSql,
+  SqlExecutionRequest,
+  SqlExecutionResponse,
+} from "./sqlApi";
+import { InsightEvent, InsightExecEnum, InsightNameEnum } from "src/insights";
+import moment from "moment";
+
+export type InsightEventState = Omit<InsightEvent, "insights"> & {
+  insightName: string;
+};
+
+export type InsightEventsResponse = InsightEventState[];
+
+type InsightQuery<ResponseColumnType> = {
+  name: InsightNameEnum;
+  query: string;
+  toState: (
+    response: SqlExecutionResponse<ResponseColumnType>,
+    results: Record<string, InsightEventState>,
+  ) => InsightEventState[];
+};
+
+// The only insight we currently report is "High Wait Time", which is the insight
+// associated with each row in the crdb_internal.transaction_contention_events table.
+export const HIGH_WAIT_CONTENTION_THRESHOLD = moment.duration(
+  200,
+  "milliseconds",
+);
+
+type TransactionContentionResponseColumns = {
+  blocking_txn_id: string;
+  blocking_queries: string[];
+  collection_ts: string;
+  contention_duration: string;
+  app_name: string;
+};
+
+function transactionContentionResultsToEventState(
+  response: SqlExecutionResponse<TransactionContentionResponseColumns>,
+  results: Record<string, InsightEventState>,
+): InsightEventState[] {
+  response.execution.txn_results[0].rows.forEach(row => {
+    const key = row.blocking_txn_id;
+    if (!results[key]) {
+      results[key] = {
+        executionID: row.blocking_txn_id,
+        queries: row.blocking_queries,
+        startTime: moment(row.collection_ts),
+        elapsedTime: moment.duration(row.contention_duration).asMilliseconds(),
+        application: row.app_name,
+        insightName: highWaitTimeQuery.name,
+        execType: InsightExecEnum.TRANSACTION,
+      };
+    }
+  });
+
+  return Object.values(results);
+}
+
+const highWaitTimeQuery: InsightQuery<TransactionContentionResponseColumns> = {
+  name: InsightNameEnum.highWaitTime,
+  query: `SELECT
+            blocking_txn_id,
+            blocking_queries,
+            collection_ts,
+            contention_duration,
+            app_name
+          FROM
+            crdb_internal.transaction_contention_events AS tce
+              JOIN (
+              SELECT
+                transaction_fingerprint_id,
+                app_name,
+                array_agg(metadata ->> 'query') AS blocking_queries
+              FROM
+                crdb_internal.statement_statistics
+              GROUP BY
+                transaction_fingerprint_id,
+                app_name
+            ) AS bqs ON bqs.transaction_fingerprint_id = tce.blocking_txn_fingerprint_id
+          WHERE
+            contention_duration > INTERVAL '${HIGH_WAIT_CONTENTION_THRESHOLD.toISOString()}'
+  `,
+  toState: transactionContentionResultsToEventState,
+};
+
+// getInsightEventState is currently hardcoded to use the High Wait Time insight type
+// for transaction contention events
+export function getInsightEventState(): Promise<InsightEventsResponse> {
+  const request: SqlExecutionRequest = {
+    statements: [
+      {
+        sql: `${highWaitTimeQuery.query}`,
+      },
+    ],
+    execute: true,
+  };
+  return executeSql<TransactionContentionResponseColumns>(request).then(
+    result => {
+      if (!result.execution.txn_results[0].rows) {
+        // No data.
+        return [];
+      }
+
+      const results: Record<string, InsightEventState> = {};
+      return highWaitTimeQuery.toState(result, results);
+    },
+  );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -26,6 +26,7 @@ export * from "./empty";
 export * from "./filter";
 export * from "./highlightedText";
 export * from "./indexDetailsPage";
+export * from "./insights";
 export * from "./jobs";
 export * from "./loading";
 export * from "./modal";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,10 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./fetchData";
-export * from "./statementDiagnosticsApi";
-export * from "./statementsApi";
-export * from "./basePath";
-export * from "./nodesApi";
-export * from "./clusterLocksApi";
-export * from "./insightsApi";
+export * from "./workloadInsights";
+export * from "./utils";
+export * from "./types";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -1,0 +1,78 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Moment } from "moment";
+import { HIGH_WAIT_CONTENTION_THRESHOLD } from "../api";
+import { Filters } from "../queryFilter";
+
+export enum InsightNameEnum {
+  highWaitTime = "highWaitTime",
+}
+
+export enum InsightExecEnum {
+  TRANSACTION = "transaction",
+  STATEMENT = "statement",
+}
+
+export type InsightEvent = {
+  executionID: string;
+  queries: string[];
+  insights: Insight[];
+  startTime: Moment;
+  elapsedTime: number;
+  application: string;
+  execType: InsightExecEnum;
+};
+
+export type Insight = {
+  name: InsightNameEnum;
+  label: string;
+  description: string;
+};
+
+const highWaitTimeInsight = (
+  execType: InsightExecEnum = InsightExecEnum.TRANSACTION,
+): Insight => {
+  const threshold = HIGH_WAIT_CONTENTION_THRESHOLD.asMilliseconds();
+  return {
+    name: InsightNameEnum.highWaitTime,
+    label: "High Wait Time",
+    description:
+      `This ${execType} has been waiting for more than ${threshold}ms on other ${execType}s to execute. ` +
+      `Click the ${execType} execution ID to see more details.`,
+  };
+};
+
+export const InsightTypes = [highWaitTimeInsight];
+
+export const InsightExecOptions = [
+  {
+    value: InsightExecEnum.TRANSACTION.toString(),
+    label: "Transaction Executions",
+  },
+  {
+    value: InsightExecEnum.STATEMENT.toString(),
+    label: "Statement Executions",
+  },
+];
+
+export type InsightEventFilters = Omit<
+  Filters,
+  | "database"
+  | "sqlType"
+  | "fullScan"
+  | "distributed"
+  | "regions"
+  | "nodes"
+  | "username"
+  | "sessionStatus"
+  | "timeNumber"
+  | "timeUnit"
+>;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -1,0 +1,116 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { unset } from "src/util";
+import { InsightEventsResponse, InsightEventState } from "src/api/insightsApi";
+import {
+  Insight,
+  InsightExecEnum,
+  InsightTypes,
+  InsightEvent,
+  InsightEventFilters,
+} from "./types";
+
+export const getInsights = (eventState: InsightEventState): Insight[] => {
+  const insights: Insight[] = [];
+  InsightTypes.forEach(insight => {
+    if (insight(eventState.execType).name == eventState.insightName) {
+      insights.push(insight(eventState.execType));
+    }
+  });
+  return insights;
+};
+
+export function getInsightsFromState(
+  insightEventsResponse: InsightEventsResponse,
+): InsightEvent[] {
+  const insightEvents: InsightEvent[] = [];
+  if (!insightEventsResponse || insightEventsResponse?.length < 0) {
+    return insightEvents;
+  }
+
+  insightEventsResponse.forEach(e => {
+    const insightsForEvent = getInsights(e);
+    if (insightsForEvent.length < 1) {
+      return;
+    } else {
+      insightEvents.push({
+        executionID: e.executionID,
+        queries: e.queries,
+        insights: insightsForEvent,
+        startTime: e.startTime,
+        elapsedTime: e.elapsedTime,
+        application: e.application,
+        execType: InsightExecEnum.TRANSACTION,
+      });
+    }
+  });
+
+  return insightEvents;
+}
+
+export const filterTransactionInsights = (
+  transactions: InsightEvent[] | null,
+  filters: InsightEventFilters,
+  internalAppNamePrefix: string,
+  search?: string,
+): InsightEvent[] => {
+  if (transactions == null) return [];
+
+  let filteredTransactions = transactions;
+
+  const isInternal = (txn: InsightEvent) =>
+    txn.application.startsWith(internalAppNamePrefix);
+  if (filters.app) {
+    filteredTransactions = filteredTransactions.filter((txn: InsightEvent) => {
+      const apps = filters.app.toString().split(",");
+      let showInternal = false;
+      if (apps.includes(internalAppNamePrefix)) {
+        showInternal = true;
+      }
+      if (apps.includes(unset)) {
+        apps.push("");
+      }
+
+      return (
+        (showInternal && isInternal(txn)) || apps.includes(txn.application)
+      );
+    });
+  } else {
+    filteredTransactions = filteredTransactions.filter(txn => !isInternal(txn));
+  }
+  if (search) {
+    filteredTransactions = filteredTransactions.filter(
+      txn =>
+        !search ||
+        txn.executionID?.includes(search) ||
+        txn.queries?.find(query => query.includes(search)),
+    );
+  }
+  return filteredTransactions;
+};
+
+export function getAppsFromTransactionInsights(
+  transactions: InsightEvent[] | null,
+  internalAppNamePrefix: string,
+): string[] {
+  if (transactions == null) return [];
+
+  const uniqueAppNames = new Set(
+    transactions.map(t => {
+      if (t.application.startsWith(internalAppNamePrefix)) {
+        return internalAppNamePrefix;
+      }
+      return t.application ? t.application : unset;
+    }),
+  );
+
+  return Array.from(uniqueAppNames).sort();
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,10 +8,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./fetchData";
-export * from "./statementDiagnosticsApi";
-export * from "./statementsApi";
-export * from "./basePath";
-export * from "./nodesApi";
-export * from "./clusterLocksApi";
-export * from "./insightsApi";
+export * from "./transactionInsights";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,10 +8,5 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./fetchData";
-export * from "./statementDiagnosticsApi";
-export * from "./statementsApi";
-export * from "./basePath";
-export * from "./nodesApi";
-export * from "./clusterLocksApi";
-export * from "./insightsApi";
+export * from "./transactionInsightsView";
+export * from "./transactionInsightsTable";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
@@ -1,0 +1,64 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { TransactionInsightsViewProps } from "./transactionInsightsView";
+import moment from "moment";
+import { InsightExecEnum } from "../../types";
+
+export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
+  transactions: [
+    {
+      executionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
+      queries: [
+        "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
+      ],
+      insightName: "highWaitTime",
+      startTime: moment.utc("2022.08.10"),
+      elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
+      application: "demo",
+      execType: InsightExecEnum.TRANSACTION,
+    },
+    {
+      executionID: "e72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
+      queries: [
+        "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
+        "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
+      ],
+      insightName: "highWaitTime",
+      startTime: moment.utc("2022.08.10"),
+      elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
+      application: "demo",
+      execType: InsightExecEnum.TRANSACTION,
+    },
+    {
+      executionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a0",
+      queries: [
+        "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
+      ],
+      insightName: "highWaitTime",
+      startTime: moment.utc("2022.08.10"),
+      elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
+      application: "demo",
+      execType: InsightExecEnum.TRANSACTION,
+    },
+  ],
+  transactionsError: null,
+  sortSetting: {
+    ascending: false,
+    columnTitle: "startTime",
+  },
+  filters: {
+    app: "",
+  },
+  internalAppNamePrefix: "$ internal",
+  refreshTransactionInsights: () => {},
+  onSortChange: () => {},
+  onFiltersChange: () => {},
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -1,0 +1,86 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import {
+  SortedTable,
+  ISortedTablePagination,
+  ColumnDescriptor,
+  SortSetting,
+} from "src/sortedtable";
+import { DATE_FORMAT, Duration } from "src/util";
+import { InsightExecEnum, InsightEvent } from "src/insights";
+import { QueriesCell, InsightCell, insightsTableTitles } from "../util";
+
+interface TransactionInsightsTable {
+  data: InsightEvent[];
+  sortSetting: SortSetting;
+  onChangeSortSetting: (ss: SortSetting) => void;
+  pagination: ISortedTablePagination;
+  renderNoResult?: React.ReactNode;
+}
+
+export function makeTransactionInsightsColumns(): ColumnDescriptor<InsightEvent>[] {
+  const execType = InsightExecEnum.TRANSACTION;
+  return [
+    {
+      name: "executionID",
+      title: insightsTableTitles.executionID(execType),
+      cell: (item: InsightEvent) => String(item.executionID),
+      sort: (item: InsightEvent) => String(item.executionID),
+    },
+    {
+      name: "query",
+      title: insightsTableTitles.query(execType),
+      cell: (item: InsightEvent) =>
+        QueriesCell({ transactionQueries: item.queries, textLimit: 50 }),
+      sort: (item: InsightEvent) => item.queries.length,
+    },
+    {
+      name: "insights",
+      title: insightsTableTitles.insights(execType),
+      cell: (item: InsightEvent) =>
+        item.insights ? item.insights.map(insight => InsightCell(insight)) : "",
+      sort: (item: InsightEvent) =>
+        item.insights
+          ? item.insights.map(insight => insight.label).toString()
+          : "",
+    },
+    {
+      name: "startTime",
+      title: insightsTableTitles.startTime(execType),
+      cell: (item: InsightEvent) => item.startTime.format(DATE_FORMAT),
+      sort: (item: InsightEvent) => item.startTime.unix(),
+    },
+    {
+      name: "elapsedTime",
+      title: insightsTableTitles.elapsedTime(execType),
+      cell: (item: InsightEvent) => Duration(item.elapsedTime * 1e6),
+      sort: (item: InsightEvent) => item.elapsedTime,
+    },
+    {
+      name: "applicationName",
+      title: insightsTableTitles.applicationName(execType),
+      cell: (item: InsightEvent) => item.application,
+      sort: (item: InsightEvent) => item.application,
+    },
+  ];
+}
+
+export const TransactionInsightsTable: React.FC<
+  TransactionInsightsTable
+> = props => {
+  const columns = makeTransactionInsightsColumns();
+  return (
+    <SortedTable columns={columns} className="statements-table" {...props} />
+  );
+};
+
+TransactionInsightsTable.defaultProps = {};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -1,0 +1,266 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useEffect, useState } from "react";
+import classNames from "classnames/bind";
+import { useHistory } from "react-router-dom";
+import {
+  ISortedTablePagination,
+  SortSetting,
+} from "src/sortedtable/sortedtable";
+import { Loading } from "src/loading/loading";
+import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
+import { Search } from "src/search/search";
+import {
+  calculateActiveFilters,
+  defaultFilters,
+  Filter,
+  Filters,
+  getFullFiltersAsStringRecord,
+} from "src/queryFilter/filter";
+import { getInsightEventFiltersFromURL } from "src/queryFilter/utils";
+import { Pagination } from "src/pagination";
+import { queryByName, syncHistory } from "src/util/query";
+import { getTableSortFromURL } from "src/sortedtable/getTableSortFromURL";
+import { TableStatistics } from "src/tableStatistics";
+
+import { InsightEventsResponse } from "src/api/insightsApi";
+import {
+  filterTransactionInsights,
+  getAppsFromTransactionInsights,
+  getInsightsFromState,
+  InsightEventFilters,
+  InsightExecOptions,
+} from "src/insights";
+import {
+  EmptyInsightsTablePlaceholder,
+  DropDownSelect,
+  WorkloadInsightsError,
+} from "../util";
+import { TransactionInsightsTable } from "./transactionInsightsTable";
+
+import styles from "src/statementsPage/statementsPage.module.scss";
+import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
+const cx = classNames.bind(styles);
+const sortableTableCx = classNames.bind(sortableTableStyles);
+
+export type TransactionInsightsViewStateProps = {
+  transactions: InsightEventsResponse;
+  transactionsError: Error | null;
+  filters: InsightEventFilters;
+  sortSetting: SortSetting;
+  internalAppNamePrefix: string;
+};
+
+export type TransactionInsightsViewDispatchProps = {
+  onFiltersChange: (filters: InsightEventFilters) => void;
+  onSortChange: (ss: SortSetting) => void;
+  refreshTransactionInsights: () => void;
+};
+
+export type TransactionInsightsViewProps = TransactionInsightsViewStateProps &
+  TransactionInsightsViewDispatchProps;
+
+const INSIGHT_TXN_SEARCH_PARAM = "q";
+
+export const TransactionInsightsView: React.FC<
+  TransactionInsightsViewProps
+> = ({
+  sortSetting,
+  transactions,
+  transactionsError,
+  filters,
+  internalAppNamePrefix,
+  refreshTransactionInsights,
+  onFiltersChange,
+  onSortChange,
+}: TransactionInsightsViewProps) => {
+  const [pagination, setPagination] = useState<ISortedTablePagination>({
+    current: 1,
+    pageSize: 10,
+  });
+  const history = useHistory();
+  const [search, setSearch] = useState<string>(
+    queryByName(history.location, INSIGHT_TXN_SEARCH_PARAM),
+  );
+
+  useEffect(() => {
+    // Refresh every 10 seconds.
+    refreshTransactionInsights();
+    const interval = setInterval(refreshTransactionInsights, 10 * 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [refreshTransactionInsights]);
+
+  useEffect(() => {
+    // We use this effect to sync settings defined on the URL (sort, filters),
+    // with the redux store. The only time we do this is when the user navigates
+    // to the page directly via the URL and specifies settings in the query string.
+    // Note that the desired behaviour is currently that the user is unable to
+    // clear filters via the URL, and must do so with page controls.
+    const sortSettingURL = getTableSortFromURL(history.location);
+    const filtersFromURL = getInsightEventFiltersFromURL(history.location);
+
+    if (sortSettingURL) {
+      onSortChange(sortSettingURL);
+    }
+    if (filtersFromURL) {
+      onFiltersChange(filtersFromURL);
+    }
+  }, [history, onSortChange, onFiltersChange]);
+
+  useEffect(() => {
+    // This effect runs when the filters or sort settings received from
+    // redux changes and syncs the URL params with redux.
+    syncHistory(
+      {
+        ascending: sortSetting.ascending.toString(),
+        columnTitle: sortSetting.columnTitle,
+        ...getFullFiltersAsStringRecord(filters),
+        [INSIGHT_TXN_SEARCH_PARAM]: search,
+      },
+      history,
+    );
+  }, [
+    history,
+    filters,
+    sortSetting.ascending,
+    sortSetting.columnTitle,
+    search,
+  ]);
+
+  const onChangePage = (current: number): void => {
+    setPagination({
+      current: current,
+      pageSize: 10,
+    });
+  };
+
+  const resetPagination = () => {
+    setPagination({
+      current: 1,
+      pageSize: 10,
+    });
+  };
+
+  const onChangeSortSetting = (ss: SortSetting): void => {
+    onSortChange(ss);
+    resetPagination();
+  };
+
+  const onSubmitSearch = (newSearch: string) => {
+    if (newSearch === search) return;
+    setSearch(newSearch);
+    resetPagination();
+  };
+
+  const clearSearch = () => onSubmitSearch("");
+
+  const onSubmitFilters = (selectedFilters: InsightEventFilters) => {
+    onFiltersChange(selectedFilters);
+    resetPagination();
+  };
+
+  const clearFilters = () =>
+    onSubmitFilters({
+      app: defaultFilters.app,
+    });
+
+  const transactionInsights = getInsightsFromState(transactions);
+
+  const apps = getAppsFromTransactionInsights(
+    transactionInsights,
+    internalAppNamePrefix,
+  );
+  const countActiveFilters = calculateActiveFilters(filters);
+  const filteredTransactions = filterTransactionInsights(
+    transactionInsights,
+    filters,
+    internalAppNamePrefix,
+    search,
+  );
+
+  return (
+    <div className={cx("root")}>
+      <PageConfig>
+        {/* TODO: Uncomment when statements data are added.
+        <PageConfigItem>
+          <DropDownSelect
+            label={InsightExecOptions[0].label}
+            options={InsightExecOptions}
+        </PageConfigItem>/>
+        */}
+        <PageConfigItem>
+          <Search
+            placeholder="Search Transactions"
+            onSubmit={onSubmitSearch}
+            onClear={clearSearch}
+            defaultValue={search}
+          />
+        </PageConfigItem>
+        <PageConfigItem>
+          <Filter
+            activeFilters={countActiveFilters}
+            onSubmitFilters={onSubmitFilters}
+            appNames={apps}
+            filters={filters}
+          />
+        </PageConfigItem>
+      </PageConfig>
+      <div className={cx("table-area")}>
+        <Loading
+          loading={transactions == null}
+          page="transaction insights"
+          error={transactionsError}
+          renderError={() =>
+            WorkloadInsightsError({
+              execType: "transaction insights",
+            })
+          }
+        >
+          <div>
+            <section className={sortableTableCx("cl-table-container")}>
+              <div>
+                <TableStatistics
+                  pagination={pagination}
+                  search={search}
+                  totalCount={filteredTransactions?.length}
+                  arrayItemName="transaction insights"
+                  activeFilters={countActiveFilters}
+                  onClearFilters={clearFilters}
+                />
+              </div>
+              <TransactionInsightsTable
+                data={filteredTransactions}
+                sortSetting={sortSetting}
+                onChangeSortSetting={onChangeSortSetting}
+                renderNoResult={
+                  <EmptyInsightsTablePlaceholder
+                    isEmptySearchResults={
+                      search?.length > 0 && filteredTransactions?.length > 0
+                    }
+                  />
+                }
+                pagination={pagination}
+              />
+            </section>
+            <Pagination
+              pageSize={pagination.pageSize}
+              current={pagination.current}
+              total={filteredTransactions?.length}
+              onChange={onChangePage}
+            />
+          </div>
+        </Loading>
+      </div>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/dropDownSelect.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/dropDownSelect.tsx
@@ -1,0 +1,54 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { useHistory, useLocation } from "react-router-dom";
+import { viewAttr, tabAttr } from "src/util";
+import { queryByName } from "src/util/query";
+import { Dropdown, DropdownOption } from "src/dropdown";
+
+type SelectProps = {
+  label: string;
+  options: { value: string; label: string }[];
+};
+
+export const DropDownSelect = ({
+  label,
+  options,
+}: SelectProps): React.ReactElement => {
+  const history = useHistory();
+  const location = useLocation();
+  const tab = queryByName(location, tabAttr);
+
+  const onViewChange = (view: string): void => {
+    const searchParams = new URLSearchParams({
+      [viewAttr]: view,
+    });
+    if (tab) {
+      searchParams.set(tabAttr, tab);
+    }
+    history.push({
+      search: searchParams.toString(),
+    });
+  };
+
+  const dropDownOptions = (): DropdownOption[] => {
+    return options.map(option => ({
+      name: option.label,
+      value: option.value,
+    }));
+  };
+
+  return (
+    <Dropdown items={dropDownOptions()} onChange={onViewChange}>
+      {label}
+    </Dropdown>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/emptyInsightsTablePlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/emptyInsightsTablePlaceholder.tsx
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { EmptyTable, EmptyTableProps } from "src/empty";
+import { Anchor } from "src/anchor";
+import { transactionContention } from "src/util";
+import magnifyingGlassImg from "src/assets/emptyState/magnifying-glass.svg";
+import emptyTableResultsImg from "src/assets/emptyState/empty-table-results.svg";
+
+const footer = (
+  <Anchor href={transactionContention} target="_blank">
+    Learn more about transaction contention.
+  </Anchor>
+);
+
+const emptySearchResults = {
+  title: "No insight events match your search.",
+  icon: magnifyingGlassImg,
+  footer,
+};
+
+export const EmptyInsightsTablePlaceholder: React.FC<{
+  isEmptySearchResults: boolean;
+}> = isEmptySearchResults => {
+  const emptyPlaceholderProps: EmptyTableProps = isEmptySearchResults
+    ? emptySearchResults
+    : {
+        title: "No insight events since this page was last refreshed.",
+        icon: emptyTableResultsImg,
+        footer,
+      };
+
+  return <EmptyTable {...emptyPlaceholderProps} />;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,10 +8,9 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./fetchData";
-export * from "./statementDiagnosticsApi";
-export * from "./statementsApi";
-export * from "./basePath";
-export * from "./nodesApi";
-export * from "./clusterLocksApi";
-export * from "./insightsApi";
+export * from "./insightCell";
+export * from "./queriesCell";
+export * from "./emptyInsightsTablePlaceholder";
+export * from "./insightsColumns";
+export * from "./dropDownSelect";
+export * from "./workloadInsightsError";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightCell.tsx
@@ -1,0 +1,37 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import classNames from "classnames/bind";
+import { Tooltip } from "@cockroachlabs/ui-components";
+import { Insight } from "src/insights";
+import styles from "./insightTable.module.scss";
+
+const cx = classNames.bind(styles);
+
+function mapInsightTypesToStatus(insight: Insight): string {
+  switch (insight.label) {
+    case "High Wait Time":
+      return "warning";
+    default:
+      return "info";
+  }
+}
+
+export function InsightCell(insight: Insight) {
+  const status = mapInsightTypesToStatus(insight);
+  return (
+    <Tooltip content={insight.description} style="tableTitle">
+      <span className={cx("insight-type", `insight-type--${status}`)}>
+        {insight.label}
+      </span>
+    </Tooltip>
+  );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightTable.module.scss
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@import "src/core/index.module";
+
+.insight-type {
+  display: flex;
+  font-weight: $font-weight--bold;
+  border-bottom: 1px dashed $colors--neutral-5;
+  &--warning {
+    color: $colors--functional-orange-4;
+  }
+  &--info {
+    color: $colors--info-4;
+  }
+}
+
+.insight-table {
+  display:flex;
+}
+
+.action {
+  color: $colors--link;
+  display: flex;
+  line-height: $line-height--medium;
+  &:hover {
+    color: $colors--link;
+    text-decoration: underline;
+  }
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+}
+
+.queries-row {
+  display: flex;
+  border-bottom: 1px dashed $colors--neutral-5;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -1,0 +1,117 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Tooltip } from "@cockroachlabs/ui-components";
+import { InsightExecEnum } from "src/insights";
+
+export const insightsColumnLabels = {
+  executionID: "Execution ID",
+  query: "Execution",
+  insights: "Insights",
+  startTime: "Start Time (UTC)",
+  elapsedTime: "Elapsed Time",
+  applicationName: "Application",
+};
+
+export type InsightsTableColumnKeys = keyof typeof insightsColumnLabels;
+
+type InsightsTableTitleType = {
+  [key in InsightsTableColumnKeys]: (execType: InsightExecEnum) => JSX.Element;
+};
+
+export function getLabel(
+  key: InsightsTableColumnKeys,
+  execType?: string,
+): string {
+  switch (execType) {
+    case InsightExecEnum.TRANSACTION:
+      return "Transaction " + insightsColumnLabels[key];
+    case InsightExecEnum.STATEMENT:
+      return "Statement " + insightsColumnLabels[key];
+    default:
+      return insightsColumnLabels[key];
+  }
+}
+
+export const insightsTableTitles: InsightsTableTitleType = {
+  executionID: (execType: InsightExecEnum) => {
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={<p>The {execType} execution ID.</p>}
+      >
+        {getLabel("executionID", execType)}
+      </Tooltip>
+    );
+  },
+  query: (execType: InsightExecEnum) => {
+    let tooltipText = `The ${execType} query.`;
+    if (execType == InsightExecEnum.TRANSACTION) {
+      tooltipText = "The queries attempted in the transaction.";
+    }
+    return (
+      <Tooltip style="tableTitle" placement="bottom" content={tooltipText}>
+        {getLabel("query", execType)}
+      </Tooltip>
+    );
+  },
+  insights: (execType: InsightExecEnum) => {
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <p>
+            The category of insight identified for the {execType} execution.
+          </p>
+        }
+      >
+        {getLabel("insights")}
+      </Tooltip>
+    );
+  },
+  startTime: (execType: InsightExecEnum) => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={<p>The timestamp at which the {execType} started.</p>}
+      >
+        {getLabel("startTime")}
+      </Tooltip>
+    );
+  },
+  elapsedTime: (execType: InsightExecEnum) => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={
+          <p>The time elapsed since the {execType} started execution.</p>
+        }
+      >
+        {getLabel("elapsedTime")}
+      </Tooltip>
+    );
+  },
+  applicationName: (execType: InsightExecEnum) => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={<p>The name of the application that ran the {execType}.</p>}
+      >
+        {getLabel("applicationName")}
+      </Tooltip>
+    );
+  },
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
@@ -1,0 +1,52 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Tooltip } from "@cockroachlabs/ui-components";
+import { limitText } from "src/util";
+import classNames from "classnames/bind";
+import styles from "./insightTable.module.scss";
+
+const cx = classNames.bind(styles);
+
+interface QueriesCellProps {
+  transactionQueries: string[];
+  textLimit: number;
+}
+
+export const QueriesCell = ({
+  transactionQueries,
+  textLimit,
+}: QueriesCellProps): React.ReactElement => {
+  if (
+    transactionQueries.length < 2 &&
+    transactionQueries[0].length < textLimit
+  ) {
+    return <div>{transactionQueries[0]}</div>;
+  } else {
+    const limitedText = limitText(transactionQueries[0], textLimit);
+    return (
+      <Tooltip
+        placement="bottom"
+        content={
+          <div>
+            {transactionQueries.map(query => (
+              <div key={query.slice(0, 3) + transactionQueries.indexOf(query)}>
+                {query}
+              </div>
+            ))}
+          </div>
+        }
+      >
+        <div className={cx("queries-row")}>{limitedText}</div>
+      </Tooltip>
+    );
+  }
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/workloadInsightsError.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/workloadInsightsError.tsx
@@ -1,0 +1,41 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import classNames from "classnames/bind";
+import styles from "./insightTable.module.scss";
+
+const cx = classNames.bind(styles);
+
+type SQLInsightsErrorProps = {
+  execType: string;
+};
+
+export const WorkloadInsightsError = (
+  props: SQLInsightsErrorProps,
+): React.ReactElement => {
+  return (
+    <div className={cx("row")}>
+      <span>
+        This page had an unexpected error while loading
+        {" " + props.execType}.
+      </span>
+      &nbsp;
+      <a
+        className={cx("action")}
+        onClick={() => {
+          window.location.reload();
+        }}
+      >
+        Reload this page
+      </a>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/utils.ts
@@ -14,6 +14,7 @@ import {
   ActiveStatementFilters,
   ActiveTransactionFilters,
 } from "src/activeExecutions/types";
+import { InsightEventFilters } from "../insights";
 
 // This function returns a Filters object populated with values from the URL, or null
 // if there were no filters set.
@@ -62,6 +63,22 @@ export function getActiveTransactionFiltersFromURL(
   };
 
   // If every entry is null, there were no active stmt filters. Return null.
+  if (Object.values(appFilters).every(val => !val)) return null;
+
+  return appFilters;
+}
+
+export function getInsightEventFiltersFromURL(
+  location: Location,
+): Partial<InsightEventFilters> | null {
+  const filters = getFiltersFromURL(location);
+  if (!filters) return null;
+
+  const appFilters = {
+    app: filters.app,
+  };
+
+  // If every entry is null, there were no active filters. Return null.
   if (Object.values(appFilters).every(val => !val)) return null;
 
   return appFilters;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/index.ts
@@ -8,6 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export const limitText = (text: string, limit: number): string => {
-  return text.length > limit ? text.slice(0, limit - 3).concat("...") : text;
-};
+export * from "./insights.reducer";
+export * from "./insights.sagas";
+export * from "./insights.selectors";

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/insights.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/insights.reducer.ts
@@ -1,0 +1,53 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { DOMAIN_NAME, noopReducer } from "../utils";
+import moment, { Moment } from "moment";
+import { InsightEventsResponse } from "src/api/insightsApi";
+
+export type InsightsState = {
+  data: InsightEventsResponse;
+  lastUpdated: Moment;
+  lastError: Error;
+  valid: boolean;
+};
+
+const initialState: InsightsState = {
+  data: null,
+  lastUpdated: null,
+  lastError: null,
+  valid: true,
+};
+
+const insightsSlice = createSlice({
+  name: `${DOMAIN_NAME}/insightsSlice`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<InsightEventsResponse>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+      state.lastUpdated = moment.utc();
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    invalidated: state => {
+      state.valid = false;
+    },
+    // Define actions that don't change state.
+    refresh: noopReducer,
+    request: noopReducer,
+  },
+});
+
+export const { reducer, actions } = insightsSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/insights.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/insights.sagas.ts
@@ -1,0 +1,47 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, delay, put, takeLatest } from "redux-saga/effects";
+
+import { actions } from "./insights.reducer";
+import { getInsightEventState } from "src/api/insightsApi";
+import { throttleWithReset } from "../utils";
+import { rootActions } from "../reducers";
+
+export function* refreshInsightsSaga() {
+  yield put(actions.request());
+}
+
+export function* requestInsightsSaga(): any {
+  try {
+    const result = yield call(getInsightEventState);
+    yield put(actions.received(result));
+  } catch (e) {
+    yield put(actions.failed(e));
+  }
+}
+
+export function* receivedInsightsSaga(delayMs: number) {
+  yield delay(delayMs);
+  yield put(actions.invalidated());
+}
+
+export function* insightsSaga(cacheInvalidationPeriod: number = 10 * 1000) {
+  yield all([
+    throttleWithReset(
+      cacheInvalidationPeriod,
+      actions.refresh,
+      [actions.invalidated, rootActions.resetState],
+      refreshInsightsSaga,
+    ),
+    takeLatest(actions.request, requestInsightsSaga),
+    takeLatest(actions.received, receivedInsightsSaga, cacheInvalidationPeriod),
+  ]);
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/insights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/insights.selectors.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cockroach Authors.
+// Copyright 2020 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -8,10 +8,10 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./fetchData";
-export * from "./statementDiagnosticsApi";
-export * from "./statementsApi";
-export * from "./basePath";
-export * from "./nodesApi";
-export * from "./clusterLocksApi";
-export * from "./insightsApi";
+import { createSelector } from "reselect";
+import { adminUISelector } from "../utils/selectors";
+
+export const selectInsights = createSelector(adminUISelector, adminUiState => {
+  if (!adminUiState.insights) return [];
+  return adminUiState.insights.data;
+});

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -32,11 +32,13 @@ export type LocalStorageState = {
   "sortSetting/TransactionsPage": SortSetting;
   "sortSetting/SessionsPage": SortSetting;
   "sortSetting/JobsPage": SortSetting;
+  "sortSetting/InsightsPage": SortSetting;
   "filters/ActiveStatementsPage": Filters;
   "filters/ActiveTransactionsPage": Filters;
   "filters/StatementsPage": Filters;
   "filters/TransactionsPage": Filters;
   "filters/SessionsPage": Filters;
+  "filters/InsightsPage": Filters;
   "search/StatementsPage": string;
   "search/TransactionsPage": string;
   "typeSetting/JobsPage": number;
@@ -59,7 +61,16 @@ const defaultSortSettingActiveExecutions: SortSetting = {
   columnTitle: "startTime",
 };
 
+const defaultSortSettingInsights: SortSetting = {
+  ascending: false,
+  columnTitle: "startTime",
+};
+
 const defaultFiltersActiveExecutions = {
+  app: defaultFilters.app,
+};
+
+const defaultFiltersInsights = {
   app: defaultFilters.app,
 };
 
@@ -120,6 +131,9 @@ const initialState: LocalStorageState = {
   "sortSetting/SessionsPage":
     JSON.parse(localStorage.getItem("sortSetting/SessionsPage")) ||
     defaultSessionsSortSetting,
+  "sortSetting/InsightsPage":
+    JSON.parse(localStorage.getItem("sortSetting/InsightsPage")) ||
+    defaultSortSettingInsights,
   "filters/ActiveStatementsPage":
     JSON.parse(localStorage.getItem("filters/ActiveStatementsPage")) ||
     defaultFiltersActiveExecutions,
@@ -134,6 +148,9 @@ const initialState: LocalStorageState = {
     defaultFilters,
   "filters/SessionsPage":
     JSON.parse(localStorage.getItem("filters/SessionsPage")) || defaultFilters,
+  "filters/InsightsPage":
+    JSON.parse(localStorage.getItem("filters/InsightsPage")) ||
+    defaultFiltersInsights,
   "search/StatementsPage":
     JSON.parse(localStorage.getItem("search/StatementsPage")) || null,
   "search/TransactionsPage":

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -39,6 +39,7 @@ import {
   ClusterLocksReqState,
   reducer as clusterLocks,
 } from "./clusterLocks/clusterLocks.reducer";
+import { InsightsState, reducer as insights } from "./insights";
 
 export type AdminUiState = {
   statementDiagnostics: StatementDiagnosticsState;
@@ -54,6 +55,7 @@ export type AdminUiState = {
   jobs: JobsState;
   job: JobState;
   clusterLocks: ClusterLocksReqState;
+  insights: InsightsState;
 };
 
 export type AppState = {
@@ -66,6 +68,7 @@ export const reducers = combineReducers<AdminUiState>({
   nodes,
   liveness,
   sessions,
+  insights,
   terminateQuery,
   uiConfig,
   sqlStats,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -24,6 +24,7 @@ import { sqlStatsSaga } from "./sqlStats";
 import { sqlDetailsStatsSaga } from "./statementDetails";
 import { indexStatsSaga } from "./indexStats/indexStats.sagas";
 import { clusterLocksSaga } from "./clusterLocks/clusterLocks.saga";
+import { insightsSaga } from "./insights/insights.sagas";
 
 export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
   yield all([
@@ -31,6 +32,7 @@ export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
     fork(statementsDiagnosticsSagas, cacheInvalidationPeriod),
     fork(nodesSaga, cacheInvalidationPeriod),
     fork(livenessSaga, cacheInvalidationPeriod),
+    fork(insightsSaga),
     fork(jobsSaga),
     fork(jobSaga),
     fork(sessionsSaga),

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
@@ -12,7 +12,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { getHighlightedText } from "src/highlightedText";
 import { Tooltip } from "@cockroachlabs/ui-components";
-import { limitText } from "../utils";
+import { limitText } from "src/util";
 import classNames from "classnames/bind";
 import statementsStyles from "../../statementsTable/statementsTableContent.module.scss";
 import transactionsCellsStyles from "./transactionsCells.module.scss";

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -123,3 +123,6 @@ export const transactionsTable = docsURL("ui-transactions-page.html");
 export const performanceTuningRecipes = docsURLNoVersion(
   "performance-recipes.html#fix-slow-writes",
 );
+export const transactionContention = docsURL(
+  "transactions.html#transaction-contention",
+);

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -209,3 +209,8 @@ export function Count(count: number): string {
   const fractionDigits = Number.isInteger(unitVal) ? 0 : 1;
   return unitVal.toFixed(fractionDigits) + " " + scale.units;
 }
+
+// limitText returns a shortened form of text that surpasses a given limit
+export const limitText = (text: string, limit: number): string => {
+  return text.length > limit ? text.slice(0, limit - 3).concat("...") : text;
+};

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -31,6 +31,10 @@ stubComponentInModule(
   "src/views/transactions/activeTransactionDetailsConnected",
   "default",
 );
+stubComponentInModule(
+  "src/views/insights/workloadInsightsPageConnected",
+  "default",
+);
 
 import React from "react";
 import { Action, Store } from "redux";
@@ -411,6 +415,15 @@ describe("Routing to", () => {
     test("'/execution/transaction/transactionID' routes to <ActiveTransactionDetails>", () => {
       navigateToPath("/execution/transaction/transactionID");
       screen.getByTestId("activeTransactionDetailsConnected");
+    });
+  });
+  {
+    /* insights */
+  }
+  describe("'/insights' path", () => {
+    test("routes to <InsightsOverviewPage> component", () => {
+      navigateToPath("/insights");
+      screen.getByTestId("workloadInsightsPageConnected");
     });
   });
   {

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -78,6 +78,7 @@ import ActiveStatementDetails from "./views/statements/activeStatementDetailsCon
 import ActiveTransactionDetails from "./views/transactions/activeTransactionDetailsConnected";
 import "styl/app.styl";
 import { Tracez } from "src/views/tracez/tracez";
+import InsightsOverviewPage from "src/views/insights/insightsOverview";
 
 // NOTE: If you are adding a new path to the router, and that path contains any
 // components that are personally identifying information, you MUST update the
@@ -288,6 +289,12 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   exact
                   from={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
                   to={`/transaction/:${txnFingerprintIdAttr}`}
+                />
+                {/* Insights */}
+                <Route
+                  exact
+                  path="/insights"
+                  component={InsightsOverviewPage}
                 />
 
                 {/* debug pages */}

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -395,6 +395,14 @@ export const refreshLiveWorkload = (): ThunkAction<any, any, any, Action> => {
   };
 };
 
+const insightsReducerObj = new CachedDataReducer(
+  clusterUiApi.getInsightEventState,
+  "insights",
+  moment.duration(10, "s"),
+  moment.duration(30, "s"),
+);
+export const refreshInsights = insightsReducerObj.refresh;
+
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<api.EventsResponseMessage>;
@@ -430,6 +438,7 @@ export interface APIReducersState {
   userSQLRoles: CachedDataReducerState<api.UserSQLRolesResponseMessage>;
   hotRanges: PaginatedCachedDataReducerState<api.HotRangesV2ResponseMessage>;
   clusterLocks: CachedDataReducerState<clusterUiApi.ClusterLocksResponse>;
+  insights: CachedDataReducerState<clusterUiApi.InsightEventsResponse>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -471,6 +480,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [userSQLRolesReducerObj.actionNamespace]: userSQLRolesReducerObj.reducer,
   [hotRangesReducerObj.actionNamespace]: hotRangesReducerObj.reducer,
   [clusterLocksReducerObj.actionNamespace]: clusterLocksReducerObj.reducer,
+  [insightsReducerObj.actionNamespace]: insightsReducerObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
@@ -45,6 +45,11 @@ export class Sidebar extends React.Component<SidebarProps> {
       activeFor: ["/sql-activity", "/session", "/transaction", "/statement"],
     },
     {
+      path: "/insights",
+      text: "Insights",
+      activeFor: ["/insights"],
+    },
+    {
       path: "/reports/network",
       text: "Network Latency",
       activeFor: ["/reports/network"],

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsOverview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsOverview.tsx
@@ -1,0 +1,72 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// All changes made on this file, should also be done on the equivalent
+// file on managed-service repo.
+
+import React, { useState } from "react";
+import Helmet from "react-helmet";
+import { Tabs } from "antd";
+import "antd/lib/tabs/style";
+import { commonStyles, util } from "@cockroachlabs/cluster-ui";
+import { RouteComponentProps } from "react-router-dom";
+import { tabAttr, viewAttr } from "src/util/constants";
+import WorkloadInsightsPageConnected from "src/views/insights/workloadInsightsPageConnected";
+
+const { TabPane } = Tabs;
+
+export enum InsightsTabType {
+  WORKLOAD_INSIGHTS = "Workload Insights",
+}
+
+export const INSIGHTS_DEFAULT_TAB: InsightsTabType =
+  InsightsTabType.WORKLOAD_INSIGHTS;
+
+const InsightsOverviewPage = (props: RouteComponentProps) => {
+  const currentTab =
+    util.queryByName(props.location, tabAttr) ||
+    InsightsTabType.WORKLOAD_INSIGHTS;
+  const currentView = util.queryByName(props.location, viewAttr);
+  const [restoreSqlViewParam, setRestoreSqlViewParam] = useState<string | null>(
+    currentView,
+  );
+
+  const onTabChange = (tabId: string): void => {
+    const params = new URLSearchParams({ tab: tabId });
+    if (tabId !== InsightsTabType.WORKLOAD_INSIGHTS) {
+      setRestoreSqlViewParam(currentView);
+    } else if (currentView || restoreSqlViewParam) {
+      params.set("view", currentView ?? restoreSqlViewParam ?? "");
+    }
+    props.history.push({
+      search: params.toString(),
+    });
+  };
+
+  return (
+    <div>
+      <Helmet title={currentTab} />
+      <h3 className={commonStyles("base-heading")}>Insights</h3>
+      <Tabs
+        defaultActiveKey={INSIGHTS_DEFAULT_TAB}
+        className={commonStyles("cockroach--tabs")}
+        onChange={onTabChange}
+        activeKey={currentTab}
+        destroyInactiveTabPane
+      >
+        <TabPane tab="Workload Insights" key="Workload Insights">
+          <WorkloadInsightsPageConnected />
+        </TabPane>
+      </Tabs>
+    </div>
+  );
+};
+
+export default InsightsOverviewPage;

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -1,0 +1,41 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { LocalSetting } from "src/redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import { createSelector } from "reselect";
+import {
+  defaultFilters,
+  SortSetting,
+  InsightEventFilters,
+} from "@cockroachlabs/cluster-ui";
+
+export const filtersLocalSetting = new LocalSetting<
+  AdminUIState,
+  InsightEventFilters
+>("filters/InsightsPage", (state: AdminUIState) => state.localSettings, {
+  app: defaultFilters.app,
+});
+
+export const sortSettingLocalSetting = new LocalSetting<
+  AdminUIState,
+  SortSetting
+>("sortSetting/InsightsPage", (state: AdminUIState) => state.localSettings, {
+  ascending: false,
+  columnTitle: "startTime",
+});
+
+export const selectInsights = createSelector(
+  (state: AdminUIState) => state.cachedData,
+  adminUiState => {
+    if (!adminUiState.insights) return [];
+    return adminUiState.insights.data;
+  },
+);

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPageConnected.tsx
@@ -1,0 +1,58 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { refreshInsights } from "src/redux/apiReducers";
+import { AdminUIState } from "src/redux/state";
+import {
+  InsightEventFilters,
+  SortSetting,
+  TransactionInsightsViewStateProps,
+  TransactionInsightsViewDispatchProps,
+  TransactionInsightsView,
+} from "@cockroachlabs/cluster-ui";
+import { selectAppName } from "src/selectors/activeExecutionsSelectors";
+import {
+  filtersLocalSetting,
+  sortSettingLocalSetting,
+  selectInsights,
+} from "src/views/insights/insightsSelectors";
+
+const mapStateToProps = (
+  state: AdminUIState,
+  _props: RouteComponentProps,
+): TransactionInsightsViewStateProps => ({
+  transactions: selectInsights(state),
+  transactionsError: state.cachedData?.insights.lastError,
+  filters: filtersLocalSetting.selector(state),
+  sortSetting: sortSettingLocalSetting.selector(state),
+  internalAppNamePrefix: selectAppName(state),
+});
+
+const mapDispatchToProps = {
+  onFiltersChange: (filters: InsightEventFilters) =>
+    filtersLocalSetting.set(filters),
+  onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),
+  refreshTransactionInsights: refreshInsights,
+};
+
+const WorkloadInsightsPageConnected = withRouter(
+  connect<
+    TransactionInsightsViewStateProps,
+    TransactionInsightsViewDispatchProps,
+    RouteComponentProps
+  >(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(TransactionInsightsView),
+);
+
+export default WorkloadInsightsPageConnected;


### PR DESCRIPTION
This commit adds the v1 Insights page to the DB Console, via the cluster-ui package. The v1 Insights page only includes a Transactions Insights overview page, populated with information served a new "endpoint" built on top of the SQL-over-HTTP API.

Note this PR is dependent on the changes in #84617 and https://github.com/cockroachdb/cockroach/pull/85080.

After https://github.com/cockroachdb/cockroach/pull/84998 is merged with all the needed columns, we can rewrite the insights API to query the internal insights table.

Fixes https://github.com/cockroachdb/cockroach/issues/83774.

Release note (ui change): Added new Insights page to DB Console