### PR TITLE
kvcoord: randomly choose the key on which to anchor txn record

### DIFF
--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -27,9 +27,9 @@ message TxnMeta {
       (gogoproto.nullable) = false];
   reserved 2;
   // key is the key which anchors the transaction. This is typically
-  // the first key read or written during the transaction and
-  // determines which range in the cluster will hold the transaction
-  // record.
+  // a random locking (write, SFU etc.) key accessed in the first batch by
+  // the transaction. It determines which range in the cluster will hold the
+  // transaction record.
   bytes key = 3; // TODO(tschottdorf): [(gogoproto.casttype) = "Key"];
   // Incremented on txn retry.
   int32 epoch = 4 [(gogoproto.casttype) = "TxnEpoch"];


### PR DESCRIPTION
Previoulsy, we would pick the first locking key in a batch request
for a transaction as the anchor key for its transaction record. With
this patch, instead of picking the first locking key, we switch the
policy to randomly pick the anchor key from the set of locking keys in
the batch. Doing so allows us to distribute transaction records more
evenly among the ranges in the cluster for certain types of workloads.
As we collocate the async intent cleanup process with the leaseholder of
the transaction record's anchor key, this helps to more evenly
distribute this work around the cluster for such workloads.

References #83788

Release note: None