### PR TITLE
logictest: rename a config

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -757,7 +757,7 @@ var logicTestConfigs = []testClusterConfig{
 		overrideVectorize:   "off",
 	},
 	{
-		name:                "local-v1.1@v1.0-noupgrade",
+		name:                "local-v1.1-at-v1.0-noupgrade",
 		numNodes:            1,
 		overrideDistSQLMode: "off",
 		bootstrapVersion:    roachpb.Version{Major: 1},

--- a/pkg/sql/logictest/testdata/logic_test/active_version
+++ b/pkg/sql/logictest/testdata/logic_test/active_version
@@ -1,4 +1,4 @@
-# LogicTest: local-v1.1@v1.0-noupgrade
+# LogicTest: local-v1.1-at-v1.0-noupgrade
 
 query T
 SELECT crdb_internal.active_version()

--- a/pkg/sql/logictest/testdata/logic_test/cluster_version
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_version
@@ -1,4 +1,4 @@
-# LogicTest: local-v1.1@v1.0-noupgrade
+# LogicTest: local-v1.1-at-v1.0-noupgrade
 
 query T
 SHOW CLUSTER SETTING version


### PR DESCRIPTION
This commit renames `local-v1.1@v1.0-noupgrade` logic test config to
`local-v1.1-at-v1.0-noupgrade` which aids with the refactoring of the
logic test suite.

Release note: None