### PR TITLE
server: minor cleanup

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -696,7 +696,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		stopper,
 		txnMetrics,
 		stores,
-		nil,
 		cfg.ClusterIDContainer,
 		gcoords.Regular.GetWorkQueue(admission.KVWork),
 		gcoords.Stores,


### PR DESCRIPTION
This patch removes an argument that was always passed as nil.

Release note: None