### PR TITLE
dev: add 'generate js' subcommand

### DIFF
--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -9,8 +9,12 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
+cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
+cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
@@ -24,8 +28,12 @@ bazel info bazel-bin --color=no
 bazel info workspace --color=no
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
+cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
+cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=oss --env.target=http://localhost:8080 --port 3000
@@ -41,8 +49,12 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
+cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
+cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000 --https
@@ -58,8 +70,12 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
+cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
+cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://example.crdb.io:4848 --port 3000
@@ -75,8 +91,12 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
+cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
+cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 12345
@@ -111,8 +131,12 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
+cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
+cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui jest --watch
@@ -125,7 +149,9 @@ rm -rf crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 
 exec
 dev ui clean --all
@@ -136,7 +162,9 @@ rm -rf crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
+rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
+rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/node_modules
 rm -rf crdb-checkout/pkg/ui/workspaces/db-console/src/js/node_modules

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -49,6 +49,8 @@ type UIDirectories struct {
 	clusterUI string
 	// dbConsole is the absolute path to ./pkg/ui/workspaces/db-console.
 	dbConsole string
+	// eslintPlugin is the absolute path to ./pkg/ui/workspaces/eslint-plugin-crdb.
+	eslintPlugin string
 }
 
 // getUIDirs computes the absolute path to the root of each UI sub-project.
@@ -59,8 +61,9 @@ func getUIDirs(d *dev) (*UIDirectories, error) {
 	}
 
 	return &UIDirectories{
-		clusterUI: path.Join(workspace, "./pkg/ui/workspaces/cluster-ui"),
-		dbConsole: path.Join(workspace, "./pkg/ui/workspaces/db-console"),
+		clusterUI:    path.Join(workspace, "./pkg/ui/workspaces/cluster-ui"),
+		dbConsole:    path.Join(workspace, "./pkg/ui/workspaces/db-console"),
+		eslintPlugin: path.Join(workspace, "./pkg/ui/workspaces/eslint-plugin-crdb"),
 	}, nil
 }
 
@@ -286,7 +289,9 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 				filepath.Join(uiDirs.dbConsole, "src", "js", "protos.d.ts"),
 				filepath.Join(uiDirs.dbConsole, "ccl", "src", "js", "protos.js"),
 				filepath.Join(uiDirs.dbConsole, "ccl", "src", "js", "protos.d.ts"),
+				filepath.Join(uiDirs.dbConsole, "dist"),
 				filepath.Join(uiDirs.clusterUI, "dist"),
+				filepath.Join(uiDirs.eslintPlugin, "dist"),
 			}
 			if all {
 				workspace, err := d.getWorkspace(d.cli.Context())

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -127,7 +127,7 @@ Replaces 'make ui-watch'.`,
 				return err
 			}
 
-			if err := arrangeFilesForWatchers(d /* ossOnly */, isOss); err != nil {
+			if err := copyBuildOutputToWorkspace(d /* ossOnly */, isOss); err != nil {
 				log.Fatalf("failed to arrange files for watchers: %v", err)
 				return err
 			}
@@ -323,9 +323,10 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 	return cleanCmd
 }
 
-// arrangeFilesForWatchers moves files from Bazel's build output directory
+// copyBuildOutputToWorkspace moves files from Bazel's build output directory
 // into the locations they'd be found during a non-Bazel build, so that test
-// watchers can successfully operate outside of the Bazel sandbox.
+// watchers and developer tooling can successfully operate outside of the Bazel
+// sandbox.
 //
 // Unfortunately, Bazel's reliance on symlinks conflicts with Jest's refusal to
 // traverse symlinks during `--watch` mode. Ibazel is unable to keep `jest`
@@ -333,12 +334,12 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 // kill Jest when a file changes defeat the purpose of Jest's watch mode, and
 // makes devs pay the cost of node + jest startup times after every file change.
 // Similar issues apply to webpack's watch-mode, as compiled output doesn't
-// exist outside of the Bazel sandbox. As a workaround, arrangeFilesForWatchers
+// exist outside of the Bazel sandbox. As a workaround, copyBuildOutputToWorkspace
 // copies files out of the Bazel sandbox and allows Jest or webpack (in watch
 // mode) to be executed from directly within a pkg/ui/workspaces/... directory.
 //
 // See https://github.com/bazelbuild/rules_nodejs/issues/2028
-func arrangeFilesForWatchers(d *dev, ossOnly bool) error {
+func copyBuildOutputToWorkspace(d *dev, ossOnly bool) error {
 	bazelBin, err := d.getBazelBin(d.cli.Context())
 	if err != nil {
 		return err
@@ -376,6 +377,21 @@ func arrangeFilesForWatchers(d *dev, ossOnly bool) error {
 		}
 	}
 
+	// Delete eslint-plugin output tree that was previously copied out of the sandbox
+	err = d.os.RemoveAll(filepath.Join(dstDirs.eslintPlugin, "dist"))
+	if err != nil {
+		return err
+	}
+
+	// Copy the eslint-plugin output tree back out of the sandbox
+	err = d.os.CopyAll(
+		filepath.Join(bazelBin, "pkg", "ui", "workspaces", "eslint-plugin-crdb", "dist"),
+		filepath.Join(dstDirs.eslintPlugin, "dist"),
+	)
+	if err != nil {
+		return err
+	}
+
 	// Delete cluster-ui output tree that was previously copied out of the sandbox
 	err = d.os.RemoveAll(filepath.Join(dstDirs.clusterUI, "dist"))
 	if err != nil {
@@ -387,6 +403,22 @@ func arrangeFilesForWatchers(d *dev, ossOnly bool) error {
 		filepath.Join(bazelBin, "pkg", "ui", "workspaces", "cluster-ui", "dist"),
 		filepath.Join(dstDirs.clusterUI, "dist"),
 	)
+	if err != nil {
+		return err
+	}
+
+	// Delete db-console output tree that was previously copied out of the sandbox
+	err = d.os.RemoveAll(filepath.Join(dstDirs.dbConsole, "dist"))
+	if err != nil {
+		return err
+	}
+
+	// Copy the db-console output tree back out of the sandbox
+	err = d.os.CopyAll(
+		filepath.Join(bazelBin, "pkg", "ui", "workspaces", "db-console", "dist"),
+		filepath.Join(dstDirs.dbConsole, "dist"),
+	)
+
 	if err != nil {
 		return err
 	}
@@ -438,7 +470,7 @@ Replaces 'make ui-test' and 'make ui-test-watch'.`,
 					return err
 				}
 
