### PR TITLE
sql: remove a redundant return argument from (*planner).SchemaChange

### DIFF
--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -55,12 +55,10 @@ func buildOpaque(
 		}
 		// TODO (Chengxiong): Remove this version gate in 22.2
 		if evalCtx.Settings.Version.IsActive(ctx, clusterversion.EnableDeclarativeSchemaChanger) {
-			scPlan, usePlan, err := p.SchemaChange(ctx, stmt)
+			var err error
+			plan, err = p.SchemaChange(ctx, stmt)
 			if err != nil {
 				return nil, err
-			}
-			if usePlan {
-				plan = scPlan
 			}
 		}
 	}


### PR DESCRIPTION
Previously, (*planner).SchemaChange returns (planNode, bool, error),
where the bool is intended to mean "whether we should use the plan
planned by the new schema changer". But we don't think there is actually
a case where planNode is non-nil but usePlan is false -- we always see
that the returned planNode and bool are "in sync", meaning they are both
either non-nil/true or nil/false.

This means the boolean return is redundant and we can act based on
nil-ness of planNode, and this PR does that.

Release note: None