### PR TITLE
changefeedccl: smart family selection with expressions

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6311,8 +6311,8 @@ func normalizeCDCExpression(t *testing.T, execCfgI interface{}, exprStr string) 
 	defer cleanup()
 
 	execCtx := p.(sql.JobExecContext)
-	_, err = cdceval.NormalizeAndValidateSelectForTarget(
-		context.Background(), execCtx, desc, target, sc, false,
+	_, _, err = cdceval.NormalizeAndValidateSelectForTarget(
+		context.Background(), execCtx, desc, target, sc, false, false,
 	)
 	require.NoError(t, err)
 	log.Infof(context.Background(), "PostNorm: %s", tree.StmtDebugString(sc))

--- a/pkg/sql/catalog/table_col_set.go
+++ b/pkg/sql/catalog/table_col_set.go
@@ -88,3 +88,6 @@ func (s *TableColSet) UnionWith(rhs TableColSet) { s.set.UnionWith(rhs.set) }
 // numbers are shown as ranges. For example, for the set {1, 2, 3  5, 6, 10},
 // the output is "(1-3,5,6,10)".
 func (s TableColSet) String() string { return s.set.String() }
+
+// Intersects returns true if s has any elements in common with rhs.
+func (s TableColSet) Intersects(rhs TableColSet) bool { return s.set.Intersects(rhs.set) }


### PR DESCRIPTION
ccl: implemented functionality to determine the number of column families that
are referenced by a SELECT statement in changefeed expressions and handle
appropriately

Resolves: https://github.com/cockroachdb/cockroach/issues/82607

Release note (enterprise change): implemented functionality to determine the
number of column families that are referenced by a SELECT statement in
changefeed expressions and handle appropriately