### PR TITLE
sql: add is_visible to indexes info table

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -280,10 +280,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTBBBIT colnames
+query ITITTBBBBIT colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded shard_bucket_count created_at
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded  is_visible  shard_bucket_count  created_at
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2790,6 +2790,7 @@ CREATE TABLE crdb_internal.table_indexes (
   is_unique           BOOL NOT NULL,
   is_inverted         BOOL NOT NULL,
   is_sharded          BOOL NOT NULL,
+  is_visible          BOOL NOT NULL,
   shard_bucket_count  INT,
   created_at          TIMESTAMP
 )
@@ -2835,6 +2836,7 @@ CREATE TABLE crdb_internal.table_indexes (
 							tree.MakeDBool(tree.DBool(idx.IsUnique())),
 							tree.MakeDBool(idx.GetType() == descpb.IndexDescriptor_INVERTED),
 							tree.MakeDBool(tree.DBool(idx.IsSharded())),
+							tree.MakeDBool(tree.DBool(!idx.IsNotVisible())),
 							shardBucketCnt,
 							createdAt,
 						)

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -100,6 +100,8 @@ ORDER BY
 	return d.showTableDetails(n.Name, showCreateQuery)
 }
 
+// delegateShowIndexes implements SHOW INDEX FROM, SHOW INDEXES FROM, SHOW KEYS
+// FROM which returns all the indexes in the given table.
 func (d *delegator) delegateShowIndexes(n *tree.ShowIndexes) (tree.Statement, error) {
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Indexes)
 	getIndexesQuery := `
@@ -111,7 +113,8 @@ SELECT
     column_name,
     direction,
     storing::BOOL,
-    implicit::BOOL`
+    implicit::BOOL,
+    is_visible::BOOL AS visible`
 
 	if n.WithComment {
 		getIndexesQuery += `,
@@ -135,7 +138,7 @@ WHERE
     AND table_schema=%[5]s
     AND table_name=%[2]s
 ORDER BY
-    1, 2, 3, 4, 5, 6, 7, 8;`
+    1, 2, 4;`
 
 	return d.showTableDetails(n.Table, getIndexesQuery)
 }

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -1051,11 +1051,11 @@ CREATE TABLE t.test (a STRING PRIMARY KEY, b STRING, c STRING, INDEX foo (c));
 	mt.CheckQueryResults(t,
 		"SHOW INDEXES FROM t.test",
 		[][]string{
-			{"test", "test_pkey", "false", "1", "a", "ASC", "false", "false"},
-			{"test", "test_pkey", "false", "2", "b", "N/A", "true", "false"},
-			{"test", "test_pkey", "false", "3", "d", "N/A", "true", "false"},
-			{"test", "ufo", "true", "1", "d", "ASC", "false", "false"},
-			{"test", "ufo", "true", "2", "a", "ASC", "false", "true"},
+			{"test", "test_pkey", "false", "1", "a", "ASC", "false", "false", "true"},
+			{"test", "test_pkey", "false", "2", "b", "N/A", "true", "false", "true"},
+			{"test", "test_pkey", "false", "3", "d", "N/A", "true", "false", "true"},
+			{"test", "ufo", "true", "1", "d", "ASC", "false", "false", "true"},
+			{"test", "ufo", "true", "2", "a", "ASC", "false", "true", "true"},
 		},
 	)
 

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1154,19 +1154,20 @@ var informationSchemaStatisticsTable = virtualSchemaTable{
 					direction tree.Datum, isStored, isImplicit bool,
 				) error {
 					return addRow(
-						dbNameStr,                         // table_catalog
-						scNameStr,                         // table_schema
-						tbNameStr,                         // table_name
-						yesOrNoDatum(!index.IsUnique()),   // non_unique
-						scNameStr,                         // index_schema
-						tree.NewDString(index.GetName()),  // index_name
-						tree.NewDInt(tree.DInt(sequence)), // seq_in_index
-						tree.NewDString(colName),          // column_name
-						tree.DNull,                        // collation
-						tree.DNull,                        // cardinality
-						direction,                         // direction
-						yesOrNoDatum(isStored),            // storing
-						yesOrNoDatum(isImplicit),          // implicit
+						dbNameStr,                           // table_catalog
+						scNameStr,                           // table_schema
+						tbNameStr,                           // table_name
+						yesOrNoDatum(!index.IsUnique()),     // non_unique
+						scNameStr,                           // index_schema
+						tree.NewDString(index.GetName()),    // index_name
+						tree.NewDInt(tree.DInt(sequence)),   // seq_in_index
+						tree.NewDString(colName),            // column_name
+						tree.DNull,                          // collation
+						tree.DNull,                          // cardinality
+						direction,                           // direction
+						yesOrNoDatum(isStored),              // storing
+						yesOrNoDatum(isImplicit),            // implicit
+						yesOrNoDatum(!index.IsNotVisible()), // is_visible
 					)
 				}
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -49,17 +49,17 @@ ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)
 statement error pq: multiple primary keys for table "t" are not allowed
 ALTER TABLE t ADD CONSTRAINT bar PRIMARY KEY (b)
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM t
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-t           foo         false       1             b            ASC        false    false
-t           foo         false       2             a            ASC        true     true
-t           t_f_idx     true        1             f            ASC        false    false
-t           t_f_idx     true        2             a            ASC        false    true
-t           t_pkey      false       1             a            ASC        false    false
-t           t_pkey      false       2             f            N/A        true     false
-t           t_pkey      false       3             b            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t           foo         false       1             b            ASC        false    false     true
+t           foo         false       2             a            ASC        true     true      true
+t           t_f_idx     true        1             f            ASC        false    false     true
+t           t_f_idx     true        2             a            ASC        false    true      true
+t           t_pkey      false       1             a            ASC        false    false     true
+t           t_pkey      false       2             f            N/A        true     false     true
+t           t_pkey      false       3             b            N/A        true     false     true
 
 query III
 SELECT * FROM t
@@ -226,16 +226,16 @@ LIMIT 2
 SCHEMA CHANGE GC  GC for DROP INDEX test.public.t@foo CASCADE  root  running    waiting for GC TTL  0  ·
 SCHEMA CHANGE     DROP INDEX test.public.t@foo CASCADE         root  succeeded  NULL                1  ·
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM t
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-t           t_f_idx     true        1             f            ASC        false    false
-t           t_f_idx     true        2             a            ASC        false    true
-t           t_pkey      false       1             a            ASC        false    false
-t           t_pkey      false       2             f            N/A        true     false
-t           t_pkey      false       3             b            N/A        true     false
-t           t_pkey      false       4             c            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t           t_f_idx     true        1             f            ASC        false    false     true
+t           t_f_idx     true        2             a            ASC        false    true      true
+t           t_pkey      false       1             a            ASC        false    false     true
+t           t_pkey      false       2             f            N/A        true     false     true
+t           t_pkey      false       3             b            N/A        true     false     true
+t           t_pkey      false       4             c            N/A        true     false     true
 
 statement ok
 ALTER TABLE t DROP b, DROP c
