### PR TITLE
roachtest: less verbose explain in unoptimized-query-oracle and costfuzz

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -296,7 +296,7 @@ func (h *queryComparisonHelper) runQuery(stmt string) ([][]string, error) {
 
 	// First use EXPLAIN to try to get the query plan. This is best-effort, and
 	// only for the purpose of debugging, so ignore any errors.
-	explainStmt := "EXPLAIN (OPT, VERBOSE) " + stmt
+	explainStmt := "EXPLAIN " + stmt
 	explainRows, err := runQueryImpl(explainStmt)
 	if err == nil {
 		h.statementsAndExplains = append(


### PR DESCRIPTION
Looks like `EXPLAIN (VERBOSE, OPT)` is sometimes large enough to cause
OOMs. Let's just use ordinary `EXPLAIN` for now.

Fixes: #84545

Release note: None