### PR TITLE
dev: fix `dev doctor` when run under a git worktree

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=43
+DEV_VERSION=44
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
Broke it as part of 39fcab0dbb51e0a5a08b6dcad0fdf89f4dd99ca3.

Release note: None