### PR TITLE
kvserver/reports: replication_constraint_stats use voter constraints

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1935,6 +1935,8 @@ func (ds *DistSender) sendToReplicas(
 	}
 
 	// Filter the replicas to only those that are relevant to the routing policy.
+	// NB: When changing leaseholder policy constraint_status_report should be
+	// updated appropriately.
 	var replicaFilter ReplicaSliceFilter
 	switch ba.RoutingPolicy {
 	case roachpb.RoutingPolicy_LEASEHOLDER:

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -372,7 +372,11 @@ func (v *criticalLocalitiesVisitor) visitSameZone(ctx context.Context, r *roachp
 func (v *criticalLocalitiesVisitor) countRange(
 	ctx context.Context, zoneKey ZoneKey, r *roachpb.RangeDescriptor,
 ) {
-	stores := v.storeResolver(r)
+	replicas := r.Replicas().Descriptors()
+	stores := make([]roachpb.StoreDescriptor, len(replicas))
+	for i, r := range replicas {
+		stores[i] = v.storeResolver(r.StoreID)
+	}
 
 	// Collect all the localities of all the replicas. Note that we collect
 	// "expanded" localities: if a replica has a multi-tier locality like

--- a/pkg/kv/kvserver/reports/critical_localities_report_test.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report_test.go
@@ -101,8 +101,8 @@ func TestCriticalLocalitiesReport(t *testing.T) {
 					// All the learners are dead, but learners don't matter. So only reg1
 					// is critical for this range.
 					{key: "/Table/t5", stores: "1 2 3 4l 5l 6l 7l"},
-					// Joint-consensus case. Here 1,2,3 are part of the outgoing quorum and
-					// 1,4,8 are part of the incoming quorum. 4 and 5 are dead, which
+					// Joint-consensus case. Here 1,2,4 are part of the outgoing quorum and
+					// 1,5,8 are part of the incoming quorum. 4 and 5 are dead, which
 					// makes all the other nodes critical. So localities "reg1",
 					// "reg1,az1", "reg1,az=2" and "reg8" are critical for this range.
 					{key: "/Table/t6", stores: "1 2o 4o 5i 8i"},

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -190,19 +190,15 @@ func (stats *Reporter) update(
 	}
 
 	allStores := stats.storePool.GetStores()
-	var getStoresFromGossip StoreResolver = func(
-		r *roachpb.RangeDescriptor,
-	) []roachpb.StoreDescriptor {
-		storeDescs := make([]roachpb.StoreDescriptor, len(r.Replicas().VoterDescriptors()))
+	var storesFromGossip StoreResolver = func(
+		id roachpb.StoreID,
+	) roachpb.StoreDescriptor {
 		// We'll return empty descriptors for stores that gossip doesn't have a
 		// descriptor for. These stores will be considered to satisfy all
 		// constraints.
 		// TODO(andrei): note down that some descriptors were missing from gossip
 		// somewhere in the report.
-		for i, repl := range r.Replicas().VoterDescriptors() {
-			storeDescs[i] = allStores[repl.StoreID]
-		}
-		return storeDescs
+		return allStores[id]
 	}
 
 	isLiveMap := stats.liveness.GetIsLiveMap()
@@ -220,10 +216,10 @@ func (stats *Reporter) update(
 
 	// Create the visitors that we're going to pass to visitRanges() below.
 	constraintConfVisitor := makeConstraintConformanceVisitor(
-		ctx, stats.latestConfig, getStoresFromGossip)
+		ctx, stats.latestConfig, storesFromGossip)
 	localityStatsVisitor := makeCriticalLocalitiesVisitor(
 		ctx, nodeLocalities, stats.latestConfig,
-		getStoresFromGossip, isNodeLive)
+		storesFromGossip, isNodeLive)
 	replicationStatsVisitor := makeReplicationStatsVisitor(ctx, stats.latestConfig, isNodeLive)
 
 	// Iterate through all the ranges.
@@ -507,10 +503,10 @@ func getZoneByID(id config.ObjectID, cfg *config.SystemConfig) (*zonepb.ZoneConf
 	return zone, nil
 }
 
-// StoreResolver is a function resolving a range to a store descriptor for each
-// of the replicas. Empty store descriptors are to be returned when there's no
-// information available for the store.
-type StoreResolver func(*roachpb.RangeDescriptor) []roachpb.StoreDescriptor
+// StoreResolver is a function resolving a store descriptor by its id. Empty
+// store descriptors are to be returned when there's no information available
+// for the store.
+type StoreResolver func(roachpb.StoreID) roachpb.StoreDescriptor
 
 // rangeVisitor abstracts the interface for range iteration implemented by all
 // report generators.

--- a/pkg/roachpb/metadata_replicas.go
+++ b/pkg/roachpb/metadata_replicas.go
@@ -507,6 +507,9 @@ var errReplicaCannotHoldLease = errors.Errorf("replica cannot hold lease")
 // leaseHolderRemovalAllowed is intended to check if the cluster version is
 // EnableLeaseHolderRemoval or higher.
 // TODO(shralex): remove this flag in 23.1
+// NB: This logic should be in sync with constraint_stats_report as report
+// will check voter constraint violations. When changing this method, you need
+// to update replica filter in report to keep it correct.
 func CheckCanReceiveLease(
 	wouldbeLeaseholder ReplicaDescriptor, replDescs ReplicaSet, leaseHolderRemovalAllowed bool,
 ) error {


### PR DESCRIPTION
Previously replication_constraint_stats were using zone constraints regardless
of the fact that num_voters and a separate voter constraints were provided.
This was causing report to have violations because range had less voters than
replicas, but still were trying to check if we have as many voters as
full replica constraints.
This was causing ambiguity in reports as there were no violation and no way
to figure out which constraint is being violated.
This patch changes report to use voter constraints if they are provided or
use voters and non voters if voter count is configured lower than replica
count, but voter constraints are not provided.

Release note (bug fix): table system.replication_constraint_stats is not
showing erroneous voter contraint violations when num_voters is configured.

Release justification: bugfix to an issue which also needs backporting.

Fixes #84695