### PR TITLE
release-22.1: ccl/sqlproxyccl: increase cluster name parsing length limit

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -43,10 +43,14 @@ var (
 	// See "options" in https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS.
 	clusterIdentifierLongOptionRE = regexp.MustCompile(`(?:-c\s*|--)cluster=([\S]*)`)
 
-	// clusterNameRegex restricts cluster names to have between 6 and 20
-	// alphanumeric characters, with dashes allowed within the name (but not as a
-	// starting or ending character).
-	clusterNameRegex = regexp.MustCompile("^[a-z0-9][a-z0-9-]{4,18}[a-z0-9]$")
+	// clusterNameRegex restricts cluster names to have between 6 and 100
+	// alphanumeric characters, with dashes allowed within the name (but not as
+	// a starting or ending character).
+	//
+	// Note that the limit for cluster names within CockroachCloud is likely
+	// smaller than 100 characters. We don't perform an exact match here for
+	// more flexibility.
+	clusterNameRegex = regexp.MustCompile("^[a-z0-9][a-z0-9-]{4,98}[a-z0-9]$")
 )
 
 const (

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1430,7 +1430,7 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 		{
 			name: "invalid cluster identifier in database param",
 			params: map[string]string{
-				// Cluster names need to be between 6 to 20 alphanumeric characters.
+				// Cluster names need to be between 6 to 100 alphanumeric characters.
 				"database": "short-0.defaultdb",
 			},
 			expectedError: "invalid cluster identifier 'short-0'",
@@ -1439,11 +1439,18 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 		{
 			name: "invalid cluster identifier in options param",
 			params: map[string]string{
-				// Cluster names need to be between 6 to 20 alphanumeric characters.
-				"options": "--cluster=cockroachlabsdotcomfoobarbaz-0",
+				// Cluster names need to be between 6 to 100 alphanumeric characters.
+				"options": fmt.Sprintf("--cluster=%s-0", strings.Repeat("a", 101)),
 			},
-			expectedError: "invalid cluster identifier 'cockroachlabsdotcomfoobarbaz-0'",
-			expectedHint:  "Is 'cockroachlabsdotcomfoobarbaz' a valid cluster name?\n--\n" + clusterNameFormHint,
+			expectedError: fmt.Sprintf(
+				"invalid cluster identifier '%s-0'",
+				strings.Repeat("a", 101),
+			),
+			expectedHint: fmt.Sprintf(
+				"Is '%s' a valid cluster name?\n--\n%s",
+				strings.Repeat("a", 101),
+				clusterNameFormHint,
+			),
 		},
 		{
 			name:          "invalid database param (1)",
@@ -1524,10 +1531,10 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 		{
 			name: "cluster identifier in database param",
 			params: map[string]string{
-				"database": "happy-koala-7.defaultdb",
+				"database": fmt.Sprintf("%s-7.defaultdb", strings.Repeat("a", 100)),
 				"foo":      "bar",
 			},
-			expectedClusterName: "happy-koala",
+			expectedClusterName: strings.Repeat("a", 100),
 			expectedTenantID:    7,
 			expectedParams:      map[string]string{"database": "defaultdb", "foo": "bar"},
 		},


### PR DESCRIPTION
### Only merge this once https://github.com/cockroachdb/cockroach/pull/84632 has been merged.

--

Backport 1/1 commits from #84632.

/cc @cockroachdb/release

---

Previously, cluster names as part of proxy connection strings were restricted
to 6 and 20 alphanumeric characters due to CockroachCloud's limit. There are
plans to increase the length limit on the CockroachCloud side, so this length
limit here has to be lifted.

This commit increases the cluster name length limit from 20 characters to
100 characters. Note that the limit for cluster names within CockroachCloud
is likely smaller than 100 characters. We don't do an exact match here for
more flexibility on CockroachCloud's end.

The limit was originally added to avoid sqlproxy from parsing long strings,
which may be unreasonable. Given that 100 characters are not a lot when it
comes to parsing, this change is acceptable.

Release note: None

Release justification: sqlproxyccl only change.
