### PR TITLE
sql: clean up PartitionSpans a bit

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1005,6 +1005,13 @@ func (h *distSQLNodeHealth) check(ctx context.Context, sqlInstanceID base.SQLIns
 func (dsp *DistSQLPlanner) PartitionSpans(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
 ) ([]SpanPartition, error) {
+	if len(spans) == 0 {
+		panic("no spans")
+	}
+	if planCtx.isLocal {
+		// If we're planning locally, map all spans to the gateway.
+		return []SpanPartition{{dsp.gatewaySQLInstanceID, spans}}, nil
+	}
 	if dsp.codec.ForSystemTenant() {
 		return dsp.partitionSpansSystem(ctx, planCtx, spans)
 	}
@@ -1015,38 +1022,11 @@ func (dsp *DistSQLPlanner) PartitionSpans(
 // for a system tenant.
 func (dsp *DistSQLPlanner) partitionSpansSystem(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
-) ([]SpanPartition, error) {
-	if len(spans) == 0 {
-		panic("no spans")
-	}
-	partitions := make([]SpanPartition, 0, 1)
-	if planCtx.isLocal {
-		// If we're planning locally, map all spans to the local node.
-		partitions = append(partitions,
-			SpanPartition{dsp.gatewaySQLInstanceID, spans})
-		return partitions, nil
-	}
+) (partitions []SpanPartition, _ error) {
 	// nodeMap maps a SQLInstanceID to an index inside the partitions array.
 	nodeMap := make(map[base.SQLInstanceID]int)
 	it := planCtx.spanIter
-	for i := range spans {
-
-		span := spans[i]
-		noEndKey := false
-		if len(span.EndKey) == 0 {
-			// If we see a span to partition that has no end key, it means that
-			// we're going to do a point lookup on the start key of this span.
-			//
-			// The code below us doesn't really tolerate spans without an
-			// EndKey, so we manufacture a single-key span for this case. Note
-			// that we still, however, will preserve the point lookup.
-			span = roachpb.Span{
-				Key:    span.Key,
-				EndKey: span.Key.Next(),
-			}
-			noEndKey = true
-		}
-
+	for _, span := range spans {
 		// rSpan is the span we are currently partitioning.
 		rSpan, err := keys.SpanAddr(span)
 		if err != nil {
@@ -1084,12 +1064,6 @@ func (dsp *DistSQLPlanner) partitionSpansSystem(
 				)
 			}
 
-			// Limit the end key to the end of the span we are resolving.
-			endKey := desc.EndKey
-			if rSpan.EndKey.Less(endKey) {
-				endKey = rSpan.EndKey
-			}
-
 			sqlInstanceID := base.SQLInstanceID(replDesc.NodeID)
 			partitionIdx, inNodeMap := nodeMap[sqlInstanceID]
 			if !inNodeMap {
@@ -1113,13 +1087,19 @@ func (dsp *DistSQLPlanner) partitionSpansSystem(
 			}
 			partition := &partitions[partitionIdx]
 
-			if noEndKey {
-				// The original span had no EndKey, and we want to preserve it
-				// so that we could use a GetRequest.
-				partition.Spans = append(partition.Spans, roachpb.Span{
-					Key: lastKey.AsRawKey(),
-				})
+			if len(span.EndKey) == 0 {
+				// If we see a span to partition that has no end key, it means
+				// that we're going to do a point lookup on the start key of
+				// this span. Thus, we include the span into partition.Spans
+				// without trying to merge it with the last span.
+				partition.Spans = append(partition.Spans, span)
 				break
+			}
+
+			// Limit the end key to the end of the span we are resolving.
+			endKey := desc.EndKey
+			if rSpan.EndKey.Less(endKey) {
+				endKey = rSpan.EndKey
 			}
 
 			if lastSQLInstanceID == sqlInstanceID {
@@ -1148,17 +1128,7 @@ func (dsp *DistSQLPlanner) partitionSpansSystem(
 // assignments are made to all available instances in a round-robin fashion.
 func (dsp *DistSQLPlanner) partitionSpansTenant(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
-) ([]SpanPartition, error) {
-	if len(spans) == 0 {
-		panic("no spans")
-	}
-	partitions := make([]SpanPartition, 0, 1)
-	if planCtx.isLocal {
-		// If we're planning locally, map all spans to the local node.
-		partitions = append(partitions,
-			SpanPartition{dsp.gatewaySQLInstanceID, spans})
-		return partitions, nil
-	}
+) (partitions []SpanPartition, _ error) {
 	if dsp.sqlInstanceProvider == nil {
 		return nil, errors.AssertionFailedf("sql instance provider not available in multi-tenant environment")
 	}
@@ -1180,8 +1150,7 @@ func (dsp *DistSQLPlanner) partitionSpansTenant(
 	nodeMap := make(map[base.SQLInstanceID]int)
 	var lastKey roachpb.Key
 	var lastIdx int
-	for i := range spans {
-		span := spans[i]
+	for i, span := range spans {
 		if log.V(1) {
 			log.Infof(ctx, "partitioning span %s", span)
 		}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -848,6 +848,19 @@ func TestPartitionSpans(t *testing.T) {
 				2: {{"C", "C2"}},
 			},
 		},
+
+		// A single span touching multiple ranges but on the same node results
+		// in a single partitioned span.
+		{
+			ranges:      []testSpanResolverRange{{"A", 1}, {"A1", 1}, {"B", 2}},
+			gatewayNode: 1,
+
+			spans: [][2]string{{"A", "B"}},
+
+			partitions: map[int][][2]string{
+				1: {{"A", "B"}},
+			},
+		},
 	}
 
 	// We need a mock Gossip to contain addresses for the nodes. Otherwise the


### PR DESCRIPTION
This commit cleans up `PartitionSpans` implementations a bit:
- it pulls out some of the code shared between `partitionSpansSystem`
and `partitionSpansTenant` into `PartitionSpans` to avoid the
duplication
- it refactors the way we handle spans with no end keys (such spans are
converted into GetRequests later on).

Release note: None