@@ -382,15 +382,15 @@ ALTER TABLE t DROP COLUMN g CASCADE
 statement ok
 ALTER TABLE o DROP COLUMN h
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM o
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-o           o_pkey      false       1             rowid        ASC        false    false
-o           o_pkey      false       2             gf           N/A        true     false
-o           o_pkey      false       3             i            N/A        true     false
-o           oi          true        1             i            ASC        false    false
-o           oi          true        2             rowid        ASC        false    true
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+o           o_pkey      false       1             rowid        ASC        false    false     true
+o           o_pkey      false       2             gf           N/A        true     false     true
+o           o_pkey      false       3             i            N/A        true     false     true
+o           oi          true        1             i            ASC        false    false     true
+o           oi          true        2             rowid        ASC        false    true      true
 
 statement ok
 ALTER TABLE t ADD f INT CHECK (f > 1)

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -400,10 +400,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTBBBIT colnames
+query ITITTBBBBIT colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded shard_bucket_count created_at
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded  is_visible  shard_bucket_count  created_at
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -23,14 +23,14 @@ CREATE INDEX bar ON t (c)
 statement error index \"bar\" contains duplicate column \"b\"
 CREATE INDEX bar ON t (b, b);
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM t
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-t           foo         true        1             b            ASC        false    false
-t           foo         true        2             a            ASC        false    true
-t           t_pkey      false       1             a            ASC        false    false
-t           t_pkey      false       2             b            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t           foo         true        1             b            ASC        false    false     true
+t           foo         true        2             a            ASC        false    true      true
+t           t_pkey      false       1             a            ASC        false    false     true
+t           t_pkey      false       2             b            N/A        true     false     true
 
 statement ok
 INSERT INTO t VALUES (2,1)
@@ -38,14 +38,14 @@ INSERT INTO t VALUES (2,1)
 statement error pgcode 23505 violates unique constraint "bar"
 CREATE UNIQUE INDEX bar ON t (b)
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM t
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-t           foo         true        1             b            ASC        false    false
-t           foo         true        2             a            ASC        false    true
-t           t_pkey      false       1             a            ASC        false    false
-t           t_pkey      false       2             b            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t           foo         true        1             b            ASC        false    false     true
+t           foo         true        2             a            ASC        false    true      true
+t           t_pkey      false       1             a            ASC        false    false     true
+t           t_pkey      false       2             b            N/A        true     false     true
 
 # test for DESC index
 
@@ -68,18 +68,18 @@ CREATE INDEX b_desc ON t (b DESC)
 statement ok
 CREATE INDEX b_asc ON t (b ASC, c DESC)
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM t
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-t           b_asc       true        1             b            ASC        false    false
-t           b_asc       true        2             c            DESC       false    false
-t           b_asc       true        3             a            ASC        false    true
-t           b_desc      true        1             b            DESC       false    false
-t           b_desc      true        2             a            ASC        false    true
-t           t_pkey      false       1             a            ASC        false    false
-t           t_pkey      false       2             b            N/A        true     false
-t           t_pkey      false       3             c            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t           b_asc       true        1             b            ASC        false    false     true
+t           b_asc       true        2             c            DESC       false    false     true
+t           b_asc       true        3             a            ASC        false    true      true
+t           b_desc      true        1             b            DESC       false    false     true
+t           b_desc      true        2             a            ASC        false    true      true
+t           t_pkey      false       1             a            ASC        false    false     true
+t           t_pkey      false       2             b            N/A        true     false     true
+t           t_pkey      false       3             c            N/A        true     false     true
 
 statement error pgcode 42P01 relation "foo" does not exist
 CREATE INDEX fail ON foo (b DESC)
@@ -100,12 +100,12 @@ CREATE INDEX foo ON privs (b)
 
 user root
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM privs
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-privs       privs_pkey  false       1             a            ASC        false    false
-privs       privs_pkey  false       2             b            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+privs       privs_pkey  false       1             a            ASC        false    false     true
+privs       privs_pkey  false       2             b            N/A        true     false     true
 
 statement ok
 GRANT CREATE ON privs TO testuser
