### PR TITLE
colflow: introduce a cluster setting for max retries of FD acquisition

### DIFF
--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/col/coldataext",
         "//pkg/roachpb",
         "//pkg/rpc/nodedialer",
+        "//pkg/settings",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/colcontainer",
         "//pkg/sql/colexec",

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -248,10 +248,6 @@ type TestingKnobs struct {
 	// that should be acquired by a single disk-spilling operator in the
 	// vectorized engine.
 	VecFDsToAcquire int
-	// VecFDsAcquireMaxRetriesCount, if positive, determines the maximum number
-	// of retries done when acquiring the file descriptors for a disk-spilling
-	// operator in the vectorized engine.
-	VecFDsAcquireMaxRetriesCount int
 
 	// TableReaderBatchBytesLimit, if not 0, overrides the limit that the
 	// TableReader will set on the size of results it wants to get for individual


### PR DESCRIPTION
We recently introduced a mechanism of retrying the acquision of file
descriptors needed for the disk-spilling queries to be able to get out
of a deadlock. We hard-coded the number of retries at 8, and this commit
makes that number configurable via a cluster setting (the idea is that
some users might be ok retrying for longer, so they will have an option
to do that). This cluster setting will also be the escape hatch to the
previous behavior (indefinite wait on `Acquire`) when the setting is set
to zero.

Release note: None