-				err = arrangeFilesForWatchers(d /* ossOnly */, false)
+				err = copyBuildOutputToWorkspace(d /* ossOnly */, false)
 				if err != nil {
 					// nolint:errwrap
 					return fmt.Errorf("unable to arrange files properly for watch-mode testing: %+v", err)

--- a/pkg/ui/workspaces/cluster-ui/tsconfig.json
+++ b/pkg/ui/workspaces/cluster-ui/tsconfig.json
@@ -13,7 +13,14 @@
     "outDir": "./dist/types",
     "target": "es6",
     "skipLibCheck": true,
-    "sourceMap": false
+    "sourceMap": false,
+    "baseUrl": ".",
+    "paths": {
+      "@cockroachlabs/crdb-protobuf-client": [
+        "../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js",
+        "./node_modules/@cockroachlabs/crdb-protobuf-client"
+      ]
+    }
   },
   "exclude": [
     "node_modules",

--- a/pkg/ui/workspaces/db-console/jest.config.js
+++ b/pkg/ui/workspaces/db-console/jest.config.js
@@ -117,16 +117,23 @@ module.exports = {
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  moduleNameMapper: Object.assign(
-    {},
-    pathsToModuleNameMapper(compilerOptions.paths, { prefix: "<rootDir>/" }),
-    {
-      "\\.(jpg|ico|jpeg|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|gif|png|svg)$":
-        "<rootDir>/src/test-utils/file.mock.js",
-      "\\.(css|scss|less|styl)$": "identity-obj-proxy",
-      "^react($|/.+)": "<rootDir>/node_modules/react$1",
-    },
-  ),
+  moduleNameMapper: (function(){
+    const map = Object.assign(
+      {},
+      pathsToModuleNameMapper(
+        Object.fromEntries(
+          Object.entries(compilerOptions.paths).filter(([name, _paths]) => !name.includes("@cockroachlabs"))
+        ), { prefix: "<rootDir>/" }),
+      {
+        "\\.(jpg|ico|jpeg|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|gif|png|svg)$":
+          "<rootDir>/src/test-utils/file.mock.js",
+        "\\.(css|scss|less|styl)$": "identity-obj-proxy",
+        "^react($|/.+)": "<rootDir>/node_modules/react$1",
+      },
+    );
+    console.log(map);
+    return map;
+  })(),
 
   // An alternative API to setting the NODE_PATH env variable, modulePaths is an array of absolute paths to additional locations to search when resolving modules.
   modulePaths: ["<rootDir>/", ...module.paths],

--- a/pkg/ui/workspaces/db-console/tsconfig.json
+++ b/pkg/ui/workspaces/db-console/tsconfig.json
@@ -27,6 +27,14 @@
       "src/*": [
         "ccl/src/*",
         "src/*"
+      ],
+      "@cockroachlabs/cluster-ui": [
+        "../../../../_bazel/bin/pkg/ui/workspaces/cluster-ui",
+        "./node_modules/@cockroachlabs/cluster-ui"
+      ],
+      "@cockroachlabs/crdb-protobuf-client": [
+        "../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js",
+        "./node_modules/@cockroachlabs/crdb-protobuf-client"
       ]
     }
   },


### PR DESCRIPTION
Interactive development of UI features requires a few prerequisites to
be built to satisfy editor requirements. Specifically, cluster-ui
depends on the typings produced from building
@cockroachlabs/crdb-protobuf-client, db-console depends on the typings
produced from building both the protobuf client and cluster-ui, and
eslint editor plugins require @cockroachlabs/eslint-plugin-crdb to be
compiled and the compiled output to be in the Bazel workspace. Add a
./dev generate js target that compiles the minimum set of dependencies
to bootstrap a development environment.

This requires a small change to the `tsconfig.json` for cluster-ui and
db-console to ensure they know where to find the Bazel-produced output
of the packages in this repo.

fixes #84738