### PR TITLE
backupccl/backuprand: add geos

### DIFF
--- a/pkg/ccl/backupccl/backuprand/BUILD.bazel
+++ b/pkg/ccl/backupccl/backuprand/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "backup_rand_test.go",
         "main_test.go",
     ],
+    data = ["//c-deps:libgeos"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Sometimes random data invokes geospatial functions. See
[this failure](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_GitHubCiOptional/5788685?showRootCauses=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true)

Release note: None