### PR TITLE
rowenc: fix recent bugs with DOidWrappers and inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1686,3 +1686,8 @@ SELECT primes FROM cb WHERE primes && numbers ORDER BY primes
 {2,3}
 {2,3}
 {2,3,5}
+
+# Regression test for incorrectly unwrapping a DOidWrapper (#84569).
+statement ok
+CREATE TABLE t84569 (name_col NAME NOT NULL, INVERTED INDEX (name_col gin_trgm_ops DESC));
+INSERT INTO t84569 (name_col) VALUES ('X'::NAME)

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -587,7 +587,9 @@ func EncodeInvertedIndexTableKeys(
 		// need to pass in the inverted index column kind to this function.
 		// We pad the keys when writing them to the index.
 		// TODO(jordan): why are we doing this padding at all? Postgres does it.
-		return encodeTrigramInvertedIndexTableKeys(string(*val.(*tree.DString)), inKey, version, true /* pad */)
+		// val could be a DOidWrapper, so we need to use the unwrapped datum
+		// here.
+		return encodeTrigramInvertedIndexTableKeys(string(*datum.(*tree.DString)), inKey, version, true /* pad */)
 	}
 	return nil, errors.AssertionFailedf("trying to apply inverted index to unsupported type %s", datum.ResolvedType())
 }
@@ -672,7 +674,9 @@ func EncodeExistsInvertedIndexSpans(
 	datum := eval.UnwrapDatum(evalCtx, val)
 	switch val.ResolvedType().Family() {
 	case types.StringFamily:
-		s := string(*val.(*tree.DString))
+		// val could be a DOidWrapper, so we need to use the unwrapped datum
+		// here.
+		s := string(*datum.(*tree.DString))
 		return json.EncodeExistsInvertedIndexSpans(nil /* inKey */, s)
 	case types.ArrayFamily:
 		if val.ResolvedType().ArrayContents().Family() != types.StringFamily {


### PR DESCRIPTION
Previously, we were using the passed-in datum asserting that it is
a `DString` whereas it could be a `DOidWrapper`, and this is now fixed.

Fixes: #84569.

Release note: None (no stable release with the bugs)