### PR TITLE
cli: remove unused parameter

### DIFF
--- a/pkg/cli/debug_merge_logs.go
+++ b/pkg/cli/debug_merge_logs.go
@@ -171,8 +171,9 @@ func newMergedStreamFromPatterns(
 	if err != nil {
 		return nil, err
 	}
-	files, err := findLogFiles(paths, filePattern, programFilter,
-		groupIndex(filePattern, "program"), to)
+	files, err := findLogFiles(
+		paths, filePattern, programFilter, groupIndex(filePattern, "program"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -332,12 +333,11 @@ type fileInfo struct {
 }
 
 func findLogFiles(
-	paths []string, filePattern, programFilter *regexp.Regexp, programGroup int, to time.Time,
+	paths []string, filePattern, programFilter *regexp.Regexp, programGroup int,
 ) ([]fileInfo, error) {
 	if programGroup == 0 || programFilter == nil {
 		programGroup = 0
 	}
-	to = to.Truncate(time.Second) // log files only have second resolution
 	var files []fileInfo
 	for _, p := range paths {
 		// NB: come go1.16, we should use WalkDir here as it is more efficient.
@@ -365,7 +365,6 @@ func findLogFiles(
 		}); err != nil {
 			return nil, err
 		}
-
 	}
 	return files, nil
 }


### PR DESCRIPTION
This was vestigial and removed in af8fabb055f3d54eab5d015e93ceac421783264b. It
could be used to avoid opening files with a creation time after to. I think it
might have been buggy before that commit. No harm in removing an unused argument.

Release note: None