### PR TITLE
sql/sqlinstance/instancestorage: use CommitInBatch to optimize round-…

### DIFF
--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -100,7 +100,9 @@ func (s *Storage) CreateInstance(
 			log.Warningf(ctx, "failed to encode row for instance id %d: %v", instanceID, err)
 			return err
 		}
-		return txn.Put(ctx, row.Key, row.Value)
+		b := txn.NewBatch()
+		b.Put(row.Key, row.Value)
+		return txn.CommitInBatch(ctx, b)
 	})
 
 	if err != nil {


### PR DESCRIPTION
…trips

By using CommitInBatch we can hit the 1PC optimization and avoid a round-trip
to the leaseholder of the range in question.

Release note: None