### PR TITLE
kv/bulk: use Key.Next in createSplitSSTable, not Key.PrefixEnd

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -627,7 +627,7 @@ func (b *SSTBatcher) GetSummary() roachpb.BulkOpSummary {
 }
 
 type sstSpan struct {
-	start, end roachpb.Key
+	start, end roachpb.Key // [inclusive, exclusive)
 	sstBytes   []byte
 	stats      enginepb.MVCCStats
 }
@@ -829,7 +829,7 @@ func createSplitSSTable(
 				return nil, nil, err
 			}
 
-			left = &sstSpan{start: first, end: last.PrefixEnd(), sstBytes: sstFile.Data()}
+			left = &sstSpan{start: first, end: last.Next(), sstBytes: sstFile.Data()}
 			*sstFile = storage.MemFile{}
 			w = storage.MakeIngestionSSTWriter(ctx, settings, sstFile)
 			split = true
@@ -853,6 +853,6 @@ func createSplitSSTable(
 	if err != nil {
 		return nil, nil, err
 	}
-	right = &sstSpan{start: first, end: last.PrefixEnd(), sstBytes: sstFile.Data()}
+	right = &sstSpan{start: first, end: last.Next(), sstBytes: sstFile.Data()}
 	return left, right, nil
 }

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -60,7 +60,8 @@ func (s *Store) SendWithWriteBytes(
 		arg := union.GetInner()
 		header := arg.Header()
 		if err := verifyKeys(header.Key, header.EndKey, roachpb.IsRange(arg)); err != nil {
-			return nil, nil, roachpb.NewError(err)
+			return nil, nil, roachpb.NewError(errors.Wrapf(err,
+				"failed to verify keys for %s", arg.Method()))
 		}
 	}
 


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/issues/84743.

This commit switches `createSplitSSTable` to use `Key.Next` when generating exclusive end keys for spans, instead of `Key.PrefixEnd`. I was thinking that this could explain https://github.com/cockroachdb/cockroach/issues/84743, but I don't think it does. `Key.PrefixEnd` can be a no-op for certain keys, but it wouldn't have been for the key in that issue. Instead, it would just create a loose exclusive upper bound instead of a tight one.

When originally creating an `AddSSTableRequest` bounds, we properly treat the batch's end key as exclusive using `Key.Next`: https://github.com/cockroachdb/cockroach/blob/4a8f1bef28a06669bd8c73968a2a961cbc20b827/pkg/kv/bulk/sst_batcher.go#L458-L460