### PR TITLE
release-22.1: logictestccl: parallelize a few top-level tests

### DIFF
--- a/pkg/ccl/logictestccl/BUILD.bazel
+++ b/pkg/ccl/logictestccl/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "@cockroach//c-deps:libgeos",
     ],
     embed = [":logictestccl"],
+    shard_count = 4,
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/logic_test.go
+++ b/pkg/ccl/logictestccl/logic_test.go
@@ -45,6 +45,12 @@ func TestTenantLogic(t *testing.T) {
 	logictest.RunLogicTestWithDefaultConfig(
 		t, logictest.TestServerArgs{}, "3node-tenant", true, /* runCCLConfigs */
 		filepath.Join(testdataDir, logictestGlob))
+}
+
+// TestTenantCCLLogic is the same as TestTenantLogic but runs all CCL logic test
+// files.
+func TestTenantCCLLogic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	logictest.RunLogicTestWithDefaultConfig(
 		t, logictest.TestServerArgs{}, "3node-tenant", true, /* runCCLConfigs */
 		testutils.TestDataPath(t, logictestGlob))


### PR DESCRIPTION
This commit makes the tests in `logictestccl` parallelizable under bazel
in order to avoid timeouts (i.e. just the tests taking longer than
1 hour timeout) by giving four shards to the package. Additionally, in
order to improve parallelization `TestTenantLogic` is broken down into
two top-level tests. This commit is directly against 22.1 branch because
on master the whole logic test suite is refactored for even more
parallelization.

Addresses timeouts like https://teamcityartifacts.crdb.io/presignedTokenAuth/19216d26-fbba-4cd3-a062-891dfdd0a8db/repository/download/Cockroach_UnitTests_BazelUnitTests/5805605:id/bazel-testlogs/pkg/ccl/logictestccl/logictestccl_test/test.log.

Release note: None

Release justification: test-only change.