### PR TITLE
release-22.1: sql: remove the artifact of canceling the txn-scoped context

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -277,9 +277,6 @@ func (ex *connExecutor) execStmtInOpenState(
 	ast := parserStmt.AST
 	ctx = withStatement(ctx, ast)
 
-	var cancelQuery context.CancelFunc
-	ctx, cancelQuery = contextutil.WithCancel(ctx)
-
 	makeErrEvent := func(err error) (fsm.Event, fsm.EventPayload, error) {
 		ev, payload := ex.makeErrEvent(err, ast)
 		return ev, payload, nil
@@ -323,10 +320,9 @@ func (ex *connExecutor) execStmtInOpenState(
 		ex.planner.EvalContext().Placeholders = pinfo
 	}
 
+	var cancelQuery context.CancelFunc
+	ctx, cancelQuery = contextutil.WithCancel(ctx)
 	ex.addActiveQuery(ast, formatWithPlaceholders(ast, ex.planner.EvalContext()), queryID, cancelQuery)
-	if ex.executorType != executorTypeInternal {
-		ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1)
-	}
 
 	// Make sure that we always unregister the query. It also deals with
 	// overwriting res.Error to a more user-friendly message in case of query
@@ -338,10 +334,6 @@ func (ex *connExecutor) execStmtInOpenState(
 				// queryTimedOut.
 				<-doneAfterFunc
 			}
-		}
-		ex.removeActiveQuery(queryID, ast)
-		if ex.executorType != executorTypeInternal {
-			ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1)
 		}
 
 		// Detect context cancelation and overwrite whatever error might have been
@@ -359,6 +351,12 @@ func (ex *connExecutor) execStmtInOpenState(
 			}
 			res.SetError(cancelchecker.QueryCanceledError)
 			retPayload = eventNonRetriableErrPayload{err: cancelchecker.QueryCanceledError}
+		}
+
+		ex.removeActiveQuery(queryID, ast)
+		cancelQuery()
+		if ex.executorType != executorTypeInternal {
+			ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1)
 		}
 
 		// If the query timed out, we intercept the error, payload, and event here
@@ -381,6 +379,10 @@ func (ex *connExecutor) execStmtInOpenState(
 			retPayload = eventNonRetriableErrPayload{err: sqlerrors.QueryTimeoutError}
 		}
 	}(ctx, res)
+
+	if ex.executorType != executorTypeInternal {
+		ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1)
+	}
 
 	p := &ex.planner
 	stmtTS := ex.server.cfg.Clock.PhysicalTime()
