### PR TITLE
release-21.1: [CRDB-9550] kv: adjust number of voters needed calculation when determining replication status

### DIFF
--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -54,14 +54,14 @@ func TestConformanceReport(t *testing.T) {
 		{
 			name: "simple no violations",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name:   "db1",
 						tables: []table{{name: "t1"}, {name: "t2"}},
 						// The database has a zone requesting everything to be on SSDs.
 						zone: &zone{
-							replicas:    3,
+							voters:      3,
 							constraints: "[+ssd]",
 						},
 					},
@@ -101,27 +101,27 @@ func TestConformanceReport(t *testing.T) {
 			name: "violations at multiple levels",
 			// Test zone constraints inheritance at all levels.
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3, constraints: "[+default]"},
+				defaultZone: zone{voters: 3, constraints: "[+default]"},
 				schema: []database{
 					{
 						name: "db1",
 						// All the objects will have zones asking for different tags.
 						zone: &zone{
-							replicas:    3,
+							voters:      3,
 							constraints: "[+db1]",
 						},
 						tables: []table{
 							{
 								name: "t1",
 								zone: &zone{
-									replicas:    3,
+									voters:      3,
 									constraints: "[+t1]",
 								},
 							},
 							{
 								name: "t2",
 								zone: &zone{
-									replicas:    3,
+									voters:      3,
 									constraints: "[+t2]",
 								},
 							},
@@ -220,14 +220,14 @@ func TestConformanceReport(t *testing.T) {
 			// violation, and another entry for "dc1" with one violation.
 			name: "constraint conjunctions",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name:   "db1",
 						tables: []table{{name: "t1"}, {name: "t2"}},
 						// The database has a zone requesting everything to be on SSDs.
 						zone: &zone{
-							replicas: 2,
+							voters: 2,
 							// The first conjunction will be satisfied; the second won't.
 							constraints: `{"+region=us,+dc=dc1":1,"+region=us,+dc=dc2":1}`,
 						},
@@ -303,16 +303,21 @@ func runConformanceReportTest(t *testing.T, tc conformanceConstraintTestCase) {
 }
 
 type zone struct {
-	// 0 means unset.
-	replicas int32
+	// indicates the number of replicas that
+	// are voters. 0 means unset.
+	voters int32
+	// indicates the number of replicas that
+	// are non-voting.
+	nonVoters int32
 	// "" means unset. "[]" means empty.
 	constraints string
 }
 
 func (z zone) toZoneConfig() zonepb.ZoneConfig {
 	cfg := zonepb.NewZoneConfig()
-	if z.replicas != 0 {
-		cfg.NumReplicas = proto.Int32(z.replicas)
+	cfg.NumReplicas = proto.Int32(z.voters + z.nonVoters)
+	if z.nonVoters != 0 && z.voters != 0 {
+		cfg.NumVoters = proto.Int32(z.voters)
 	}
 	if z.constraints != "" {
 		var constraintsList zonepb.ConstraintsList

--- a/pkg/kv/kvserver/reports/replication_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report_test.go
@@ -325,6 +325,136 @@ func TestReplicationStatsReport(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "simple no violations with non-voters",
+			baseReportTestCase: baseReportTestCase{
+				defaultZone: zone{voters: 1, nonVoters: 2},
+				schema: []database{
+					{
+						name: "db1",
+						tables: []table{
+							{name: "t1",
+								partitions: []partition{{
+									name:  "p1",
+									start: []int{100},
+									end:   []int{200},
+									zone:  &zone{constraints: "[+p1]"},
+								}},
+							},
+							{name: "t2"},
+						},
+						zone: &zone{
+							// Change replication options so that db1 gets a report entry.
+							nonVoters: 3,
+						},
+					},
+				},
+				splits: []split{
+					{key: "/Table/t1", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/1", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/2", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/3", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/100", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/150", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/200", stores: []int{1, 2, 3}},
+					{key: "/Table/t2", stores: []int{1, 2, 3}},
+					{key: "/Table/t2/pk", stores: []int{1, 2, 3}},
+				},
+				nodes: []node{
+					{id: 1, stores: []store{{id: 1}}},
+					{id: 2, stores: []store{{id: 2}}},
+					{id: 3, stores: []store{{id: 3}}},
+				},
+			},
+			exp: []replicationStatsEntry{
+				{
+					object: "db1",
+					zoneRangeStatus: zoneRangeStatus{
+						numRanges:       8,
+						unavailable:     0,
+						underReplicated: 0,
+						// All ranges are over-replicated because they have
+						// too many voters.
+						overReplicated: 8,
+					},
+				},
+				{
+					object: "t1.p1",
+					zoneRangeStatus: zoneRangeStatus{
+						numRanges:       2,
+						unavailable:     0,
+						underReplicated: 0,
+						overReplicated:  2,
+					},
+				},
+			},
+		},
+		{
+			name: "voters inherited and overwriting lower level num replicas",
+			baseReportTestCase: baseReportTestCase{
+				defaultZone: zone{voters: 3, nonVoters: 1},
+				schema: []database{
+					{
+						name: "db1",
+						tables: []table{
+							{name: "t1",
+								partitions: []partition{{
+									name:  "p1",
+									start: []int{100},
+									end:   []int{200},
+									zone:  &zone{constraints: "[+p1]"},
+								}},
+							},
+							{name: "t2"},
+						},
+						zone: &zone{
+							// Change replication options so that db1 gets a report entry.
+							nonVoters: 2,
+						},
+					},
+				},
+				splits: []split{
+					{key: "/Table/t1", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/1", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/2", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/3", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/100", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/150", stores: []int{1, 2, 3}},
+					{key: "/Table/t1/pk/200", stores: []int{1, 2, 3}},
+					{key: "/Table/t2", stores: []int{1, 2, 3}},
+					{key: "/Table/t2/pk", stores: []int{1, 2, 3}},
+				},
+				nodes: []node{
+					{id: 1, stores: []store{{id: 1}}},
+					{id: 2, stores: []store{{id: 2}}},
+					{id: 3, stores: []store{{id: 3}}},
+				},
+			},
+			exp: []replicationStatsEntry{
+				{
+					object: "db1",
+					zoneRangeStatus: zoneRangeStatus{
+						// no ranges are over-replicated because voters is inherited
+						// from the higher level
+						numRanges:       8,
+						unavailable:     0,
+						underReplicated: 0,
+						overReplicated:  0,
+					},
+				},
+				{
+					object: "t1.p1",
+					zoneRangeStatus: zoneRangeStatus{
+						numRanges:       2,
+						unavailable:     0,
+						underReplicated: 0,
+						overReplicated:  0,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/kv/kvserver/reports/replication_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report_test.go
@@ -192,7 +192,7 @@ func TestReplicationStatsReport(t *testing.T) {
 		{
 			name: "simple no violations",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name: "db1",
@@ -209,7 +209,7 @@ func TestReplicationStatsReport(t *testing.T) {
 						},
 						zone: &zone{
 							// Change replication options so that db1 gets a report entry.
-							replicas: 3,
+							voters: 3,
 						},
 					},
 					{
@@ -273,7 +273,7 @@ func TestReplicationStatsReport(t *testing.T) {
 		{
 			name: "simple violations",
 			baseReportTestCase: baseReportTestCase{
-				defaultZone: zone{replicas: 3},
+				defaultZone: zone{voters: 3},
 				schema: []database{
 					{
 						name: "db1",

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -589,7 +589,7 @@ func TestRangeIteration(t *testing.T) {
 		schema: []database{{
 			name: "db1",
 			zone: &zone{
-				replicas: 3,
+				voters: 3,
 			},
 			tables: []table{
 				{


### PR DESCRIPTION
Backport 2/2 commits from #76430.

/cc @cockroachdb/release

---

Currently, when a range has non-voting replicas and it is queried through replication
stats, it will be reported as underreplicated. This is because in the case where a
zone is configured to have non-voting replicas, for the over/under replicated counts,
we compare the number of current voters to the total number of replicas which is
erroneus. Instead, we will compare current number of voters to the total number of
voters if voters has been set and otherwise will defer to the total number of replicas.
This patch ignores the desired non-voters count for the purposes of this report, for
better or worse. Resolves #69335.

Release justification: low risk bug fix

Release note (bug fix): use total number of voters if set when determining replication
status

Before change:
![Screen Shot 2022-02-11 at 10 03 57 AM](https://user-images.githubusercontent.com/17861665/153615571-85163409-5bac-40f4-9669-20dce77185cf.png)

After change:
![Screen Shot 2022-02-11 at 9 53 04 AM](https://user-images.githubusercontent.com/17861665/153615316-785b156b-bd23-4cfa-a76d-7c9fa47fbf1e.png)
