### PR TITLE
release-21.2: DatumToHLC truncates timestamp

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -64,6 +64,13 @@ SELECT * FROM (SELECT now()) AS OF SYSTEM TIME '2018-01-01'
 ----
 2018-01-01 00:00:00 +0000 UTC
 
+# Verify that timezones are not truncated
+
+query T
+SELECT * FROM (SELECT now()) AS OF SYSTEM TIME '2018-01-01 00:00:00-1:00'
+----
+2018-01-01 01:00:00 +0000 UTC
+
 # Verify that zero intervals indistinguishable from zero cause an error.
 
 statement error pq: AS OF SYSTEM TIME: interval value '0.1us' too small, absolute value must be >= 1µs

--- a/pkg/sql/sem/tree/as_of.go
+++ b/pkg/sql/sem/tree/as_of.go
@@ -231,7 +231,7 @@ func DatumToHLC(evalCtx *EvalContext, stmtTimestamp time.Time, d Datum) (hlc.Tim
 			syn = true
 		}
 		// Attempt to parse as timestamp.
-		if dt, _, err := ParseDTimestamp(evalCtx, s, time.Nanosecond); err == nil {
+		if dt, _, err := ParseDTimestampTZ(evalCtx, s, time.Nanosecond); err == nil {
 			ts.WallTime = dt.Time.UnixNano()
 			ts.Synthetic = syn
 			break

--- a/pkg/util/timeutil/pgdate/field_extract.go
+++ b/pkg/util/timeutil/pgdate/field_extract.go
@@ -710,7 +710,7 @@ func (fe *fieldExtract) MakeTimestamp() time.Time {
 	return time.Date(year, time.Month(month), day, hour, min, sec, nano, fe.MakeLocation())
 }
 
-// MakeTimestampWIthoutTimezone returns a time.Time containing all extracted
+// MakeTimestampWithoutTimezone returns a time.Time containing all extracted
 // information, minus any timezone information (which is stripped). The returned
 // time always has UTC location. See ParseTimestampWithoutTimezone.
 func (fe *fieldExtract) MakeTimestampWithoutTimezone() time.Time {

--- a/pkg/util/timeutil/pgdate/parsing.go
+++ b/pkg/util/timeutil/pgdate/parsing.go
@@ -210,7 +210,7 @@ func ParseTimestamp(
 // For example, all these inputs return 2020-06-26 01:02:03 +0000 UTC:
 //   - '2020-06-26 01:02:03';
 //   - '2020-06-26 01:02:03+04';
-//   - 'now', if the local local time (in the current timezone) is
+//   - 'now', if the local time (in the current timezone) is
 //     2020-06-26 01:02:03. Note that this does not represent the same time
 //     instant, but the one that "reads" the same in UTC.
 //


### PR DESCRIPTION
Backport 1/1 commits from #84613.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/84605

Release note (sql): `AS OF SYSTEM TIME` now takes the time zone
into account when converting to UTC.
For example:
'2022-01-01 08:00:00-04:00'
is treated the same as
'2022-01-01 12:00:00'
instead of
'2022-01-01 08:00:00'

Release justification: Fix `AS OF SYSTEM TIME` time zone bug.