### PR TITLE
sql: owner now shows is_grantable=true

### DIFF
--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -446,22 +446,22 @@ func restoreV201ZoneconfigPrivilegeTest(exportDir string) func(t *testing.T) {
 		require.NoError(t, err)
 		sqlDB.Exec(t, `RESTORE FROM $1`, localFoo)
 		testDBGrants := [][]string{
-			{"test", "admin", "ALL", "false"},
-			{"test", "root", "ALL", "false"},
+			{"test", "admin", "ALL", "true"},
+			{"test", "root", "ALL", "true"},
 			{"test", "testuser", "ZONECONFIG", "false"},
 		}
 		sqlDB.CheckQueryResults(t, `show grants on database test`, testDBGrants)
 
 		testTableGrants := [][]string{
-			{"test", "public", "test_table", "admin", "ALL", "false"},
-			{"test", "public", "test_table", "root", "ALL", "false"},
+			{"test", "public", "test_table", "admin", "ALL", "true"},
+			{"test", "public", "test_table", "root", "ALL", "true"},
 			{"test", "public", "test_table", "testuser", "ZONECONFIG", "false"},
 		}
 		sqlDB.CheckQueryResults(t, `show grants on test.test_table`, testTableGrants)
 
 		testTable2Grants := [][]string{
-			{"test", "public", "test_table2", "admin", "ALL", "false"},
-			{"test", "public", "test_table2", "root", "ALL", "false"},
+			{"test", "public", "test_table2", "admin", "ALL", "true"},
+			{"test", "public", "test_table2", "root", "ALL", "true"},
 			{"test", "public", "test_table2", "testuser", "ALL", "false"},
 		}
 		sqlDB.CheckQueryResults(t, `show grants on test.test_table2`, testTable2Grants)

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -129,14 +129,14 @@ SHOW GRANTS ON TYPE testdb.greeting_owner;
 testdb public greeting_owner admin ALL true
 testdb public greeting_owner public USAGE false
 testdb public greeting_owner root ALL true
-testdb public greeting_owner testuser ALL false
+testdb public greeting_owner testuser ALL true
 
 query-sql
 SHOW GRANTS ON TABLE testdb.testtable_greeting_owner;
 ----
 testdb public testtable_greeting_owner admin ALL true
 testdb public testtable_greeting_owner root ALL true
-testdb public testtable_greeting_owner testuser ALL false
+testdb public testtable_greeting_owner testuser ALL true
 
 
 # Let's take a backup of this cluster.
@@ -220,14 +220,14 @@ SHOW GRANTS ON TYPE testdb.greeting_owner;
 testdb public greeting_owner admin ALL true
 testdb public greeting_owner public USAGE false
 testdb public greeting_owner root ALL true
-testdb public greeting_owner testuser ALL false
+testdb public greeting_owner testuser ALL true
 
 query-sql
 SHOW GRANTS ON TABLE testdb.testtable_greeting_owner;
 ----
 testdb public testtable_greeting_owner admin ALL true
 testdb public testtable_greeting_owner root ALL true
-testdb public testtable_greeting_owner testuser ALL false
+testdb public testtable_greeting_owner testuser ALL true
 
 subtest end
 
@@ -281,14 +281,14 @@ SHOW GRANTS ON SCHEMA testuser_db.sc;
 ----
 testuser_db sc admin ALL true
 testuser_db sc root ALL true
-testuser_db sc testuser ALL false
+testuser_db sc testuser ALL true
 
 query-sql
 SHOW GRANTS ON testuser_db.sc.othertable
 ----
 testuser_db sc othertable admin ALL true
 testuser_db sc othertable root ALL true
-testuser_db sc othertable testuser ALL false
+testuser_db sc othertable testuser ALL true
 
 # Observe that none of `testuser` privileges in the backed up cluster are
 # restored.
@@ -303,7 +303,7 @@ SHOW GRANTS ON testuser_db.testtable_greeting_usage;
 ----
 testuser_db public testtable_greeting_usage admin ALL true
 testuser_db public testtable_greeting_usage root ALL true
-testuser_db public testtable_greeting_usage testuser ALL false
+testuser_db public testtable_greeting_usage testuser ALL true
 
 
 # Ensure that testuser is the owner of the restored schema and table.

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
@@ -29,7 +29,7 @@ SHOW GRANTS ON SCHEMA testuser_s;
 database_name  schema_name  grantee   privilege_type  is_grantable
 d              testuser_s   admin     ALL             true
 d              testuser_s   root      ALL             true
-d              testuser_s   testuser  ALL             false
+d              testuser_s   testuser  ALL             true
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM testuser;

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
@@ -17,7 +17,7 @@ SHOW GRANTS ON testuser_s;
 database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 d              public       testuser_s  admin     ALL             true
 d              public       testuser_s  root      ALL             true
-d              public       testuser_s  testuser  ALL             false
+d              public       testuser_s  testuser  ALL             true
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM testuser;

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
@@ -35,7 +35,7 @@ SHOW GRANTS ON testuser_t
 database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 d              public       testuser_t  admin     ALL             true
 d              public       testuser_t  root      ALL             true
-d              public       testuser_t  testuser  ALL             false
+d              public       testuser_t  testuser  ALL             true
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM testuser;
@@ -196,7 +196,7 @@ SHOW GRANTS ON t5
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 d              public       t5          admin      ALL             true
 d              public       t5          root       ALL             true
-d              public       t5          testuser   SELECT          false
+d              public       t5          testuser   SELECT          true
 d              public       t5          testuser2  SELECT          false
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type
@@ -19,7 +19,7 @@ database_name  schema_name  type_name   grantee   privilege_type  is_grantable
 d              public       testuser_t  admin     ALL             true
 d              public       testuser_t  public    USAGE           false
 d              public       testuser_t  root      ALL             true
-d              public       testuser_t  testuser  ALL             false
+d              public       testuser_t  testuser  ALL             true
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM testuser;

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
@@ -30,7 +30,7 @@ SHOW GRANTS ON t1
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t1          admin      ALL             true
 test           public       t1          root       ALL             true
-test           public       t1          testuser   ALL             false
+test           public       t1          testuser   ALL             true
 test           public       t1          testuser2  SELECT          false
 
 # When creating an object, take the union of the default privileges on
@@ -48,7 +48,7 @@ SHOW GRANTS ON t2
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t2          admin      ALL             true
 test           public       t2          root       ALL             true
-test           public       t2          testuser   ALL             false
+test           public       t2          testuser   ALL             true
 test           public       t2          testuser2  INSERT          false
 test           public       t2          testuser2  SELECT          false
 
@@ -64,7 +64,7 @@ SHOW GRANTS ON t3
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t3          admin      ALL             true
 test           public       t3          root       ALL             true
-test           public       t3          testuser   ALL             false
+test           public       t3          testuser   ALL             true
 test           public       t3          testuser2  ALL             false
 
 # Revoke default privileges in schema.
@@ -80,7 +80,7 @@ SHOW GRANTS ON t4
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t4          admin      ALL             true
 test           public       t4          root       ALL             true
-test           public       t4          testuser   ALL             false
+test           public       t4          testuser   ALL             true
 test           public       t4          testuser2  SELECT          false
 
 # Multiple schemas.
@@ -103,7 +103,7 @@ SHOW GRANTS ON public.t5
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t5          admin      ALL             true
 test           public       t5          root       ALL             true
-test           public       t5          testuser   ALL             false
+test           public       t5          testuser   ALL             true
 test           public       t5          testuser2  ALL             false
 
 query TTTTTB colnames
@@ -112,7 +112,7 @@ SHOW GRANTS ON s.t6
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           s            t6          admin      ALL             true
 test           s            t6          root       ALL             true
-test           s            t6          testuser   ALL             false
+test           s            t6          testuser   ALL             true
 test           s            t6          testuser2  ALL             false
 
 # In schema for all roles.
@@ -134,7 +134,7 @@ SHOW GRANTS ON public.t7
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t7          admin      ALL             true
 test           public       t7          root       ALL             true
-test           public       t7          testuser   ALL             false
+test           public       t7          testuser   ALL             true
 test           public       t7          testuser2  SELECT          false
 
 query TTTTTB colnames
@@ -143,7 +143,7 @@ SHOW GRANTS ON s.t8
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           s            t8          admin      ALL             true
 test           s            t8          root       ALL             true
-test           s            t8          testuser   ALL             false
+test           s            t8          testuser   ALL             true
 test           s            t8          testuser2  SELECT          false
 
 # Switch user to root, since we defined it on FOR ALL ROLES, the privileges

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
@@ -170,7 +170,7 @@ SHOW GRANTS ON TABLE t7;
 database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 test           public       t7          admin     ALL             true
 test           public       t7          root      ALL             true
-test           public       t7          testuser  ALL             false
+test           public       t7          testuser  ALL             true
 
 statement ok
 GRANT SELECT ON TABLE t7 TO testuser
@@ -242,7 +242,7 @@ SHOW GRANTS ON TABLE t12;
 database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 test           public       t12         admin     ALL             true
 test           public       t12         root      ALL             true
-test           public       t12         testuser  ALL             false
+test           public       t12         testuser  ALL             true
 
 statement ok
 GRANT INSERT, DELETE ON TABLE t12 TO testuser
@@ -269,7 +269,7 @@ SHOW GRANTS ON TABLE t13
 database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 test           public       t13         admin     ALL             true
 test           public       t13         root      ALL             true
-test           public       t13         testuser  ALL             false
+test           public       t13         testuser  ALL             true
 
 # one created user to another (testuser to testuser2)
 user testuser
@@ -508,7 +508,7 @@ SHOW GRANTS ON seq1
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       seq1        admin      ALL             true
 test           public       seq1        root       ALL             true
-test           public       seq1        testuser   ALL             false
+test           public       seq1        testuser   ALL             true
 test           public       seq1        testuser2  CREATE          true
 
 # Test Types
@@ -530,7 +530,7 @@ database_name  schema_name  type_name  grantee    privilege_type  is_grantable
 test           public       type1      admin      ALL             true
 test           public       type1      public     USAGE           false
 test           public       type1      root       ALL             true
-test           public       type1      testuser   ALL             false
+test           public       type1      testuser   ALL             true
 test           public       type1      testuser2  USAGE           true
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -137,9 +137,39 @@ SHOW GRANTS ON b.t
 database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 b              public       t           admin     ALL             true
 b              public       t           root      ALL             true
-b              public       t           testuser  ALL             false
+b              public       t           testuser  ALL             true
 
 # Calling SHOW GRANTS on an invalid user should error out.
 
 statement error role/user "invaliduser" does not exist
 SHOW GRANTS FOR invaliduser
+
+# Verify that owner and child of owner have is_grantable implicitly.
+
+user root
+
+statement ok
+CREATE USER owner_grant_option_child
+
+statement ok
+GRANT testuser to owner_grant_option_child
+
+statement ok
+ALTER USER testuser WITH createdb
+
+user testuser
+
+statement ok
+CREATE DATABASE owner_grant_option
+
+statement ok
+GRANT CONNECT ON DATABASE owner_grant_option TO owner_grant_option_child
+
+query TTTB colnames
+SHOW GRANTS ON DATABASE owner_grant_option
+----
+database_name       grantee                   privilege_type  is_grantable
+owner_grant_option  admin                     ALL             true
+owner_grant_option  owner_grant_option_child  CONNECT         true
+owner_grant_option  public                    CONNECT         false
+owner_grant_option  root                      ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -510,7 +510,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 test           public       t1          admin     ALL             true
 test           public       t1          root      ALL             true
-test           public       t1          testuser  ALL             false
+test           public       t1          testuser  ALL             true
 
 statement ok
 GRANT SELECT ON TABLE t1 TO testuser2
@@ -560,7 +560,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t1          admin      ALL             true
 test           public       t1          root       ALL             true
-test           public       t1          testuser   ALL             false
+test           public       t1          testuser   ALL             true
 test           public       t1          testuser2  ALL             true
 
 # non-ALL privileges should appear if ALL does not have grant option, but another privilege does
@@ -606,3 +606,28 @@ SHOW GRANTS ON grant_ordering_table FOR grant_ordering_user
 ----
 database_name  schema_name  table_name            grantee              privilege_type  is_grantable
 test           public       grant_ordering_table  grant_ordering_user  ALL             false
+
+# Verify that owner and child of owner have is_grantable implicitly.
+
+statement ok
+CREATE USER owner_grant_option_child
+
+statement oko
+GRANT testuser to owner_grant_option_child
+
+user testuser
+
+statement ok
+CREATE TABLE owner_grant_option()
+
+statement ok
+GRANT SELECT ON TABLE owner_grant_option TO owner_grant_option_child
+
+query TTTTTB colnames
+SHOW GRANTS ON TABLE owner_grant_option
+----
+database_name  schema_name  table_name          grantee                   privilege_type  is_grantable
+test           public       owner_grant_option  admin                     ALL             true
+test           public       owner_grant_option  owner_grant_option_child  SELECT          true
+test           public       owner_grant_option  root                      ALL             true
+test           public       owner_grant_option  testuser                  ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -73,7 +73,7 @@ SHOW GRANTS ON SCHEMA s
 database_name  schema_name  grantee    privilege_type  is_grantable
 test           s            admin      ALL             true
 test           s            root       ALL             true
-test           s            testuser   ALL             false
+test           s            testuser   ALL             true
 test           s            testuser2  CREATE          false
 
 # Check grant information in backing table. We have to strip off the session
@@ -104,7 +104,7 @@ public     test           public              USAGE           NO
 root       test           public              ALL             YES
 admin      test           s                   ALL             YES
 root       test           s                   ALL             YES
-testuser   test           s                   ALL             NO
+testuser   test           s                   ALL             YES
 testuser2  test           s                   CREATE          NO
 
 # Check grants for testuser2, which should inherit from the public role.
@@ -126,3 +126,30 @@ pg_extension        false       true
 pg_temp             true        true
 public              true        true
 s                   true        false
+
+# Verify that owner and child of owner have is_grantable implicitly.
+
+user root
+
+statement ok
+CREATE USER owner_grant_option_child
+
+statement ok
+GRANT testuser to owner_grant_option_child
+
+user testuser
+
+statement ok
+CREATE SCHEMA owner_grant_option
+
+statement ok
+GRANT USAGE ON SCHEMA owner_grant_option TO owner_grant_option_child
+
+query TTTTB colnames
+SHOW GRANTS ON SCHEMA owner_grant_option
+----
+database_name  schema_name         grantee                   privilege_type  is_grantable
+test           owner_grant_option  admin                     ALL             true
+test           owner_grant_option  owner_grant_option_child  USAGE           true
+test           owner_grant_option  root                      ALL             true
+test           owner_grant_option  testuser                  ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_type
+++ b/pkg/sql/logictest/testdata/logic_test/grant_type
@@ -75,3 +75,34 @@ query TTTTTB
 SHOW GRANTS ON TYPE other.typ FOR user1
 ----
 other  public  typ  user1  ALL  false
+
+# Verify that owner and child of owner have is_grantable implicitly.
+
+user root
+
+statement ok
+CREATE USER owner_grant_option_child
+
+statement ok
+GRANT testuser to owner_grant_option_child
+
+statement ok
+GRANT CREATE ON DATABASE test TO testuser
+
+user testuser
+
+statement ok
+CREATE TYPE owner_grant_option AS ENUM('a')
+
+statement ok
+GRANT USAGE ON TYPE owner_grant_option TO owner_grant_option_child
+
+query TTTTTB colnames
+SHOW GRANTS ON TYPE owner_grant_option
+----
+database_name  schema_name  type_name           grantee                   privilege_type  is_grantable
+test           public       owner_grant_option  admin                     ALL             true
+test           public       owner_grant_option  owner_grant_option_child  USAGE           true
+test           public       owner_grant_option  public                    USAGE           false
+test           public       owner_grant_option  root                      ALL             true
+test           public       owner_grant_option  testuser                  ALL             true


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/82162

Release note (bug fix): Previously, the information_schema and SHOW
GRANTS command did not report that object owners have permission to GRANT
privileges on that object. This is fixed now.