### PR TITLE
changefeedccl: improve Kafka batching logic

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "encoder_avro.go",
         "encoder_csv.go",
         "encoder_json.go",
+        "error_wrapper_sink.go",
         "event_processing.go",
         "metrics.go",
         "name.go",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2058,9 +2058,8 @@ func TestChangefeedSingleColumnFamilySchemaChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// requireErrorSoon times out after 30 seconds
+	skip.UnderRaceWithIssue(t, 84736)
 	skip.UnderStress(t)
-	skip.UnderRace(t)
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
@@ -2329,6 +2328,9 @@ func requireErrorSoon(
 func TestChangefeedFailOnTableOffline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRaceWithIssue(t, 84736)
+	skip.UnderStress(t)
 
 	dataSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {
@@ -3236,6 +3238,44 @@ func TestChangefeedRetryableError(t *testing.T) {
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}
+
+func TestChangefeedKafkaMessageTooLarge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer utilccl.TestingEnableEnterprise()()
+
+	skip.UnderRaceWithIssue(t, 84736)
+	skip.UnderStress(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+
+		knobs := f.(*kafkaFeedFactory).knobs
+
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (2)`)
+
+		t.Run(`succeed eventually if batches are rejected by the server for being too large`, func(t *testing.T) {
+			knobs.batchesAreTooBig = true
+			foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+			defer closeFeed(t, foo)
+			assertPayloads(t, foo, []string{
+				`foo: [1]->{"after": {"a": 1}}`,
+				`foo: [2]->{"after": {"a": 2}}`,
+			})
+		})
+
+		t.Run(`fail permanently if individual messages are rejected by the server for being too large`, func(t *testing.T) {
+			knobs.allMessagesAreTooBig = true
+			foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+			defer closeFeed(t, foo)
+			requireErrorSoon(context.Background(), t, foo, regexp.MustCompile(`too large`))
+		})
+	}
+
+	cdcTest(t, testFn, feedTestForceSink(`kafka`))
 }
 
 func TestChangefeedJobRetryOnNoInboundStream(t *testing.T) {

--- a/pkg/ccl/changefeedccl/error_wrapper_sink.go
+++ b/pkg/ccl/changefeedccl/error_wrapper_sink.go
@@ -1,0 +1,81 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+// errorWrapperSink delegates to another sink and marks all returned errors as
+// retryable. During changefeed setup, we use the sink once without this to
+// verify configuration, but in the steady state, sink errors are assumed to be
+// transient unless otherwise specified.
+type errorWrapperSink struct {
+	wrapped Sink
+}
+
+// fatalSinkError is an error wrapper that allows sinks to indicate that the
+// error they're returning is not likely to be transient: it should be fixed
+// by manual intervention rather than automatically retrying the changefeed.
+// Examples of a fatal sink error are an expired authorization token or a
+// "message too large" response to a single-event message.
+// Note that unlike similar tags this does not modify the error, as the only
+// thing that needs to know about it is the maybeMarkRetryableError call
+// in errorWrapperSink.
+type fatalSinkError struct {
+	error
+}
+
+func maybeMarkRetryableError(e error) error {
+	if e == nil {
+		return nil
+	}
+	if errors.HasType(e, fatalSinkError{}) {
+		return e
+	}
+	return changefeedbase.MarkRetryableError(e)
+}
+
+// EmitRow implements Sink interface.
+func (s errorWrapperSink) EmitRow(
+	ctx context.Context,
+	topic TopicDescriptor,
+	key, value []byte,
+	updated, mvcc hlc.Timestamp,
+	alloc kvevent.Alloc,
+) error {
+	return maybeMarkRetryableError(s.wrapped.EmitRow(ctx, topic, key, value, updated, mvcc, alloc))
+}
+
+// EmitResolvedTimestamp implements Sink interface.
+func (s errorWrapperSink) EmitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
+) error {
+	return maybeMarkRetryableError(s.wrapped.EmitResolvedTimestamp(ctx, encoder, resolved))
+}
+
+// Flush implements Sink interface.
+func (s errorWrapperSink) Flush(ctx context.Context) error {
+	return maybeMarkRetryableError(s.wrapped.Flush(ctx))
+}
+
+// Close implements Sink interface.
+func (s errorWrapperSink) Close() error {
+	return maybeMarkRetryableError(s.wrapped.Close())
+}
+
+// Dial implements Sink interface.
+func (s errorWrapperSink) Dial() error {
+	return s.wrapped.Dial()
+}

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -242,59 +242,6 @@ func (u *sinkURL) String() string {
 	return u.URL.String()
 }
 
-// errorWrapperSink delegates to another sink and marks all returned errors as
-// retryable. During changefeed setup, we use the sink once without this to
-// verify configuration, but in the steady state, no sink error should be
-// terminal.
-type errorWrapperSink struct {
-	wrapped Sink
-}
-
-// EmitRow implements Sink interface.
-func (s errorWrapperSink) EmitRow(
-	ctx context.Context,
-	topic TopicDescriptor,
-	key, value []byte,
-	updated, mvcc hlc.Timestamp,
-	alloc kvevent.Alloc,
-) error {
-	if err := s.wrapped.EmitRow(ctx, topic, key, value, updated, mvcc, alloc); err != nil {
-		return changefeedbase.MarkRetryableError(err)
-	}
-	return nil
-}
-
-// EmitResolvedTimestamp implements Sink interface.
-func (s errorWrapperSink) EmitResolvedTimestamp(
-	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
-) error {
-	if err := s.wrapped.EmitResolvedTimestamp(ctx, encoder, resolved); err != nil {
-		return changefeedbase.MarkRetryableError(err)
-	}
-	return nil
-}
-
-// Flush implements Sink interface.
-func (s errorWrapperSink) Flush(ctx context.Context) error {
-	if err := s.wrapped.Flush(ctx); err != nil {
-		return changefeedbase.MarkRetryableError(err)
-	}
-	return nil
-}
-
-// Close implements Sink interface.
-func (s errorWrapperSink) Close() error {
-	if err := s.wrapped.Close(); err != nil {
-		return changefeedbase.MarkRetryableError(err)
-	}
-	return nil
-}
-
-// Dial implements Sink interface.
-func (s errorWrapperSink) Dial() error {
-	return s.wrapped.Dial()
-}
-
 // encDatumRowBuffer is a FIFO of `EncDatumRow`s.
 //
 // TODO(dan): There's some potential allocation savings here by reusing the same

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -85,6 +85,7 @@ type kafkaSink struct {
 	client         kafkaClient
 	producer       sarama.AsyncProducer
 	topics         *TopicNamer
+	asapSink       *kafkaSink
 
 	lastMetadataRefresh time.Time
 
@@ -167,6 +168,18 @@ func defaultSaramaConfig() *saramaConfig {
 	return config
 }
 
+// disableBatching copies a saramaConfig and overwrites
+// its flush config to completely disable batching,
+// including the batching the client usually does by default.
+func disableBatching(c *saramaConfig) *saramaConfig {
+	newConfig := *c
+	newConfig.Flush.Messages = 0
+	newConfig.Flush.MaxMessages = 1
+	newConfig.Flush.Frequency = jsonDuration(0)
+	newConfig.Flush.Bytes = 0
+	return &newConfig
+}
+
 func (s *kafkaSink) start() {
 	s.stopWorkerCh = make(chan struct{})
 	s.worker.Add(1)
@@ -174,7 +187,12 @@ func (s *kafkaSink) start() {
 }
 
 // Dial implements the Sink interface.
-func (s *kafkaSink) Dial() error {
+func (s *kafkaSink) Dial() (err error) {
+	if s.asapSink != nil {
+		defer func() {
+			err = errors.CombineErrors(err, s.asapSink.Dial())
+		}()
+	}
 	client, err := sarama.NewClient(strings.Split(s.bootstrapAddrs, `,`), s.kafkaCfg)
 	if err != nil {
 		return pgerror.Wrapf(err, pgcode.CannotConnectNow,
@@ -187,11 +205,17 @@ func (s *kafkaSink) Dial() error {
 	}
 	s.client = client
 	s.start()
-	return nil
+	return
 }
 
 // Close implements the Sink interface.
-func (s *kafkaSink) Close() error {
+func (s *kafkaSink) Close() (err error) {
+	if s.asapSink != nil {
+		asapError := s.asapSink.Close()
+		defer func() {
+			err = errors.CombineErrors(err, asapError)
+		}()
+	}
 	close(s.stopWorkerCh)
 	s.worker.Wait()
 	// If we're shutting down, we don't care what happens to the outstanding
@@ -199,9 +223,9 @@ func (s *kafkaSink) Close() error {
 	_ = s.producer.Close()
 	// s.client is only nil in tests.
 	if s.client != nil {
-		return s.client.Close()
+		err = s.client.Close()
 	}
-	return nil
+	return err
 }
 
 type messageMetadata struct {
@@ -218,6 +242,9 @@ func (s *kafkaSink) EmitRow(
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
 ) error {
+	if s.asapSink != nil {
+		return s.asapSink.EmitRow(ctx, topicDescr, key, value, updated, mvcc, alloc)
+	}
 
 	topic, err := s.topics.Name(topicDescr)
 	if err != nil {
@@ -231,13 +258,21 @@ func (s *kafkaSink) EmitRow(
 		Metadata: messageMetadata{alloc: alloc, mvcc: mvcc, updateMetrics: s.metrics.recordOneMessage()},
 	}
 	s.stats.startMessage(int64(msg.Key.Length() + msg.Value.Length()))
-	return s.emitMessage(ctx, msg)
+	return s.maybeMarkFatal(s.emitMessage(ctx, msg))
 }
 
 // EmitResolvedTimestamp implements the Sink interface.
 func (s *kafkaSink) EmitResolvedTimestamp(
 	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
 ) error {
+	// TODO: This effectively turns off batching permanently for emitting resolved timestamps,
+	// as a sink that emits resolved timestamps never flushes emitted rows, which is what
+	// triggers the state change that enables batching.
+	// Tentatively, this seems like sensible behavior--if you're batching resolved timestamps,
+	// why not just send them less often? But we should discuss this.
+	if s.asapSink != nil {
+		return s.asapSink.EmitResolvedTimestamp(ctx, encoder, resolved)
+	}
 	defer s.metrics.recordResolvedCallback()()
 
 	// Periodically ping sarama to refresh its metadata. This means talking to
@@ -255,7 +290,7 @@ func (s *kafkaSink) EmitResolvedTimestamp(
 		s.lastMetadataRefresh = timeutil.Now()
 	}
 
-	return s.topics.Each(func(topic string) error {
+	return s.maybeMarkFatal(s.topics.Each(func(topic string) error {
 		payload, err := encoder.EncodeResolvedTimestamp(ctx, topic, resolved)
 		if err != nil {
 			return err
@@ -282,11 +317,23 @@ func (s *kafkaSink) EmitResolvedTimestamp(
 			}
 		}
 		return nil
-	})
+	}))
 }
 
 // Flush implements the Sink interface.
-func (s *kafkaSink) Flush(ctx context.Context) error {
+func (s *kafkaSink) Flush(ctx context.Context) (e error) {
+	if s.asapSink != nil {
+		err := s.asapSink.Flush(ctx)
+		if err == nil {
+			// After the first successful flush,
+			// permanently switch to the primary sink.
+			_ = s.asapSink.Close()
+			s.asapSink = nil
+		}
+		return err
+	}
+	defer func() { e = s.maybeMarkFatal(e) }()
+
 	defer s.metrics.recordFlushRequestCallback()()
 
 	flushCh := make(chan struct{}, 1)
@@ -295,6 +342,7 @@ func (s *kafkaSink) Flush(ctx context.Context) error {
 	inflight := s.mu.inflight
 	flushErr := s.mu.flushErr
 	s.mu.flushErr = nil
+
 	immediateFlush := inflight == 0 || flushErr != nil
 	if !immediateFlush {
 		s.mu.flushCh = flushCh
@@ -333,12 +381,12 @@ func (s *kafkaSink) startInflightMessage(ctx context.Context) error {
 
 func (s *kafkaSink) emitMessage(ctx context.Context, msg *sarama.ProducerMessage) error {
 	if err := s.startInflightMessage(ctx); err != nil {
-		return err
+		return s.maybeMarkFatal(err)
 	}
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return s.maybeMarkFatal(ctx.Err())
 	case s.producer.Input() <- msg:
 	}
 
@@ -653,12 +701,14 @@ func makeKafkaSink(
 	if schemaTopic := u.consumeParam(changefeedbase.SinkParamSchemaTopic); schemaTopic != `` {
 		return nil, errors.Errorf(`%s is not yet supported`, changefeedbase.SinkParamSchemaTopic)
 	}
-
-	config, err := buildKafkaConfig(u, jsonStr)
+	baseSaramaCfg, err := getSaramaConfig(jsonStr)
 	if err != nil {
 		return nil, err
 	}
-
+	baseCfg, err := buildKafkaConfig(u, ``)
+	if err != nil {
+		return nil, err
+	}
 	topics, err := MakeTopicNamer(
 		targets,
 		WithPrefix(kafkaTopicPrefix), WithSingleName(kafkaTopicName), WithSanitizeFn(SQLNameToKafkaName))
@@ -667,20 +717,72 @@ func makeKafkaSink(
 		return nil, err
 	}
 
-	sink := &kafkaSink{
-		ctx:            ctx,
-		kafkaCfg:       config,
-		bootstrapAddrs: u.Host,
-		metrics:        mb(requiresResourceAccounting),
-		topics:         topics,
-	}
-
 	if unknownParams := u.remainingQueryParams(); len(unknownParams) > 0 {
 		return nil, errors.Errorf(
 			`unknown kafka sink query parameters: %s`, strings.Join(unknownParams, ", "))
 	}
 
-	return sink, nil
+	metrics := mb(requiresResourceAccounting)
+
+	makeSink := func(c *saramaConfig) (*kafkaSink, error) {
+		config := *baseCfg
+		err = c.Apply(&config)
+		return &kafkaSink{
+			ctx:            ctx,
+			kafkaCfg:       &config,
+			bootstrapAddrs: u.Host,
+			metrics:        metrics,
+			topics:         topics,
+		}, err
+	}
+
+	primarySink, err := makeSink(baseSaramaCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if primarySink.kafkaCfg.Producer.Flush.MaxMessages != 1 {
+		// Start with a sink that never batches. This allows us to
+		// fail or see success fast, and lets us make progress if
+		// some messages are too large to be part of a batch, as
+		// during a job retry we will eventually send them alone.
+		// After a successful flush we'll switch to the primary sink.
+		asapSink, err := makeSink(disableBatching(baseSaramaCfg))
+		if err != nil {
+			return nil, err
+		}
+		primarySink.asapSink = asapSink
+	}
+
+	return primarySink, nil
+}
+
+func (s *kafkaSink) maybeMarkFatal(err error) error {
+	if err == nil {
+		return nil
+	}
+	var kError sarama.KError
+	if errors.As(err, &kError) {
+		switch kError {
+		// TODO: Handle more errors here. Not everything
+		// in https://kafka.apache.org/protocol#protocol_error_codes marked
+		// non-retriable should be considered non-retriable in our case,
+		// as tearing down the feed and restarting it may fix some client issues.
+		// Theoretically.
+		case sarama.ErrMessageSizeTooLarge:
+			// If batching is enabled, a changefeed-level retry
+			// may succeed because it will disable batching for
+			// when it retries the last few events.
+			if s.batchingDisabled() {
+				return fatalSinkError{err}
+			}
+		}
+	}
+	return err
+}
+
+func (s *kafkaSink) batchingDisabled() bool {
+	return s.kafkaCfg.Producer.Flush.MaxMessages == 1
 }
 
 type kafkaStats struct {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1070,6 +1070,12 @@ func (c *cloudFeed) walkDir(path string, info os.FileInfo, err error) error {
 	return nil
 }
 
+// sinkKnobs override behavior for the simulated sink.
+type sinkKnobs struct {
+	allMessagesAreTooBig bool
+	batchesAreTooBig     bool
+}
+
 // teeGroup facilitates reading messages from input channel
 // and sending them to one or more output channels.
 type teeGroup struct {
@@ -1084,14 +1090,22 @@ func newTeeGroup() *teeGroup {
 	}
 }
 
-// tee reads incoming messages from input channel and sends them out to one or more output channels.
-func (tg *teeGroup) tee(in <-chan *sarama.ProducerMessage, out ...chan<- *sarama.ProducerMessage) {
+// tee reads incoming messages from input channel and sends them out to one or more output channels,
+// unless interceptor returns true.
+func (tg *teeGroup) tee(
+	interceptor func(*sarama.ProducerMessage) bool,
+	in <-chan *sarama.ProducerMessage,
+	out ...chan<- *sarama.ProducerMessage,
+) {
 	tg.g.Go(func() error {
 		for {
 			select {
 			case <-tg.done:
 				return nil
 			case m := <-in:
+				if interceptor != nil && interceptor(m) {
+					continue
+				}
 				for i := range out {
 					select {
 					case <-tg.done:
@@ -1140,6 +1154,7 @@ type fakeKafkaSink struct {
 	Sink
 	tg     *teeGroup
 	feedCh chan *sarama.ProducerMessage
+	knobs  *sinkKnobs
 }
 
 var _ Sink = (*fakeKafkaSink)(nil)
@@ -1147,18 +1162,38 @@ var _ Sink = (*fakeKafkaSink)(nil)
 // Dial implements Sink interface
 func (s *fakeKafkaSink) Dial() error {
 	kafka := s.Sink.(*kafkaSink)
-	kafka.client = &fakeKafkaClient{}
-	// The producer we give to kafka sink ignores close call.
-	// This is because normally, kafka sinks owns the producer and so it closes it.
-	// But in this case, if we let the sink close this producer, the test will panic
-	// because we will attempt to send acknowledgements on a closed channel.
-	producer := &ignoreCloseProducer{newAsyncProducerMock(unbuffered)}
+	if s.knobs == nil {
+		s.knobs = new(sinkKnobs)
+	}
+	mockClient := func(k *kafkaSink) {
+		k.client = &fakeKafkaClient{}
+		// The producer we give to kafka sink ignores close call.
+		// This is because normally, kafka sinks owns the producer and so it closes it.
+		// But in this case, if we let the sink close this producer, the test will panic
+		// because we will attempt to send acknowledgements on a closed channel.
+		producer := &ignoreCloseProducer{asyncProducerMock: newAsyncProducerMock(100)}
 
-	// TODO(yevgeniy): Support error injection either by acknowledging on the "errors"
-	//  channel, or by injecting error message into sarama.ProducerMessage.Metadata.
-	s.tg.tee(producer.inputCh, s.feedCh, producer.successesCh)
-	kafka.producer = producer
-	kafka.start()
+		interceptor := func(m *sarama.ProducerMessage) bool {
+			if !k.batchingDisabled() && s.knobs.batchesAreTooBig {
+				producer.errorsCh <- &sarama.ProducerError{Msg: m, Err: sarama.ErrMessageSizeTooLarge}
+				return true
+			}
+			if s.knobs.allMessagesAreTooBig {
+				producer.errorsCh <- &sarama.ProducerError{Msg: m, Err: sarama.ErrMessageSizeTooLarge}
+				return true
+			}
+			return false
+		}
+		// TODO(yevgeniy): Support error injection either by acknowledging on the "errors"
+		//  channel, or by injecting error message into sarama.ProducerMessage.Metadata.
+		s.tg.tee(interceptor, producer.inputCh, s.feedCh, producer.successesCh)
+		k.producer = producer
+		k.start()
+	}
+	mockClient(kafka)
+	if kafka.asapSink != nil {
+		mockClient(kafka.asapSink)
+	}
 	return nil
 }
 
@@ -1171,6 +1206,7 @@ func (s *fakeKafkaSink) Topics() []string {
 
 type kafkaFeedFactory struct {
 	enterpriseFeedFactory
+	knobs *sinkKnobs
 }
 
 var _ cdctest.TestFeedFactory = (*kafkaFeedFactory)(nil)
@@ -1180,6 +1216,7 @@ func makeKafkaFeedFactory(
 	srv serverutils.TestTenantInterface, db *gosql.DB,
 ) cdctest.TestFeedFactory {
 	return &kafkaFeedFactory{
+		knobs: &sinkKnobs{},
 		enterpriseFeedFactory: enterpriseFeedFactory{
 			s:  srv,
 			db: db,
@@ -1267,6 +1304,7 @@ func (k *kafkaFeedFactory) Feed(create string, args ...interface{}) (cdctest.Tes
 			Sink:   s,
 			tg:     tg,
 			feedCh: feedCh,
+			knobs:  k.knobs,
 		}
 	}
 


### PR DESCRIPTION
Our Kafka client batches by default and is configurable to batch
even more, which can lead to errors from the server if the batch
is too large.

This PR fixes this in two ways. If the batch size is one, we're
in an irrecoverable state without manual intervention, so we
no longer mark that specific error as retryable in that case.
Also, we set the sink to not batch until its first successful
flush. That ensures that even if we retry, we eventually make
progress.

Addresses https://github.com/cockroachdb/cockroach/issues/80313

Release note (enterprise change): Improved handling of Kafka message size too large error.