### PR TITLE
cluster-ui: allow dynamic timescale window from key buttons

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.tsx
@@ -47,7 +47,7 @@ export const TimeFrameControls = ({
       <ButtonGroup>
         <Tooltip
           placement="bottom"
-          title="previous time interval"
+          title="Previous time interval"
           mouseEnterDelay={delay}
           mouseLeaveDelay={delay}
         >
@@ -62,7 +62,7 @@ export const TimeFrameControls = ({
         </Tooltip>
         <Tooltip
           placement="bottom"
-          title="next time interval"
+          title="Next time interval"
           mouseEnterDelay={delay}
           mouseLeaveDelay={delay}
         >
@@ -78,7 +78,7 @@ export const TimeFrameControls = ({
       </ButtonGroup>
       <Tooltip
         placement="bottom"
-        title="past day"
+        title="Most recent interval"
         mouseEnterDelay={delay}
         mouseLeaveDelay={delay}
       >

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
@@ -11,7 +11,6 @@
 import moment from "moment";
 import { TimeScale, TimeScaleOption, TimeScaleOptions } from "./timeScaleTypes";
 import { dateFormat, timeFormat } from "./timeScaleDropdown";
-import React from "react";
 
 /**
  * timeScale1hMinOptions is a preconfigured set of time scales with 1h minimum that can be

--- a/pkg/ui/workspaces/db-console/src/redux/globalTimeScale.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/globalTimeScale.ts
@@ -8,13 +8,32 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import moment from "moment";
 import { LocalSetting } from "./localsettings";
 import { AdminUIState } from "./state";
 import { TimeScale, defaultTimeScaleSelected } from "@cockroachlabs/cluster-ui";
 
 const localSettingsSelector = (state: AdminUIState) => state.localSettings;
 
-export const globalTimeScaleLocalSetting = new LocalSetting<
-  AdminUIState,
-  TimeScale
->("timeScale/SQLActivity", localSettingsSelector, defaultTimeScaleSelected);
+const setting = new LocalSetting<AdminUIState, TimeScale>(
+  "timeScale/SQLActivity",
+  localSettingsSelector,
+  defaultTimeScaleSelected,
+);
+
+export const globalTimeScaleLocalSetting = {
+  ...setting,
+  selector: (state: AdminUIState): TimeScale => {
+    const val = setting.selector(state);
+    if (typeof val.windowSize !== "string") {
+      return val;
+    }
+    return {
+      key: val.key,
+      windowSize: val.windowSize && moment.duration(val.windowSize),
+      windowValid: val.windowValid && moment.duration(val.windowValid),
+      sampleSize: val.sampleSize && moment.duration(val.sampleSize),
+      fixedWindowEnd: val.fixedWindowEnd,
+    };
+  },
+};

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
@@ -12,7 +12,7 @@ import { Action } from "redux";
 import { PayloadAction } from "src/interfaces/action";
 import { google } from "@cockroachlabs/crdb-protobuf-client";
 import IDuration = google.protobuf.IDuration;
-import { TimeScale } from "src/redux/timeScale";
+import { TimeScale } from "@cockroachlabs/cluster-ui";
 
 export const CREATE_STATEMENT_DIAGNOSTICS_REPORT =
   "cockroachui/statements/CREATE_STATEMENT_DIAGNOSTICS_REPORT";

--- a/pkg/ui/workspaces/db-console/src/redux/timeScale.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/timeScale.spec.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { defaultTimeScaleOptions } from "@cockroachlabs/cluster-ui";
+import { defaultTimeScaleOptions, TimeScale } from "@cockroachlabs/cluster-ui";
 import * as timeScale from "./timeScale";
 import moment from "moment";
 
@@ -30,7 +30,7 @@ describe("time scale reducer", function () {
     });
 
     it("should create the correct SET_SCALE action to set time window settings", function () {
-      const payload: timeScale.TimeScale = {
+      const payload: TimeScale = {
         windowSize: moment.duration(10, "s"),
         windowValid: moment.duration(10, "s"),
         sampleSize: moment.duration(10, "s"),

--- a/pkg/ui/workspaces/db-console/src/redux/timeScale.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/timeScale.ts
@@ -16,7 +16,7 @@
 import { Action } from "redux";
 import { PayloadAction } from "src/interfaces/action";
 import _ from "lodash";
-import { defaultTimeScaleOptions } from "@cockroachlabs/cluster-ui";
+import { defaultTimeScaleOptions, TimeScale } from "@cockroachlabs/cluster-ui";
 import moment from "moment";
 
 export const SET_SCALE = "cockroachui/timewindow/SET_SCALE";
@@ -32,34 +32,6 @@ export const SET_METRICS_FIXED_WINDOW =
 export interface TimeWindow {
   start: moment.Moment;
   end: moment.Moment;
-}
-
-/**
- * TimeScale describes the requested dimensions of TimeWindows; it
- * prescribes a length for the window, along with a period of time that a
- * newly created TimeWindow will remain valid.
- */
-export interface TimeScale {
-  /**
-   * The key used to index in to the defaultTimeScaleOptions collection.
-   * The key is "Custom" when specifying a custom time that is not one of the default options
-   */
-  key?: string;
-  // The size of a global time window. Default is ten minutes.
-  windowSize: moment.Duration;
-  // The length of time the global time window is valid. The current time window
-  // is invalid if now > (metricsTime.currentWindow.end + windowValid). Default is ten
-  // seconds. If fixedWindowEnd is set this is ignored.
-  windowValid?: moment.Duration;
-  // The expected duration of individual samples for queries at this time scale.
-  sampleSize: moment.Duration;
-  /**
-   * The fixed end time of the window, or false if it should be a dynamically moving "now".
-   * Typically, when the `key` property is a default option, `fixedWindowEnd` should be false.
-   * And when the `key` property is "Custom" `fixedWindowEnd` should be a specific Moment.
-   * It is unclear if there are legitimate reasons for the two being out of sync.
-   */
-  fixedWindowEnd: moment.Moment | false;
 }
 
 export class TimeScaleState {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -66,11 +66,14 @@ import { PayloadAction } from "src/interfaces/action";
 import {
   setMetricsFixedWindow,
   TimeWindow,
-  TimeScale,
   adjustTimeScale,
 } from "src/redux/timeScale";
 import { InlineAlert } from "src/components";
-import { Anchor, TimeScaleDropdown } from "@cockroachlabs/cluster-ui";
+import {
+  Anchor,
+  TimeScaleDropdown,
+  TimeScale,
+} from "@cockroachlabs/cluster-ui";
 import { reduceStorageOfTimeSeriesDataOperationalFlags } from "src/util/docs";
 import moment from "moment";
 import {

--- a/pkg/ui/workspaces/db-console/src/views/devtools/containers/raftMessages/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/devtools/containers/raftMessages/index.tsx
@@ -39,11 +39,8 @@ import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvi
 import messagesDashboard from "./messages";
 import { getMatchParamByName } from "src/util/query";
 import { PayloadAction } from "src/interfaces/action";
-import {
-  TimeWindow,
-  TimeScale,
-  setMetricsFixedWindow,
-} from "src/redux/timeScale";
+import { TimeWindow, setMetricsFixedWindow } from "src/redux/timeScale";
+import { TimeScale } from "@cockroachlabs/cluster-ui";
 
 interface NodeGraphsOwnProps {
   refreshNodes: typeof refreshNodes;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -22,7 +22,11 @@ import { LineGraph } from "src/views/cluster/components/linegraph";
 import { DropdownOption } from "src/views/shared/components/dropdown";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
-import { AxisUnits, TimeScaleDropdown } from "@cockroachlabs/cluster-ui";
+import {
+  AxisUnits,
+  TimeScale,
+  TimeScaleDropdown,
+} from "@cockroachlabs/cluster-ui";
 import {
   PageConfig,
   PageConfigItem,
@@ -37,11 +41,7 @@ import { CustomChartState, CustomChartTable } from "./customMetric";
 import "./customChart.styl";
 import { queryByName } from "src/util/query";
 import { PayloadAction } from "src/interfaces/action";
-import {
-  TimeWindow,
-  TimeScale,
-  setMetricsFixedWindow,
-} from "src/redux/timeScale";
+import { TimeWindow, setMetricsFixedWindow } from "src/redux/timeScale";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
 

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
@@ -37,9 +37,9 @@ import TimeSeriesQueryAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggre
 import TimeSeriesQueryDerivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative;
 import Long from "long";
 import { History } from "history";
-import { TimeWindow, TimeScale } from "src/redux/timeScale";
+import { TimeWindow } from "src/redux/timeScale";
 import { PayloadAction } from "src/interfaces/action";
-import { AxisUnits } from "@cockroachlabs/cluster-ui";
+import { AxisUnits, TimeScale } from "@cockroachlabs/cluster-ui";
 
 /**
  * AxisProps represents the properties of an Axis being specified as part of a


### PR DESCRIPTION
fixes #77007

Previously, controlling the time scale window using the arrow
key buttons and 'Now' button would disable the dynamically moving
window even when the end time = now. This commit makes it so that
when the time window is changed to include the current time (i.e.
endTime = now), the time window will be changed to dynamic to
ensure the window is keep up to date with the current time.

This commit also fixes the object construction of the time scale
from session storage and corrects the 'Now' button tooltip label from
'past 1 day' to 'Most recent interval'.

Release note (bug fix): changing the time window using arrow buttons
and 'Now' button will now properly turn the timeframe into a moving
window when endTime = now.

https://www.loom.com/share/54d65c04580747dc92f7e4976b953be6