### PR TITLE
opt: build UDF expressions

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1512,6 +1512,9 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	case *FunctionPrivate:
 		fmt.Fprintf(f.Buffer, " %s", t.Name)
 
+	case *UserDefinedFunctionPrivate:
+		fmt.Fprintf(f.Buffer, " %s", t.Name)
+
 	case *WindowsItemPrivate:
 		fmt.Fprintf(f.Buffer, " frame=%q", &t.Frame)
 

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -62,6 +62,10 @@ func (c *CustomFuncs) deriveHasHoistableSubquery(scalar opt.ScalarExpr) bool {
 		// WHERE clause, it will be transformed to an Exists operator, so this case
 		// only occurs when the Any is nested, in a projection, etc.
 		return !t.Input.Relational().OuterCols.Empty()
+
+	case *memo.UserDefinedFunctionExpr:
+		// Do not attempt to hoist UDFs.
+		return false
 	}
 
 	// If HasHoistableSubquery is true for any child, then it's true for this

--- a/pkg/sql/opt/norm/testdata/rules/udf
+++ b/pkg/sql/opt/norm/testdata/rules/udf
@@ -1,0 +1,21 @@
+exec-ddl
+CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS 'SELECT 1';
+----
+
+# Do not attempt to hoist UDFs.
+norm
+SELECT one()
+----
+values
+ ├── columns: one:2
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── tuple
+      └── user-defined-function: one
+           └── values
+                ├── columns: "?column?":1!null
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(1)
+                └── (1,)

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1214,6 +1214,21 @@ define NthValue {
     Nth ScalarExpr
 }
 
+# UserDefinedFunction invokes a user-defined function. The
+# UserDefinedFunctionPrivate field contains the name of the function and a
+# pointer to its type.
+[Scalar]
+define UserDefinedFunction {
+    Body RelExpr
+    _ UserDefinedFunctionPrivate
+}
+
+[Private]
+define UserDefinedFunctionPrivate {
+    Name string
+    Typ Type
+}
+
 # KVOptions is a set of KVOptionItems that specify arbitrary keys and values
 # that are used as modifiers for various statements (see tree.KVOptions). The
 # key is a constant string but the value can be a scalar expression.

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -1,4 +1,68 @@
+exec-ddl
+CREATE TABLE abc (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT
+)
+----
+
 build
 SELECT foo()
 ----
-error (42883): unknown function: foo()
+error (42883): unknown function: foo
+
+exec-ddl
+CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS 'SELECT 1';
+----
+
+build
+SELECT one()
+----
+project
+ ├── columns: one:2
+ ├── values
+ │    └── ()
+ └── projections
+      └── user-defined-function: one [as=one:2]
+           └── project
+                ├── columns: "?column?":1!null
+                ├── values
+                │    └── ()
+                └── projections
+                     └── 1 [as="?column?":1]
+
+build
+SELECT *, one() FROM abc
+----
+project
+ ├── columns: a:1!null b:2 c:3 one:7
+ ├── scan abc
+ │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ └── projections
+      └── user-defined-function: one [as=one:7]
+           └── project
+                ├── columns: "?column?":6!null
+                ├── values
+                │    └── ()
+                └── projections
+                     └── 1 [as="?column?":6]
+
+build
+SELECT * FROM abc WHERE one() = c
+----
+project
+ ├── columns: a:1!null b:2 c:3
+ └── select
+      ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan abc
+      │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── filters
+           └── eq
+                ├── user-defined-function: one
+                │    └── project
+                │         ├── columns: "?column?":6!null
+                │         ├── values
+                │         │    └── ()
+                │         └── projections
+                │              └── 1 [as="?column?":6]
+                └── c:3

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -1,0 +1,4 @@
+build
+SELECT foo()
+----
+error (42883): unknown function: foo()

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -274,6 +274,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 		semaCtx: tree.MakeSemaContext(),
 		evalCtx: eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}
+	ot.semaCtx.SearchPath = tree.EmptySearchPath
 	ot.semaCtx.FunctionResolver = ot.catalog
 	// To allow opttester tests to use now(), we hardcode a preset transaction
 	// time. May 10, 2017 is a historic day: the release date of CockroachDB 1.0.


### PR DESCRIPTION
#### opt: set opt tester search path to empty

`OptTester` now sets its `SemaContext`'s `SearchPath` to
`EmptySearchPath`, instead of `nil`, to avoid nil pointer exceptions
when resolving unknown functions.

Release note: None

#### opt: build UDF expressions

This commit adds basic support for building UDFs in optbuilder. Only
scalar, nullary (arity of zero) functions with a single statement in the
body are supported. Support for more types of UDFs will follow in future
commits. Note that this commit does not add support for execution of
UDFs, only building them within an optimizer expression.

Release note: None