### PR TITLE
ttl: reference TTL config as int64

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -364,7 +364,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 	statsCloseCh := make(chan struct{})
 	ch := make(chan rangeToProcess, rangeConcurrency)
 	rowCount := int64(0)
-	for i := 0; i < rangeConcurrency; i++ {
+	for i := int64(0); i < rangeConcurrency; i++ {
 		g.GoCtx(func(ctx context.Context) error {
 			for r := range ch {
 				start := timeutil.Now()
@@ -484,39 +484,40 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 	return nil
 }
 
-func getSelectBatchSize(sv *settings.Values, ttl catpb.RowLevelTTL) int {
-	if bs := ttl.SelectBatchSize; bs != 0 {
-		return int(bs)
+func getSelectBatchSize(sv *settings.Values, ttl catpb.RowLevelTTL) int64 {
+	bs := ttl.SelectBatchSize
+	if bs == 0 {
+		bs = defaultSelectBatchSize.Get(sv)
 	}
-	return int(defaultSelectBatchSize.Get(sv))
+	return bs
 }
 
-func getDeleteBatchSize(sv *settings.Values, ttl catpb.RowLevelTTL) int {
-	if bs := ttl.DeleteBatchSize; bs != 0 {
-		return int(bs)
+func getDeleteBatchSize(sv *settings.Values, ttl catpb.RowLevelTTL) int64 {
+	bs := ttl.DeleteBatchSize
+	if bs == 0 {
+		bs = defaultDeleteBatchSize.Get(sv)
 	}
-	return int(defaultDeleteBatchSize.Get(sv))
+	return bs
 }
 
-func getRangeConcurrency(sv *settings.Values, ttl catpb.RowLevelTTL) int {
-	if rc := ttl.RangeConcurrency; rc != 0 {
-		return int(rc)
+func getRangeConcurrency(sv *settings.Values, ttl catpb.RowLevelTTL) int64 {
+	rc := ttl.RangeConcurrency
+	if rc == 0 {
+		rc = defaultRangeConcurrency.Get(sv)
 	}
-	return int(defaultRangeConcurrency.Get(sv))
+	return rc
 }
 
 func getDeleteRateLimit(sv *settings.Values, ttl catpb.RowLevelTTL) int64 {
-	val := func() int64 {
-		if bs := ttl.DeleteRateLimit; bs != 0 {
-			return bs
-		}
-		return defaultDeleteRateLimit.Get(sv)
-	}()
-	// Put the maximum tokens possible if there is no rate limit.
-	if val == 0 {
-		return math.MaxInt64
+	rl := ttl.DeleteRateLimit
+	if rl == 0 {
+		rl = defaultDeleteRateLimit.Get(sv)
 	}
-	return val
+	// Put the maximum tokens possible if there is no rate limit.
+	if rl == 0 {
+		rl = math.MaxInt64
+	}
+	return rl
 }
 
 func fetchStatistics(
@@ -595,7 +596,7 @@ func runTTLOnRange(
 	endPK tree.Datums,
 	pkColumns []string,
 	relationName string,
-	selectBatchSize, deleteBatchSize int,
+	selectBatchSize, deleteBatchSize int64,
 	deleteRateLimiter *quotapool.RateLimiter,
 	aost tree.DTimestampTZ,
 	ttlExpression string,
@@ -652,14 +653,15 @@ func runTTLOnRange(
 		if err != nil {
 			return rangeRowCount, errors.Wrapf(err, "error selecting rows to delete")
 		}
-		metrics.RowSelections.Inc(int64(len(expiredRowsPKs)))
+		numExpiredRows := int64(len(expiredRowsPKs))
+		metrics.RowSelections.Inc(numExpiredRows)
 
 		// Step 2. Delete the rows which have expired.
 
-		for startRowIdx := 0; startRowIdx < len(expiredRowsPKs); startRowIdx += deleteBatchSize {
+		for startRowIdx := int64(0); startRowIdx < numExpiredRows; startRowIdx += deleteBatchSize {
 			until := startRowIdx + deleteBatchSize
-			if until > len(expiredRowsPKs) {
-				until = len(expiredRowsPKs)
+			if until > numExpiredRows {
+				until = numExpiredRows
 			}
 			deleteBatch := expiredRowsPKs[startRowIdx:until]
 			if err := db.TxnWithSteppingEnabled(ctx, sessiondatapb.TTLLow, func(ctx context.Context, txn *kv.Txn) error {
@@ -709,7 +711,7 @@ func runTTLOnRange(
 
 		// If we selected less than the select batch size, we have selected every
 		// row and so we end it here.
-		if len(expiredRowsPKs) < selectBatchSize {
+		if numExpiredRows < selectBatchSize {
 			break
 		}
 	}

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder.go
@@ -34,7 +34,7 @@ type selectQueryBuilder struct {
 	pkColumns       []string
 	selectOpName    string
 	startPK, endPK  tree.Datums
-	selectBatchSize int
+	selectBatchSize int64
 	aost            tree.DTimestampTZ
 	ttlExpression   string
 
@@ -59,7 +59,7 @@ func makeSelectQueryBuilder(
 	relationName string,
 	startPK, endPK tree.Datums,
 	aost tree.DTimestampTZ,
-	selectBatchSize int,
+	selectBatchSize int64,
 	ttlExpression string,
 ) selectQueryBuilder {
 	// We will have a maximum of 1 + len(pkColumns)*2 columns, where one
@@ -212,7 +212,7 @@ func (b *selectQueryBuilder) moveCursor(rows []tree.Datums) error {
 type deleteQueryBuilder struct {
 	tableID         descpb.ID
 	pkColumns       []string
-	deleteBatchSize int
+	deleteBatchSize int64
 	deleteOpName    string
 	ttlExpression   string
 
@@ -229,10 +229,10 @@ func makeDeleteQueryBuilder(
 	cutoff time.Time,
 	pkColumns []string,
 	relationName string,
-	deleteBatchSize int,
+	deleteBatchSize int64,
 	ttlExpression string,
 ) deleteQueryBuilder {
-	cachedArgs := make([]interface{}, 0, 1+len(pkColumns)*deleteBatchSize)
+	cachedArgs := make([]interface{}, 0, 1+int64(len(pkColumns))*deleteBatchSize)
 	cachedArgs = append(cachedArgs, cutoff)
 
 	return deleteQueryBuilder{
@@ -273,7 +273,7 @@ func (b *deleteQueryBuilder) buildQuery(numRows int) string {
 
 func (b *deleteQueryBuilder) buildQueryAndArgs(rows []tree.Datums) (string, []interface{}) {
 	var q string
-	if len(rows) == b.deleteBatchSize {
+	if int64(len(rows)) == b.deleteBatchSize {
 		if b.cachedQuery == "" {
 			b.cachedQuery = b.buildQuery(len(rows))
 		}


### PR DESCRIPTION
The TTL DistSQL change requires new protobufs be added to pass config
from the TTL job to the TTL processor. The source of the config is int64
and the new protobufs store the config as int64 so change current usage
of configs to int64 to avoid converting back and forth in different layers.

Release note: None