### PR TITLE
opt: fix crdb_internal.decode_plan_gist to work with unknown index

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -157,3 +157,17 @@ SELECT crdb_internal.decode_plan_gist('$lookup_join_gist')
 └── • scan
       table: s83537@s83537_pkey
       spans: FULL SCAN
+
+# Ensure that we can decode a gist even if we do not have the schema info.
+query T
+SELECT crdb_internal.decode_plan_gist('AgGSARIAAwlAsJ8BE5IBAhcGFg==')
+----
+• limit
+│
+└── • index join
+    │ table: ?@?
+    │
+    └── • scan
+          table: ?@?
+          spans: 32 spans
+          limit: 10200

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -493,7 +493,7 @@ func (u *unknownTable) DeletableIndexCount() int {
 }
 
 func (u *unknownTable) Index(i cat.IndexOrdinal) cat.Index {
-	panic(errors.AssertionFailedf("not implemented"))
+	return &unknownIndex{}
 }
 
 func (u *unknownTable) StatisticCount() int {


### PR DESCRIPTION
Release note (bug fix): `crdb_internal.decode_plan_gist` will no longer
produce an internal error when it is used to decode a plan gist for which
no schema information is available.