### PR TITLE
sqlproxyccl: add connection latency metrics

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -95,6 +95,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/netutil/addr",
         "//pkg/util/randutil",
         "//pkg/util/stop",

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	pgproto3 "github.com/jackc/pgproto3/v2"
 	"google.golang.org/grpc/codes"
@@ -71,6 +73,13 @@ type connector struct {
 	//
 	// NOTE: This field is optional.
 	TLSConfig *tls.Config
+
+	// DialTenantLatency tracks how long it takes to retrieve the address for
+	// a tenant and set up a tcp connection to the address.
+	DialTenantLatency *metric.Histogram
+
+	// DialTenantRetries counts how often dialing a tenant is retried.
+	DialTenantRetries *metric.Counter
 
 	// Testing knobs for internal connector calls. If specified, these will
 	// be called instead of the actual logic.
@@ -166,6 +175,11 @@ func (c *connector) dialTenantCluster(
 		return c.testingKnobs.dialTenantCluster(ctx, requester)
 	}
 
+	if c.DialTenantLatency != nil {
+		start := timeutil.Now()
+		defer func() { c.DialTenantLatency.RecordValue(timeutil.Since(start).Nanoseconds()) }()
+	}
+
 	// Repeatedly try to make a connection until context is canceled, or until
 	// we get a non-retriable error. This is preferable to terminating client
 	// connections, because in most cases those connections will simply be
@@ -183,7 +197,14 @@ func (c *connector) dialTenantCluster(
 	var serverAddr string
 	var err error
 
+	isRetry := false
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		// Track the number of dial retries.
+		if isRetry && c.DialTenantRetries != nil {
+			c.DialTenantRetries.Inc(1)
+		}
+		isRetry = true
+
 		// Retrieve a SQL pod address to connect to.
 		serverAddr, err = c.lookupAddr(ctx)
 		if err != nil {

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -24,8 +24,12 @@ type metrics struct {
 	RoutingErrCount        *metric.Counter
 	RefusedConnCount       *metric.Counter
 	SuccessfulConnCount    *metric.Counter
+	ConnectionLatency      *metric.Histogram
 	AuthFailedCount        *metric.Counter
 	ExpiredClientConnCount *metric.Counter
+
+	DialTenantLatency *metric.Histogram
+	DialTenantRetries *metric.Counter
 
 	ConnMigrationSuccessCount                *metric.Counter
 	ConnMigrationErrorFatalCount             *metric.Counter
@@ -56,6 +60,12 @@ var (
 		Help:        "Number of connections being proxied",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
+	}
+	metaConnectionLatency = metric.Metadata{
+		Name:        "proxy.sql.connection_latency",
+		Unit:        metric.Unit_NANOSECONDS,
+		Help:        "Latency histogram for connecting and authenticating to a tenant cluster.",
+		Measurement: "Latency",
 	}
 	metaRoutingErrCount = metric.Metadata{
 		Name:        "proxy.err.routing",
@@ -111,6 +121,18 @@ var (
 		Measurement: "Expired Client Connections",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaDialTenantLatency = metric.Metadata{
+		Name:        "proxy.dial_tenant.latency",
+		Unit:        metric.Unit_NANOSECONDS,
+		Help:        "Latency histogram for establishing a tcp connection to a tenant cluster.",
+		Measurement: "Latency",
+	}
+	metaDialTenantRetries = metric.Metadata{
+		Name:        "proxy.dial_tenant.retries",
+		Unit:        metric.Unit_COUNT,
+		Help:        "Number of retries dialing a tenant cluster.",
+		Measurement: "Retries",
+	}
 	// Connection migration metrics.
 	//
 	// attempted = success + error_fatal + error_recoverable
@@ -156,6 +178,7 @@ var (
 
 // makeProxyMetrics instantiates the metrics holder for proxy monitoring.
 func makeProxyMetrics() metrics {
+
 	return metrics{
 		BackendDisconnectCount: metric.NewCounter(metaBackendDisconnectCount),
 		IdleDisconnectCount:    metric.NewCounter(metaIdleDisconnectCount),
@@ -165,8 +188,18 @@ func makeProxyMetrics() metrics {
 		RoutingErrCount:        metric.NewCounter(metaRoutingErrCount),
 		RefusedConnCount:       metric.NewCounter(metaRefusedConnCount),
 		SuccessfulConnCount:    metric.NewCounter(metaSuccessfulConnCount),
+		ConnectionLatency: metric.NewLatency(
+			metaConnMigrationAttemptedCount,
+			base.DefaultHistogramWindowInterval(),
+		),
 		AuthFailedCount:        metric.NewCounter(metaAuthFailedCount),
 		ExpiredClientConnCount: metric.NewCounter(metaExpiredClientConnCount),
+		// Connector metrics.
+		DialTenantLatency: metric.NewLatency(
+			metaDialTenantLatency,
+			base.DefaultHistogramWindowInterval(),
+		),
+		DialTenantRetries: metric.NewCounter(metaDialTenantRetries),
 		// Connection migration metrics.
 		ConnMigrationSuccessCount:          metric.NewCounter(metaConnMigrationSuccessCount),
 		ConnMigrationErrorFatalCount:       metric.NewCounter(metaConnMigrationErrorFatalCount),

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -291,6 +291,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	})
 
 	require.Equal(t, int64(4), s.metrics.SuccessfulConnCount.Count())
+	require.Equal(t, int64(4), s.metrics.ConnectionLatency.TotalCount())
 	require.Equal(t, int64(2), s.metrics.AuthFailedCount.Count())
 	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
 }
@@ -432,6 +433,7 @@ func TestProxyTLSClose(t *testing.T) {
 	_ = conn.Close(ctx)
 
 	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
+	require.Equal(t, int64(1), s.metrics.ConnectionLatency.TotalCount())
 	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
 }
 
@@ -538,6 +540,7 @@ func TestInsecureProxy(t *testing.T) {
 	})
 	require.Equal(t, int64(1), s.metrics.AuthFailedCount.Count())
 	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
+	require.Equal(t, int64(1), s.metrics.ConnectionLatency.TotalCount())
 }
 
 func TestErroneousFrontend(t *testing.T) {
@@ -614,6 +617,7 @@ func TestProxyRefuseConn(t *testing.T) {
 	te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "too many attempts")
 	require.Equal(t, int64(1), s.metrics.RefusedConnCount.Count())
 	require.Equal(t, int64(0), s.metrics.SuccessfulConnCount.Count())
+	require.Equal(t, int64(0), s.metrics.ConnectionLatency.TotalCount())
 	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
 }
 


### PR DESCRIPTION
This change adds three new metrics.

proxy.sql.connection_latency measures how long it takes to establish a
connection. A connection is considered established once authorization is
complete. connection_latency is a useful signal for dashboards, but it
is likely a bad signal for alerting. Authorization requires several
round trips between the server and the client.

proxy.dial_tenant.latency measures how long it takes to find the correct
tenant process and set up a tls connection to it. This latency measure
is expected to be a good alerting signal because all of the components
involved are contained in the cluster.

proxy.dial_tenant.retries measures how many times the sql proxy retries
setting up a tenant connection. This metric helps work around an issue
with relying a latency metric for alerting. If connecting to a tenant
fails, the sql proxy may retry indefinitely without updating the latency
metric.

The metrics were created with the following example alert conditions in
mind:

10 seconds < quantile(0.99, proxy.dial_tenant.latency)

rate(count(proxy.dial_tenant.latency)) < proxy.dial_tenant.retries

Release note: None