### PR TITLE
release-22.1: colexec: fixed nullableArgs projection operators 

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1992,7 +1992,7 @@ func planProjectionOperators(
 		}
 		return planProjectionExpr(
 			ctx, evalCtx, t.Operator, t.ResolvedType(), t.TypedLeft(), t.TypedRight(),
-			columnTypes, input, acc, factory, t.Fn.Fn, nil /* cmpExpr */, releasables,
+			columnTypes, input, acc, factory, t.Fn.Fn, nil /* cmpExpr */, releasables, t.Fn.NullableArgs,
 		)
 	case *tree.CaseExpr:
 		allocator := colmem.NewAllocator(ctx, acc, factory)
@@ -2144,7 +2144,7 @@ func planProjectionOperators(
 	case *tree.ComparisonExpr:
 		return planProjectionExpr(
 			ctx, evalCtx, t.Operator, t.ResolvedType(), t.TypedLeft(), t.TypedRight(),
-			columnTypes, input, acc, factory, nil /* binFn */, t, releasables,
+			columnTypes, input, acc, factory, nil /* binFn */, t, releasables, t.Fn.NullableArgs,
 		)
 	case tree.Datum:
 		op, err = projectDatum(t)
@@ -2311,6 +2311,7 @@ func planProjectionExpr(
 	binFn tree.TwoArgFn,
 	cmpExpr *tree.ComparisonExpr,
 	releasables *[]execinfra.Releasable,
+	nullableArgs bool,
 ) (op colexecop.Operator, resultIdx int, typs []*types.T, err error) {
 	if err := checkSupportedProjectionExpr(left, right); err != nil {
 		return nil, resultIdx, typs, err
@@ -2347,7 +2348,7 @@ func planProjectionExpr(
 		// appended to the input batch.
 		op, err = colexecproj.GetProjectionLConstOperator(
 			allocator, typs, left.ResolvedType(), outputType, projOp, input,
-			rightIdx, lConstArg, resultIdx, evalCtx, binFn, cmpExpr,
+			rightIdx, lConstArg, resultIdx, evalCtx, binFn, cmpExpr, nullableArgs,
 		)
 	} else {
 		var leftIdx int
@@ -2424,7 +2425,7 @@ func planProjectionExpr(
 				// all other projection operators.
 				op, err = colexecproj.GetProjectionRConstOperator(
 					allocator, typs, right.ResolvedType(), outputType, projOp,
-					input, leftIdx, rConstArg, resultIdx, evalCtx, binFn, cmpExpr,
+					input, leftIdx, rConstArg, resultIdx, evalCtx, binFn, cmpExpr, nullableArgs,
 				)
 			}
 		} else {
@@ -2439,7 +2440,7 @@ func planProjectionExpr(
 			resultIdx = len(typs)
 			op, err = colexecproj.GetProjectionOperator(
 				allocator, typs, outputType, projOp, input, leftIdx, rightIdx,
-				resultIdx, evalCtx, binFn, cmpExpr,
+				resultIdx, evalCtx, binFn, cmpExpr, nullableArgs,
 			)
 		}
 	}

--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -70,10 +70,6 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -102,11 +98,6 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -128,11 +119,6 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -163,10 +149,6 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -195,11 +177,6 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -221,11 +198,6 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -256,10 +228,6 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -288,11 +256,6 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -314,11 +277,6 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -349,10 +307,6 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -381,11 +335,6 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -407,11 +356,6 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -442,10 +386,6 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -474,11 +414,6 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -500,11 +435,6 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -535,10 +465,6 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -567,11 +493,6 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -593,11 +514,6 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -628,10 +544,6 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -660,11 +572,6 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -686,11 +593,6 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -721,10 +623,6 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -753,11 +651,6 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -779,11 +672,6 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -814,10 +702,6 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -846,11 +730,6 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -872,11 +751,6 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -909,10 +783,6 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -954,11 +824,6 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -993,11 +858,6 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1028,10 +888,6 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1060,11 +916,6 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1086,11 +937,6 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1121,10 +967,6 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1153,11 +995,6 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1179,11 +1016,6 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1214,10 +1046,6 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1246,11 +1074,6 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1272,11 +1095,6 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1307,10 +1125,6 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1339,11 +1153,6 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1365,11 +1174,6 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1400,10 +1204,6 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1432,11 +1232,6 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1458,11 +1253,6 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1493,10 +1283,6 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1525,11 +1311,6 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1551,11 +1332,6 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1586,10 +1362,6 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1618,11 +1390,6 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1644,11 +1411,6 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1679,10 +1441,6 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1711,11 +1469,6 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1737,11 +1490,6 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1772,10 +1520,6 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1804,11 +1548,6 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1830,11 +1569,6 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1867,10 +1601,6 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1912,11 +1642,6 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1951,11 +1676,6 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1986,10 +1706,6 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2018,11 +1734,6 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2044,11 +1755,6 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2079,10 +1785,6 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2111,11 +1813,6 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2137,11 +1834,6 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2172,10 +1864,6 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2204,11 +1892,6 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2230,11 +1913,6 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2265,10 +1943,6 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2297,11 +1971,6 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2323,11 +1992,6 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2358,10 +2022,6 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2390,11 +2050,6 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2416,11 +2071,6 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2451,10 +2101,6 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2483,11 +2129,6 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2509,11 +2150,6 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2544,10 +2180,6 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2576,11 +2208,6 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2602,11 +2229,6 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2637,10 +2259,6 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2669,11 +2287,6 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2695,11 +2308,6 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2730,10 +2338,6 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2762,11 +2366,6 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2788,11 +2387,6 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2825,10 +2419,6 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2870,11 +2460,6 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2909,11 +2494,6 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2944,10 +2524,6 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2990,11 +2566,6 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3030,11 +2601,6 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3065,10 +2631,6 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3111,11 +2673,6 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3151,11 +2708,6 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3186,10 +2738,6 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3232,11 +2780,6 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3272,11 +2815,6 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3307,10 +2845,6 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3351,11 +2885,6 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3389,11 +2918,6 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3424,10 +2948,6 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3468,11 +2988,6 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3506,11 +3021,6 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3541,10 +3051,6 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3585,11 +3091,6 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3623,11 +3124,6 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3658,10 +3154,6 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3702,11 +3194,6 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3740,11 +3227,6 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3775,10 +3257,6 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3823,11 +3301,6 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3865,11 +3338,6 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3902,10 +3370,6 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3956,11 +3420,6 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4004,11 +3463,6 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4039,10 +3493,6 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4083,11 +3533,6 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4121,11 +3566,6 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4156,10 +3596,6 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4200,11 +3636,6 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4238,11 +3669,6 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4273,10 +3699,6 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4317,11 +3739,6 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4355,11 +3772,6 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4390,10 +3802,6 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4438,11 +3846,6 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4480,11 +3883,6 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4517,10 +3915,6 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4571,11 +3965,6 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4619,11 +4008,6 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4654,10 +4038,6 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4698,11 +4078,6 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4736,11 +4111,6 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4771,10 +4141,6 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4815,11 +4181,6 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4853,11 +4214,6 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4888,10 +4244,6 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4932,11 +4284,6 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4970,11 +4317,6 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5005,10 +4347,6 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5053,11 +4391,6 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5095,11 +4428,6 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5132,10 +4460,6 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5186,11 +4510,6 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5234,11 +4553,6 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5269,10 +4583,6 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5307,11 +4617,6 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5339,11 +4644,6 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5374,10 +4674,6 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5412,11 +4708,6 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5444,11 +4735,6 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5479,10 +4765,6 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5517,11 +4799,6 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5549,11 +4826,6 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5584,10 +4856,6 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5612,11 +4880,6 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5634,11 +4897,6 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Add(arg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5671,10 +4929,6 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5725,11 +4979,6 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5773,11 +5022,6 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5810,10 +5054,6 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5863,11 +5103,6 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5910,11 +5145,6 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5947,10 +5177,6 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6000,11 +5226,6 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6047,11 +5268,6 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6084,10 +5300,6 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6137,11 +5349,6 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6184,11 +5391,6 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6221,10 +5423,6 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6274,11 +5472,6 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6321,11 +5514,6 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6356,10 +5544,6 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6402,11 +5586,6 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6442,11 +5621,6 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6477,10 +5651,6 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6523,11 +5693,6 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6563,11 +5728,6 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6598,10 +5758,6 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6644,11 +5800,6 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6684,11 +5835,6 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6719,10 +5865,6 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6763,11 +5905,6 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6801,11 +5938,6 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6836,10 +5968,6 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6880,11 +6008,6 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6918,11 +6041,6 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6953,10 +6071,6 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6997,11 +6111,6 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7035,11 +6144,6 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7070,10 +6174,6 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7114,11 +6214,6 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7152,11 +6247,6 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7187,10 +6277,6 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7235,11 +6321,6 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7277,11 +6358,6 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7314,10 +6390,6 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7368,11 +6440,6 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7416,11 +6483,6 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7451,10 +6513,6 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7495,11 +6553,6 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7533,11 +6586,6 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7568,10 +6616,6 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7612,11 +6656,6 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7650,11 +6689,6 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7685,10 +6719,6 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7729,11 +6759,6 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7767,11 +6792,6 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7802,10 +6822,6 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7850,11 +6866,6 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7892,11 +6903,6 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7929,10 +6935,6 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7983,11 +6985,6 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8031,11 +7028,6 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8066,10 +7058,6 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8110,11 +7098,6 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8148,11 +7131,6 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8183,10 +7161,6 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8227,11 +7201,6 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8265,11 +7234,6 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8300,10 +7264,6 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8344,11 +7304,6 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8382,11 +7337,6 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8417,10 +7367,6 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8465,11 +7411,6 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8507,11 +7448,6 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8544,10 +7480,6 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8598,11 +7530,6 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8646,11 +7573,6 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8681,10 +7603,6 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8719,11 +7637,6 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8751,11 +7664,6 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8786,10 +7694,6 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8820,11 +7724,6 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8848,11 +7747,6 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8883,10 +7777,6 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8921,11 +7811,6 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8953,11 +7838,6 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8988,10 +7868,6 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9016,11 +7892,6 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9038,11 +7909,6 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Sub(arg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9075,10 +7941,6 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9129,11 +7991,6 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9177,11 +8034,6 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9212,10 +8064,6 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9257,11 +8105,6 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9296,11 +8139,6 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9331,10 +8169,6 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9368,11 +8202,6 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9399,11 +8228,6 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9434,10 +8258,6 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9471,11 +8291,6 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9502,11 +8317,6 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9537,10 +8347,6 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9574,11 +8380,6 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9605,11 +8406,6 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9642,10 +8438,6 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9687,11 +8479,6 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9726,11 +8513,6 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9763,10 +8545,6 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9816,11 +8594,6 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9863,11 +8636,6 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9900,10 +8668,6 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9953,11 +8717,6 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10000,11 +8759,6 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10037,10 +8791,6 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10090,11 +8840,6 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10137,11 +8882,6 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10174,10 +8914,6 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10227,11 +8963,6 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10274,11 +9005,6 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10311,10 +9037,6 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10364,11 +9086,6 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10411,11 +9128,6 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10446,10 +9158,6 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10492,11 +9200,6 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10532,11 +9235,6 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10567,10 +9265,6 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10613,11 +9307,6 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10653,11 +9342,6 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10688,10 +9372,6 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10734,11 +9414,6 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10774,11 +9449,6 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10809,10 +9479,6 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10853,11 +9519,6 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10891,11 +9552,6 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10926,10 +9582,6 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10964,11 +9616,6 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10996,11 +9643,6 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11031,10 +9673,6 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11091,11 +9729,6 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11145,11 +9778,6 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11180,10 +9808,6 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11240,11 +9864,6 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11294,11 +9913,6 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11329,10 +9943,6 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11389,11 +9999,6 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11443,11 +10048,6 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11478,10 +10078,6 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11526,11 +10122,6 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11568,11 +10159,6 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11603,10 +10189,6 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11631,11 +10213,6 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11653,11 +10230,6 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11688,10 +10260,6 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11748,11 +10316,6 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11802,11 +10365,6 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11837,10 +10395,6 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11897,11 +10451,6 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11951,11 +10500,6 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11986,10 +10530,6 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12046,11 +10586,6 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12100,11 +10635,6 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12135,10 +10665,6 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12183,11 +10709,6 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12225,11 +10746,6 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12260,10 +10776,6 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12288,11 +10800,6 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12310,11 +10817,6 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12345,10 +10847,6 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12405,11 +10903,6 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12459,11 +10952,6 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12494,10 +10982,6 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12554,11 +11038,6 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12608,11 +11087,6 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12643,10 +11117,6 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12703,11 +11173,6 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12757,11 +11222,6 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12792,10 +11252,6 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12840,11 +11296,6 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12882,11 +11333,6 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12917,10 +11363,6 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12945,11 +11387,6 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12967,11 +11404,6 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13002,10 +11434,6 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13040,11 +11468,6 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13072,11 +11495,6 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13107,10 +11525,6 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13135,11 +11549,6 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13157,11 +11566,6 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13192,10 +11596,6 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13220,11 +11620,6 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13242,11 +11637,6 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13277,10 +11667,6 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13305,11 +11691,6 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13327,11 +11708,6 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13362,10 +11738,6 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13390,11 +11762,6 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13412,11 +11779,6 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13447,10 +11809,6 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13475,11 +11833,6 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13497,11 +11850,6 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13532,10 +11880,6 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13570,11 +11914,6 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13602,11 +11941,6 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13637,10 +11971,6 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13691,11 +12021,6 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13739,11 +12064,6 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13774,10 +12094,6 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13828,11 +12144,6 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13876,11 +12187,6 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13911,10 +12217,6 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13965,11 +12267,6 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14013,11 +12310,6 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14048,10 +12340,6 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14100,11 +12388,6 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14146,11 +12429,6 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14181,10 +12459,6 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14233,11 +12507,6 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14279,11 +12548,6 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14314,10 +12578,6 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14366,11 +12626,6 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14412,11 +12667,6 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14447,10 +12697,6 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14499,11 +12745,6 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14545,11 +12786,6 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14580,10 +12816,6 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14636,11 +12868,6 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14686,11 +12913,6 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14721,10 +12943,6 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14773,11 +12991,6 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14819,11 +13032,6 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14854,10 +13062,6 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14906,11 +13110,6 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14952,11 +13151,6 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14987,10 +13181,6 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15039,11 +13229,6 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15085,11 +13270,6 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15120,10 +13300,6 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15176,11 +13352,6 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15226,11 +13397,6 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15261,10 +13427,6 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15313,11 +13475,6 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15359,11 +13516,6 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15394,10 +13546,6 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15446,11 +13594,6 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15492,11 +13635,6 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15527,10 +13665,6 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15579,11 +13713,6 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15625,11 +13754,6 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15660,10 +13784,6 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15716,11 +13836,6 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15766,11 +13881,6 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15801,10 +13911,6 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15847,11 +13953,6 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15887,11 +13988,6 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15922,10 +14018,6 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15958,11 +14050,6 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15988,11 +14075,6 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Div(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16023,10 +14105,6 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16059,11 +14137,6 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16089,11 +14162,6 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Div(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16124,10 +14192,6 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16160,11 +14224,6 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16190,11 +14249,6 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.Div(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16225,10 +14279,6 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16261,11 +14311,6 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16291,11 +14336,6 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 					projCol[i] = p.constArg.DivFloat(float64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16326,10 +14366,6 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16380,11 +14416,6 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16428,11 +14459,6 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16463,10 +14489,6 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16517,11 +14539,6 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16565,11 +14582,6 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16600,10 +14612,6 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16654,11 +14662,6 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16702,11 +14705,6 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16737,10 +14735,6 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16789,11 +14783,6 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16835,11 +14824,6 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16870,10 +14854,6 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16912,11 +14892,6 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16948,11 +14923,6 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16983,10 +14953,6 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17025,11 +14991,6 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17061,11 +15022,6 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17096,10 +15052,6 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17138,11 +15090,6 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17174,11 +15121,6 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17209,10 +15151,6 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17265,11 +15203,6 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17315,11 +15248,6 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17350,10 +15278,6 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17392,11 +15316,6 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17428,11 +15347,6 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17463,10 +15377,6 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17505,11 +15415,6 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17541,11 +15446,6 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17576,10 +15476,6 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17618,11 +15514,6 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17654,11 +15545,6 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17689,10 +15575,6 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17745,11 +15627,6 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17795,11 +15672,6 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17830,10 +15702,6 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17872,11 +15740,6 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17908,11 +15771,6 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17943,10 +15801,6 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17985,11 +15839,6 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18021,11 +15870,6 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18056,10 +15900,6 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18098,11 +15938,6 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18134,11 +15969,6 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18169,10 +15999,6 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18225,11 +16051,6 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18275,11 +16096,6 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18310,10 +16126,6 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18356,11 +16168,6 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18396,11 +16203,6 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18431,10 +16233,6 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18485,11 +16283,6 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18533,11 +16326,6 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18568,10 +16356,6 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18622,11 +16406,6 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18670,11 +16449,6 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18705,10 +16479,6 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18759,11 +16529,6 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18807,11 +16572,6 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18842,10 +16602,6 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18894,11 +16650,6 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18940,11 +16691,6 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18975,10 +16721,6 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19017,11 +16759,6 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19053,11 +16790,6 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19088,10 +16820,6 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19130,11 +16858,6 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19166,11 +16889,6 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19201,10 +16919,6 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19243,11 +16957,6 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19279,11 +16988,6 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19314,10 +17018,6 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19370,11 +17070,6 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19420,11 +17115,6 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19455,10 +17145,6 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19497,11 +17183,6 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19533,11 +17214,6 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19568,10 +17244,6 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19610,11 +17282,6 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19646,11 +17313,6 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19681,10 +17343,6 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19723,11 +17381,6 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19759,11 +17412,6 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19794,10 +17442,6 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19850,11 +17494,6 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19900,11 +17539,6 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19935,10 +17569,6 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19977,11 +17607,6 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20013,11 +17638,6 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20048,10 +17668,6 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20090,11 +17706,6 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20126,11 +17737,6 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20161,10 +17767,6 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20203,11 +17805,6 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20239,11 +17836,6 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20274,10 +17866,6 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20330,11 +17918,6 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20380,11 +17963,6 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20415,10 +17993,6 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20461,11 +18035,6 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20501,11 +18070,6 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20536,10 +18100,6 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20582,11 +18142,6 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20622,11 +18177,6 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20657,10 +18207,6 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20703,11 +18249,6 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20743,11 +18284,6 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20778,10 +18314,6 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20824,11 +18356,6 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20864,11 +18391,6 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20899,10 +18421,6 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20943,11 +18461,6 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20981,11 +18494,6 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21016,10 +18524,6 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21072,11 +18576,6 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21122,11 +18621,6 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21157,10 +18651,6 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21213,11 +18703,6 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21263,11 +18748,6 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21298,10 +18778,6 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21354,11 +18830,6 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21404,11 +18875,6 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21439,10 +18905,6 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21487,11 +18949,6 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21529,11 +18986,6 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21564,10 +19016,6 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21620,11 +19068,6 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21670,11 +19113,6 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21705,10 +19143,6 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21761,11 +19195,6 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21811,11 +19240,6 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21846,10 +19270,6 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21902,11 +19322,6 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21952,11 +19367,6 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21987,10 +19397,6 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22035,11 +19441,6 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22077,11 +19478,6 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22112,10 +19508,6 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22168,11 +19560,6 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22218,11 +19605,6 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22253,10 +19635,6 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22309,11 +19687,6 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22359,11 +19732,6 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22394,10 +19762,6 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22450,11 +19814,6 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22500,11 +19859,6 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22535,10 +19889,6 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22583,11 +19933,6 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22625,11 +19970,6 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22660,10 +20000,6 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22698,11 +20034,6 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22730,11 +20061,6 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22765,10 +20091,6 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22806,11 +20128,6 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22841,11 +20158,6 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22876,10 +20188,6 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22915,11 +20223,6 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22948,11 +20251,6 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22985,10 +20283,6 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23030,11 +20324,6 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23069,11 +20358,6 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23104,10 +20388,6 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23148,11 +20428,6 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23186,11 +20461,6 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23221,10 +20491,6 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23265,11 +20531,6 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23303,11 +20564,6 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23338,10 +20594,6 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23382,11 +20634,6 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23420,11 +20667,6 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23455,10 +20697,6 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23499,11 +20737,6 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23537,11 +20770,6 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23572,10 +20800,6 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23616,11 +20840,6 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23654,11 +20873,6 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23689,10 +20903,6 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23733,11 +20943,6 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23771,11 +20976,6 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23806,10 +21006,6 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23850,11 +21046,6 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23888,11 +21079,6 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23923,10 +21109,6 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23967,11 +21149,6 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24005,11 +21182,6 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24040,10 +21212,6 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24084,11 +21252,6 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24122,11 +21285,6 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24159,10 +21317,6 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24212,11 +21366,6 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24259,11 +21408,6 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24296,10 +21440,6 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24349,11 +21489,6 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24396,11 +21531,6 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24433,10 +21563,6 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24486,11 +21612,6 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24533,11 +21654,6 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24568,10 +21684,6 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24612,11 +21724,6 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24650,11 +21757,6 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24685,10 +21787,6 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24729,11 +21827,6 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24767,11 +21860,6 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24802,10 +21890,6 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24846,11 +21930,6 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24884,11 +21963,6 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24919,10 +21993,6 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24963,11 +22033,6 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25001,11 +22066,6 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25036,10 +22096,6 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25080,11 +22136,6 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25118,11 +22169,6 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25153,10 +22199,6 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25197,11 +22239,6 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25235,11 +22272,6 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25270,10 +22302,6 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25314,11 +22342,6 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25352,11 +22375,6 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25387,10 +22405,6 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25431,11 +22445,6 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25469,11 +22478,6 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25504,10 +22508,6 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25548,11 +22548,6 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25586,11 +22581,6 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25623,10 +22613,6 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25676,11 +22662,6 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25723,11 +22704,6 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25760,10 +22736,6 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25813,11 +22785,6 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25860,11 +22827,6 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25897,10 +22859,6 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25950,11 +22908,6 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25997,11 +22950,6 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26032,10 +22980,6 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26083,11 +23027,6 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26128,11 +23067,6 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26163,10 +23097,6 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26208,11 +23138,6 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26247,11 +23172,6 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26282,10 +23202,6 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26327,11 +23243,6 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26366,11 +23277,6 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26401,10 +23307,6 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26446,11 +23348,6 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26485,11 +23382,6 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26520,10 +23412,6 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26589,11 +23477,6 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26652,11 +23535,6 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26687,10 +23565,6 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26750,11 +23624,6 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26807,11 +23676,6 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26842,10 +23706,6 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26905,11 +23765,6 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26962,11 +23817,6 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26997,10 +23847,6 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27060,11 +23906,6 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27117,11 +23958,6 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27152,10 +23988,6 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27197,11 +24029,6 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27236,11 +24063,6 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27271,10 +24093,6 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27336,11 +24154,6 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27395,11 +24208,6 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch

--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -71,7 +71,9 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -150,7 +152,9 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -229,7 +233,9 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -308,7 +314,9 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -387,7 +395,9 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -466,7 +476,9 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -545,7 +557,9 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -624,7 +638,9 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -703,7 +719,9 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -784,7 +802,9 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -889,7 +909,9 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -968,7 +990,9 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1047,7 +1071,9 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1126,7 +1152,9 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1205,7 +1233,9 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1284,7 +1314,9 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1363,7 +1395,9 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1442,7 +1476,9 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1521,7 +1557,9 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1602,7 +1640,9 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1707,7 +1747,9 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1786,7 +1828,9 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1865,7 +1909,9 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1944,7 +1990,9 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2023,7 +2071,9 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2102,7 +2152,9 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2181,7 +2233,9 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2260,7 +2314,9 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2339,7 +2395,9 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2420,7 +2478,9 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2525,7 +2585,9 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2632,7 +2694,9 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2739,7 +2803,9 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2846,7 +2912,9 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2949,7 +3017,9 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3052,7 +3122,9 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3155,7 +3227,9 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3258,7 +3332,9 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3371,7 +3447,9 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3494,7 +3572,9 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3597,7 +3677,9 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3700,7 +3782,9 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3803,7 +3887,9 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3916,7 +4002,9 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4039,7 +4127,9 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4142,7 +4232,9 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4245,7 +4337,9 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4348,7 +4442,9 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4461,7 +4557,9 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4584,7 +4682,9 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4675,7 +4775,9 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4766,7 +4868,9 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4857,7 +4961,9 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4930,7 +5036,9 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5055,7 +5163,9 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5178,7 +5288,9 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5301,7 +5413,9 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5424,7 +5538,9 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5545,7 +5661,9 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5652,7 +5770,9 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5759,7 +5879,9 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5866,7 +5988,9 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5969,7 +6093,9 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6072,7 +6198,9 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6175,7 +6303,9 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6278,7 +6408,9 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6391,7 +6523,9 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6514,7 +6648,9 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6617,7 +6753,9 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6720,7 +6858,9 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6823,7 +6963,9 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6936,7 +7078,9 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7059,7 +7203,9 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7162,7 +7308,9 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7265,7 +7413,9 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7368,7 +7518,9 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7481,7 +7633,9 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7604,7 +7758,9 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7695,7 +7851,9 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7778,7 +7936,9 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7869,7 +8029,9 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7942,7 +8104,9 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8065,7 +8229,9 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8170,7 +8336,9 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8259,7 +8427,9 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8348,7 +8518,9 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8439,7 +8611,9 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8546,7 +8720,9 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8669,7 +8845,9 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8792,7 +8970,9 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8915,7 +9095,9 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9038,7 +9220,9 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9159,7 +9343,9 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9266,7 +9452,9 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9373,7 +9561,9 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9480,7 +9670,9 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9583,7 +9775,9 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9674,7 +9868,9 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9809,7 +10005,9 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9944,7 +10142,9 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10079,7 +10279,9 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10190,7 +10392,9 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10261,7 +10465,9 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10396,7 +10602,9 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10531,7 +10739,9 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10666,7 +10876,9 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10777,7 +10989,9 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10848,7 +11062,9 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10983,7 +11199,9 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11118,7 +11336,9 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11253,7 +11473,9 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11364,7 +11586,9 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11435,7 +11659,9 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11526,7 +11752,9 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11597,7 +11825,9 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11668,7 +11898,9 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11739,7 +11971,9 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11810,7 +12044,9 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11881,7 +12117,9 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11972,7 +12210,9 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12095,7 +12335,9 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12218,7 +12460,9 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12341,7 +12585,9 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12460,7 +12706,9 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12579,7 +12827,9 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12698,7 +12948,9 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12817,7 +13069,9 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12944,7 +13198,9 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13063,7 +13319,9 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13182,7 +13440,9 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13301,7 +13561,9 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13428,7 +13690,9 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13547,7 +13811,9 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13666,7 +13932,9 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13785,7 +14053,9 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13912,7 +14182,9 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14019,7 +14291,9 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14106,7 +14380,9 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14193,7 +14469,9 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14280,7 +14558,9 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14367,7 +14647,9 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14490,7 +14772,9 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14613,7 +14897,9 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14736,7 +15022,9 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14855,7 +15143,9 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14954,7 +15244,9 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15053,7 +15345,9 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15152,7 +15446,9 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15279,7 +15575,9 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15378,7 +15676,9 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15477,7 +15777,9 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15576,7 +15878,9 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15703,7 +16007,9 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15802,7 +16108,9 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15901,7 +16209,9 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16000,7 +16310,9 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16127,7 +16439,9 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16234,7 +16548,9 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16357,7 +16673,9 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16480,7 +16798,9 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16603,7 +16923,9 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16722,7 +17044,9 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16821,7 +17145,9 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16920,7 +17246,9 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17019,7 +17347,9 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17146,7 +17476,9 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17245,7 +17577,9 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17344,7 +17678,9 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17443,7 +17779,9 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17570,7 +17908,9 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17669,7 +18009,9 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17768,7 +18110,9 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17867,7 +18211,9 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17994,7 +18340,9 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18101,7 +18449,9 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18208,7 +18558,9 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18315,7 +18667,9 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18422,7 +18776,9 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18525,7 +18881,9 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18652,7 +19010,9 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18779,7 +19139,9 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18906,7 +19268,9 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19017,7 +19381,9 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19144,7 +19510,9 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19271,7 +19639,9 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19398,7 +19768,9 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19509,7 +19881,9 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19636,7 +20010,9 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19763,7 +20139,9 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19890,7 +20268,9 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20001,7 +20381,9 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20092,7 +20474,9 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20189,7 +20573,9 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20284,7 +20670,9 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20389,7 +20777,9 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20492,7 +20882,9 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20595,7 +20987,9 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20698,7 +21092,9 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20801,7 +21197,9 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20904,7 +21302,9 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21007,7 +21407,9 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21110,7 +21512,9 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21213,7 +21617,9 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21318,7 +21724,9 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21441,7 +21849,9 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21564,7 +21974,9 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21685,7 +22097,9 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21788,7 +22202,9 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21891,7 +22307,9 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21994,7 +22412,9 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22097,7 +22517,9 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22200,7 +22622,9 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22303,7 +22727,9 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22406,7 +22832,9 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22509,7 +22937,9 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22614,7 +23044,9 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22737,7 +23169,9 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22860,7 +23294,9 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22981,7 +23417,9 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23098,7 +23536,9 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23203,7 +23643,9 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23308,7 +23750,9 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23413,7 +23857,9 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23566,7 +24012,9 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23707,7 +24155,9 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23848,7 +24298,9 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23989,7 +24441,9 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24094,7 +24548,9 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24228,6 +24684,7 @@ func GetProjectionLConstOperator(
 	evalCtx *tree.EvalContext,
 	binFn tree.TwoArgFn,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
@@ -24235,6 +24692,7 @@ func GetProjectionLConstOperator(
 		allocator:      allocator,
 		colIdx:         colIdx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	leftType, rightType := constType, inputTypes[colIdx]

--- a/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
@@ -127,10 +127,12 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec._RET_TYP()
+		// {{/*
 		// Some operators can result in NULL with non-NULL inputs, like the JSON
 		// fetch value operator, ->. Therefore, _outNulls is defined to allow
 		// updating the output Nulls from within _ASSIGN functions when the result
 		// of a projection is Null.
+		// */}}
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			_SET_PROJECTION(true)
@@ -164,11 +166,13 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS, false)
 		}
 	}
+	// {{/*
 	// _outNulls has been updated from within the _ASSIGN function to include
 	// any NULLs that resulted from the projection.
 	// If _HAS_NULLS is true, union _outNulls with the set of input Nulls.
 	// If _HAS_NULLS is false, then there are no input Nulls. _outNulls is
 	// projVec.Nulls() so there is no need to call projVec.SetNulls().
+	// */}}
 	// {{if _HAS_NULLS}}
 	projVec.SetNulls(_outNulls.Or(*colNulls))
 	// {{end}}

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -73,10 +73,6 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -105,11 +101,6 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -131,11 +122,6 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -166,10 +152,6 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -198,11 +180,6 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -224,11 +201,6 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -259,10 +231,6 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -291,11 +259,6 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -317,11 +280,6 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -352,10 +310,6 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -384,11 +338,6 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -410,11 +359,6 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -445,10 +389,6 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -477,11 +417,6 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -503,11 +438,6 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -538,10 +468,6 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -570,11 +496,6 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -596,11 +517,6 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -631,10 +547,6 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -663,11 +575,6 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -689,11 +596,6 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -724,10 +626,6 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -756,11 +654,6 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -782,11 +675,6 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -817,10 +705,6 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -849,11 +733,6 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -875,11 +754,6 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -912,10 +786,6 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -957,11 +827,6 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -996,11 +861,6 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1031,10 +891,6 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1063,11 +919,6 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1089,11 +940,6 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1124,10 +970,6 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1156,11 +998,6 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1182,11 +1019,6 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1217,10 +1049,6 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1249,11 +1077,6 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1275,11 +1098,6 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1310,10 +1128,6 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1342,11 +1156,6 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1368,11 +1177,6 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1403,10 +1207,6 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1435,11 +1235,6 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1461,11 +1256,6 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1496,10 +1286,6 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1528,11 +1314,6 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1554,11 +1335,6 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1589,10 +1365,6 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1621,11 +1393,6 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1647,11 +1414,6 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1682,10 +1444,6 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1714,11 +1472,6 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1740,11 +1493,6 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1775,10 +1523,6 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1807,11 +1551,6 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1833,11 +1572,6 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1870,10 +1604,6 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -1915,11 +1645,6 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1954,11 +1679,6 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1989,10 +1709,6 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2021,11 +1737,6 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2047,11 +1758,6 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2082,10 +1788,6 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2114,11 +1816,6 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2140,11 +1837,6 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2175,10 +1867,6 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2207,11 +1895,6 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2233,11 +1916,6 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2268,10 +1946,6 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2300,11 +1974,6 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2326,11 +1995,6 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2361,10 +2025,6 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2393,11 +2053,6 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2419,11 +2074,6 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2454,10 +2104,6 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2486,11 +2132,6 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2512,11 +2153,6 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2547,10 +2183,6 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2579,11 +2211,6 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2605,11 +2232,6 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2640,10 +2262,6 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2672,11 +2290,6 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2698,11 +2311,6 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2733,10 +2341,6 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2765,11 +2369,6 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2791,11 +2390,6 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2828,10 +2422,6 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2873,11 +2463,6 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2912,11 +2497,6 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2947,10 +2527,6 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -2993,11 +2569,6 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3033,11 +2604,6 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3068,10 +2634,6 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3114,11 +2676,6 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3154,11 +2711,6 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3189,10 +2741,6 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3235,11 +2783,6 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3275,11 +2818,6 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3310,10 +2848,6 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3354,11 +2888,6 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3392,11 +2921,6 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3427,10 +2951,6 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3471,11 +2991,6 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3509,11 +3024,6 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3544,10 +3054,6 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3588,11 +3094,6 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3626,11 +3127,6 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3661,10 +3157,6 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3705,11 +3197,6 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3743,11 +3230,6 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3778,10 +3260,6 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3826,11 +3304,6 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3868,11 +3341,6 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3905,10 +3373,6 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -3958,11 +3422,6 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4005,11 +3464,6 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4040,10 +3494,6 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4084,11 +3534,6 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4122,11 +3567,6 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4157,10 +3597,6 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4201,11 +3637,6 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4239,11 +3670,6 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4274,10 +3700,6 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4318,11 +3740,6 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4356,11 +3773,6 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4391,10 +3803,6 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4439,11 +3847,6 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4481,11 +3884,6 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4518,10 +3916,6 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4571,11 +3965,6 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4618,11 +4007,6 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4653,10 +4037,6 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4697,11 +4077,6 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4735,11 +4110,6 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4770,10 +4140,6 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4814,11 +4180,6 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4852,11 +4213,6 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4887,10 +4243,6 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -4931,11 +4283,6 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4969,11 +4316,6 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5004,10 +4346,6 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5052,11 +4390,6 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5094,11 +4427,6 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5131,10 +4459,6 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5184,11 +4508,6 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5231,11 +4550,6 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5266,10 +4580,6 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5304,11 +4614,6 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5336,11 +4641,6 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5371,10 +4671,6 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5409,11 +4705,6 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5441,11 +4732,6 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5476,10 +4762,6 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5514,11 +4796,6 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5546,11 +4823,6 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5581,10 +4853,6 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5609,11 +4877,6 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5631,11 +4894,6 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Add(p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5668,10 +4926,6 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5721,11 +4975,6 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5768,11 +5017,6 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5805,10 +5049,6 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5859,11 +5099,6 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5907,11 +5142,6 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5944,10 +5174,6 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -5998,11 +5224,6 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6046,11 +5267,6 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6083,10 +5299,6 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6137,11 +5349,6 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6185,11 +5392,6 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6222,10 +5424,6 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6276,11 +5474,6 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6324,11 +5517,6 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6359,10 +5547,6 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6405,11 +5589,6 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6445,11 +5624,6 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6480,10 +5654,6 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6526,11 +5696,6 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6566,11 +5731,6 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6601,10 +5761,6 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6647,11 +5803,6 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6687,11 +5838,6 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6722,10 +5868,6 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6766,11 +5908,6 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6804,11 +5941,6 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6839,10 +5971,6 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -6883,11 +6011,6 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6921,11 +6044,6 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6956,10 +6074,6 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7000,11 +6114,6 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7038,11 +6147,6 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7073,10 +6177,6 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7117,11 +6217,6 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7155,11 +6250,6 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7190,10 +6280,6 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7238,11 +6324,6 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7280,11 +6361,6 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7317,10 +6393,6 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7370,11 +6442,6 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7417,11 +6484,6 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7452,10 +6514,6 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7496,11 +6554,6 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7534,11 +6587,6 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7569,10 +6617,6 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7613,11 +6657,6 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7651,11 +6690,6 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7686,10 +6720,6 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7730,11 +6760,6 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7768,11 +6793,6 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7803,10 +6823,6 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7851,11 +6867,6 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7893,11 +6904,6 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7930,10 +6936,6 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -7983,11 +6985,6 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8030,11 +7027,6 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8065,10 +7057,6 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8109,11 +7097,6 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8147,11 +7130,6 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8182,10 +7160,6 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8226,11 +7200,6 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8264,11 +7233,6 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8299,10 +7263,6 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8343,11 +7303,6 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8381,11 +7336,6 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8416,10 +7366,6 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8464,11 +7410,6 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8506,11 +7447,6 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8543,10 +7479,6 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8596,11 +7528,6 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8643,11 +7570,6 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8678,10 +7600,6 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8716,11 +7634,6 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8748,11 +7661,6 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8783,10 +7691,6 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8817,11 +7721,6 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8845,11 +7744,6 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8880,10 +7774,6 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -8918,11 +7808,6 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8950,11 +7835,6 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8985,10 +7865,6 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9013,11 +7889,6 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9035,11 +7906,6 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Sub(p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9072,10 +7938,6 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9125,11 +7987,6 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9172,11 +8029,6 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9207,10 +8059,6 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9252,11 +8100,6 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9291,11 +8134,6 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9326,10 +8164,6 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9364,11 +8198,6 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9396,11 +8225,6 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9431,10 +8255,6 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9469,11 +8289,6 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9501,11 +8316,6 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9536,10 +8346,6 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9574,11 +8380,6 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9606,11 +8407,6 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9643,10 +8439,6 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9688,11 +8480,6 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9727,11 +8514,6 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9764,10 +8546,6 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9818,11 +8596,6 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9866,11 +8639,6 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9903,10 +8671,6 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -9956,11 +8720,6 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10003,11 +8762,6 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10040,10 +8794,6 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10094,11 +8844,6 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10142,11 +8887,6 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10179,10 +8919,6 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10233,11 +8969,6 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10281,11 +9012,6 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10318,10 +9044,6 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10372,11 +9094,6 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10420,11 +9137,6 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10455,10 +9167,6 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10501,11 +9209,6 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10541,11 +9244,6 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10576,10 +9274,6 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10622,11 +9316,6 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10662,11 +9351,6 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10697,10 +9381,6 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10743,11 +9423,6 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10783,11 +9458,6 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10818,10 +9488,6 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10862,11 +9528,6 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10900,11 +9561,6 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10935,10 +9591,6 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -10973,11 +9625,6 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11005,11 +9652,6 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11040,10 +9682,6 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11100,11 +9738,6 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11154,11 +9787,6 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11189,10 +9817,6 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11249,11 +9873,6 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11303,11 +9922,6 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11338,10 +9952,6 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11398,11 +10008,6 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11452,11 +10057,6 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11487,10 +10087,6 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11535,11 +10131,6 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11577,11 +10168,6 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11612,10 +10198,6 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11640,11 +10222,6 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11662,11 +10239,6 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11697,10 +10269,6 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11757,11 +10325,6 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11811,11 +10374,6 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11846,10 +10404,6 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -11906,11 +10460,6 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11960,11 +10509,6 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11995,10 +10539,6 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12055,11 +10595,6 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12109,11 +10644,6 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12144,10 +10674,6 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12192,11 +10718,6 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12234,11 +10755,6 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12269,10 +10785,6 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12297,11 +10809,6 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12319,11 +10826,6 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12354,10 +10856,6 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12414,11 +10912,6 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12468,11 +10961,6 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12503,10 +10991,6 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12563,11 +11047,6 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12617,11 +11096,6 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12652,10 +11126,6 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12712,11 +11182,6 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12766,11 +11231,6 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12801,10 +11261,6 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12849,11 +11305,6 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12891,11 +11342,6 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12926,10 +11372,6 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -12954,11 +11396,6 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12976,11 +11413,6 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Mul(int64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13011,10 +11443,6 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13049,11 +11477,6 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13081,11 +11504,6 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13116,10 +11534,6 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13144,11 +11558,6 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13166,11 +11575,6 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.MulFloat(float64(arg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13201,10 +11605,6 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13229,11 +11629,6 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13251,11 +11646,6 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13286,10 +11676,6 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13314,11 +11700,6 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13336,11 +11717,6 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13371,10 +11747,6 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13399,11 +11771,6 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13421,11 +11788,6 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Mul(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13456,10 +11818,6 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13484,11 +11842,6 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13506,11 +11859,6 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.MulFloat(float64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13541,10 +11889,6 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13579,11 +11923,6 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13611,11 +11950,6 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 					projCol[i] = arg.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13646,10 +11980,6 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13700,11 +12030,6 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13748,11 +12073,6 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13783,10 +12103,6 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13837,11 +12153,6 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13885,11 +12196,6 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13920,10 +12226,6 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -13974,11 +12276,6 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14022,11 +12319,6 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14057,10 +12349,6 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14109,11 +12397,6 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14155,11 +12438,6 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14190,10 +12468,6 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14242,11 +12516,6 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14288,11 +12557,6 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14323,10 +12587,6 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14375,11 +12635,6 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14421,11 +12676,6 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14456,10 +12706,6 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14508,11 +12754,6 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14554,11 +12795,6 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14589,10 +12825,6 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14645,11 +12877,6 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14695,11 +12922,6 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14730,10 +12952,6 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14782,11 +13000,6 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14828,11 +13041,6 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14863,10 +13071,6 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -14915,11 +13119,6 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14961,11 +13160,6 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14996,10 +13190,6 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15048,11 +13238,6 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15094,11 +13279,6 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15129,10 +13309,6 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15185,11 +13361,6 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15235,11 +13406,6 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15270,10 +13436,6 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15322,11 +13484,6 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15368,11 +13525,6 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15403,10 +13555,6 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15455,11 +13603,6 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15501,11 +13644,6 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15536,10 +13674,6 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15588,11 +13722,6 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15634,11 +13763,6 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15669,10 +13793,6 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15725,11 +13845,6 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15775,11 +13890,6 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15810,10 +13920,6 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15856,11 +13962,6 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15896,11 +13997,6 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15931,10 +14027,6 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -15967,11 +14059,6 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15997,11 +14084,6 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Div(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16032,10 +14114,6 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16068,11 +14146,6 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16098,11 +14171,6 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Div(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16133,10 +14201,6 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16169,11 +14233,6 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16199,11 +14258,6 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.Div(int64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16234,10 +14288,6 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16270,11 +14320,6 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16300,11 +14345,6 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 					projCol[i] = arg.DivFloat(float64(p.constArg))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16335,10 +14375,6 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16389,11 +14425,6 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16437,11 +14468,6 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16472,10 +14498,6 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16526,11 +14548,6 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16574,11 +14591,6 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16609,10 +14621,6 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16663,11 +14671,6 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16711,11 +14714,6 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16746,10 +14744,6 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16798,11 +14792,6 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16844,11 +14833,6 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16879,10 +14863,6 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -16921,11 +14901,6 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16957,11 +14932,6 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16992,10 +14962,6 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17034,11 +15000,6 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17070,11 +15031,6 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17105,10 +15061,6 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17147,11 +15099,6 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17183,11 +15130,6 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17218,10 +15160,6 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17274,11 +15212,6 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17324,11 +15257,6 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17359,10 +15287,6 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17401,11 +15325,6 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17437,11 +15356,6 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17472,10 +15386,6 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17514,11 +15424,6 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17550,11 +15455,6 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17585,10 +15485,6 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17627,11 +15523,6 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17663,11 +15554,6 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17698,10 +15584,6 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17754,11 +15636,6 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17804,11 +15681,6 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17839,10 +15711,6 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17881,11 +15749,6 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17917,11 +15780,6 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17952,10 +15810,6 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -17994,11 +15848,6 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18030,11 +15879,6 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18065,10 +15909,6 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18107,11 +15947,6 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18143,11 +15978,6 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18178,10 +16008,6 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18234,11 +16060,6 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18284,11 +16105,6 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18319,10 +16135,6 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18365,11 +16177,6 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18405,11 +16212,6 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18440,10 +16242,6 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18494,11 +16292,6 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18542,11 +16335,6 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18577,10 +16365,6 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18631,11 +16415,6 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18679,11 +16458,6 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18714,10 +16488,6 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18768,11 +16538,6 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18816,11 +16581,6 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18851,10 +16611,6 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -18903,11 +16659,6 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18949,11 +16700,6 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18984,10 +16730,6 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19026,11 +16768,6 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19062,11 +16799,6 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19097,10 +16829,6 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19139,11 +16867,6 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19175,11 +16898,6 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19210,10 +16928,6 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19252,11 +16966,6 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19288,11 +16997,6 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19323,10 +17027,6 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19379,11 +17079,6 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19429,11 +17124,6 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19464,10 +17154,6 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19506,11 +17192,6 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19542,11 +17223,6 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19577,10 +17253,6 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19619,11 +17291,6 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19655,11 +17322,6 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19690,10 +17352,6 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19732,11 +17390,6 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19768,11 +17421,6 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19803,10 +17451,6 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19859,11 +17503,6 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19909,11 +17548,6 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19944,10 +17578,6 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -19986,11 +17616,6 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20022,11 +17647,6 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20057,10 +17677,6 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20099,11 +17715,6 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20135,11 +17746,6 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20170,10 +17776,6 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20212,11 +17814,6 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20248,11 +17845,6 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20283,10 +17875,6 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20339,11 +17927,6 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20389,11 +17972,6 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20424,10 +18002,6 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20470,11 +18044,6 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20510,11 +18079,6 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20545,10 +18109,6 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20591,11 +18151,6 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20631,11 +18186,6 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20666,10 +18216,6 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20712,11 +18258,6 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20752,11 +18293,6 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20787,10 +18323,6 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20833,11 +18365,6 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20873,11 +18400,6 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20908,10 +18430,6 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -20952,11 +18470,6 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20990,11 +18503,6 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21025,10 +18533,6 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21081,11 +18585,6 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21131,11 +18630,6 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21166,10 +18660,6 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21222,11 +18712,6 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21272,11 +18757,6 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21307,10 +18787,6 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21363,11 +18839,6 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21413,11 +18884,6 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21448,10 +18914,6 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21496,11 +18958,6 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21538,11 +18995,6 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21573,10 +19025,6 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21629,11 +19077,6 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21679,11 +19122,6 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21714,10 +19152,6 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21770,11 +19204,6 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21820,11 +19249,6 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21855,10 +19279,6 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -21911,11 +19331,6 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21961,11 +19376,6 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21996,10 +19406,6 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22044,11 +19450,6 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22086,11 +19487,6 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22121,10 +19517,6 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22177,11 +19569,6 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22227,11 +19614,6 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22262,10 +19644,6 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22318,11 +19696,6 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22368,11 +19741,6 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22403,10 +19771,6 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22459,11 +19823,6 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22509,11 +19868,6 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22544,10 +19898,6 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22592,11 +19942,6 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22634,11 +19979,6 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22669,10 +20009,6 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22707,11 +20043,6 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22739,11 +20070,6 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22774,10 +20100,6 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22815,11 +20137,6 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22850,11 +20167,6 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22885,10 +20197,6 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -22924,11 +20232,6 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22957,11 +20260,6 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22994,10 +20292,6 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23039,11 +20333,6 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23078,11 +20367,6 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23113,10 +20397,6 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23157,11 +20437,6 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23195,11 +20470,6 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23230,10 +20500,6 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23274,11 +20540,6 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23312,11 +20573,6 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23347,10 +20603,6 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23391,11 +20643,6 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23429,11 +20676,6 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23464,10 +20706,6 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23508,11 +20746,6 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23546,11 +20779,6 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23581,10 +20809,6 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23625,11 +20849,6 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23663,11 +20882,6 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23698,10 +20912,6 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23742,11 +20952,6 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23780,11 +20985,6 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23815,10 +21015,6 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23859,11 +21055,6 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23897,11 +21088,6 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23932,10 +21118,6 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -23976,11 +21158,6 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24014,11 +21191,6 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24049,10 +21221,6 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24093,11 +21261,6 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24131,11 +21294,6 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24168,10 +21326,6 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24222,11 +21376,6 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24270,11 +21419,6 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24307,10 +21451,6 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24361,11 +21501,6 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24409,11 +21544,6 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24446,10 +21576,6 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24500,11 +21626,6 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24548,11 +21669,6 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24583,10 +21699,6 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24627,11 +21739,6 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24665,11 +21772,6 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24700,10 +21802,6 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24744,11 +21842,6 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24782,11 +21875,6 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24817,10 +21905,6 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24861,11 +21945,6 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24899,11 +21978,6 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24934,10 +22008,6 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -24978,11 +22048,6 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25016,11 +22081,6 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25051,10 +22111,6 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25095,11 +22151,6 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25133,11 +22184,6 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25168,10 +22214,6 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25212,11 +22254,6 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25250,11 +22287,6 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25285,10 +22317,6 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25329,11 +22357,6 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25367,11 +22390,6 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25402,10 +22420,6 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25446,11 +22460,6 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25484,11 +22493,6 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25519,10 +22523,6 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25563,11 +22563,6 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25601,11 +22596,6 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25638,10 +22628,6 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25692,11 +22678,6 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25740,11 +22721,6 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25777,10 +22753,6 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25831,11 +22803,6 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25879,11 +22846,6 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25916,10 +22878,6 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -25970,11 +22928,6 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26018,11 +22971,6 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26053,10 +23001,6 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26104,11 +23048,6 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26149,11 +23088,6 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26184,10 +23118,6 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26230,11 +23160,6 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26270,11 +23195,6 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26305,10 +23225,6 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26351,11 +23267,6 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26391,11 +23302,6 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26426,10 +23332,6 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26472,11 +23374,6 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26512,11 +23409,6 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26547,10 +23439,6 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26616,11 +23504,6 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26679,11 +23562,6 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26714,10 +23592,6 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26778,11 +23652,6 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26836,11 +23705,6 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26871,10 +23735,6 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -26935,11 +23795,6 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26993,11 +23848,6 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27028,10 +23878,6 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27092,11 +23938,6 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27150,11 +23991,6 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27185,10 +24021,6 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27230,11 +24062,6 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27269,11 +24096,6 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27304,10 +24126,6 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27369,11 +24187,6 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27428,11 +24241,6 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27463,10 +24271,6 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27519,11 +24323,6 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27569,11 +24368,6 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27604,10 +24398,6 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27643,11 +24433,6 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27676,11 +24461,6 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27711,10 +24491,6 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27763,11 +24539,6 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27809,11 +24580,6 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27844,10 +24610,6 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -27896,11 +24658,6 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27942,11 +24699,6 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27977,10 +24729,6 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28029,11 +24777,6 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28075,11 +24818,6 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28110,10 +24848,6 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28166,11 +24900,6 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28216,11 +24945,6 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28251,10 +24975,6 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28291,11 +25011,6 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28325,11 +25040,6 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28360,10 +25070,6 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28422,11 +25128,6 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28478,11 +25179,6 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28513,10 +25209,6 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28575,11 +25267,6 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28631,11 +25318,6 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28666,10 +25348,6 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28728,11 +25406,6 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28784,11 +25457,6 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28819,10 +25487,6 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -28897,11 +25561,6 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28969,11 +25628,6 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29004,10 +25658,6 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29056,11 +25706,6 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29102,11 +25747,6 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29137,10 +25777,6 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29199,11 +25835,6 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29255,11 +25886,6 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29290,10 +25916,6 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29352,11 +25974,6 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29408,11 +26025,6 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29443,10 +26055,6 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29505,11 +26113,6 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29561,11 +26164,6 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29596,10 +26194,6 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29674,11 +26268,6 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29746,11 +26335,6 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29781,10 +26365,6 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29833,11 +26413,6 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29879,11 +26454,6 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29914,10 +26484,6 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -29976,11 +26542,6 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30032,11 +26593,6 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30067,10 +26623,6 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30129,11 +26681,6 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30185,11 +26732,6 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30220,10 +26762,6 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30282,11 +26820,6 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30338,11 +26871,6 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30373,10 +26901,6 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30451,11 +26975,6 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30523,11 +27042,6 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30558,10 +27072,6 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30610,11 +27120,6 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30656,11 +27161,6 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30691,10 +27191,6 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30769,11 +27265,6 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30841,11 +27332,6 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30876,10 +27362,6 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -30954,11 +27436,6 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31026,11 +27503,6 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31061,10 +27533,6 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31139,11 +27607,6 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31211,11 +27674,6 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31246,10 +27704,6 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31324,11 +27778,6 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31396,11 +27845,6 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31431,10 +27875,6 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31487,11 +27927,6 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31537,11 +27972,6 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31572,10 +28002,6 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31626,11 +28052,6 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31674,11 +28095,6 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31709,10 +28125,6 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31749,11 +28161,6 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31783,11 +28190,6 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31818,10 +28220,6 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31869,11 +28267,6 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31914,11 +28307,6 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31949,10 +28337,6 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -31992,11 +28376,6 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32029,11 +28408,6 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32064,10 +28438,6 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32120,11 +28490,6 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32170,11 +28535,6 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32205,10 +28565,6 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32244,11 +28600,6 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32277,11 +28628,6 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32312,10 +28658,6 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32364,11 +28706,6 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32410,11 +28747,6 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32445,10 +28777,6 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32497,11 +28825,6 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32543,11 +28866,6 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32578,10 +28896,6 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32630,11 +28944,6 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32676,11 +28985,6 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32711,10 +29015,6 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32767,11 +29067,6 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32817,11 +29112,6 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32852,10 +29142,6 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -32892,11 +29178,6 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32926,11 +29207,6 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32961,10 +29237,6 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33023,11 +29295,6 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33079,11 +29346,6 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33114,10 +29376,6 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33176,11 +29434,6 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33232,11 +29485,6 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33267,10 +29515,6 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33329,11 +29573,6 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33385,11 +29624,6 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33420,10 +29654,6 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33498,11 +29728,6 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33570,11 +29795,6 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33605,10 +29825,6 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33657,11 +29873,6 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33703,11 +29914,6 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33738,10 +29944,6 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33800,11 +30002,6 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33856,11 +30053,6 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33891,10 +30083,6 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -33953,11 +30141,6 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34009,11 +30192,6 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34044,10 +30222,6 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34106,11 +30280,6 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34162,11 +30331,6 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34197,10 +30361,6 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34275,11 +30435,6 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34347,11 +30502,6 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34382,10 +30532,6 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34434,11 +30580,6 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34480,11 +30621,6 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34515,10 +30651,6 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34577,11 +30709,6 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34633,11 +30760,6 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34668,10 +30790,6 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34730,11 +30848,6 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34786,11 +30899,6 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34821,10 +30929,6 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -34883,11 +30987,6 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34939,11 +31038,6 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34974,10 +31068,6 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35052,11 +31142,6 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35124,11 +31209,6 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35159,10 +31239,6 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35211,11 +31287,6 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35257,11 +31328,6 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35292,10 +31358,6 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35370,11 +31432,6 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35442,11 +31499,6 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35477,10 +31529,6 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35555,11 +31603,6 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35627,11 +31670,6 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35662,10 +31700,6 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35740,11 +31774,6 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35812,11 +31841,6 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35847,10 +31871,6 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -35925,11 +31945,6 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35997,11 +32012,6 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36032,10 +32042,6 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36088,11 +32094,6 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36138,11 +32139,6 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36173,10 +32169,6 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36227,11 +32219,6 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36275,11 +32262,6 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36310,10 +32292,6 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36350,11 +32328,6 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36384,11 +32357,6 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36419,10 +32387,6 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36470,11 +32434,6 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36515,11 +32474,6 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36550,10 +32504,6 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36593,11 +32543,6 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36630,11 +32575,6 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36665,10 +32605,6 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36721,11 +32657,6 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36771,11 +32702,6 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36806,10 +32732,6 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36845,11 +32767,6 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36878,11 +32795,6 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36913,10 +32825,6 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -36965,11 +32873,6 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37011,11 +32914,6 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37046,10 +32944,6 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37098,11 +32992,6 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37144,11 +33033,6 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37179,10 +33063,6 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37231,11 +33111,6 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37277,11 +33152,6 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37312,10 +33182,6 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37368,11 +33234,6 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37418,11 +33279,6 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37453,10 +33309,6 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37493,11 +33345,6 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37527,11 +33374,6 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37562,10 +33404,6 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37624,11 +33462,6 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37680,11 +33513,6 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37715,10 +33543,6 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37777,11 +33601,6 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37833,11 +33652,6 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37868,10 +33682,6 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -37930,11 +33740,6 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37986,11 +33791,6 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38021,10 +33821,6 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38099,11 +33895,6 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38171,11 +33962,6 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38206,10 +33992,6 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38258,11 +34040,6 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38304,11 +34081,6 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38339,10 +34111,6 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38401,11 +34169,6 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38457,11 +34220,6 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38492,10 +34250,6 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38554,11 +34308,6 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38610,11 +34359,6 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38645,10 +34389,6 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38707,11 +34447,6 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38763,11 +34498,6 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38798,10 +34528,6 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -38876,11 +34602,6 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38948,11 +34669,6 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38983,10 +34699,6 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39035,11 +34747,6 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39081,11 +34788,6 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39116,10 +34818,6 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39178,11 +34876,6 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39234,11 +34927,6 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39269,10 +34957,6 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39331,11 +35015,6 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39387,11 +35066,6 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39422,10 +35096,6 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39484,11 +35154,6 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39540,11 +35205,6 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39575,10 +35235,6 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39653,11 +35309,6 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39725,11 +35376,6 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39760,10 +35406,6 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39812,11 +35454,6 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39858,11 +35495,6 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39893,10 +35525,6 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -39971,11 +35599,6 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40043,11 +35666,6 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40078,10 +35696,6 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40156,11 +35770,6 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40228,11 +35837,6 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40263,10 +35867,6 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40341,11 +35941,6 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40413,11 +36008,6 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40448,10 +36038,6 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40526,11 +36112,6 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40598,11 +36179,6 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40633,10 +36209,6 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40689,11 +36261,6 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40739,11 +36306,6 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40774,10 +36336,6 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40828,11 +36386,6 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40876,11 +36429,6 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40911,10 +36459,6 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -40951,11 +36495,6 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40985,11 +36524,6 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41020,10 +36554,6 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41071,11 +36601,6 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41116,11 +36641,6 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41151,10 +36671,6 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41194,11 +36710,6 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41231,11 +36742,6 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41266,10 +36772,6 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41322,11 +36824,6 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41372,11 +36869,6 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41407,10 +36899,6 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41446,11 +36934,6 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41479,11 +36962,6 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41514,10 +36992,6 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41566,11 +37040,6 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41612,11 +37081,6 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41647,10 +37111,6 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41699,11 +37159,6 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41745,11 +37200,6 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41780,10 +37230,6 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41832,11 +37278,6 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41878,11 +37319,6 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41913,10 +37349,6 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -41969,11 +37401,6 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42019,11 +37446,6 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42054,10 +37476,6 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42094,11 +37512,6 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42128,11 +37541,6 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42163,10 +37571,6 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42225,11 +37629,6 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42281,11 +37680,6 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42316,10 +37710,6 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42378,11 +37768,6 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42434,11 +37819,6 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42469,10 +37849,6 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42531,11 +37907,6 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42587,11 +37958,6 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42622,10 +37988,6 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42700,11 +38062,6 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42772,11 +38129,6 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42807,10 +38159,6 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -42859,11 +38207,6 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42905,11 +38248,6 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42940,10 +38278,6 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43002,11 +38336,6 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43058,11 +38387,6 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43093,10 +38417,6 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43155,11 +38475,6 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43211,11 +38526,6 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43246,10 +38556,6 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43308,11 +38614,6 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43364,11 +38665,6 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43399,10 +38695,6 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43477,11 +38769,6 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43549,11 +38836,6 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43584,10 +38866,6 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43636,11 +38914,6 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43682,11 +38955,6 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43717,10 +38985,6 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43779,11 +39043,6 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43835,11 +39094,6 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43870,10 +39124,6 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -43932,11 +39182,6 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43988,11 +39233,6 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44023,10 +39263,6 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44085,11 +39321,6 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44141,11 +39372,6 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44176,10 +39402,6 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44254,11 +39476,6 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44326,11 +39543,6 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44361,10 +39573,6 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44413,11 +39621,6 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44459,11 +39662,6 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44494,10 +39692,6 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44572,11 +39766,6 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44644,11 +39833,6 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44679,10 +39863,6 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44757,11 +39937,6 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44829,11 +40004,6 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44864,10 +40034,6 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -44942,11 +40108,6 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45014,11 +40175,6 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45049,10 +40205,6 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45127,11 +40279,6 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45199,11 +40346,6 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45234,10 +40376,6 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45290,11 +40428,6 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45340,11 +40473,6 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45375,10 +40503,6 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45429,11 +40553,6 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45477,11 +40596,6 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45512,10 +40626,6 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45552,11 +40662,6 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45586,11 +40691,6 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45621,10 +40721,6 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45672,11 +40768,6 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45717,11 +40808,6 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45752,10 +40838,6 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45795,11 +40877,6 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45832,11 +40909,6 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45867,10 +40939,6 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -45923,11 +40991,6 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45973,11 +41036,6 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46008,10 +41066,6 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46047,11 +41101,6 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46080,11 +41129,6 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46115,10 +41159,6 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46167,11 +41207,6 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46213,11 +41248,6 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46248,10 +41278,6 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46300,11 +41326,6 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46346,11 +41367,6 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46381,10 +41397,6 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46433,11 +41445,6 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46479,11 +41486,6 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46514,10 +41516,6 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46570,11 +41568,6 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46620,11 +41613,6 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46655,10 +41643,6 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46695,11 +41679,6 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46729,11 +41708,6 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46764,10 +41738,6 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46826,11 +41796,6 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46882,11 +41847,6 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46917,10 +41877,6 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -46979,11 +41935,6 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47035,11 +41986,6 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47070,10 +42016,6 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47132,11 +42074,6 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47188,11 +42125,6 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47223,10 +42155,6 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47301,11 +42229,6 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47373,11 +42296,6 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47408,10 +42326,6 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47460,11 +42374,6 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47506,11 +42415,6 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47541,10 +42445,6 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47603,11 +42503,6 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47659,11 +42554,6 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47694,10 +42584,6 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47756,11 +42642,6 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47812,11 +42693,6 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47847,10 +42723,6 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -47909,11 +42781,6 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47965,11 +42832,6 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48000,10 +42862,6 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48078,11 +42936,6 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48150,11 +43003,6 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48185,10 +43033,6 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48237,11 +43081,6 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48283,11 +43122,6 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48318,10 +43152,6 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48380,11 +43210,6 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48436,11 +43261,6 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48471,10 +43291,6 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48533,11 +43349,6 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48589,11 +43400,6 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48624,10 +43430,6 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48686,11 +43488,6 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48742,11 +43539,6 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48777,10 +43569,6 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -48855,11 +43643,6 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48927,11 +43710,6 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48962,10 +43740,6 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49014,11 +43788,6 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49060,11 +43829,6 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49095,10 +43859,6 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49173,11 +43933,6 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49245,11 +44000,6 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49280,10 +44030,6 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49358,11 +44104,6 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49430,11 +44171,6 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49465,10 +44201,6 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49543,11 +44275,6 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49615,11 +44342,6 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49650,10 +44372,6 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49728,11 +44446,6 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49800,11 +44513,6 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49835,10 +44543,6 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -49891,11 +44595,6 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49941,11 +44640,6 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49976,10 +44670,6 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50030,11 +44720,6 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50078,11 +44763,6 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50113,10 +44793,6 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50153,11 +44829,6 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50187,11 +44858,6 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50222,10 +44888,6 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50273,11 +44935,6 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50318,11 +44975,6 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50353,10 +45005,6 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50396,11 +45044,6 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50433,11 +45076,6 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50468,10 +45106,6 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50524,11 +45158,6 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50574,11 +45203,6 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50609,10 +45233,6 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50648,11 +45268,6 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50681,11 +45296,6 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50716,10 +45326,6 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50768,11 +45374,6 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50814,11 +45415,6 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50849,10 +45445,6 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -50901,11 +45493,6 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50947,11 +45534,6 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50982,10 +45564,6 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51034,11 +45612,6 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51080,11 +45653,6 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51115,10 +45683,6 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51171,11 +45735,6 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51221,11 +45780,6 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51256,10 +45810,6 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51296,11 +45846,6 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51330,11 +45875,6 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51365,10 +45905,6 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51427,11 +45963,6 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51483,11 +46014,6 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51518,10 +46044,6 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51580,11 +46102,6 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51636,11 +46153,6 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51671,10 +46183,6 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51733,11 +46241,6 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51789,11 +46292,6 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51824,10 +46322,6 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -51902,11 +46396,6 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51974,11 +46463,6 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52009,10 +46493,6 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52061,11 +46541,6 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52107,11 +46582,6 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52142,10 +46612,6 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52204,11 +46670,6 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52260,11 +46721,6 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52295,10 +46751,6 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52357,11 +46809,6 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52413,11 +46860,6 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52448,10 +46890,6 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52510,11 +46948,6 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52566,11 +46999,6 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52601,10 +47029,6 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52679,11 +47103,6 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52751,11 +47170,6 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52786,10 +47200,6 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52838,11 +47248,6 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52884,11 +47289,6 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52919,10 +47319,6 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -52981,11 +47377,6 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53037,11 +47428,6 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53072,10 +47458,6 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -53134,11 +47516,6 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53190,11 +47567,6 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53225,10 +47597,6 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -53287,11 +47655,6 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53343,11 +47706,6 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53378,10 +47736,6 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -53456,11 +47810,6 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53528,11 +47877,6 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53563,10 +47907,6 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -53615,11 +47955,6 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53661,11 +47996,6 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53696,10 +48026,6 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -53774,11 +48100,6 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53846,11 +48167,6 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53881,10 +48197,6 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -53959,11 +48271,6 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54031,11 +48338,6 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54066,10 +48368,6 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -54144,11 +48442,6 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54216,11 +48509,6 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54251,10 +48539,6 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -54329,11 +48613,6 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54401,11 +48680,6 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54436,10 +48710,6 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -54492,11 +48762,6 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54542,11 +48807,6 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54577,10 +48837,6 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -54631,11 +48887,6 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54679,11 +48930,6 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54714,10 +48960,6 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -54754,11 +48996,6 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54788,11 +49025,6 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54823,10 +49055,6 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -54874,11 +49102,6 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54919,11 +49142,6 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54954,10 +49172,6 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -54997,11 +49211,6 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55034,11 +49243,6 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -74,7 +74,9 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -153,7 +155,9 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -232,7 +236,9 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -311,7 +317,9 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -390,7 +398,9 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -469,7 +479,9 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -548,7 +560,9 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -627,7 +641,9 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -706,7 +722,9 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -787,7 +805,9 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -892,7 +912,9 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -971,7 +993,9 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1050,7 +1074,9 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1129,7 +1155,9 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1208,7 +1236,9 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1287,7 +1317,9 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1366,7 +1398,9 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1445,7 +1479,9 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1524,7 +1560,9 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1605,7 +1643,9 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1710,7 +1750,9 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1789,7 +1831,9 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1868,7 +1912,9 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1947,7 +1993,9 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2026,7 +2074,9 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2105,7 +2155,9 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2184,7 +2236,9 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2263,7 +2317,9 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2342,7 +2398,9 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2423,7 +2481,9 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2528,7 +2588,9 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2635,7 +2697,9 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2742,7 +2806,9 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2849,7 +2915,9 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2952,7 +3020,9 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3055,7 +3125,9 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3158,7 +3230,9 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3261,7 +3335,9 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3374,7 +3450,9 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3495,7 +3573,9 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3598,7 +3678,9 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3701,7 +3783,9 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3804,7 +3888,9 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3917,7 +4003,9 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4038,7 +4126,9 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4141,7 +4231,9 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4244,7 +4336,9 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4347,7 +4441,9 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4460,7 +4556,9 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4581,7 +4679,9 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4672,7 +4772,9 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4763,7 +4865,9 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4854,7 +4958,9 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4927,7 +5033,9 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5050,7 +5158,9 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5175,7 +5285,9 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5300,7 +5412,9 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5425,7 +5539,9 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5548,7 +5664,9 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5655,7 +5773,9 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5762,7 +5882,9 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5869,7 +5991,9 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5972,7 +6096,9 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6075,7 +6201,9 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6178,7 +6306,9 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6281,7 +6411,9 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6394,7 +6526,9 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6515,7 +6649,9 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6618,7 +6754,9 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6721,7 +6859,9 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6824,7 +6964,9 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6937,7 +7079,9 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7058,7 +7202,9 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7161,7 +7307,9 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7264,7 +7412,9 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7367,7 +7517,9 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7480,7 +7632,9 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7601,7 +7755,9 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7692,7 +7848,9 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7775,7 +7933,9 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7866,7 +8026,9 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7939,7 +8101,9 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8060,7 +8224,9 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8165,7 +8331,9 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8256,7 +8424,9 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8347,7 +8517,9 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8440,7 +8612,9 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8547,7 +8721,9 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8672,7 +8848,9 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8795,7 +8973,9 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8920,7 +9100,9 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9045,7 +9227,9 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9168,7 +9352,9 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9275,7 +9461,9 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9382,7 +9570,9 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9489,7 +9679,9 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9592,7 +9784,9 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9683,7 +9877,9 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9818,7 +10014,9 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9953,7 +10151,9 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10088,7 +10288,9 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10199,7 +10401,9 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10270,7 +10474,9 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10405,7 +10611,9 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10540,7 +10748,9 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10675,7 +10885,9 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10786,7 +10998,9 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10857,7 +11071,9 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10992,7 +11208,9 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11127,7 +11345,9 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11262,7 +11482,9 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11373,7 +11595,9 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11444,7 +11668,9 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11535,7 +11761,9 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11606,7 +11834,9 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11677,7 +11907,9 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11748,7 +11980,9 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11819,7 +12053,9 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11890,7 +12126,9 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11981,7 +12219,9 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12104,7 +12344,9 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12227,7 +12469,9 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12350,7 +12594,9 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12469,7 +12715,9 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12588,7 +12836,9 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12707,7 +12957,9 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12826,7 +13078,9 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12953,7 +13207,9 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13072,7 +13328,9 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13191,7 +13449,9 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13310,7 +13570,9 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13437,7 +13699,9 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13556,7 +13820,9 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13675,7 +13941,9 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13794,7 +14062,9 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13921,7 +14191,9 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14028,7 +14300,9 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14115,7 +14389,9 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14202,7 +14478,9 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14289,7 +14567,9 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14376,7 +14656,9 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14499,7 +14781,9 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14622,7 +14906,9 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14745,7 +15031,9 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14864,7 +15152,9 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14963,7 +15253,9 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15062,7 +15354,9 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15161,7 +15455,9 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15288,7 +15584,9 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15387,7 +15685,9 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15486,7 +15786,9 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15585,7 +15887,9 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15712,7 +16016,9 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15811,7 +16117,9 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15910,7 +16218,9 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16009,7 +16319,9 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16136,7 +16448,9 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16243,7 +16557,9 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16366,7 +16682,9 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16489,7 +16807,9 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16612,7 +16932,9 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16731,7 +17053,9 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16830,7 +17154,9 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16929,7 +17255,9 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17028,7 +17356,9 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17155,7 +17485,9 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17254,7 +17586,9 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17353,7 +17687,9 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17452,7 +17788,9 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17579,7 +17917,9 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17678,7 +18018,9 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17777,7 +18119,9 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17876,7 +18220,9 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18003,7 +18349,9 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18110,7 +18458,9 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18217,7 +18567,9 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18324,7 +18676,9 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18431,7 +18785,9 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18534,7 +18890,9 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18661,7 +19019,9 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18788,7 +19148,9 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18915,7 +19277,9 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19026,7 +19390,9 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19153,7 +19519,9 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19280,7 +19648,9 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19407,7 +19777,9 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19518,7 +19890,9 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19645,7 +20019,9 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19772,7 +20148,9 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19899,7 +20277,9 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20010,7 +20390,9 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20101,7 +20483,9 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20198,7 +20582,9 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20293,7 +20679,9 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20398,7 +20786,9 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20501,7 +20891,9 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20604,7 +20996,9 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20707,7 +21101,9 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20810,7 +21206,9 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20913,7 +21311,9 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21016,7 +21416,9 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21119,7 +21521,9 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21222,7 +21626,9 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21327,7 +21733,9 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21452,7 +21860,9 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21577,7 +21987,9 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21700,7 +22112,9 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21803,7 +22217,9 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21906,7 +22322,9 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22009,7 +22427,9 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22112,7 +22532,9 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22215,7 +22637,9 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22318,7 +22742,9 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22421,7 +22847,9 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22524,7 +22952,9 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22629,7 +23059,9 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22754,7 +23186,9 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22879,7 +23313,9 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23002,7 +23438,9 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23119,7 +23557,9 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23226,7 +23666,9 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23333,7 +23775,9 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23440,7 +23884,9 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23593,7 +24039,9 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23736,7 +24184,9 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23879,7 +24329,9 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24022,7 +24474,9 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24127,7 +24581,9 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24272,7 +24728,9 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24399,7 +24857,9 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24492,7 +24952,9 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24611,7 +25073,9 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24730,7 +25194,9 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24849,7 +25315,9 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24976,7 +25444,9 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25071,7 +25541,9 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25210,7 +25682,9 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25349,7 +25823,9 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25488,7 +25964,9 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25659,7 +26137,9 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25778,7 +26258,9 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25917,7 +26399,9 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26056,7 +26540,9 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26195,7 +26681,9 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26366,7 +26854,9 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26485,7 +26975,9 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26624,7 +27116,9 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26763,7 +27257,9 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26902,7 +27398,9 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27073,7 +27571,9 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27192,7 +27692,9 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27363,7 +27865,9 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27534,7 +28038,9 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27705,7 +28211,9 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27876,7 +28384,9 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28003,7 +28513,9 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28126,7 +28638,9 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28221,7 +28735,9 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28338,7 +28854,9 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28439,7 +28957,9 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28566,7 +29086,9 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28659,7 +29181,9 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28778,7 +29302,9 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28897,7 +29423,9 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29016,7 +29544,9 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29143,7 +29673,9 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29238,7 +29770,9 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29377,7 +29911,9 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29516,7 +30052,9 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29655,7 +30193,9 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29826,7 +30366,9 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29945,7 +30487,9 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30084,7 +30628,9 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30223,7 +30769,9 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30362,7 +30910,9 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30533,7 +31083,9 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30652,7 +31204,9 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30791,7 +31345,9 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30930,7 +31486,9 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31069,7 +31627,9 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31240,7 +31800,9 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31359,7 +31921,9 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31530,7 +32094,9 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31701,7 +32267,9 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31872,7 +32440,9 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32043,7 +32613,9 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32170,7 +32742,9 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32293,7 +32867,9 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32388,7 +32964,9 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32505,7 +33083,9 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32606,7 +33186,9 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32733,7 +33315,9 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32826,7 +33410,9 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32945,7 +33531,9 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33064,7 +33652,9 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33183,7 +33773,9 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33310,7 +33902,9 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33405,7 +33999,9 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33544,7 +34140,9 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33683,7 +34281,9 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33822,7 +34422,9 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33993,7 +34595,9 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34112,7 +34716,9 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34251,7 +34857,9 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34390,7 +34998,9 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34529,7 +35139,9 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34700,7 +35312,9 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34819,7 +35433,9 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34958,7 +35574,9 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35097,7 +35715,9 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35236,7 +35856,9 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35407,7 +36029,9 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35526,7 +36150,9 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35697,7 +36323,9 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35868,7 +36496,9 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36039,7 +36669,9 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36210,7 +36842,9 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36337,7 +36971,9 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36460,7 +37096,9 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36555,7 +37193,9 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36672,7 +37312,9 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36773,7 +37415,9 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36900,7 +37544,9 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36993,7 +37639,9 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37112,7 +37760,9 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37231,7 +37881,9 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37350,7 +38002,9 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37477,7 +38131,9 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37572,7 +38228,9 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37711,7 +38369,9 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37850,7 +38510,9 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37989,7 +38651,9 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38160,7 +38824,9 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38279,7 +38945,9 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38418,7 +39086,9 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38557,7 +39227,9 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38696,7 +39368,9 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38867,7 +39541,9 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38986,7 +39662,9 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39125,7 +39803,9 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39264,7 +39944,9 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39403,7 +40085,9 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39574,7 +40258,9 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39693,7 +40379,9 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39864,7 +40552,9 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40035,7 +40725,9 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40206,7 +40898,9 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40377,7 +41071,9 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40504,7 +41200,9 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40627,7 +41325,9 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40722,7 +41422,9 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40839,7 +41541,9 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40940,7 +41644,9 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41067,7 +41773,9 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41160,7 +41868,9 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41279,7 +41989,9 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41398,7 +42110,9 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41517,7 +42231,9 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41644,7 +42360,9 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41739,7 +42457,9 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41878,7 +42598,9 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42017,7 +42739,9 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42156,7 +42880,9 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42327,7 +43053,9 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42446,7 +43174,9 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42585,7 +43315,9 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42724,7 +43456,9 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42863,7 +43597,9 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43034,7 +43770,9 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43153,7 +43891,9 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43292,7 +44032,9 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43431,7 +44173,9 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43570,7 +44314,9 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43741,7 +44487,9 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43860,7 +44608,9 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44031,7 +44781,9 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44202,7 +44954,9 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44373,7 +45127,9 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44544,7 +45300,9 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44671,7 +45429,9 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44794,7 +45554,9 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44889,7 +45651,9 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45006,7 +45770,9 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45107,7 +45873,9 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45234,7 +46002,9 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45327,7 +46097,9 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45446,7 +46218,9 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45565,7 +46339,9 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45684,7 +46460,9 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45811,7 +46589,9 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45906,7 +46686,9 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46045,7 +46827,9 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46184,7 +46968,9 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46323,7 +47109,9 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46494,7 +47282,9 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46613,7 +47403,9 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46752,7 +47544,9 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46891,7 +47685,9 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47030,7 +47826,9 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47201,7 +47999,9 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47320,7 +48120,9 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47459,7 +48261,9 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47598,7 +48402,9 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47737,7 +48543,9 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47908,7 +48716,9 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48027,7 +48837,9 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48198,7 +49010,9 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48369,7 +49183,9 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48540,7 +49356,9 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48711,7 +49529,9 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48838,7 +49658,9 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48961,7 +49783,9 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -49056,7 +49880,9 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -49173,7 +49999,9 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -49263,6 +50091,7 @@ func GetProjectionRConstOperator(
 	evalCtx *tree.EvalContext,
 	binFn tree.TwoArgFn,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
@@ -49270,6 +50099,7 @@ func GetProjectionRConstOperator(
 		allocator:      allocator,
 		colIdx:         colIdx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	leftType, rightType := inputTypes[colIdx], constType

--- a/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
@@ -42,10 +42,6 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -69,11 +65,6 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -90,11 +81,6 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = bytes.HasPrefix(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -125,10 +111,6 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -152,11 +134,6 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -173,11 +150,6 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = bytes.HasSuffix(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -208,10 +180,6 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -235,11 +203,6 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -256,11 +219,6 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = bytes.Contains(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -291,10 +249,6 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -318,11 +272,6 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -339,11 +288,6 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = p.constArg.Match(arg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -374,10 +318,6 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -401,11 +341,6 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -422,11 +357,6 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = !bytes.HasPrefix(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -457,10 +387,6 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -484,11 +410,6 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -505,11 +426,6 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = !bytes.HasSuffix(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -540,10 +456,6 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -567,11 +479,6 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -588,11 +495,6 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = !bytes.Contains(arg, p.constArg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -623,10 +525,6 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 			projVec.Nulls().UnsetNulls()
 		}
 		projCol := projVec.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
@@ -650,11 +548,6 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*colNulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -671,11 +564,6 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 					projCol[i] = !p.constArg.Match(arg)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch

--- a/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
@@ -43,7 +43,9 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -112,7 +114,9 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -181,7 +185,9 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -250,7 +256,9 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -319,7 +327,9 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -388,7 +398,9 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -457,7 +469,9 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -526,7 +540,9 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-		if vec.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotNullable {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -89,10 +89,6 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -128,11 +124,6 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -158,11 +149,6 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -190,10 +176,6 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -229,11 +211,6 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -259,11 +236,6 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -291,10 +263,6 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -330,11 +298,6 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -360,11 +323,6 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -392,10 +350,6 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -431,11 +385,6 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -461,11 +410,6 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -493,10 +437,6 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -532,11 +472,6 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -562,11 +497,6 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -594,10 +524,6 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -633,11 +559,6 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -663,11 +584,6 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -695,10 +611,6 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -734,11 +646,6 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -764,11 +671,6 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -796,10 +698,6 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -835,11 +733,6 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -865,11 +758,6 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -897,10 +785,6 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -936,11 +820,6 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -966,11 +845,6 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1000,10 +874,6 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1051,11 +921,6 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1093,11 +958,6 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1125,10 +985,6 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1164,11 +1020,6 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1194,11 +1045,6 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1226,10 +1072,6 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1265,11 +1107,6 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1295,11 +1132,6 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1327,10 +1159,6 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1366,11 +1194,6 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1396,11 +1219,6 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1428,10 +1246,6 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1467,11 +1281,6 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1497,11 +1306,6 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1529,10 +1333,6 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1568,11 +1368,6 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1598,11 +1393,6 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1630,10 +1420,6 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1669,11 +1455,6 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1699,11 +1480,6 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1731,10 +1507,6 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1770,11 +1542,6 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1800,11 +1567,6 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1832,10 +1594,6 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1871,11 +1629,6 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -1901,11 +1654,6 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -1933,10 +1681,6 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -1972,11 +1716,6 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2002,11 +1741,6 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2036,10 +1770,6 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2087,11 +1817,6 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2129,11 +1854,6 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2161,10 +1881,6 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2200,11 +1916,6 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2230,11 +1941,6 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2262,10 +1968,6 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2301,11 +2003,6 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2331,11 +2028,6 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2363,10 +2055,6 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2402,11 +2090,6 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2432,11 +2115,6 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2464,10 +2142,6 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2503,11 +2177,6 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2533,11 +2202,6 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2565,10 +2229,6 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2604,11 +2264,6 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2634,11 +2289,6 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2666,10 +2316,6 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2705,11 +2351,6 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2735,11 +2376,6 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2767,10 +2403,6 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2806,11 +2438,6 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2836,11 +2463,6 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2868,10 +2490,6 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -2907,11 +2525,6 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -2937,11 +2550,6 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -2969,10 +2577,6 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3008,11 +2612,6 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3038,11 +2637,6 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3072,10 +2666,6 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3123,11 +2713,6 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3165,11 +2750,6 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3197,10 +2777,6 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3250,11 +2826,6 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3294,11 +2865,6 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3326,10 +2892,6 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3379,11 +2941,6 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3423,11 +2980,6 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3455,10 +3007,6 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3508,11 +3056,6 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3552,11 +3095,6 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3584,10 +3122,6 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3635,11 +3169,6 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3677,11 +3206,6 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3709,10 +3233,6 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3760,11 +3280,6 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3802,11 +3317,6 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3834,10 +3344,6 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -3885,11 +3391,6 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -3927,11 +3428,6 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -3959,10 +3455,6 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4010,11 +3502,6 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4052,11 +3539,6 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4084,10 +3566,6 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4139,11 +3617,6 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4185,11 +3658,6 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4219,10 +3687,6 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4279,11 +3743,6 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4330,11 +3789,6 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4362,10 +3816,6 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4413,11 +3863,6 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4455,11 +3900,6 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4487,10 +3927,6 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4538,11 +3974,6 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4580,11 +4011,6 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4612,10 +4038,6 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4663,11 +4085,6 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4705,11 +4122,6 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4737,10 +4149,6 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4792,11 +4200,6 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4838,11 +4241,6 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -4872,10 +4270,6 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -4932,11 +4326,6 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -4983,11 +4372,6 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5015,10 +4399,6 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5066,11 +4446,6 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5108,11 +4483,6 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5140,10 +4510,6 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5191,11 +4557,6 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5233,11 +4594,6 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5265,10 +4621,6 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5316,11 +4668,6 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5358,11 +4705,6 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5390,10 +4732,6 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5445,11 +4783,6 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5491,11 +4824,6 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5525,10 +4853,6 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5585,11 +4909,6 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5636,11 +4955,6 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5668,10 +4982,6 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5713,11 +5023,6 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5749,11 +5054,6 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5781,10 +5081,6 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5826,11 +5122,6 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5862,11 +5153,6 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -5894,10 +5180,6 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -5939,11 +5221,6 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -5975,11 +5252,6 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6007,10 +5279,6 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6042,11 +5310,6 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6068,11 +5331,6 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg1.Add(arg2)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6102,10 +5360,6 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6162,11 +5416,6 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6213,11 +5462,6 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6247,10 +5491,6 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6307,11 +5547,6 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6358,11 +5593,6 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6392,10 +5622,6 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6452,11 +5678,6 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6503,11 +5724,6 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6537,10 +5753,6 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6597,11 +5809,6 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6648,11 +5855,6 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6682,10 +5884,6 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6742,11 +5940,6 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6793,11 +5986,6 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6825,10 +6013,6 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -6878,11 +6062,6 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -6922,11 +6101,6 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -6954,10 +6128,6 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7007,11 +6177,6 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7051,11 +6216,6 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7083,10 +6243,6 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7136,11 +6292,6 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7180,11 +6331,6 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7212,10 +6358,6 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7263,11 +6405,6 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7305,11 +6442,6 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7337,10 +6469,6 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7388,11 +6516,6 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7430,11 +6553,6 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7462,10 +6580,6 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7513,11 +6627,6 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7555,11 +6664,6 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7587,10 +6691,6 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7638,11 +6738,6 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7680,11 +6775,6 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7712,10 +6802,6 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7767,11 +6853,6 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7813,11 +6894,6 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7847,10 +6923,6 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -7907,11 +6979,6 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -7958,11 +7025,6 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -7990,10 +7052,6 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8041,11 +7099,6 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8083,11 +7136,6 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8115,10 +7163,6 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8166,11 +7210,6 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8208,11 +7247,6 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8240,10 +7274,6 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8291,11 +7321,6 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8333,11 +7358,6 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8365,10 +7385,6 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8420,11 +7436,6 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8466,11 +7477,6 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8500,10 +7506,6 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8560,11 +7562,6 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8611,11 +7608,6 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8643,10 +7635,6 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8694,11 +7682,6 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8736,11 +7719,6 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8768,10 +7746,6 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8819,11 +7793,6 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8861,11 +7830,6 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -8893,10 +7857,6 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -8944,11 +7904,6 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -8986,11 +7941,6 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9018,10 +7968,6 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9073,11 +8019,6 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9119,11 +8060,6 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9153,10 +8089,6 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9213,11 +8145,6 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9264,11 +8191,6 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9296,10 +8218,6 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9341,11 +8259,6 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9377,11 +8290,6 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9409,10 +8317,6 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9450,11 +8354,6 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9482,11 +8381,6 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9514,10 +8408,6 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9559,11 +8449,6 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9595,11 +8480,6 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 					projCol[i] = t_res
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9627,10 +8507,6 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9662,11 +8538,6 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9688,11 +8559,6 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg1.Sub(arg2)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9722,10 +8588,6 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9782,11 +8644,6 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9833,11 +8690,6 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9865,10 +8717,6 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -9916,11 +8764,6 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -9958,11 +8801,6 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -9990,10 +8828,6 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10034,11 +8868,6 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10069,11 +8898,6 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10101,10 +8925,6 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10145,11 +8965,6 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10180,11 +8995,6 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10212,10 +9022,6 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10256,11 +9062,6 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10291,11 +9092,6 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10325,10 +9121,6 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10376,11 +9168,6 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10418,11 +9205,6 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10452,10 +9234,6 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10512,11 +9290,6 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10563,11 +9336,6 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10597,10 +9365,6 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10656,11 +9420,6 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10706,11 +9465,6 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10740,10 +9494,6 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10800,11 +9550,6 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10851,11 +9596,6 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -10885,10 +9625,6 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -10945,11 +9681,6 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -10996,11 +9727,6 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11030,10 +9756,6 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11090,11 +9812,6 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11141,11 +9858,6 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11173,10 +9885,6 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11226,11 +9934,6 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11270,11 +9973,6 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11302,10 +10000,6 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11355,11 +10049,6 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11399,11 +10088,6 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11431,10 +10115,6 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11484,11 +10164,6 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11528,11 +10203,6 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11560,10 +10230,6 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11611,11 +10277,6 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11653,11 +10314,6 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11685,10 +10341,6 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11730,11 +10382,6 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11766,11 +10413,6 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11798,10 +10440,6 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -11865,11 +10503,6 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -11923,11 +10556,6 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -11955,10 +10583,6 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12022,11 +10646,6 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12080,11 +10699,6 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12112,10 +10726,6 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12179,11 +10789,6 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12237,11 +10842,6 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12269,10 +10869,6 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12324,11 +10920,6 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12370,11 +10961,6 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12402,10 +10988,6 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12437,11 +11019,6 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12463,11 +11040,6 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12495,10 +11067,6 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12562,11 +11130,6 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12620,11 +11183,6 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12652,10 +11210,6 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12719,11 +11273,6 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12777,11 +11326,6 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12809,10 +11353,6 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -12876,11 +11416,6 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -12934,11 +11469,6 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -12966,10 +11496,6 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13021,11 +11547,6 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13067,11 +11588,6 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13099,10 +11615,6 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13134,11 +11646,6 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13160,11 +11667,6 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13192,10 +11694,6 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13259,11 +11757,6 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13317,11 +11810,6 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13349,10 +11837,6 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13416,11 +11900,6 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13474,11 +11953,6 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13506,10 +11980,6 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13573,11 +12043,6 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13631,11 +12096,6 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13663,10 +12123,6 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13718,11 +12174,6 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13764,11 +12215,6 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13796,10 +12242,6 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13831,11 +12273,6 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13857,11 +12294,6 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.Mul(int64(arg1))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -13889,10 +12321,6 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -13934,11 +12362,6 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -13970,11 +12393,6 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14002,10 +12420,6 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14037,11 +12451,6 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14063,11 +12472,6 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 					projCol[i] = arg2.MulFloat(float64(arg1))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14095,10 +12499,6 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14130,11 +12530,6 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14156,11 +12551,6 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14188,10 +12578,6 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14223,11 +12609,6 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14249,11 +12630,6 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14281,10 +12657,6 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14316,11 +12688,6 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14342,11 +12709,6 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 					projCol[i] = arg1.Mul(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14374,10 +12736,6 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14409,11 +12767,6 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14435,11 +12788,6 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 					projCol[i] = arg1.MulFloat(float64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14467,10 +12815,6 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14512,11 +12856,6 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14548,11 +12887,6 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 					projCol[i] = arg1.MulFloat(f)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14580,10 +12914,6 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14641,11 +12971,6 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14693,11 +13018,6 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14725,10 +13045,6 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14786,11 +13102,6 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14838,11 +13149,6 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -14870,10 +13176,6 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -14931,11 +13233,6 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -14983,11 +13280,6 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15015,10 +13307,6 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15074,11 +13362,6 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15124,11 +13407,6 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15156,10 +13434,6 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15215,11 +13489,6 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15265,11 +13534,6 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15297,10 +13561,6 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15356,11 +13616,6 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15406,11 +13661,6 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15438,10 +13688,6 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15497,11 +13743,6 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15547,11 +13788,6 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15579,10 +13815,6 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15642,11 +13874,6 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15696,11 +13923,6 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15728,10 +13950,6 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15787,11 +14005,6 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15837,11 +14050,6 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -15869,10 +14077,6 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -15928,11 +14132,6 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -15978,11 +14177,6 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16010,10 +14204,6 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16069,11 +14259,6 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16119,11 +14304,6 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16151,10 +14331,6 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16214,11 +14390,6 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16268,11 +14439,6 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16300,10 +14466,6 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16359,11 +14521,6 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16409,11 +14566,6 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16441,10 +14593,6 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16500,11 +14648,6 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16550,11 +14693,6 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16582,10 +14720,6 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16641,11 +14775,6 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16691,11 +14820,6 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16723,10 +14847,6 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16786,11 +14906,6 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16840,11 +14955,6 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -16872,10 +14982,6 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -16925,11 +15031,6 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -16969,11 +15070,6 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17001,10 +15097,6 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17044,11 +15136,6 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17078,11 +15165,6 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 					projCol[i] = arg1.Div(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17110,10 +15192,6 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17153,11 +15231,6 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17187,11 +15260,6 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 					projCol[i] = arg1.Div(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17219,10 +15287,6 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17262,11 +15326,6 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17296,11 +15355,6 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 					projCol[i] = arg1.Div(int64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17328,10 +15382,6 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17371,11 +15421,6 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17405,11 +15450,6 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 					projCol[i] = arg1.DivFloat(float64(arg2))
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17437,10 +15477,6 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17498,11 +15534,6 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17550,11 +15581,6 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17582,10 +15608,6 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17643,11 +15665,6 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17695,11 +15712,6 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17727,10 +15739,6 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17788,11 +15796,6 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17840,11 +15843,6 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -17872,10 +15870,6 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -17931,11 +15925,6 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -17981,11 +15970,6 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18013,10 +15997,6 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18062,11 +16042,6 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18102,11 +16077,6 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18134,10 +16104,6 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18183,11 +16149,6 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18223,11 +16184,6 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18255,10 +16211,6 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18304,11 +16256,6 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18344,11 +16291,6 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18376,10 +16318,6 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18439,11 +16377,6 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18493,11 +16426,6 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18525,10 +16453,6 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18574,11 +16498,6 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18614,11 +16533,6 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18646,10 +16560,6 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18695,11 +16605,6 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18735,11 +16640,6 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18767,10 +16667,6 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18816,11 +16712,6 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -18856,11 +16747,6 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -18888,10 +16774,6 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -18951,11 +16833,6 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19005,11 +16882,6 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19037,10 +16909,6 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19086,11 +16954,6 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19126,11 +16989,6 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19158,10 +17016,6 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19207,11 +17061,6 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19247,11 +17096,6 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19279,10 +17123,6 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19328,11 +17168,6 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19368,11 +17203,6 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19400,10 +17230,6 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19463,11 +17289,6 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19517,11 +17338,6 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19549,10 +17365,6 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19602,11 +17414,6 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19646,11 +17453,6 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19678,10 +17480,6 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19739,11 +17537,6 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19791,11 +17584,6 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19823,10 +17611,6 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -19884,11 +17668,6 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -19936,11 +17715,6 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -19968,10 +17742,6 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20029,11 +17799,6 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20081,11 +17846,6 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20113,10 +17873,6 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20172,11 +17928,6 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20222,11 +17973,6 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20254,10 +18000,6 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20303,11 +18045,6 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20343,11 +18080,6 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20375,10 +18107,6 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20424,11 +18152,6 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20464,11 +18187,6 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20496,10 +18214,6 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20545,11 +18259,6 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20585,11 +18294,6 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20617,10 +18321,6 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20680,11 +18380,6 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20734,11 +18429,6 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20766,10 +18456,6 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20815,11 +18501,6 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20855,11 +18536,6 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -20887,10 +18563,6 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -20936,11 +18608,6 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -20976,11 +18643,6 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21008,10 +18670,6 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21057,11 +18715,6 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21097,11 +18750,6 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21129,10 +18777,6 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21192,11 +18836,6 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21246,11 +18885,6 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21278,10 +18912,6 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21327,11 +18957,6 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21367,11 +18992,6 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21399,10 +19019,6 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21448,11 +19064,6 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21488,11 +19099,6 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21520,10 +19126,6 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21569,11 +19171,6 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21609,11 +19206,6 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21641,10 +19233,6 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21704,11 +19292,6 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21758,11 +19341,6 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21790,10 +19368,6 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21843,11 +19417,6 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -21887,11 +19456,6 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -21919,10 +19483,6 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -21972,11 +19532,6 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22016,11 +19571,6 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22048,10 +19598,6 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22101,11 +19647,6 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22145,11 +19686,6 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22177,10 +19713,6 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22230,11 +19762,6 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22274,11 +19801,6 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22306,10 +19828,6 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22357,11 +19875,6 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22399,11 +19912,6 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22431,10 +19939,6 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22494,11 +19998,6 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22548,11 +20047,6 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22580,10 +20074,6 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22643,11 +20133,6 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22697,11 +20182,6 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22729,10 +20209,6 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22792,11 +20268,6 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22846,11 +20317,6 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -22878,10 +20344,6 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -22933,11 +20395,6 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -22979,11 +20436,6 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23011,10 +20463,6 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23074,11 +20522,6 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23128,11 +20571,6 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23160,10 +20598,6 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23223,11 +20657,6 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23277,11 +20706,6 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23309,10 +20733,6 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23372,11 +20792,6 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23426,11 +20841,6 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23458,10 +20868,6 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23513,11 +20919,6 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23559,11 +20960,6 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23591,10 +20987,6 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23654,11 +21046,6 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23708,11 +21095,6 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23740,10 +21122,6 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23803,11 +21181,6 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -23857,11 +21230,6 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -23889,10 +21257,6 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -23952,11 +21316,6 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24006,11 +21365,6 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24038,10 +21392,6 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24093,11 +21443,6 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24139,11 +21484,6 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24171,10 +21511,6 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24216,11 +21552,6 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24252,11 +21583,6 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24284,10 +21610,6 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24331,11 +21653,6 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24369,11 +21686,6 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24401,10 +21713,6 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24446,11 +21754,6 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24482,11 +21785,6 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 					projCol.Set(i, _j)
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24516,10 +21814,6 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24567,11 +21861,6 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24609,11 +21898,6 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24641,10 +21925,6 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24692,11 +21972,6 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24734,11 +22009,6 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24766,10 +22036,6 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24817,11 +22083,6 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24859,11 +22120,6 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -24891,10 +22147,6 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -24942,11 +22194,6 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -24984,11 +22231,6 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25016,10 +22258,6 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25067,11 +22305,6 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25109,11 +22342,6 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25141,10 +22369,6 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25192,11 +22416,6 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25234,11 +22453,6 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25266,10 +22480,6 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25317,11 +22527,6 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25359,11 +22564,6 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25391,10 +22591,6 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25442,11 +22638,6 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25484,11 +22675,6 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25516,10 +22702,6 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25567,11 +22749,6 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25609,11 +22786,6 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25641,10 +22813,6 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25692,11 +22860,6 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25734,11 +22897,6 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25768,10 +22926,6 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25828,11 +22982,6 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -25879,11 +23028,6 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -25913,10 +23057,6 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -25973,11 +23113,6 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26024,11 +23159,6 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26058,10 +23188,6 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26118,11 +23244,6 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26169,11 +23290,6 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26201,10 +23317,6 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26252,11 +23364,6 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26294,11 +23401,6 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26326,10 +23428,6 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26377,11 +23475,6 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26419,11 +23512,6 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26451,10 +23539,6 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26502,11 +23586,6 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26544,11 +23623,6 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26576,10 +23650,6 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26627,11 +23697,6 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26669,11 +23734,6 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26701,10 +23761,6 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26752,11 +23808,6 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26794,11 +23845,6 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26826,10 +23872,6 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -26877,11 +23919,6 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -26919,11 +23956,6 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -26951,10 +23983,6 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27002,11 +24030,6 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27044,11 +24067,6 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27076,10 +24094,6 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27127,11 +24141,6 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27169,11 +24178,6 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27201,10 +24205,6 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27252,11 +24252,6 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27294,11 +24289,6 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27328,10 +24318,6 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27388,11 +24374,6 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27439,11 +24420,6 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27473,10 +24449,6 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27533,11 +24505,6 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27584,11 +24551,6 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27618,10 +24580,6 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27678,11 +24636,6 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27729,11 +24682,6 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27761,10 +24709,6 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27818,11 +24762,6 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27866,11 +24805,6 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -27898,10 +24832,6 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -27950,11 +24880,6 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -27993,11 +24918,6 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28025,10 +24945,6 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28077,11 +24993,6 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28120,11 +25031,6 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28152,10 +25058,6 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28204,11 +25106,6 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28247,11 +25144,6 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28279,10 +25171,6 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28354,11 +25242,6 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28420,11 +25303,6 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28452,10 +25330,6 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28522,11 +25396,6 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28583,11 +25452,6 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28615,10 +25479,6 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28685,11 +25545,6 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28746,11 +25601,6 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28778,10 +25628,6 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28848,11 +25694,6 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -28909,11 +25750,6 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -28941,10 +25777,6 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -28992,11 +25824,6 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29034,11 +25861,6 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29066,10 +25888,6 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29137,11 +25955,6 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29199,11 +26012,6 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29231,10 +26039,6 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29294,11 +26098,6 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29348,11 +26147,6 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29380,10 +26174,6 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29425,11 +26215,6 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29461,11 +26246,6 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29493,10 +26273,6 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29552,11 +26328,6 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29602,11 +26373,6 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29634,10 +26400,6 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29693,11 +26455,6 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29743,11 +26500,6 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29775,10 +26527,6 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29834,11 +26582,6 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -29884,11 +26627,6 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -29916,10 +26654,6 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -29979,11 +26713,6 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30033,11 +26762,6 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30065,10 +26789,6 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30112,11 +26832,6 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30150,11 +26865,6 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30182,10 +26892,6 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30251,11 +26957,6 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30311,11 +27012,6 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30343,10 +27039,6 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30412,11 +27104,6 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30472,11 +27159,6 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30504,10 +27186,6 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30573,11 +27251,6 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30633,11 +27306,6 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30665,10 +27333,6 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30750,11 +27414,6 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30826,11 +27485,6 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30858,10 +27512,6 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -30917,11 +27567,6 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -30967,11 +27612,6 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -30999,10 +27639,6 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31068,11 +27704,6 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31128,11 +27759,6 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31160,10 +27786,6 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31229,11 +27851,6 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31289,11 +27906,6 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31321,10 +27933,6 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31390,11 +27998,6 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31450,11 +28053,6 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31482,10 +28080,6 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31567,11 +28161,6 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31643,11 +28232,6 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31675,10 +28259,6 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31734,11 +28314,6 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31784,11 +28359,6 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31816,10 +28386,6 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -31885,11 +28451,6 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -31945,11 +28506,6 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -31977,10 +28533,6 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32046,11 +28598,6 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32106,11 +28653,6 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32138,10 +28680,6 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32207,11 +28745,6 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32267,11 +28800,6 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32299,10 +28827,6 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32384,11 +28908,6 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32460,11 +28979,6 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32492,10 +29006,6 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32551,11 +29061,6 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32601,11 +29106,6 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32633,10 +29133,6 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32718,11 +29214,6 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32794,11 +29285,6 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -32826,10 +29312,6 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -32911,11 +29393,6 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -32987,11 +29464,6 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33019,10 +29491,6 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33104,11 +29572,6 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33180,11 +29643,6 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33212,10 +29670,6 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33297,11 +29751,6 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33373,11 +29822,6 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33405,10 +29849,6 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33468,11 +29908,6 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33522,11 +29957,6 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33554,10 +29984,6 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33615,11 +30041,6 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33667,11 +30088,6 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33699,10 +30115,6 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33746,11 +30158,6 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33784,11 +30191,6 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33816,10 +30218,6 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -33873,11 +30271,6 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -33921,11 +30314,6 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -33953,10 +30341,6 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34002,11 +30386,6 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34042,11 +30421,6 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34074,10 +30448,6 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34137,11 +30507,6 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34191,11 +30556,6 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34223,10 +30583,6 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34268,11 +30624,6 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34304,11 +30655,6 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34336,10 +30682,6 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34395,11 +30737,6 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34445,11 +30782,6 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34477,10 +30809,6 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34536,11 +30864,6 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34586,11 +30909,6 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34618,10 +30936,6 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34677,11 +30991,6 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34727,11 +31036,6 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34759,10 +31063,6 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34822,11 +31122,6 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34876,11 +31171,6 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -34908,10 +31198,6 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -34955,11 +31241,6 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -34993,11 +31274,6 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35025,10 +31301,6 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35094,11 +31366,6 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35154,11 +31421,6 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35186,10 +31448,6 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35255,11 +31513,6 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35315,11 +31568,6 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35347,10 +31595,6 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35416,11 +31660,6 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35476,11 +31715,6 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35508,10 +31742,6 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35593,11 +31823,6 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35669,11 +31894,6 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35701,10 +31921,6 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35760,11 +31976,6 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35810,11 +32021,6 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -35842,10 +32048,6 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -35911,11 +32113,6 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -35971,11 +32168,6 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36003,10 +32195,6 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36072,11 +32260,6 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36132,11 +32315,6 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36164,10 +32342,6 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36233,11 +32407,6 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36293,11 +32462,6 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36325,10 +32489,6 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36410,11 +32570,6 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36486,11 +32641,6 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36518,10 +32668,6 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36577,11 +32723,6 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36627,11 +32768,6 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36659,10 +32795,6 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36728,11 +32860,6 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36788,11 +32915,6 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36820,10 +32942,6 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -36889,11 +33007,6 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -36949,11 +33062,6 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -36981,10 +33089,6 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37050,11 +33154,6 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37110,11 +33209,6 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37142,10 +33236,6 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37227,11 +33317,6 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37303,11 +33388,6 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37335,10 +33415,6 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37394,11 +33470,6 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37444,11 +33515,6 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37476,10 +33542,6 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37561,11 +33623,6 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37637,11 +33694,6 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37669,10 +33721,6 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37754,11 +33802,6 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -37830,11 +33873,6 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -37862,10 +33900,6 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -37947,11 +33981,6 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38023,11 +34052,6 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38055,10 +34079,6 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38140,11 +34160,6 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38216,11 +34231,6 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38248,10 +34258,6 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38311,11 +34317,6 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38365,11 +34366,6 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38397,10 +34393,6 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38458,11 +34450,6 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38510,11 +34497,6 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38542,10 +34524,6 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38589,11 +34567,6 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38627,11 +34600,6 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38659,10 +34627,6 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38716,11 +34680,6 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38764,11 +34723,6 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38796,10 +34750,6 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38845,11 +34795,6 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -38885,11 +34830,6 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -38917,10 +34857,6 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -38980,11 +34916,6 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39034,11 +34965,6 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39066,10 +34992,6 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39111,11 +35033,6 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39147,11 +35064,6 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39179,10 +35091,6 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39238,11 +35146,6 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39288,11 +35191,6 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39320,10 +35218,6 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39379,11 +35273,6 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39429,11 +35318,6 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39461,10 +35345,6 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39520,11 +35400,6 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39570,11 +35445,6 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39602,10 +35472,6 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39665,11 +35531,6 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39719,11 +35580,6 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39751,10 +35607,6 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39798,11 +35650,6 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39836,11 +35683,6 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -39868,10 +35710,6 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -39937,11 +35775,6 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -39997,11 +35830,6 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40029,10 +35857,6 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40098,11 +35922,6 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40158,11 +35977,6 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40190,10 +36004,6 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40259,11 +36069,6 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40319,11 +36124,6 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40351,10 +36151,6 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40436,11 +36232,6 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40512,11 +36303,6 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40544,10 +36330,6 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40603,11 +36385,6 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40653,11 +36430,6 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40685,10 +36457,6 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40754,11 +36522,6 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40814,11 +36577,6 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -40846,10 +36604,6 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -40915,11 +36669,6 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -40975,11 +36724,6 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41007,10 +36751,6 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41076,11 +36816,6 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41136,11 +36871,6 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41168,10 +36898,6 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41253,11 +36979,6 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41329,11 +37050,6 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41361,10 +37077,6 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41420,11 +37132,6 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41470,11 +37177,6 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41502,10 +37204,6 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41571,11 +37269,6 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41631,11 +37324,6 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41663,10 +37351,6 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41732,11 +37416,6 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41792,11 +37471,6 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41824,10 +37498,6 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -41893,11 +37563,6 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -41953,11 +37618,6 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -41985,10 +37645,6 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42070,11 +37726,6 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42146,11 +37797,6 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42178,10 +37824,6 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42237,11 +37879,6 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42287,11 +37924,6 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42319,10 +37951,6 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42404,11 +38032,6 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42480,11 +38103,6 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42512,10 +38130,6 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42597,11 +38211,6 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42673,11 +38282,6 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42705,10 +38309,6 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42790,11 +38390,6 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -42866,11 +38461,6 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -42898,10 +38488,6 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -42983,11 +38569,6 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43059,11 +38640,6 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43091,10 +38667,6 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43154,11 +38726,6 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43208,11 +38775,6 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43240,10 +38802,6 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43301,11 +38859,6 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43353,11 +38906,6 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43385,10 +38933,6 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43432,11 +38976,6 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43470,11 +39009,6 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43502,10 +39036,6 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43559,11 +39089,6 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43607,11 +39132,6 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43639,10 +39159,6 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43688,11 +39204,6 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43728,11 +39239,6 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43760,10 +39266,6 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43823,11 +39325,6 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43877,11 +39374,6 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -43909,10 +39401,6 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -43954,11 +39442,6 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -43990,11 +39473,6 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44022,10 +39500,6 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44081,11 +39555,6 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44131,11 +39600,6 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44163,10 +39627,6 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44222,11 +39682,6 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44272,11 +39727,6 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44304,10 +39754,6 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44363,11 +39809,6 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44413,11 +39854,6 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44445,10 +39881,6 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44508,11 +39940,6 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44562,11 +39989,6 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44594,10 +40016,6 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44641,11 +40059,6 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44679,11 +40092,6 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44711,10 +40119,6 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44780,11 +40184,6 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -44840,11 +40239,6 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -44872,10 +40266,6 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -44941,11 +40331,6 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45001,11 +40386,6 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45033,10 +40413,6 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45102,11 +40478,6 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45162,11 +40533,6 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45194,10 +40560,6 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45279,11 +40641,6 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45355,11 +40712,6 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45387,10 +40739,6 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45446,11 +40794,6 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45496,11 +40839,6 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45528,10 +40866,6 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45597,11 +40931,6 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45657,11 +40986,6 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45689,10 +41013,6 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45758,11 +41078,6 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45818,11 +41133,6 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -45850,10 +41160,6 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -45919,11 +41225,6 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -45979,11 +41280,6 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46011,10 +41307,6 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46096,11 +41388,6 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46172,11 +41459,6 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46204,10 +41486,6 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46263,11 +41541,6 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46313,11 +41586,6 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46345,10 +41613,6 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46414,11 +41678,6 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46474,11 +41733,6 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46506,10 +41760,6 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46575,11 +41825,6 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46635,11 +41880,6 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46667,10 +41907,6 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46736,11 +41972,6 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46796,11 +42027,6 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -46828,10 +42054,6 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -46913,11 +42135,6 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -46989,11 +42206,6 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47021,10 +42233,6 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47080,11 +42288,6 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47130,11 +42333,6 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47162,10 +42360,6 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47247,11 +42441,6 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47323,11 +42512,6 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47355,10 +42539,6 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47440,11 +42620,6 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47516,11 +42691,6 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47548,10 +42718,6 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47633,11 +42799,6 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47709,11 +42870,6 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47741,10 +42897,6 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47826,11 +42978,6 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -47902,11 +43049,6 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -47934,10 +43076,6 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -47997,11 +43135,6 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48051,11 +43184,6 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48083,10 +43211,6 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48144,11 +43268,6 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48196,11 +43315,6 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48228,10 +43342,6 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48275,11 +43385,6 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48313,11 +43418,6 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48345,10 +43445,6 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48402,11 +43498,6 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48450,11 +43541,6 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48482,10 +43568,6 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48531,11 +43613,6 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48571,11 +43648,6 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48603,10 +43675,6 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48666,11 +43734,6 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48720,11 +43783,6 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48752,10 +43810,6 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48797,11 +43851,6 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48833,11 +43882,6 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -48865,10 +43909,6 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -48924,11 +43964,6 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -48974,11 +44009,6 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49006,10 +44036,6 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49065,11 +44091,6 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49115,11 +44136,6 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49147,10 +44163,6 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49206,11 +44218,6 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49256,11 +44263,6 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49288,10 +44290,6 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49351,11 +44349,6 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49405,11 +44398,6 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49437,10 +44425,6 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49484,11 +44468,6 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49522,11 +44501,6 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49554,10 +44528,6 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49623,11 +44593,6 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49683,11 +44648,6 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49715,10 +44675,6 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49784,11 +44740,6 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -49844,11 +44795,6 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -49876,10 +44822,6 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -49945,11 +44887,6 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50005,11 +44942,6 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50037,10 +44969,6 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50122,11 +45050,6 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50198,11 +45121,6 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50230,10 +45148,6 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50289,11 +45203,6 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50339,11 +45248,6 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50371,10 +45275,6 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50440,11 +45340,6 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50500,11 +45395,6 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50532,10 +45422,6 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50601,11 +45487,6 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50661,11 +45542,6 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50693,10 +45569,6 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50762,11 +45634,6 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -50822,11 +45689,6 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -50854,10 +45716,6 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -50939,11 +45797,6 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51015,11 +45868,6 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51047,10 +45895,6 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51106,11 +45950,6 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51156,11 +45995,6 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51188,10 +46022,6 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51257,11 +46087,6 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51317,11 +46142,6 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51349,10 +46169,6 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51418,11 +46234,6 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51478,11 +46289,6 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51510,10 +46316,6 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51579,11 +46381,6 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51639,11 +46436,6 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51671,10 +46463,6 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51756,11 +46544,6 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51832,11 +46615,6 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -51864,10 +46642,6 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -51923,11 +46697,6 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -51973,11 +46742,6 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52005,10 +46769,6 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52090,11 +46850,6 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52166,11 +46921,6 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52198,10 +46948,6 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52283,11 +47029,6 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52359,11 +47100,6 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52391,10 +47127,6 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52476,11 +47208,6 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52552,11 +47279,6 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52584,10 +47306,6 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52669,11 +47387,6 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52745,11 +47458,6 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52777,10 +47485,6 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52840,11 +47544,6 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -52894,11 +47593,6 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -52926,10 +47620,6 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -52987,11 +47677,6 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53039,11 +47724,6 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53071,10 +47751,6 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53118,11 +47794,6 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53156,11 +47827,6 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53188,10 +47854,6 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53245,11 +47907,6 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53293,11 +47950,6 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53325,10 +47977,6 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53374,11 +48022,6 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53414,11 +48057,6 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53446,10 +48084,6 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53509,11 +48143,6 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53563,11 +48192,6 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53595,10 +48219,6 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53640,11 +48260,6 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53676,11 +48291,6 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53708,10 +48318,6 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53767,11 +48373,6 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53817,11 +48418,6 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53849,10 +48445,6 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -53908,11 +48500,6 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -53958,11 +48545,6 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -53990,10 +48572,6 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54049,11 +48627,6 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54099,11 +48672,6 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54131,10 +48699,6 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54194,11 +48758,6 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54248,11 +48807,6 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54280,10 +48834,6 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54327,11 +48877,6 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54365,11 +48910,6 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54397,10 +48937,6 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54466,11 +49002,6 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54526,11 +49057,6 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54558,10 +49084,6 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54627,11 +49149,6 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54687,11 +49204,6 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54719,10 +49231,6 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54788,11 +49296,6 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -54848,11 +49351,6 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -54880,10 +49378,6 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -54965,11 +49459,6 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55041,11 +49530,6 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55073,10 +49557,6 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55132,11 +49612,6 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55182,11 +49657,6 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55214,10 +49684,6 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55283,11 +49749,6 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55343,11 +49804,6 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55375,10 +49831,6 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55444,11 +49896,6 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55504,11 +49951,6 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55536,10 +49978,6 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55605,11 +50043,6 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55665,11 +50098,6 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55697,10 +50125,6 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55782,11 +50206,6 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55858,11 +50277,6 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -55890,10 +50304,6 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -55949,11 +50359,6 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -55999,11 +50404,6 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -56031,10 +50431,6 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -56100,11 +50496,6 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -56160,11 +50551,6 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -56192,10 +50578,6 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -56261,11 +50643,6 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -56321,11 +50698,6 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -56353,10 +50725,6 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -56422,11 +50790,6 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -56482,11 +50845,6 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -56514,10 +50872,6 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -56599,11 +50953,6 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -56675,11 +51024,6 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -56707,10 +51051,6 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -56766,11 +51106,6 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -56816,11 +51151,6 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -56848,10 +51178,6 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -56933,11 +51259,6 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -57009,11 +51330,6 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -57041,10 +51357,6 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -57126,11 +51438,6 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -57202,11 +51509,6 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -57234,10 +51536,6 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -57319,11 +51617,6 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -57395,11 +51688,6 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -57427,10 +51715,6 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -57512,11 +51796,6 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -57588,11 +51867,6 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -57620,10 +51894,6 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -57683,11 +51953,6 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -57737,11 +52002,6 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -57769,10 +52029,6 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -57830,11 +52086,6 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -57882,11 +52133,6 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -57914,10 +52160,6 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -57961,11 +52203,6 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -57999,11 +52236,6 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -58031,10 +52263,6 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -58088,11 +52316,6 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -58136,11 +52359,6 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch
@@ -58168,10 +52386,6 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
-		// Some operators can result in NULL with non-NULL inputs, like the JSON
-		// fetch value operator, ->. Therefore, _outNulls is defined to allow
-		// updating the output Nulls from within _ASSIGN functions when the result
-		// of a projection is Null.
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
@@ -58217,11 +52431,6 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 		} else {
 			if sel := batch.Selection(); sel != nil {
@@ -58257,11 +52466,6 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 
 				}
 			}
-			// _outNulls has been updated from within the _ASSIGN function to include
-			// any NULLs that resulted from the projection.
-			// If $hasNulls is true, union _outNulls with the set of input Nulls.
-			// If $hasNulls is false, then there are no input Nulls. _outNulls is
-			// projVec.Nulls() so there is no need to call projVec.SetNulls().
 		}
 	})
 	return batch

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -53,18 +53,20 @@ var (
 // around the problem we specify it here.
 type projConstOpBase struct {
 	colexecop.OneInputHelper
-	allocator *colmem.Allocator
-	colIdx    int
-	outputIdx int
+	allocator    *colmem.Allocator
+	colIdx       int
+	outputIdx    int
+	nullableArgs bool
 }
 
 // projOpBase contains all of the fields for non-constant projections.
 type projOpBase struct {
 	colexecop.OneInputHelper
-	allocator *colmem.Allocator
-	col1Idx   int
-	col2Idx   int
-	outputIdx int
+	allocator    *colmem.Allocator
+	col1Idx      int
+	col2Idx      int
+	outputIdx    int
+	nullableArgs bool
 }
 
 type projBitandInt16Int16Op struct {
@@ -90,7 +92,9 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -177,7 +181,9 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -264,7 +270,9 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -351,7 +359,9 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -438,7 +448,9 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -525,7 +537,9 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -612,7 +626,9 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -699,7 +715,9 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -786,7 +804,9 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -875,7 +895,9 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -986,7 +1008,9 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1073,7 +1097,9 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1160,7 +1186,9 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1247,7 +1275,9 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1334,7 +1364,9 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1421,7 +1453,9 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1508,7 +1542,9 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1595,7 +1631,9 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1682,7 +1720,9 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1771,7 +1811,9 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1882,7 +1924,9 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1969,7 +2013,9 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2056,7 +2102,9 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2143,7 +2191,9 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2230,7 +2280,9 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2317,7 +2369,9 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2404,7 +2458,9 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2491,7 +2547,9 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2578,7 +2636,9 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2667,7 +2727,9 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2778,7 +2840,9 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2893,7 +2957,9 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3008,7 +3074,9 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3123,7 +3191,9 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3234,7 +3304,9 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3345,7 +3417,9 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3456,7 +3530,9 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3567,7 +3643,9 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3688,7 +3766,9 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3817,7 +3897,9 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3928,7 +4010,9 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4039,7 +4123,9 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4150,7 +4236,9 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4271,7 +4359,9 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4400,7 +4490,9 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4511,7 +4603,9 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4622,7 +4716,9 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4733,7 +4829,9 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4854,7 +4952,9 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4983,7 +5083,9 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5082,7 +5184,9 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5181,7 +5285,9 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5280,7 +5386,9 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5361,7 +5469,9 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5492,7 +5602,9 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5623,7 +5735,9 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5754,7 +5868,9 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5885,7 +6001,9 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6014,7 +6132,9 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6129,7 +6249,9 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6244,7 +6366,9 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6359,7 +6483,9 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6470,7 +6596,9 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6581,7 +6709,9 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6692,7 +6822,9 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6803,7 +6935,9 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6924,7 +7058,9 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7053,7 +7189,9 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7164,7 +7302,9 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7275,7 +7415,9 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7386,7 +7528,9 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7507,7 +7651,9 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7636,7 +7782,9 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7747,7 +7895,9 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7858,7 +8008,9 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7969,7 +8121,9 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8090,7 +8244,9 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8219,7 +8375,9 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8318,7 +8476,9 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8409,7 +8569,9 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8508,7 +8670,9 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8589,7 +8753,9 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8718,7 +8884,9 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8829,7 +8997,9 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8926,7 +9096,9 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9023,7 +9195,9 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9122,7 +9296,9 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9235,7 +9411,9 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9366,7 +9544,9 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9495,7 +9675,9 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9626,7 +9808,9 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9757,7 +9941,9 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9886,7 +10072,9 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10001,7 +10189,9 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10116,7 +10306,9 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10231,7 +10423,9 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10342,7 +10536,9 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10441,7 +10637,9 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10584,7 +10782,9 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10727,7 +10927,9 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10870,7 +11072,9 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10989,7 +11193,9 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11068,7 +11274,9 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11211,7 +11419,9 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11354,7 +11564,9 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11497,7 +11709,9 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11616,7 +11830,9 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11695,7 +11911,9 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11838,7 +12056,9 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11981,7 +12201,9 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12124,7 +12346,9 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12243,7 +12467,9 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12322,7 +12548,9 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12421,7 +12649,9 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12500,7 +12730,9 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12579,7 +12811,9 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12658,7 +12892,9 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12737,7 +12973,9 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12816,7 +13054,9 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12915,7 +13155,9 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13046,7 +13288,9 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13177,7 +13421,9 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13308,7 +13554,9 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13435,7 +13683,9 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13562,7 +13812,9 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13689,7 +13941,9 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13816,7 +14070,9 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13951,7 +14207,9 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14078,7 +14336,9 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14205,7 +14465,9 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14332,7 +14594,9 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14467,7 +14731,9 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14594,7 +14860,9 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14721,7 +14989,9 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14848,7 +15118,9 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14983,7 +15255,9 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15098,7 +15372,9 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15193,7 +15469,9 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15288,7 +15566,9 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15383,7 +15663,9 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15478,7 +15760,9 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15609,7 +15893,9 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15740,7 +16026,9 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15871,7 +16159,9 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15998,7 +16288,9 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16105,7 +16397,9 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16212,7 +16506,9 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16319,7 +16615,9 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16454,7 +16752,9 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16561,7 +16861,9 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16668,7 +16970,9 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16775,7 +17079,9 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16910,7 +17216,9 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17017,7 +17325,9 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17124,7 +17434,9 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17231,7 +17543,9 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17366,7 +17680,9 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17481,7 +17797,9 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17612,7 +17930,9 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17743,7 +18063,9 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17874,7 +18196,9 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18001,7 +18325,9 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18108,7 +18434,9 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18215,7 +18543,9 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18322,7 +18652,9 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18457,7 +18789,9 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18564,7 +18898,9 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18671,7 +19007,9 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18778,7 +19116,9 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18913,7 +19253,9 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19020,7 +19362,9 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19127,7 +19471,9 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19234,7 +19580,9 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19369,7 +19717,9 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19484,7 +19834,9 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19599,7 +19951,9 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19714,7 +20068,9 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19829,7 +20185,9 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19940,7 +20298,9 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20075,7 +20435,9 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20210,7 +20572,9 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20345,7 +20709,9 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20464,7 +20830,9 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20599,7 +20967,9 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20734,7 +21104,9 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20869,7 +21241,9 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20988,7 +21362,9 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21123,7 +21499,9 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21258,7 +21636,9 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21393,7 +21773,9 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21512,7 +21894,9 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21611,7 +21995,9 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21714,7 +22100,9 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21815,7 +22203,9 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21926,7 +22316,9 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22037,7 +22429,9 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22148,7 +22542,9 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22259,7 +22655,9 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22370,7 +22768,9 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22481,7 +22881,9 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22592,7 +22994,9 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22703,7 +23107,9 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22814,7 +23220,9 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22927,7 +23335,9 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23058,7 +23468,9 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23189,7 +23601,9 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23318,7 +23732,9 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23429,7 +23845,9 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23540,7 +23958,9 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23651,7 +24071,9 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23762,7 +24184,9 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23873,7 +24297,9 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23984,7 +24410,9 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24095,7 +24523,9 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24206,7 +24636,9 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24319,7 +24751,9 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24450,7 +24884,9 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24581,7 +25017,9 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24710,7 +25148,9 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24833,7 +25273,9 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24946,7 +25388,9 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25059,7 +25503,9 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25172,7 +25618,9 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25331,7 +25779,9 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25480,7 +25930,9 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25629,7 +26081,9 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25778,7 +26232,9 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25889,7 +26345,9 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26040,7 +26498,9 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26175,7 +26635,9 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26274,7 +26736,9 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26401,7 +26865,9 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26528,7 +26994,9 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26655,7 +27123,9 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26790,7 +27260,9 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26893,7 +27365,9 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27040,7 +27514,9 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27187,7 +27663,9 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27334,7 +27812,9 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27513,7 +27993,9 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27640,7 +28122,9 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27787,7 +28271,9 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27934,7 +28420,9 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28081,7 +28569,9 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28260,7 +28750,9 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28387,7 +28879,9 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28534,7 +29028,9 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28681,7 +29177,9 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28828,7 +29326,9 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29007,7 +29507,9 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29134,7 +29636,9 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29313,7 +29817,9 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29492,7 +29998,9 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29671,7 +30179,9 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29850,7 +30360,9 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29985,7 +30497,9 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30116,7 +30630,9 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30219,7 +30735,9 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30342,7 +30860,9 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30449,7 +30969,9 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30584,7 +31106,9 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30683,7 +31207,9 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30810,7 +31336,9 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30937,7 +31465,9 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31064,7 +31594,9 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31199,7 +31731,9 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31302,7 +31836,9 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31449,7 +31985,9 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31596,7 +32134,9 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31743,7 +32283,9 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31922,7 +32464,9 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32049,7 +32593,9 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32196,7 +32742,9 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32343,7 +32891,9 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32490,7 +33040,9 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32669,7 +33221,9 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32796,7 +33350,9 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32943,7 +33499,9 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33090,7 +33648,9 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33237,7 +33797,9 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33416,7 +33978,9 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33543,7 +34107,9 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33722,7 +34288,9 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33901,7 +34469,9 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34080,7 +34650,9 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34259,7 +34831,9 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34394,7 +34968,9 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34525,7 +35101,9 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34628,7 +35206,9 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34751,7 +35331,9 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34858,7 +35440,9 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34993,7 +35577,9 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35092,7 +35678,9 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35219,7 +35807,9 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35346,7 +35936,9 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35473,7 +36065,9 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35608,7 +36202,9 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35711,7 +36307,9 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35858,7 +36456,9 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36005,7 +36605,9 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36152,7 +36754,9 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36331,7 +36935,9 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36458,7 +37064,9 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36605,7 +37213,9 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36752,7 +37362,9 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36899,7 +37511,9 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37078,7 +37692,9 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37205,7 +37821,9 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37352,7 +37970,9 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37499,7 +38119,9 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37646,7 +38268,9 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37825,7 +38449,9 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37952,7 +38578,9 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38131,7 +38759,9 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38310,7 +38940,9 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38489,7 +39121,9 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38668,7 +39302,9 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38803,7 +39439,9 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38934,7 +39572,9 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39037,7 +39677,9 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39160,7 +39802,9 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39267,7 +39911,9 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39402,7 +40048,9 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39501,7 +40149,9 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39628,7 +40278,9 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39755,7 +40407,9 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39882,7 +40536,9 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40017,7 +40673,9 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40120,7 +40778,9 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40267,7 +40927,9 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40414,7 +41076,9 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40561,7 +41225,9 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40740,7 +41406,9 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40867,7 +41535,9 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41014,7 +41684,9 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41161,7 +41833,9 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41308,7 +41982,9 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41487,7 +42163,9 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41614,7 +42292,9 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41761,7 +42441,9 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41908,7 +42590,9 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42055,7 +42739,9 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42234,7 +42920,9 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42361,7 +43049,9 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42540,7 +43230,9 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42719,7 +43411,9 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42898,7 +43592,9 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43077,7 +43773,9 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43212,7 +43910,9 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43343,7 +44043,9 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43446,7 +44148,9 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43569,7 +44273,9 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43676,7 +44382,9 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43811,7 +44519,9 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43910,7 +44620,9 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44037,7 +44749,9 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44164,7 +44878,9 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44291,7 +45007,9 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44426,7 +45144,9 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44529,7 +45249,9 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44676,7 +45398,9 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44823,7 +45547,9 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44970,7 +45696,9 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45149,7 +45877,9 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45276,7 +46006,9 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45423,7 +46155,9 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45570,7 +46304,9 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45717,7 +46453,9 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45896,7 +46634,9 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46023,7 +46763,9 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46170,7 +46912,9 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46317,7 +47061,9 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46464,7 +47210,9 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46643,7 +47391,9 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46770,7 +47520,9 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46949,7 +47701,9 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47128,7 +47882,9 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47307,7 +48063,9 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47486,7 +48244,9 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47621,7 +48381,9 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47752,7 +48514,9 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47855,7 +48619,9 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47978,7 +48744,9 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48085,7 +48853,9 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48220,7 +48990,9 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48319,7 +49091,9 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48446,7 +49220,9 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48573,7 +49349,9 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48700,7 +49478,9 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48835,7 +49615,9 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48938,7 +49720,9 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49085,7 +49869,9 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49232,7 +50018,9 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49379,7 +50167,9 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49558,7 +50348,9 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49685,7 +50477,9 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49832,7 +50626,9 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49979,7 +50775,9 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50126,7 +50924,9 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50305,7 +51105,9 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50432,7 +51234,9 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50579,7 +51383,9 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50726,7 +51532,9 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50873,7 +51681,9 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51052,7 +51862,9 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51179,7 +51991,9 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51358,7 +52172,9 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51537,7 +52353,9 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51716,7 +52534,9 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51895,7 +52715,9 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -52030,7 +52852,9 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -52161,7 +52985,9 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -52264,7 +53090,9 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -52387,7 +53215,9 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		if hasNullsAndNotNullable {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -52485,6 +53315,7 @@ func GetProjectionOperator(
 	evalCtx *tree.EvalContext,
 	binFn tree.TwoArgFn,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projOpBase := projOpBase{
@@ -52493,6 +53324,7 @@ func GetProjectionOperator(
 		col1Idx:        col1Idx,
 		col2Idx:        col2Idx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 
 	leftType, rightType := inputTypes[col1Idx], inputTypes[col2Idx]

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -132,10 +132,12 @@ func (p _OP_NAME) Next() coldata.Batch {
 		vec2 := batch.ColVec(p.col2Idx)
 		col1 := vec1._L_TYP()
 		col2 := vec2._R_TYP()
+		// {{/*
 		// Some operators can result in NULL with non-NULL inputs, like the JSON
 		// fetch value operator, ->. Therefore, _outNulls is defined to allow
 		// updating the output Nulls from within _ASSIGN functions when the result
 		// of a projection is Null.
+		// */}}
 		_outNulls := projVec.Nulls()
 		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			_SET_PROJECTION(true)
@@ -171,11 +173,13 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 			_SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS, false)
 		}
 	}
+	// {{/*
 	// _outNulls has been updated from within the _ASSIGN function to include
 	// any NULLs that resulted from the projection.
 	// If _HAS_NULLS is true, union _outNulls with the set of input Nulls.
 	// If _HAS_NULLS is false, then there are no input Nulls. _outNulls is
 	// projVec.Nulls() so there is no need to call projVec.SetNulls().
+	// */}}
 	// {{if _HAS_NULLS}}
 	projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
 	// {{end}}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -83,18 +83,20 @@ func _ASSIGN(_, _, _, _, _, _ interface{}) {
 // around the problem we specify it here.
 type projConstOpBase struct {
 	colexecop.OneInputHelper
-	allocator *colmem.Allocator
-	colIdx    int
-	outputIdx int
+	allocator    *colmem.Allocator
+	colIdx       int
+	outputIdx    int
+	nullableArgs bool
 }
 
 // projOpBase contains all of the fields for non-constant projections.
 type projOpBase struct {
 	colexecop.OneInputHelper
-	allocator *colmem.Allocator
-	col1Idx   int
-	col2Idx   int
-	outputIdx int
+	allocator    *colmem.Allocator
+	col1Idx      int
+	col2Idx      int
+	outputIdx    int
+	nullableArgs bool
 }
 
 // {{define "projOp"}}
@@ -139,7 +141,23 @@ func (p _OP_NAME) Next() coldata.Batch {
 		// of a projection is Null.
 		// */}}
 		_outNulls := projVec.Nulls()
-		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+
+		// {{/*
+		// If nullableArgs is true, the function’s definition can handle null
+		// arguments. We would still want to perform the projection, and there is no
+		// need to call projVec.SetNulls(). The behaviour will just be the same as
+		// _HAS_NULLS is false. Since currently only ConcatDatumDatum needs this
+		// nullableArgs == true behaviour, logic for nullableArgs is only added to
+		// the if statement for function with Datum, Datum. If we later introduce
+		// another projection operation that has nullableArgs == true, we should
+		// update this code accordingly.
+		// */}}
+		// {{if and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum")}}
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		// {{else}}
+		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		// {{end}}
+		if hasNullsAndNotNullable {
 			_SET_PROJECTION(true)
 		} else {
 			_SET_PROJECTION(false)
@@ -262,6 +280,7 @@ func GetProjectionOperator(
 	evalCtx *tree.EvalContext,
 	binFn tree.TwoArgFn,
 	cmpExpr *tree.ComparisonExpr,
+	nullableArgs bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projOpBase := projOpBase{
@@ -270,6 +289,7 @@ func GetProjectionOperator(
 		col1Idx:        col1Idx,
 		col2Idx:        col2Idx,
 		outputIdx:      outputIdx,
+		nullableArgs:   nullableArgs,
 	}
 
 	leftType, rightType := inputTypes[col1Idx], inputTypes[col2Idx]

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -113,9 +113,10 @@ func TestGetProjectionConstOperator(t *testing.T) {
 	constVal := 31.37
 	constArg := tree.NewDFloat(tree.DFloat(constVal))
 	outputIdx := 5
+	nullableArgs := false
 	op, err := GetProjectionRConstOperator(
 		testAllocator, inputTypes, types.Float, types.Float, binOp, input, colIdx,
-		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil, /* cmpExpr */
+		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
 	)
 	if err != nil {
 		t.Error(err)
@@ -126,6 +127,7 @@ func TestGetProjectionConstOperator(t *testing.T) {
 			allocator:      testAllocator,
 			colIdx:         colIdx,
 			outputIdx:      outputIdx,
+			nullableArgs:   nullableArgs,
 		},
 		constArg: constVal,
 	}
@@ -145,9 +147,10 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 	constVal := int16(31)
 	constArg := tree.NewDInt(tree.DInt(constVal))
 	outputIdx := 5
+	nullableArgs := false
 	op, err := GetProjectionRConstOperator(
 		testAllocator, inputTypes, types.Int2, types.Int, cmpOp, input, colIdx,
-		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil, /* cmpExpr */
+		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
 	)
 	if err != nil {
 		t.Error(err)
@@ -158,6 +161,7 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 			allocator:      testAllocator,
 			colIdx:         colIdx,
 			outputIdx:      outputIdx,
+			nullableArgs:   nullableArgs,
 		},
 		constArg: constVal,
 	}
@@ -274,9 +278,10 @@ func TestGetProjectionOperator(t *testing.T) {
 	inputTypes[col1Idx] = typ
 	inputTypes[col2Idx] = typ
 	outputIdx := 9
+	nullableArgs := false
 	op, err := GetProjectionOperator(
 		testAllocator, inputTypes, types.Int2, binOp, input, col1Idx, col2Idx,
-		outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil, /* cmpExpr */
+		outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
 	)
 	if err != nil {
 		t.Error(err)
@@ -288,6 +293,7 @@ func TestGetProjectionOperator(t *testing.T) {
 			col1Idx:        col1Idx,
 			col2Idx:        col2Idx,
 			outputIdx:      outputIdx,
+			nullableArgs:   nullableArgs,
 		},
 	}
 	if !reflect.DeepEqual(op, expected) {

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -983,6 +983,25 @@ SELECT NULL::INT[] || NULL::INT[]
 ----
 NULL
 
+# The following test check for projection operators that can handle nullable arguments.
+statement ok
+CREATE TABLE t_bool (b BOOL[]);
+
+query T
+SELECT b || NULL FROM t_bool;
+----
+
+statement ok
+INSERT INTO t_bool VALUES (Array[]);
+
+query T
+SELECT b || NULL FROM t_bool;
+----
+{}
+
+statement ok
+DROP TABLE t_bool;
+
 # Array equality
 
 query B


### PR DESCRIPTION
Backport 2/2 commits from #84159.

/cc @cockroachdb/release

---

Previously, the `Concat` projection operators on arrays directly copy nulls into
the output without performing the actual projection whenever either argument was
null. This is incorrect because `Concat` operator can actually handle null arguments,
and we want the actual projection result instead. Since currently the only
projection operator that needs `nullableArgs == true` behaviour is
`ConcatDatumDatum`, this PR fixed this by adding a boolean field `nullableArgs`
to the logic for operators with `Datum`, `Datum`. If we later introduce another
projection operation that has nullableArgs == true, we should update this code
accordingly.

Fixes: https://github.com/cockroachdb/cockroach/issues/83091

Release note (bug fix): Fixed a bug in `Concat` projection operators on arrays
that gave output of nulls when the projection operator can actually handle null
arguments and may result in a non-null output.

----

Release justification: bug fix