### PR TITLE
changefeedccl: De-flake TestChangefeedBackfillCheckpoint test.

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
+++ b/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
@@ -29,6 +29,7 @@ type MockWebhookSink struct {
 		statusCodes      []int
 		statusCodesIndex int
 		rows             []string
+		notify           chan struct{}
 	}
 }
 
@@ -144,6 +145,19 @@ func (s *MockWebhookSink) Pop() string {
 	return ""
 }
 
+// NotifyMessage arranges for channel to be closed when message arrives.
+func (s *MockWebhookSink) NotifyMessage() chan struct{} {
+	c := make(chan struct{})
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.mu.rows) > 0 {
+		close(c)
+	} else {
+		s.mu.notify = c
+	}
+	return c
+}
+
 func (s *MockWebhookSink) requestHandler(hw http.ResponseWriter, hr *http.Request) {
 	method := hr.Method
 
@@ -177,7 +191,12 @@ func (s *MockWebhookSink) publish(hw http.ResponseWriter, hr *http.Request) erro
 	s.mu.numCalls++
 	if s.mu.statusCodes[s.mu.statusCodesIndex] >= http.StatusOK && s.mu.statusCodes[s.mu.statusCodesIndex] < http.StatusMultipleChoices {
 		s.mu.rows = append(s.mu.rows, string(row))
+		if s.mu.notify != nil {
+			close(s.mu.notify)
+			s.mu.notify = nil
+		}
 	}
+
 	hw.WriteHeader(s.mu.statusCodes[s.mu.statusCodesIndex])
 	s.mu.statusCodesIndex = (s.mu.statusCodesIndex + 1) % len(s.mu.statusCodes)
 	s.mu.Unlock()

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5608,7 +5608,7 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 	// TODO(ssd): Tenant testing disabled because of use of DB()
 	for _, sz := range []int64{100 << 20, 100} {
 		maxCheckpointSize = sz
-		cdcTestNamedWithSystem(t, fmt.Sprintf("limit=%s", humanize.Bytes(uint64(sz))), testFn, feedTestEnterpriseSinks)
+		cdcTestNamedWithSystem(t, fmt.Sprintf("limit=%s", humanize.Bytes(uint64(sz))), testFn, feedTestForceSink("webhook"))
 	}
 }
 

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -40,7 +40,6 @@ const (
 	applicationTypeJSON = `application/json`
 	applicationTypeCSV  = `text/csv`
 	authorizationHeader = `Authorization`
-	defaultConnTimeout  = 3 * time.Second
 )
 
 func isWebhookSink(u *url.URL) bool {
@@ -303,10 +302,9 @@ func makeWebhookSink(
 		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptTopicInValue)
 	}
 
-	connTimeout := opts.ClientTimeout
-	if connTimeout == nil {
-		t := defaultConnTimeout
-		connTimeout = &t
+	var connTimeout time.Duration
+	if opts.ClientTimeout != nil {
+		connTimeout = *opts.ClientTimeout
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -328,7 +326,7 @@ func makeWebhookSink(
 	}
 
 	// TODO(yevgeniy): Establish HTTP connection in Dial().
-	sink.client, err = makeWebhookClient(u, *connTimeout)
+	sink.client, err = makeWebhookClient(u, connTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1429,7 +1429,9 @@ func (f *webhookFeedFactory) Feed(create string, args ...interface{}) (cdctest.T
 
 		if createStmt.SinkURI == nil {
 			createStmt.SinkURI = tree.NewStrVal(
-				fmt.Sprintf("webhook-%s?insecure_tls_skip_verify=true&client_cert=%s&client_key=%s", sinkDest.URL(), base64.StdEncoding.EncodeToString(clientCertPEM), base64.StdEncoding.EncodeToString(clientKeyPEM)))
+				fmt.Sprintf("webhook-%s?insecure_tls_skip_verify=true&client_cert=%s&client_key=%s",
+					sinkDest.URL(), base64.StdEncoding.EncodeToString(clientCertPEM),
+					base64.StdEncoding.EncodeToString(clientKeyPEM)))
 		}
 	} else {
 		sinkDest, err = cdctest.StartMockWebhookSink(cert)
@@ -1582,6 +1584,7 @@ func (f *webhookFeed) Next() (*cdctest.TestFeedMessage, error) {
 		case <-time.After(timeout()):
 			return nil, &contextutil.TimeoutError{}
 		case <-f.ss.eventReady():
+		case <-f.mockSink.NotifyMessage():
 		case <-f.shutdown:
 			return nil, f.terminalJobError()
 		}


### PR DESCRIPTION
Fixes #84121

cockroachdb/cockroach#84007 introduced a change to add a timeout
to test feed library to prevent flaky tests from hanging for a long
time.  This timeout lead to `TestChangefeedBackfillCheckpoint` test
to become flaky.  The main contributor of the slowness of that test
was the fact that the test processes 1000 messages (twice), and
the fact that a `webhook` sink and it's mock sink implementation
are very slow (50+ms per message).

The webhook sink, and mock webhook sink performance will be
addressed separately (#84676)

For now, marginally improve mock webhook sink performance
by detecting when messages become available directly, instead
of relying on resolved timestamps.  Also, significantly increase
the internal test timeout when reading many messages in a unit test.

While troubleshooting this issue, observed large number of
error messages `http: TLS handshake error from 127.0.0.1:34276: EOF`.
The problem is that the webhook sink specified an arbitrary, and
very small default timeout of 3 seconds.  The default in Go
library is 0 -- no timeout; and we should have this default
as well.  Fixes #75745

Release Notes: None