### PR TITLE
ccl/changefeedccl: add assume role auth to GCP pubsub

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -125,6 +125,7 @@ go_library(
         "@com_github_shopify_sarama//:sarama",
         "@com_github_xdg_go_scram//:scram",
         "@com_google_cloud_go_pubsub//:pubsub",
+        "@org_golang_google_api//impersonate",
         "@org_golang_google_api//option",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -417,7 +417,7 @@ func (p *Provider) Create(
 	args := []string{
 		"compute", "instances", "create",
 		"--subnet", "default",
-		"--scopes", "default,storage-rw",
+		"--scopes", "cloud-platform",
 		"--image", providerOpts.Image,
 		"--image-project", "ubuntu-os-cloud",
 		"--boot-disk-type", "pd-ssd",


### PR DESCRIPTION
The URI for GCP pubsub now accept an "ASSUME_ROLE" parameter, which specifies
a comma-separated list of service accounts to be chain assumed by the service
account authenticated by the implicit or specified credentials. For example,
the URI

```
gcpubsub://project?AUTH=implicit&topic_name=topic&ASSUME_ROLE=roleA,roleB
```

will inform the implicit service account to roleB through the delegate roleA
in order to access the pubsub resource.

Release note (enterprise change): The URI for GCP pubsub now accept an
"ASSUME_ROLE" parameter, which specifies a comma-separated list of service
accounts to be chain assumed by the service account authenticated by the
implicit or specified credentials.