@@ -500,7 +502,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		timeoutTicker = time.AfterFunc(
 			timerDuration,
 			func() {
-				ex.cancelQuery(queryID)
+				cancelQuery()
 				queryTimedOut = true
 				doneAfterFunc <- struct{}{}
 			})

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1891,8 +1891,9 @@ type queryMeta struct {
 	// Current phase of execution of query.
 	phase queryPhase
 
-	// Cancellation function for the context associated with this query's transaction.
-	ctxCancel context.CancelFunc
+	// Cancellation function for the context associated with this query's
+	// statement.
+	cancelQuery context.CancelFunc
 
 	// If set, this query will not be reported as part of SHOW QUERIES. This is
 	// set based on the statement implementing tree.HiddenFromShowQueries.
@@ -1901,10 +1902,10 @@ type queryMeta struct {
 	progressAtomic uint64
 }
 
-// cancel cancels the query associated with this queryMeta, by closing the associated
-// txn context.
+// cancel cancels the query associated with this queryMeta, by closing the
+// associated stmt context.
 func (q *queryMeta) cancel() {
-	q.ctxCancel()
+	q.cancelQuery()
 }
 
 // getStatement returns a cleaned version of the query associated

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -78,11 +77,6 @@ type txnState struct {
 	// took more than this.
 	recordingThreshold time.Duration
 	recordingStart     time.Time
-
-	// cancel is Ctx's cancellation function. Called upon COMMIT/ROLLBACK of the
-	// transaction to release resources associated with the context. nil when no
-	// txn is in progress.
-	cancel context.CancelFunc
 
 	// The timestamp to report for current_timestamp(), now() etc.
 	// This must be constant for the lifetime of a SQL transaction.
@@ -179,16 +173,15 @@ func (ts *txnState) resetForNewSQLTxn(
 	opName := sqlTxnName
 	alreadyRecording := tranCtx.sessionTracing.Enabled()
 
-	var txnCtx context.Context
 	var sp *tracing.Span
 	duration := traceTxnThreshold.Get(&tranCtx.settings.SV)
 	if alreadyRecording || duration > 0 {
-		txnCtx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName,
+		ts.Ctx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName,
 			tracing.WithRecording(tracing.RecordingVerbose))
 	} else if ts.testingForceRealTracingSpans {
-		txnCtx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName, tracing.WithForceRealSpan())
+		ts.Ctx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName, tracing.WithForceRealSpan())
 	} else {
-		txnCtx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName)
+		ts.Ctx, sp = tracing.EnsureChildSpan(connCtx, tranCtx.tracer, opName)
 	}
 	if txnType == implicitTxn {
 		sp.SetTag("implicit", attribute.StringValue("true"))
@@ -199,7 +192,6 @@ func (ts *txnState) resetForNewSQLTxn(
 		ts.recordingStart = timeutil.Now()
 	}
 
-	ts.Ctx, ts.cancel = contextutil.WithCancel(txnCtx)
 	ts.mon.Start(ts.Ctx, tranCtx.connMon, mon.BoundAccount{} /* reserved */)
 	ts.mu.Lock()
 	ts.mu.stmtCount = 0
@@ -237,10 +229,6 @@ func (ts *txnState) resetForNewSQLTxn(
 // returned.
 func (ts *txnState) finishSQLTxn() (txnID uuid.UUID) {
 	ts.mon.Stop(ts.Ctx)
-	if ts.cancel != nil {
-		ts.cancel()
-		ts.cancel = nil
-	}
 	sp := tracing.SpanFromContext(ts.Ctx)
 	if sp == nil {
 		panic(errors.AssertionFailedf("No span in context? Was resetForNewSQLTxn() called previously?"))
@@ -270,10 +258,6 @@ func (ts *txnState) finishExternalTxn() {
 		ts.mon.Stop(ts.connCtx)
 	} else {
 		ts.mon.Stop(ts.Ctx)
-	}
-	if ts.cancel != nil {
-		ts.cancel()
-		ts.cancel = nil
 	}
 
 	if ts.Ctx != nil {

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -84,7 +84,6 @@ func makeTestContext(stopper *stop.Stopper) testContext {
 func (tc *testContext) createOpenState(typ txnType) (fsm.State, *txnState) {
 	sp := tc.tracer.StartSpan("createOpenState")
 	ctx := tracing.ContextWithSpan(tc.ctx, sp)
-	ctx, cancel := context.WithCancel(ctx)
 
 	txnStateMon := mon.NewMonitor("test mon",
 		mon.MemoryResource,
@@ -99,7 +98,6 @@ func (tc *testContext) createOpenState(typ txnType) (fsm.State, *txnState) {
 	ts := txnState{
 		Ctx:           ctx,
 		connCtx:       tc.ctx,
-		cancel:        cancel,
 		sqlTimestamp:  timeutil.Now(),
 		priority:      roachpb.NormalUserPriority,
 		mon:           txnStateMon,


### PR DESCRIPTION
Backport 1/1 commits from #84628.
Backport 1/1 commits from #84851.

/cc @cockroachdb/release

---

This commit removes an old artifact of having a txn-scoped context
cancellation that is performed when finishing the txn. As Andrei points
out, this txn-scoped cancellation is likely a leftover from ancient
times and is no longer needed. In particular, this also fixes the bug of
using the span after it was finished (which would occur with high
vmodule on `context.go` file).

Fixes: #84890.

Release note: None

Release justification: bug fix.