@@ -115,14 +115,14 @@ user testuser
 statement ok
 CREATE INDEX foo ON privs (b)
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM privs
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-privs       foo         true        1             b            ASC        false    false
-privs       foo         true        2             a            ASC        false    true
-privs       privs_pkey  false       1             a            ASC        false    false
-privs       privs_pkey  false       2             b            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+privs       foo         true        1             b            ASC        false    false     true
+privs       foo         true        2             a            ASC        false    true      true
+privs       privs_pkey  false       1             a            ASC        false    false     true
+privs       privs_pkey  false       2             b            N/A        true     false     true
 
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1554,6 +1554,7 @@ CREATE TABLE crdb_internal.table_indexes (
    is_unique BOOL NOT NULL,
    is_inverted BOOL NOT NULL,
    is_sharded BOOL NOT NULL,
+   is_visible BOOL NOT NULL,
    shard_bucket_count INT8 NULL,
    created_at TIMESTAMP NULL
 )  CREATE TABLE crdb_internal.table_indexes (
@@ -1565,6 +1566,7 @@ CREATE TABLE crdb_internal.table_indexes (
    is_unique BOOL NOT NULL,
    is_inverted BOOL NOT NULL,
    is_sharded BOOL NOT NULL,
+   is_visible BOOL NOT NULL,
    shard_bucket_count INT8 NULL,
    created_at TIMESTAMP NULL
 )  {}  {}
@@ -3312,7 +3314,8 @@ CREATE TABLE information_schema.statistics (
    cardinality INT8 NULL,
    direction STRING NOT NULL,
    storing STRING NOT NULL,
-   implicit STRING NOT NULL
+   implicit STRING NOT NULL,
+   is_visible STRING NOT NULL
 )  CREATE TABLE information_schema.statistics (
    table_catalog STRING NOT NULL,
    table_schema STRING NOT NULL,
@@ -3326,7 +3329,8 @@ CREATE TABLE information_schema.statistics (
    cardinality INT8 NULL,
    direction STRING NOT NULL,
    storing STRING NOT NULL,
-   implicit STRING NOT NULL
+   implicit STRING NOT NULL,
+   is_visible STRING NOT NULL
 )  {}  {}
 CREATE TABLE information_schema.table_constraints (
    constraint_catalog STRING NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -52,17 +52,17 @@ DROP INDEX baw
 statement ok
 INSERT INTO users VALUES (1, 'tom', 'cat'),(2, 'jerry', 'rat')
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       bar         false       1             id           ASC        false    false
-users       bar         false       2             name         ASC        false    false
-users       foo         true        1             name         ASC        false    false
-users       foo         true        2             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       bar         false       1             id           ASC        false    false     true
+users       bar         false       2             name         ASC        false    false     true
+users       foo         true        1             name         ASC        false    false     true
+users       foo         true        2             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 statement error index "zap" does not exist
 DROP INDEX users@zap
@@ -70,32 +70,32 @@ DROP INDEX users@zap
 statement ok
 DROP INDEX IF EXISTS users@zap
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       bar         false       1             id           ASC        false    false
-users       bar         false       2             name         ASC        false    false
-users       foo         true        1             name         ASC        false    false
-users       foo         true        2             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       bar         false       1             id           ASC        false    false     true
+users       bar         false       2             name         ASC        false    false     true
+users       foo         true        1             name         ASC        false    false     true
+users       foo         true        2             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 # Also test that dropping with a non-existing index still drops 'foo'.
 
 statement ok
 DROP INDEX IF EXISTS users@foo, users@zap
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       bar         false       1             id           ASC        false    false
-users       bar         false       2             name         ASC        false    false
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       bar         false       1             id           ASC        false    false     true
+users       bar         false       2             name         ASC        false    false     true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 user testuser
 
@@ -118,13 +118,13 @@ DROP INDEX users@bar RESTRICT
 statement ok
 DROP INDEX users@bar CASCADE
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 user root
 
@@ -146,17 +146,17 @@ CREATE INDEX baz ON users (name, title)
 statement ok
 DROP INDEX IF EXISTS users@invalid, users@baz
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       bar         true        1             title        ASC        false    false
-users       bar         true        2             id           ASC        false    true
-users       foo         true        1             name         ASC        false    false
-users       foo         true        2             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       bar         true        1             title        ASC        false    false     true
+users       bar         true        2             id           ASC        false    true      true
+users       foo         true        1             name         ASC        false    false     true
+users       foo         true        2             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 statement ok
 CREATE VIEW v AS SELECT name FROM users@{FORCE_INDEX=foo}
@@ -167,15 +167,15 @@ DROP INDEX users@foo
 statement ok
 DROP INDEX users@bar
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       foo         true        1             name         ASC        false    false
-users       foo         true        2             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       foo         true        1             name         ASC        false    false     true
+users       foo         true        2             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 statement ok
 CREATE VIEW v2 AS SELECT name FROM v
@@ -203,13 +203,13 @@ user root
 statement ok
 DROP INDEX users@foo CASCADE
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 query TTTTIT
 SHOW TABLES
@@ -243,13 +243,13 @@ CREATE INDEX baz ON users (name)
 statement ok
 DROP INDEX IF EXISTS baz, zap
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 # Test that it still succeeds when an index does not exist.
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -295,12 +295,12 @@ CREATE TABLE missing_col (customer INT REFERENCES customers (idz))
 statement ok
 CREATE TABLE unindexed (customer INT REFERENCES customers)
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM unindexed
 ----
-table_name  index_name      non_unique  seq_in_index  column_name  direction  storing  implicit
-unindexed   unindexed_pkey  false       1             rowid        ASC        false    false
-unindexed   unindexed_pkey  false       2             customer     N/A        true     false
+table_name  index_name      non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+unindexed   unindexed_pkey  false       1             rowid        ASC        false    false     true
+unindexed   unindexed_pkey  false       2             customer     N/A        true     false     true
 
 statement error there is no unique constraint matching given keys for referenced table products
 CREATE TABLE non_unique (product STRING REFERENCES products (vendor))
@@ -783,32 +783,32 @@ CREATE TABLE refpairs_wrong_order (
   INDEX (b, a)
 )
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM refpairs_wrong_order
 ----
-table_name            index_name                    non_unique  seq_in_index  column_name  direction  storing  implicit
-refpairs_wrong_order  refpairs_wrong_order_b_a_idx  true        1             b            ASC        false    false
-refpairs_wrong_order  refpairs_wrong_order_b_a_idx  true        2             a            ASC        false    false
-refpairs_wrong_order  refpairs_wrong_order_b_a_idx  true        3             rowid        ASC        false    true
-refpairs_wrong_order  refpairs_wrong_order_pkey     false       1             rowid        ASC        false    false
-refpairs_wrong_order  refpairs_wrong_order_pkey     false       2             a            N/A        true     false
-refpairs_wrong_order  refpairs_wrong_order_pkey     false       3             b            N/A        true     false
+table_name            index_name                    non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+refpairs_wrong_order  refpairs_wrong_order_b_a_idx  true        1             b            ASC        false    false     true
+refpairs_wrong_order  refpairs_wrong_order_b_a_idx  true        2             a            ASC        false    false     true
+refpairs_wrong_order  refpairs_wrong_order_b_a_idx  true        3             rowid        ASC        false    true      true
+refpairs_wrong_order  refpairs_wrong_order_pkey     false       1             rowid        ASC        false    false     true
+refpairs_wrong_order  refpairs_wrong_order_pkey     false       2             a            N/A        true     false     true
+refpairs_wrong_order  refpairs_wrong_order_pkey     false       3             b            N/A        true     false     true
 
 statement ok
 CREATE TABLE refpairs_c_between (a INT, b STRING, c INT, FOREIGN KEY (a, b) REFERENCES pairs (src, dest), INDEX (a, c, b))
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM refpairs_c_between
 ----
-table_name          index_name                    non_unique  seq_in_index  column_name  direction  storing  implicit
-refpairs_c_between  refpairs_c_between_a_c_b_idx  true        1             a            ASC        false    false
-refpairs_c_between  refpairs_c_between_a_c_b_idx  true        2             c            ASC        false    false
-refpairs_c_between  refpairs_c_between_a_c_b_idx  true        3             b            ASC        false    false
-refpairs_c_between  refpairs_c_between_a_c_b_idx  true        4             rowid        ASC        false    true
-refpairs_c_between  refpairs_c_between_pkey       false       1             rowid        ASC        false    false
-refpairs_c_between  refpairs_c_between_pkey       false       2             a            N/A        true     false
-refpairs_c_between  refpairs_c_between_pkey       false       3             b            N/A        true     false
-refpairs_c_between  refpairs_c_between_pkey       false       4             c            N/A        true     false
+table_name          index_name                    non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+refpairs_c_between  refpairs_c_between_a_c_b_idx  true        1             a            ASC        false    false     true
+refpairs_c_between  refpairs_c_between_a_c_b_idx  true        2             c            ASC        false    false     true
+refpairs_c_between  refpairs_c_between_a_c_b_idx  true        3             b            ASC        false    false     true
+refpairs_c_between  refpairs_c_between_a_c_b_idx  true        4             rowid        ASC        false    true      true
+refpairs_c_between  refpairs_c_between_pkey       false       1             rowid        ASC        false    false     true
+refpairs_c_between  refpairs_c_between_pkey       false       2             a            N/A        true     false     true
+refpairs_c_between  refpairs_c_between_pkey       false       3             b            N/A        true     false     true
+refpairs_c_between  refpairs_c_between_pkey       false       4             c            N/A        true     false     true
 
 statement ok
 CREATE TABLE refpairs (
@@ -820,18 +820,18 @@ CREATE TABLE refpairs (
   FAMILY "primary" (a, b, c, rowid)
 )
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM refpairs
 ----
-table_name  index_name          non_unique  seq_in_index  column_name  direction  storing  implicit
-refpairs    refpairs_a_b_c_idx  true        1             a            ASC        false    false
-refpairs    refpairs_a_b_c_idx  true        2             b            ASC        false    false
-refpairs    refpairs_a_b_c_idx  true        3             c            ASC        false    false
-refpairs    refpairs_a_b_c_idx  true        4             rowid        ASC        false    true
-refpairs    refpairs_pkey       false       1             rowid        ASC        false    false
-refpairs    refpairs_pkey       false       2             a            N/A        true     false
-refpairs    refpairs_pkey       false       3             b            N/A        true     false
-refpairs    refpairs_pkey       false       4             c            N/A        true     false
+table_name  index_name          non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+refpairs    refpairs_a_b_c_idx  true        1             a            ASC        false    false     true
+refpairs    refpairs_a_b_c_idx  true        2             b            ASC        false    false     true
+refpairs    refpairs_a_b_c_idx  true        3             c            ASC        false    false     true
+refpairs    refpairs_a_b_c_idx  true        4             rowid        ASC        false    true      true
+refpairs    refpairs_pkey       false       1             rowid        ASC        false    false     true
+refpairs    refpairs_pkey       false       2             a            N/A        true     false     true
+refpairs    refpairs_pkey       false       3             b            N/A        true     false     true
+refpairs    refpairs_pkey       false       4             c            N/A        true     false     true
 
 query TT
 SHOW CREATE TABLE refpairs

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -350,10 +350,10 @@ table_type          STRING     false        NULL            ·                  
 is_insertable_into  STRING     false        NULL            ·                      {}       false
 version             INT8       true         NULL            ·                      {}       false
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM information_schema.tables
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
 
 query TTTTB colnames
 SHOW CONSTRAINTS FROM information_schema.tables
@@ -3954,19 +3954,19 @@ user root
 statement ok
 CREATE TABLE other_db.teststatics(id INT PRIMARY KEY, c INT, d INT, e STRING, INDEX idx_c(c), UNIQUE INDEX idx_cd(c,d))
 
-query TTTTTTITIITTT colnames
+query TTTTTTITIITTTT colnames
 SELECT * FROM other_db.information_schema.statistics WHERE table_schema='public' AND table_name='teststatics' ORDER BY INDEX_SCHEMA,INDEX_NAME,SEQ_IN_INDEX
 ----
-table_catalog  table_schema  table_name   non_unique  index_schema  index_name        seq_in_index  column_name  COLLATION  cardinality  direction  storing  implicit
-other_db       public        teststatics  YES         public        idx_c             1             c            NULL       NULL         ASC        NO       NO
-other_db       public        teststatics  YES         public        idx_c             2             id           NULL       NULL         ASC        NO       YES
-other_db       public        teststatics  NO          public        idx_cd            1             c            NULL       NULL         ASC        NO       NO
-other_db       public        teststatics  NO          public        idx_cd            2             d            NULL       NULL         ASC        NO       NO
-other_db       public        teststatics  NO          public        idx_cd            3             id           NULL       NULL         ASC        YES      YES
-other_db       public        teststatics  NO          public        teststatics_pkey  1             id           NULL       NULL         ASC        NO       NO
-other_db       public        teststatics  NO          public        teststatics_pkey  2             c            NULL       NULL         N/A        YES      NO
-other_db       public        teststatics  NO          public        teststatics_pkey  3             d            NULL       NULL         N/A        YES      NO
-other_db       public        teststatics  NO          public        teststatics_pkey  4             e            NULL       NULL         N/A        YES      NO
+table_catalog  table_schema  table_name   non_unique  index_schema  index_name        seq_in_index  column_name  COLLATION  cardinality  direction  storing  implicit  is_visible
+other_db       public        teststatics  YES         public        idx_c             1             c            NULL       NULL         ASC        NO       NO        YES
+other_db       public        teststatics  YES         public        idx_c             2             id           NULL       NULL         ASC        NO       YES       YES
+other_db       public        teststatics  NO          public        idx_cd            1             c            NULL       NULL         ASC        NO       NO        YES
+other_db       public        teststatics  NO          public        idx_cd            2             d            NULL       NULL         ASC        NO       NO        YES
+other_db       public        teststatics  NO          public        idx_cd            3             id           NULL       NULL         ASC        YES      YES       YES
+other_db       public        teststatics  NO          public        teststatics_pkey  1             id           NULL       NULL         ASC        NO       NO        YES
+other_db       public        teststatics  NO          public        teststatics_pkey  2             c            NULL       NULL         N/A        YES      NO        YES
+other_db       public        teststatics  NO          public        teststatics_pkey  3             d            NULL       NULL         N/A        YES      NO        YES
+other_db       public        teststatics  NO          public        teststatics_pkey  4             e            NULL       NULL         N/A        YES      NO        YES
 
 # Verify information_schema.views
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1399,22 +1399,22 @@ CREATE TABLE tIndx2 (a INT PRIMARY KEY, b INT, INDEX ((a+b)))
 statement ok
 CREATE TABLE tIndx3 (a INT PRIMARY KEY, b INT, INVERTED INDEX ((ARRAY[a,b])))
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM tIndex
 ----
-table_name  index_name   non_unique  seq_in_index  column_name               direction  storing  implicit
-tindex      bar          true        1             crdb_internal_idx_expr    ASC        false    false
-tindex      bar          true        2             a                         ASC        false    true
-tindex      bar2         true        1             crdb_internal_idx_expr_1  ASC        false    false
-tindex      bar2         true        2             a                         ASC        false    true
-tindex      bar3         false       1             crdb_internal_idx_expr_2  ASC        false    false
-tindex      bar3         false       2             a                         ASC        true     true
-tindex      bar4         true        1             crdb_internal_idx_expr_3  ASC        false    false
-tindex      bar4         true        2             a                         ASC        false    true
-tindex      foo          true        1             b                         ASC        false    false
-tindex      foo          true        2             a                         ASC        false    true
-tindex      tindex_pkey  false       1             a                         ASC        false    false
-tindex      tindex_pkey  false       2             b                         N/A        true     false
+table_name  index_name   non_unique  seq_in_index  column_name               direction  storing  implicit  visible
+tindex      bar          true        1             crdb_internal_idx_expr    ASC        false    false     true
+tindex      bar          true        2             a                         ASC        false    true      true
+tindex      bar2         true        1             crdb_internal_idx_expr_1  ASC        false    false     true
+tindex      bar2         true        2             a                         ASC        false    true      true
+tindex      bar3         false       1             crdb_internal_idx_expr_2  ASC        false    false     true
+tindex      bar3         false       2             a                         ASC        true     true      true
+tindex      bar4         true        1             crdb_internal_idx_expr_3  ASC        false    false     true
+tindex      bar4         true        2             a                         ASC        false    true      true
+tindex      foo          true        1             b                         ASC        false    false     true
+tindex      foo          true        2             a                         ASC        false    true      true
+tindex      tindex_pkey  false       1             a                         ASC        false    false     true
+tindex      tindex_pkey  false       2             b                         N/A        true     false     true
 
 statement error  duplicate key value violates unique constraint "bar3"
 INSERT INTO tIndex VALUES (2,1)
@@ -1426,22 +1426,22 @@ INSERT INTO tIndex VALUES (20000,10000)
 #statement error pgcode 23505 violates unique constraint "bar"
 #CREATE UNIQUE INDEX bar ON tIndex (b)
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM tIndex
 ----
-table_name  index_name   non_unique  seq_in_index  column_name               direction  storing  implicit
-tindex      bar          true        1             crdb_internal_idx_expr    ASC        false    false
-tindex      bar          true        2             a                         ASC        false    true
-tindex      bar2         true        1             crdb_internal_idx_expr_1  ASC        false    false
-tindex      bar2         true        2             a                         ASC        false    true
-tindex      bar3         false       1             crdb_internal_idx_expr_2  ASC        false    false
-tindex      bar3         false       2             a                         ASC        true     true
-tindex      bar4         true        1             crdb_internal_idx_expr_3  ASC        false    false
-tindex      bar4         true        2             a                         ASC        false    true
-tindex      foo          true        1             b                         ASC        false    false
-tindex      foo          true        2             a                         ASC        false    true
-tindex      tindex_pkey  false       1             a                         ASC        false    false
-tindex      tindex_pkey  false       2             b                         N/A        true     false
+table_name  index_name   non_unique  seq_in_index  column_name               direction  storing  implicit  visible
+tindex      bar          true        1             crdb_internal_idx_expr    ASC        false    false     true
+tindex      bar          true        2             a                         ASC        false    true      true
+tindex      bar2         true        1             crdb_internal_idx_expr_1  ASC        false    false     true
+tindex      bar2         true        2             a                         ASC        false    true      true
+tindex      bar3         false       1             crdb_internal_idx_expr_2  ASC        false    false     true
+tindex      bar3         false       2             a                         ASC        true     true      true
+tindex      bar4         true        1             crdb_internal_idx_expr_3  ASC        false    false     true
+tindex      bar4         true        2             a                         ASC        false    true      true
+tindex      foo          true        1             b                         ASC        false    false     true
+tindex      foo          true        2             a                         ASC        false    true      true
+tindex      tindex_pkey  false       1             a                         ASC        false    false     true
+tindex      tindex_pkey  false       2             b                         N/A        true     false     true
 
 # test for DESC index
 
@@ -1464,18 +1464,18 @@ CREATE INDEX b_desc ON tIndx (b DESC)
 statement ok
 CREATE INDEX b_asc ON tIndx (b ASC, c DESC)
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM tIndx
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-tindx       b_asc       true        1             b            ASC        false    false
-tindx       b_asc       true        2             c            DESC       false    false
-tindx       b_asc       true        3             a            ASC        false    true
-tindx       b_desc      true        1             b            DESC       false    false
-tindx       b_desc      true        2             a            ASC        false    true
-tindx       tindx_pkey  false       1             a            ASC        false    false
-tindx       tindx_pkey  false       2             b            N/A        true     false
-tindx       tindx_pkey  false       3             c            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+tindx       b_asc       true        1             b            ASC        false    false     true
+tindx       b_asc       true        2             c            DESC       false    false     true
+tindx       b_asc       true        3             a            ASC        false    true      true
+tindx       b_desc      true        1             b            DESC       false    false     true
+tindx       b_desc      true        2             a            ASC        false    true      true
+tindx       tindx_pkey  false       1             a            ASC        false    false     true
+tindx       tindx_pkey  false       2             b            N/A        true     false     true
+tindx       tindx_pkey  false       3             c            N/A        true     false     true
 
 statement error pgcode 42P01 relation "foo" does not exist
 CREATE INDEX fail ON foo (b DESC)
@@ -1496,12 +1496,12 @@ CREATE INDEX foo ON privs (b)
 
 user root
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM privs
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-privs       privs_pkey  false       1             a            ASC        false    false
-privs       privs_pkey  false       2             b            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+privs       privs_pkey  false       1             a            ASC        false    false     true
+privs       privs_pkey  false       2             b            N/A        true     false     true
 
 statement ok
 GRANT CREATE ON privs TO testuser
@@ -1511,14 +1511,14 @@ user testuser
 statement ok
 CREATE INDEX foo ON privs (b)
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM privs
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-privs       foo         true        1             b            ASC        false    false
-privs       foo         true        2             a            ASC        false    true
-privs       privs_pkey  false       1             a            ASC        false    false
-privs       privs_pkey  false       2             b            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+privs       foo         true        1             b            ASC        false    false     true
+privs       foo         true        2             a            ASC        false    true      true
+privs       privs_pkey  false       1             a            ASC        false    false     true
+privs       privs_pkey  false       2             b            N/A        true     false     true
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -324,10 +324,10 @@ nspname      NAME       false        NULL            ·                      {} 
 nspowner     OID        true         NULL            ·                      {}       false
 nspacl       STRING[]   true         NULL            ·                      {}       false
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM pg_catalog.pg_namespace
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
 
 query TTTTB colnames
 SHOW CONSTRAINTS FROM pg_catalog.pg_namespace

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -70,18 +70,18 @@ id username  species
 2  jerry     rat
 
 # Renaming a column updates the column names in an index.
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       bar         false       1             id           ASC        false    false
-users       bar         false       2             username     ASC        false    false
-users       foo         true        1             username     ASC        false    false
-users       foo         true        2             species      N/A        true     false
-users       foo         true        3             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             username     N/A        true     false
-users       users_pkey  false       3             species      N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       bar         false       1             id           ASC        false    false     true
+users       bar         false       2             username     ASC        false    false     true
+users       foo         true        1             username     ASC        false    false     true
+users       foo         true        2             species      N/A        true     false     true
+users       foo         true        3             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             username     N/A        true     false     true
+users       users_pkey  false       3             species      N/A        true     false     true
 
 statement ok
 CREATE VIEW v1 AS SELECT id FROM users WHERE username = 'tom'

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -22,29 +22,29 @@ INSERT INTO users VALUES (1, 'tom', 'cat'),(2, 'jerry', 'rat')
 statement ok
 INSERT INTO users_dupe VALUES (1, 'tom', 'cat'),(2, 'jerry', 'rat')
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       bar         false       1             id           ASC        false    false
-users       bar         false       2             name         ASC        false    false
-users       foo         true        1             name         ASC        false    false
-users       foo         true        2             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       bar         false       1             id           ASC        false    false     true
+users       bar         false       2             name         ASC        false    false     true
+users       foo         true        1             name         ASC        false    false     true
+users       foo         true        2             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users_dupe
 ----
-table_name  index_name       non_unique  seq_in_index  column_name  direction  storing  implicit
-users_dupe  bar              false       1             id           ASC        false    false
-users_dupe  bar              false       2             name         ASC        false    false
-users_dupe  foo              true        1             name         ASC        false    false
-users_dupe  foo              true        2             id           ASC        false    true
-users_dupe  users_dupe_pkey  false       1             id           ASC        false    false
-users_dupe  users_dupe_pkey  false       2             name         N/A        true     false
-users_dupe  users_dupe_pkey  false       3             title        N/A        true     false
+table_name  index_name       non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users_dupe  bar              false       1             id           ASC        false    false     true
+users_dupe  bar              false       2             name         ASC        false    false     true
+users_dupe  foo              true        1             name         ASC        false    false     true
+users_dupe  foo              true        2             id           ASC        false    true      true
+users_dupe  users_dupe_pkey  false       1             id           ASC        false    false     true
+users_dupe  users_dupe_pkey  false       2             name         N/A        true     false     true
+users_dupe  users_dupe_pkey  false       3             title        N/A        true     false     true
 
 statement error pgcode 42P07 index name "bar" already exists
 ALTER INDEX users@foo RENAME TO bar
@@ -80,17 +80,17 @@ ALTER INDEX IF EXISTS ufooo RENAME TO ufoo
 statement ok
 ALTER INDEX ufoo RENAME TO ufo
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       bar         false       1             id           ASC        false    false
-users       bar         false       2             name         ASC        false    false
-users       ufo         true        1             name         ASC        false    false
-users       ufo         true        2             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       bar         false       1             id           ASC        false    false     true
+users       bar         false       2             name         ASC        false    false     true
+users       ufo         true        1             name         ASC        false    false     true
+users       ufo         true        2             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 user testuser
 
@@ -107,17 +107,17 @@ user testuser
 statement ok
 ALTER INDEX users@bar RENAME TO rar
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       rar         false       1             id           ASC        false    false
-users       rar         false       2             name         ASC        false    false
-users       ufo         true        1             name         ASC        false    false
-users       ufo         true        2             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       rar         false       1             id           ASC        false    false     true
+users       rar         false       2             name         ASC        false    false     true
+users       ufo         true        1             name         ASC        false    false     true
+users       ufo         true        2             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/show_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/show_indexes
@@ -9,20 +9,20 @@ CREATE TABLE t1 (
   UNIQUE INDEX d_b_idx (d ASC, b ASC)
 )
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES from t1
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-t1          c_idx       true        1             c            ASC        false    false
-t1          c_idx       true        2             a            ASC        false    true
-t1          c_idx       true        3             b            ASC        false    true
-t1          d_b_idx     false       1             d            ASC        false    false
-t1          d_b_idx     false       2             b            ASC        false    false
-t1          d_b_idx     false       3             a            ASC        true     true
-t1          t1_pkey     false       1             a            ASC        false    false
-t1          t1_pkey     false       2             b            ASC        false    false
-t1          t1_pkey     false       3             c            N/A        true     false
-t1          t1_pkey     false       4             d            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t1          c_idx       true        1             c            ASC        false    false     true
+t1          c_idx       true        2             a            ASC        false    true      true
+t1          c_idx       true        3             b            ASC        false    true      true
+t1          d_b_idx     false       1             d            ASC        false    false     true
+t1          d_b_idx     false       2             b            ASC        false    false     true
+t1          d_b_idx     false       3             a            ASC        true     true      true
+t1          t1_pkey     false       1             a            ASC        false    false     true
+t1          t1_pkey     false       2             b            ASC        false    false     true
+t1          t1_pkey     false       3             c            N/A        true     false     true
+t1          t1_pkey     false       4             d            N/A        true     false     true
 
 statement ok
 CREATE TABLE t2 (
@@ -38,29 +38,29 @@ CREATE TABLE t2 (
   INDEX d_idx (d ASC)
 )
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES from t2
 ----
-table_name  index_name   non_unique  seq_in_index  column_name  direction  storing  implicit
-t2          a_e_c_idx    true        1             a            ASC        false    false
-t2          a_e_c_idx    true        2             e            ASC        false    false
-t2          a_e_c_idx    true        3             c            ASC        false    false
-t2          a_e_c_idx    true        4             b            ASC        false    true
-t2          b_d_idx      false       1             b            ASC        false    false
-t2          b_d_idx      false       2             d            ASC        false    false
-t2          b_d_idx      false       3             c            ASC        true     true
-t2          b_d_idx      false       4             a            ASC        true     true
-t2          c_e_d_a_idx  false       1             c            ASC        false    false
-t2          c_e_d_a_idx  false       2             e            ASC        false    false
-t2          c_e_d_a_idx  false       3             d            ASC        false    false
-t2          c_e_d_a_idx  false       4             a            ASC        false    false
-t2          c_e_d_a_idx  false       5             b            ASC        true     true
-t2          d_idx        true        1             d            ASC        false    false
-t2          d_idx        true        2             c            ASC        false    true
-t2          d_idx        true        3             b            ASC        false    true
-t2          d_idx        true        4             a            ASC        false    true
-t2          t2_pkey      false       1             c            ASC        false    false
-t2          t2_pkey      false       2             b            ASC        false    false
-t2          t2_pkey      false       3             a            ASC        false    false
-t2          t2_pkey      false       4             d            N/A        true     false
-t2          t2_pkey      false       5             e            N/A        true     false
+table_name  index_name   non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t2          a_e_c_idx    true        1             a            ASC        false    false     true
+t2          a_e_c_idx    true        2             e            ASC        false    false     true
+t2          a_e_c_idx    true        3             c            ASC        false    false     true
+t2          a_e_c_idx    true        4             b            ASC        false    true      true
+t2          b_d_idx      false       1             b            ASC        false    false     true
+t2          b_d_idx      false       2             d            ASC        false    false     true
+t2          b_d_idx      false       3             c            ASC        true     true      true
+t2          b_d_idx      false       4             a            ASC        true     true      true
+t2          c_e_d_a_idx  false       1             c            ASC        false    false     true
+t2          c_e_d_a_idx  false       2             e            ASC        false    false     true
+t2          c_e_d_a_idx  false       3             d            ASC        false    false     true
+t2          c_e_d_a_idx  false       4             a            ASC        false    false     true
+t2          c_e_d_a_idx  false       5             b            ASC        true     true      true
+t2          d_idx        true        1             d            ASC        false    false     true
+t2          d_idx        true        2             c            ASC        false    true      true
+t2          d_idx        true        3             b            ASC        false    true      true
+t2          d_idx        true        4             a            ASC        false    true      true
+t2          t2_pkey      false       1             c            ASC        false    false     true
+t2          t2_pkey      false       2             b            ASC        false    false     true
+t2          t2_pkey      false       3             a            ASC        false    false     true
+t2          t2_pkey      false       4             d            N/A        true     false     true
+t2          t2_pkey      false       5             e            N/A        true     false     true

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -203,12 +203,12 @@ database_name  schema_name  table_name  grantee  privilege_type  is_grantable
 system         public       descriptor  admin    SELECT          true
 system         public       descriptor  root     SELECT          true
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SELECT * FROM [SHOW INDEX FROM system.descriptor]
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-descriptor  primary     false       1             id           ASC        false    false
-descriptor  primary     false       2             descriptor   N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+descriptor  primary     false       1             id           ASC        false    false     true
+descriptor  primary     false       2             descriptor   N/A        true     false     true
 
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINT FROM system.descriptor]
@@ -216,12 +216,12 @@ SELECT * FROM [SHOW CONSTRAINT FROM system.descriptor]
 table_name  constraint_name  constraint_type  details               validated
 descriptor  primary          PRIMARY KEY      PRIMARY KEY (id ASC)  true
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SELECT * FROM [SHOW KEYS FROM system.descriptor]
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-descriptor  primary     false       1             id           ASC        false    false
-descriptor  primary     false       2             descriptor   N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+descriptor  primary     false       1             id           ASC        false    false     true
+descriptor  primary     false       2             descriptor   N/A        true     false     true
 
 query TT colnames,rowsort
 SELECT * FROM [SHOW SCHEMAS FROM system]
@@ -494,11 +494,11 @@ CREATE TABLE showdbindexestest.table1 (key1 INT PRIMARY KEY);
 statement ok
 CREATE TABLE showdbindexestest.table2 (key2 INT PRIMARY KEY);
 
-query TTBITTBB
+query TTBITTBBB
 SHOW INDEXES FROM DATABASE showdbindexestest;
 ----
-table1  table1_pkey  false  1  key1  ASC  false  false
-table2  table2_pkey  false  1  key2  ASC  false  false
+table1  table1_pkey  false  1  key1  ASC  false  false  true
+table2  table2_pkey  false  1  key2  ASC  false  false  true
 
 statement ok
 CREATE DATABASE "$peci@l";
@@ -509,11 +509,11 @@ CREATE TABLE "$peci@l".table1 (key1 INT PRIMARY KEY);
 statement ok
 CREATE TABLE "$peci@l".table2 (key2 INT PRIMARY KEY);
 
-query TTBITTBB
+query TTBITTBBB
 SHOW INDEXES FROM DATABASE "$peci@l";
 ----
-table1  table1_pkey  false  1  key1  ASC  false  false
-table2  table2_pkey  false  1  key2  ASC  false  false
+table1  table1_pkey  false  1  key1  ASC  false  false  true
+table2  table2_pkey  false  1  key2  ASC  false  false  true
 
 # Test SHOW LOCALITY telemetry.
 query T
@@ -585,30 +585,30 @@ CREATE TABLE t (
 COMMENT ON COLUMN t.z IS 'comm"en"t2';
 COMMENT ON INDEX t@i2 IS 'comm''ent3'
 
-query TTBITTBBT
+query TTBITTBBBT
 SHOW INDEXES FROM t WITH COMMENT
 ----
-t  i1      true   1  x      ASC  false  false  NULL
-t  i1      true   2  rowid  ASC  false  true   NULL
-t  i2      true   1  y      ASC  false  false  comm'ent3
-t  i2      true   2  rowid  ASC  false  true   comm'ent3
-t  i3      true   1  z      ASC  false  false  NULL
-t  i3      true   2  rowid  ASC  false  true   NULL
-t  t_pkey  false  1  rowid  ASC  false  false  NULL
-t  t_pkey  false  2  x      N/A  true   false  NULL
-t  t_pkey  false  3  y      N/A  true   false  NULL
-t  t_pkey  false  4  z      N/A  true   false  NULL
+t  i1      true   1  x      ASC  false  false  true  NULL
+t  i1      true   2  rowid  ASC  false  true   true  NULL
+t  i2      true   1  y      ASC  false  false  true  comm'ent3
+t  i2      true   2  rowid  ASC  false  true   true  comm'ent3
+t  i3      true   1  z      ASC  false  false  true  NULL
+t  i3      true   2  rowid  ASC  false  true   true  NULL
+t  t_pkey  false  1  rowid  ASC  false  false  true  NULL
+t  t_pkey  false  2  x      N/A  true   false  true  NULL
+t  t_pkey  false  3  y      N/A  true   false  true  NULL
+t  t_pkey  false  4  z      N/A  true   false  true  NULL
 
-query TTBITTBBT
+query TTBITTBBBT
 SHOW INDEXES FROM t2 WITH COMMENT
 ----
-t2  i1       true   1  x      ASC  false  false  NULL
-t2  i1       true   2  rowid  ASC  false  true   NULL
-t2  i2       true   1  y      ASC  false  false  NULL
-t2  i2       true   2  rowid  ASC  false  true   NULL
-t2  i3       true   1  z      ASC  false  false  NULL
-t2  i3       true   2  rowid  ASC  false  true   NULL
-t2  t2_pkey  false  1  rowid  ASC  false  false  NULL
-t2  t2_pkey  false  2  x      N/A  true   false  NULL
-t2  t2_pkey  false  3  y      N/A  true   false  NULL
-t2  t2_pkey  false  4  z      N/A  true   false  NULL
+t2  i1       true   1  x      ASC  false  false  true  NULL
+t2  i1       true   2  rowid  ASC  false  true   true  NULL
+t2  i2       true   1  y      ASC  false  false  true  NULL
+t2  i2       true   2  rowid  ASC  false  true   true  NULL
+t2  i3       true   1  z      ASC  false  false  true  NULL
+t2  i3       true   2  rowid  ASC  false  true   true  NULL
+t2  t2_pkey  false  1  rowid  ASC  false  false  true  NULL
+t2  t2_pkey  false  2  x      N/A  true   false  true  NULL
+t2  t2_pkey  false  3  y      N/A  true   false  true  NULL
+t2  t2_pkey  false  4  z      N/A  true   false  true  NULL

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -8,22 +8,22 @@ CREATE TABLE t (
   UNIQUE INDEX c_idx (c) STORING (b, d)
 )
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM t
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-t           b_idx       true        1             b            ASC        false    false
-t           b_idx       true        2             c            N/A        true     false
-t           b_idx       true        3             d            N/A        true     false
-t           b_idx       true        4             a            ASC        false    true
-t           c_idx       false       1             c            ASC        false    false
-t           c_idx       false       2             b            N/A        true     false
-t           c_idx       false       3             d            N/A        true     false
-t           c_idx       false       4             a            ASC        true     true
-t           t_pkey      false       1             a            ASC        false    false
-t           t_pkey      false       2             b            N/A        true     false
-t           t_pkey      false       3             c            N/A        true     false
-t           t_pkey      false       4             d            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t           b_idx       true        1             b            ASC        false    false     true
+t           b_idx       true        2             c            N/A        true     false     true
+t           b_idx       true        3             d            N/A        true     false     true
+t           b_idx       true        4             a            ASC        false    true      true
+t           c_idx       false       1             c            ASC        false    false     true
+t           c_idx       false       2             b            N/A        true     false     true
+t           c_idx       false       3             d            N/A        true     false     true
+t           c_idx       false       4             a            ASC        true     true      true
+t           t_pkey      false       1             a            ASC        false    false     true
+t           t_pkey      false       2             b            N/A        true     false     true
+t           t_pkey      false       3             c            N/A        true     false     true
+t           t_pkey      false       4             d            N/A        true     false     true
 
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4)

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -63,39 +63,39 @@ CREATE TABLE c (
 statement ok
 COMMENT ON INDEX c_foo_idx IS 'index_comment'
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM c
 ----
-table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit
-c           c_bar_key      false       1             bar          ASC        false    false
-c           c_bar_key      false       2             id           ASC        true     true
-c           c_foo_bar_idx  true        1             foo          ASC        false    false
-c           c_foo_bar_idx  true        2             bar          DESC       false    false
-c           c_foo_bar_idx  true        3             id           ASC        false    true
-c           c_foo_idx      true        1             foo          ASC        false    false
-c           c_foo_idx      true        2             id           ASC        false    true
-c           c_foo_idx1     true        1             foo          ASC        false    false
-c           c_foo_idx1     true        2             id           ASC        false    true
-c           c_pkey         false       1             id           ASC        false    false
-c           c_pkey         false       2             foo          N/A        true     false
-c           c_pkey         false       3             bar          N/A        true     false
+table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+c           c_bar_key      false       1             bar          ASC        false    false     true
+c           c_bar_key      false       2             id           ASC        true     true      true
+c           c_foo_bar_idx  true        1             foo          ASC        false    false     true
+c           c_foo_bar_idx  true        2             bar          DESC       false    false     true
+c           c_foo_bar_idx  true        3             id           ASC        false    true      true
+c           c_foo_idx      true        1             foo          ASC        false    false     true
+c           c_foo_idx      true        2             id           ASC        false    true      true
+c           c_foo_idx1     true        1             foo          ASC        false    false     true
+c           c_foo_idx1     true        2             id           ASC        false    true      true
+c           c_pkey         false       1             id           ASC        false    false     true
+c           c_pkey         false       2             foo          N/A        true     false     true
+c           c_pkey         false       3             bar          N/A        true     false     true
 
-query TTBITTBBT colnames
+query TTBITTBBBT colnames
 SHOW INDEXES FROM c WITH COMMENT
 ----
-table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit  comment
-c           c_bar_key      false       1             bar          ASC        false    false     NULL
-c           c_bar_key      false       2             id           ASC        true     true      NULL
-c           c_foo_bar_idx  true        1             foo          ASC        false    false     NULL
-c           c_foo_bar_idx  true        2             bar          DESC       false    false     NULL
-c           c_foo_bar_idx  true        3             id           ASC        false    true      NULL
-c           c_foo_idx      true        1             foo          ASC        false    false     index_comment
-c           c_foo_idx      true        2             id           ASC        false    true      index_comment
-c           c_foo_idx1     true        1             foo          ASC        false    false     NULL
-c           c_foo_idx1     true        2             id           ASC        false    true      NULL
-c           c_pkey         false       1             id           ASC        false    false     NULL
-c           c_pkey         false       2             foo          N/A        true     false     NULL
-c           c_pkey         false       3             bar          N/A        true     false     NULL
+table_name  index_name     non_unique  seq_in_index  column_name  direction  storing  implicit  visible  comment
+c           c_bar_key      false       1             bar          ASC        false    false     true     NULL
+c           c_bar_key      false       2             id           ASC        true     true      true     NULL
+c           c_foo_bar_idx  true        1             foo          ASC        false    false     true     NULL
+c           c_foo_bar_idx  true        2             bar          DESC       false    false     true     NULL
+c           c_foo_bar_idx  true        3             id           ASC        false    true      true     NULL
+c           c_foo_idx      true        1             foo          ASC        false    false     true     index_comment
+c           c_foo_idx      true        2             id           ASC        false    true      true     index_comment
+c           c_foo_idx1     true        1             foo          ASC        false    false     true     NULL
+c           c_foo_idx1     true        2             id           ASC        false    true      true     NULL
+c           c_pkey         false       1             id           ASC        false    false     true     NULL
+c           c_pkey         false       2             foo          N/A        true     false     true     NULL
+c           c_pkey         false       3             bar          N/A        true     false     true     NULL
 
 # primary keys can never be null
 
@@ -199,20 +199,20 @@ nickname     STRING        true         NULL            ·                      
 username     STRING(10)    true         NULL            ·                      {users_pkey}          false
 email        VARCHAR(100)  true         NULL            ·                      {users_pkey}          false
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM test.users
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-users       bar         false       1             id           ASC        false    false
-users       bar         false       2             name         ASC        false    false
-users       foo         true        1             name         ASC        false    false
-users       foo         true        2             id           ASC        false    true
-users       users_pkey  false       1             id           ASC        false    false
-users       users_pkey  false       2             name         N/A        true     false
-users       users_pkey  false       3             title        N/A        true     false
-users       users_pkey  false       4             nickname     N/A        true     false
-users       users_pkey  false       5             username     N/A        true     false
-users       users_pkey  false       6             email        N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+users       bar         false       1             id           ASC        false    false     true
+users       bar         false       2             name         ASC        false    false     true
+users       foo         true        1             name         ASC        false    false     true
+users       foo         true        2             id           ASC        false    true      true
+users       users_pkey  false       1             id           ASC        false    false     true
+users       users_pkey  false       2             name         N/A        true     false     true
+users       users_pkey  false       3             title        N/A        true     false     true
+users       users_pkey  false       4             nickname     N/A        true     false     true
+users       users_pkey  false       5             username     N/A        true     false     true
+users       users_pkey  false       6             email        N/A        true     false     true
 
 statement error precision for type float must be at least 1 bit
 CREATE TABLE test.precision (x FLOAT(0))

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -613,7 +613,7 @@ distribution: local
 vectorized: true
 ·
 • sort
-│ order: +index_name,+non_unique,+seq_in_index,+column_name,+direction,+storing,+implicit
+│ order: +index_name,+seq_in_index
 │
 └── • render
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -541,22 +541,22 @@ CREATE TABLE t (
   FAMILY (a, b, c, d)
 )
 
-query TTBITTBB colnames
+query TTBITTBBB colnames
 SHOW INDEXES FROM t
 ----
-table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit
-t           b_idx       true        1             b            ASC        false    false
-t           b_idx       true        2             c            N/A        true     false
-t           b_idx       true        3             d            N/A        true     false
-t           b_idx       true        4             a            ASC        false    true
-t           c_idx       false       1             c            ASC        false    false
-t           c_idx       false       2             b            N/A        true     false
-t           c_idx       false       3             d            N/A        true     false
-t           c_idx       false       4             a            ASC        true     true
-t           t_pkey      false       1             a            ASC        false    false
-t           t_pkey      false       2             b            N/A        true     false
-t           t_pkey      false       3             c            N/A        true     false
-t           t_pkey      false       4             d            N/A        true     false
+table_name  index_name  non_unique  seq_in_index  column_name  direction  storing  implicit  visible
+t           b_idx       true        1             b            ASC        false    false     true
+t           b_idx       true        2             c            N/A        true     false     true
+t           b_idx       true        3             d            N/A        true     false     true
+t           b_idx       true        4             a            ASC        false    true      true
+t           c_idx       false       1             c            ASC        false    false     true
+t           c_idx       false       2             b            N/A        true     false     true
+t           c_idx       false       3             d            N/A        true     false     true
+t           c_idx       false       4             a            ASC        true     true      true
+t           t_pkey      false       1             a            ASC        false    false     true
+t           t_pkey      false       2             b            N/A        true     false     true
+t           t_pkey      false       3             c            N/A        true     false     true
+t           t_pkey      false       4             d            N/A        true     false     true
 
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -766,15 +766,15 @@ vectorized: true
 # Check that primary key definitions can indicate index ordering,
 # and this information is subsequently used during index selection
 # and span generation. #13882
-query TTBITTBB
+query TTBITTBBB
 CREATE TABLE abz(a INT, b INT, c INT, PRIMARY KEY (a DESC, b ASC), UNIQUE(c DESC, b ASC)); SHOW INDEX FROM abz
 ----
-abz  abz_c_b_key  false  1  c  DESC  false  false
-abz  abz_c_b_key  false  2  b  ASC   false  false
-abz  abz_c_b_key  false  3  a  ASC   true   true
-abz  abz_pkey     false  1  a  DESC  false  false
-abz  abz_pkey     false  2  b  ASC   false  false
-abz  abz_pkey     false  3  c  N/A   true   false
+abz  abz_c_b_key  false  1  c  DESC  false  false  true
+abz  abz_c_b_key  false  2  b  ASC   false  false  true
+abz  abz_c_b_key  false  3  a  ASC   true   true   true
+abz  abz_pkey     false  1  a  DESC  false  false  true
+abz  abz_pkey     false  2  b  ASC   false  false  true
+abz  abz_pkey     false  3  c  N/A   true   false  true
 
 query T
 EXPLAIN (VERBOSE) SELECT a FROM abz ORDER BY a DESC LIMIT 1

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -560,9 +560,9 @@ func TestPGPreparedQuery(t *testing.T) {
 				Results("system", "public", "users", username.RootUser, "UPDATE", true),
 		}},
 		{"SHOW INDEXES FROM system.users", []preparedQueryTest{
-			baseTest.Results("users", "primary", false, 1, "username", "ASC", false, false).
-				Results("users", "primary", false, 2, "hashedPassword", "N/A", true, false).
-				Results("users", "primary", false, 3, "isRole", "N/A", true, false),
+			baseTest.Results("users", "primary", false, 1, "username", "ASC", false, false, true).
+				Results("users", "primary", false, 2, "hashedPassword", "N/A", true, false, true).
+				Results("users", "primary", false, 3, "isRole", "N/A", true, false, true),
 		}},
 		{"SHOW TABLES FROM system", []preparedQueryTest{
 			baseTest.Results("public", "comments", "table", gosql.NullString{}, 0, gosql.NullString{}).Others(38),

--- a/pkg/sql/vtable/information_schema.go
+++ b/pkg/sql/vtable/information_schema.go
@@ -445,7 +445,8 @@ CREATE TABLE information_schema.statistics (
 	CARDINALITY   INT,
 	DIRECTION     STRING NOT NULL,
 	STORING       STRING NOT NULL,
-	IMPLICIT      STRING NOT NULL
+	IMPLICIT      STRING NOT NULL,
+	IS_VISIBLE    STRING NOT NULL
 )`
 
 // InformationSchemaTableConstraint describes the schema of the


### PR DESCRIPTION
This commit adds a new column `is_visible` to `crdb_internal.table_indexes` and
`information_schema.statistics`. It also adds a new column `visible` to the
output of following SQL statements:

```
SHOW INDEX FROM (table_name)
SHOW INDEXES FROM (table_name)
SHOW KEYS FROM (table_name)
SHOW INDEX FROM DATABASE (database_name)
SHOW INDEXES FROM DATABASE (database_name)
SHOW KEYS FROM DATABASE (database_name)
```

Since the not visible index feature has not been introduced yet, it is expected
for all test cases to output `true` for all `is_visible` or `visible` columns.

Assists: https://github.com/cockroachdb/cockroach/issues/72576, https://github.com/cockroachdb/cockroach/issues/84357

See also: https://github.com/cockroachdb/cockroach/pull/84783

Release note (sql change): A new column `is_visible` has been added to the table
`crdb_internal.table_indexes` and `information_schema.statistics`. A new column
`visible` has also been added to the output of `SHOW INDEX`, `SHOW INDEXES`, and
`SHOW KEYS`. The `is_visible` or `visible` column indicates whether the index is
visible to the optimizer.