### PR TITLE
release-22.1: pgwire,sdnotify: shortcut to /tmp in tests when necessary

### DIFF
--- a/pkg/util/sdnotify/BUILD.bazel
+++ b/pkg/util/sdnotify/BUILD.bazel
@@ -25,42 +25,55 @@ go_test(
     deps = select({
         "@io_bazel_rules_go//go/platform:aix": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:illumos": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:js": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
             "//pkg/util/log",
+            "@com_github_stretchr_testify//require",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/util/sdnotify/sdnotify_unix.go
+++ b/pkg/util/sdnotify/sdnotify_unix.go
@@ -56,7 +56,12 @@ func notify(path, msg string) error {
 }
 
 func bgExec(cmd *exec.Cmd) error {
-	l, err := listen()
+	dir, err := ioutil.TempDir("", "sdnotify")
+	if err != nil {
+		return err
+	}
+
+	l, err := listen(dir)
 	if err != nil {
 		return err
 	}
@@ -97,12 +102,7 @@ type listener struct {
 	conn    *net.UnixConn
 }
 
-func listen() (listener, error) {
-	dir, err := ioutil.TempDir("", "sdnotify")
-	if err != nil {
-		return listener{}, err
-	}
-
+func listen(dir string) (listener, error) {
 	path := filepath.Join(dir, "notify.sock")
 	conn, err := net.ListenUnixgram(netType, &net.UnixAddr{
 		Net:  netType,

--- a/pkg/util/sdnotify/sdnotify_unix_test.go
+++ b/pkg/util/sdnotify/sdnotify_unix_test.go
@@ -14,16 +14,32 @@
 package sdnotify
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
+	"github.com/stretchr/testify/require"
 )
 
 func TestSDNotify(t *testing.T) {
-	l, err := listen()
-	if err != nil {
-		t.Fatal(err)
+	tmpDir := os.TempDir()
+	// On BSD, binding to a socket is limited to a path length of 104 characters
+	// (including the NUL terminator). In glibc, this limit is 108 characters.
+	// macOS also has a tendency to produce very long temporary directory names.
+	if len(tmpDir) >= 104-1-len("sdnotify/notify.sock")-10 {
+		// Perhaps running inside a sandbox?
+		t.Logf("default temp dir name is too long: %s", tmpDir)
+		t.Logf("forcing use of /tmp instead")
+		// Note: Using /tmp may fail on some systems; this is why we
+		// prefer os.TempDir() by default.
+		tmpDir = "/tmp"
 	}
+	dir, err := ioutil.TempDir(tmpDir, "sdnotify")
+	require.NoError(t, err)
+
+	l, err := listen(dir)
+	require.NoError(t, err)
 	defer func() { _ = l.close() }()
 
 	ch := make(chan error)


### PR DESCRIPTION
Backport 1/3 commits from #84532

/cc @cockroachdb/release

----

This commit changes `TestAuthenticationAndHBARules` (pgwire) and
`TestSDNotify` (sdnotify) to use `/tmp` as socket directory if the
default temporary directory name is too long.

----
Release justification: test-only change