### PR TITLE
sql,externalconn: introduce DROP EXTERNAL CONNECTION

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -101,6 +101,7 @@ FILES = [
     "drop_constraint",
     "drop_database",
     "drop_ddl_stmt",
+    "drop_external_connection_stmt",
     "drop_index",
     "drop_owned_by_stmt",
     "drop_role_stmt",

--- a/docs/generated/sql/bnf/drop_external_connection_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_external_connection_stmt.bnf
@@ -1,0 +1,2 @@
+drop_external_connection_stmt ::=
+	'DROP' 'EXTERNAL' 'CONNECTION' string_or_placeholder

--- a/docs/generated/sql/bnf/drop_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_stmt.bnf
@@ -8,3 +8,4 @@ drop_stmt ::=
 	| drop_type_stmt
 	| drop_role_stmt
 	| drop_schedule_stmt
+	| drop_external_connection_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -187,6 +187,7 @@ drop_stmt ::=
 	drop_ddl_stmt
 	| drop_role_stmt
 	| drop_schedule_stmt
+	| drop_external_connection_stmt
 
 explain_stmt ::=
 	'EXPLAIN' explainable_stmt
@@ -604,6 +605,9 @@ drop_role_stmt ::=
 drop_schedule_stmt ::=
 	'DROP' 'SCHEDULE' a_expr
 	| 'DROP' 'SCHEDULES' select_stmt
+
+drop_external_connection_stmt ::=
+	'DROP' 'EXTERNAL' 'CONNECTION' string_or_placeholder
 
 explainable_stmt ::=
 	preparable_stmt

--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -1,8 +1,5 @@
 subtest basic-nodelocal
 
-initialize tenant=10
-----
-
 exec-sql
 CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo/bar';
 ----
@@ -26,5 +23,25 @@ inspect-system-table
 ----
 bar123 STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/baz"}}}
 foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+
+# Drop an External Connection that does not exist.
+exec-sql
+DROP EXTERNAL CONNECTION baz;
+----
+
+exec-sql
+DROP EXTERNAL CONNECTION bar123;
+----
+
+inspect-system-table
+----
+foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+
+exec-sql
+DROP EXTERNAL CONNECTION foo;
+----
+
+inspect-system-table
+----
 
 subtest end

--- a/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
@@ -1,5 +1,8 @@
 subtest basic-nodelocal
 
+initialize tenant=10
+----
+
 exec-sql
 CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo/bar';
 ----
@@ -23,5 +26,25 @@ inspect-system-table
 ----
 bar123 STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/baz"}}}
 foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+
+# Drop an External Connection that does not exist.
+exec-sql
+DROP EXTERNAL CONNECTION baz;
+----
+
+exec-sql
+DROP EXTERNAL CONNECTION bar123;
+----
+
+inspect-system-table
+----
+foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+
+exec-sql
+DROP EXTERNAL CONNECTION foo;
+----
+
+inspect-system-table
+----
 
 subtest end

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -101,6 +101,7 @@ BNF_SRCS = [
   "//docs/generated/sql/bnf:drop_constraint.bnf",
   "//docs/generated/sql/bnf:drop_database.bnf",
   "//docs/generated/sql/bnf:drop_ddl_stmt.bnf",
+  "//docs/generated/sql/bnf:drop_external_connection_stmt.bnf",
   "//docs/generated/sql/bnf:drop_index.bnf",
   "//docs/generated/sql/bnf:drop_owned_by_stmt.bnf",
   "//docs/generated/sql/bnf:drop_role_stmt.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -101,6 +101,7 @@ DIAGRAMS_SRCS = [
   "//docs/generated/sql/bnf:drop_constraint.html",
   "//docs/generated/sql/bnf:drop_database.html",
   "//docs/generated/sql/bnf:drop_ddl.html",
+  "//docs/generated/sql/bnf:drop_external_connection.html",
   "//docs/generated/sql/bnf:drop_index.html",
   "//docs/generated/sql/bnf:drop_owned_by.html",
   "//docs/generated/sql/bnf:drop_role.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -113,6 +113,7 @@ DOCS_SRCS = [
   "//docs/generated/sql/bnf:drop_constraint.bnf",
   "//docs/generated/sql/bnf:drop_database.bnf",
   "//docs/generated/sql/bnf:drop_ddl_stmt.bnf",
+  "//docs/generated/sql/bnf:drop_external_connection_stmt.bnf",
   "//docs/generated/sql/bnf:drop_index.bnf",
   "//docs/generated/sql/bnf:drop_owned_by_stmt.bnf",
   "//docs/generated/sql/bnf:drop_role_stmt.bnf",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -85,6 +85,7 @@ go_library(
         "doc.go",
         "drop_cascade.go",
         "drop_database.go",
+        "drop_external_connection.go",
         "drop_index.go",
         "drop_owned_by.go",
         "drop_role.go",

--- a/pkg/sql/drop_external_connection.go
+++ b/pkg/sql/drop_external_connection.go
@@ -1,0 +1,97 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/errors"
+)
+
+const dropExternalConnectionOp = "DROP EXTERNAL CONNECTION"
+
+type dropExternalConnectionNode struct {
+	n *tree.DropExternalConnection
+}
+
+// DropExternalConnection represents a DROP EXTERNAL CONNECTION statement.
+func (p *planner) DropExternalConnection(
+	_ context.Context, n *tree.DropExternalConnection,
+) (planNode, error) {
+	return &dropExternalConnectionNode{n: n}, nil
+}
+
+func (c *dropExternalConnectionNode) startExec(params runParams) error {
+	return params.p.dropExternalConnection(params, c.n)
+}
+
+type dropExternalConnectionEval struct {
+	externalConnectionName func() (string, error)
+}
+
+func (p *planner) makeDropExternalConnectionEval(
+	ctx context.Context, n *tree.DropExternalConnection,
+) (*dropExternalConnectionEval, error) {
+	var err error
+	eval := &dropExternalConnectionEval{}
+	eval.externalConnectionName, err = p.TypeAsString(ctx, n.ConnectionLabel, externalConnectionOp)
+	if err != nil {
+		return nil, err
+	}
+	return eval, err
+}
+
+func (p *planner) dropExternalConnection(params runParams, n *tree.DropExternalConnection) error {
+	// TODO(adityamaru): Check that the user has `DROP` privileges on the External
+	// Connection once we add support for it. Remove admin only check.
+	hasAdmin, err := params.p.HasAdminRole(params.ctx)
+	if err != nil {
+		return err
+	}
+	if !hasAdmin {
+		return pgerror.New(
+			pgcode.InsufficientPrivilege,
+			"only users with the admin role are allowed to DROP EXTERNAL CONNECTION")
+	}
+
+	// TODO(adityamaru): Add some metrics to track DROP EXTERNAL CONNECTION
+	// usage.
+
+	eval, err := p.makeDropExternalConnectionEval(params.ctx, n)
+	if err != nil {
+		return err
+	}
+
+	name, err := eval.externalConnectionName()
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve External Connection name")
+	}
+
+	if _ /* rows */, err = params.extendedEvalCtx.ExecCfg.InternalExecutor.ExecEx(
+		params.ctx,
+		dropExternalConnectionOp,
+		params.p.Txn(),
+		sessiondata.InternalExecutorOverride{User: params.p.User()},
+		`DELETE FROM system.external_connections WHERE connection_name = $1`, name,
+	); err != nil {
+		return errors.Wrapf(err, "failed to delete external connection")
+	}
+
+	return nil
+}
+
+func (c *dropExternalConnectionNode) Next(_ runParams) (bool, error) { return false, nil }
+func (c *dropExternalConnectionNode) Values() tree.Datums            { return nil }
+func (c *dropExternalConnectionNode) Close(_ context.Context)        {}

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -156,6 +156,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.CreateExtension(ctx, n)
 	case *tree.CreateExternalConnection:
 		return p.CreateExternalConnection(ctx, n)
+	case *tree.DropExternalConnection:
+		return p.DropExternalConnection(ctx, n)
 	case *tree.Deallocate:
 		return p.Deallocate(ctx, n)
 	case *tree.DeclareCursor:
@@ -297,6 +299,7 @@ func init() {
 		&tree.DeclareCursor{},
 		&tree.Discard{},
 		&tree.DropDatabase{},
+		&tree.DropExternalConnection{},
 		&tree.DropIndex{},
 		&tree.DropOwnedBy{},
 		&tree.DropRole{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -184,6 +184,8 @@ func TestContextualHelp(t *testing.T) {
 		{`DROP INDEX blah, ??`, `DROP INDEX`},
 		{`DROP INDEX blah@blih ??`, `DROP INDEX`},
 
+		{`DROP EXTERNAL CONNECTION blah ??`, `DROP EXTERNAL CONNECTION`},
+
 		{`DROP USER ??`, `DROP ROLE`},
 		{`DROP USER IF ??`, `DROP ROLE`},
 		{`DROP USER IF EXISTS bluh ??`, `DROP ROLE`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1094,6 +1094,7 @@ func (u *sqlSymUnion) routineBody() *tree.RoutineBody {
 %type <tree.Statement> drop_stmt
 %type <tree.Statement> drop_ddl_stmt
 %type <tree.Statement> drop_database_stmt
+%type <tree.Statement> drop_external_connection_stmt
 %type <tree.Statement> drop_index_stmt
 %type <tree.Statement> drop_role_stmt
 %type <tree.Statement> drop_schema_stmt
@@ -3170,6 +3171,22 @@ create_external_connection_stmt:
 	}
  | CREATE EXTERNAL CONNECTION error // SHOW HELP: CREATE EXTERNAL CONNECTION
 
+// %Help: DROP EXTERNAL CONNECTION - drop an existing external connection
+// %Category: Misc
+// %Text:
+// DROP EXTERNAL CONNECTION <name>
+//
+// Name:
+//   Unique name for this external connection.
+drop_external_connection_stmt:
+	DROP EXTERNAL CONNECTION string_or_placeholder
+	{
+      $$.val = &tree.DropExternalConnection{
+            ConnectionLabel: $4.expr(),
+      }
+	}
+	| DROP EXTERNAL CONNECTION error // SHOW HELP: DROP EXTERNAL CONNECTION
+
 // %Help: RESTORE - restore data from external storage
 // %Category: CCL
 // %Text:
@@ -4422,6 +4439,7 @@ drop_stmt:
   drop_ddl_stmt      // help texts in sub-rule
 | drop_role_stmt     // EXTEND WITH HELP: DROP ROLE
 | drop_schedule_stmt // EXTEND WITH HELP: DROP SCHEDULES
+| drop_external_connection_stmt // EXTEND WITH HELP: DROP EXTERNAL CONNECTION
 | drop_unsupported   {}
 | DROP error         // SHOW HELP: DROP
 

--- a/pkg/sql/parser/testdata/drop_external_connection
+++ b/pkg/sql/parser/testdata/drop_external_connection
@@ -1,0 +1,7 @@
+parse
+DROP EXTERNAL CONNECTION 'foo'
+----
+DROP EXTERNAL CONNECTION 'foo'
+DROP EXTERNAL CONNECTION ('foo') -- fully parenthesized
+DROP EXTERNAL CONNECTION '_' -- literals removed
+DROP EXTERNAL CONNECTION 'foo' -- identifiers removed

--- a/pkg/sql/sem/tree/drop.go
+++ b/pkg/sql/sem/tree/drop.go
@@ -217,3 +217,20 @@ func (node *DropSchema) Format(ctx *FmtCtx) {
 		ctx.WriteString(node.DropBehavior.String())
 	}
 }
+
+// DropExternalConnection represents a DROP EXTERNAL CONNECTION statement.
+type DropExternalConnection struct {
+	ConnectionLabel Expr
+}
+
+var _ Statement = &DropExternalConnection{}
+
+// Format implements the Statement interface.
+func (node *DropExternalConnection) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP EXTERNAL CONNECTION")
+
+	if node.ConnectionLabel != nil {
+		ctx.WriteString(" ")
+		ctx.FormatNode(node.ConnectionLabel)
+	}
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -670,6 +670,15 @@ func (*CreateExternalConnection) StatementType() StatementType { return TypeDDL 
 func (*CreateExternalConnection) StatementTag() string { return "CREATE EXTERNAL CONNECTION" }
 
 // StatementReturnType implements the Statement interface.
+func (*DropExternalConnection) StatementReturnType() StatementReturnType { return Ack }
+
+// StatementType implements the Statement interface.
+func (*DropExternalConnection) StatementType() StatementType { return TypeDDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*DropExternalConnection) StatementTag() string { return "DROP EXTERNAL CONNECTION" }
+
+// StatementReturnType implements the Statement interface.
 func (*CreateIndex) StatementReturnType() StatementReturnType { return DDL }
 
 // StatementType implements the Statement interface.
@@ -1900,6 +1909,7 @@ func (n *Explain) String() string                        { return AsString(n) }
 func (n *ExplainAnalyze) String() string                 { return AsString(n) }
 func (n *Export) String() string                         { return AsString(n) }
 func (n *CreateExternalConnection) String() string       { return AsString(n) }
+func (n *DropExternalConnection) String() string         { return AsString(n) }
 func (n *FetchCursor) String() string                    { return AsString(n) }
 func (n *Grant) String() string                          { return AsString(n) }
 func (n *GrantRole) String() string                      { return AsString(n) }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -385,6 +385,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&deleteRangeNode{}):                         "delete range",
 	reflect.TypeOf(&distinctNode{}):                            "distinct",
 	reflect.TypeOf(&dropDatabaseNode{}):                        "drop database",
+	reflect.TypeOf(&dropExternalConnectionNode{}):              "drop external connection",
 	reflect.TypeOf(&dropIndexNode{}):                           "drop index",
 	reflect.TypeOf(&dropSequenceNode{}):                        "drop sequence",
 	reflect.TypeOf(&dropSchemaNode{}):                          "drop schema",


### PR DESCRIPTION
This change introduces `DROP EXTERNAL CONNECTION` that can be
used to drop an existing ExternalConnection object from the
`system.external_connections` table.

Fixes: #84226

Release note (sql change): `DROP EXTERNAL CONNECTION` can be
used to drop a previously created External Connection object.