### PR TITLE
changefeedccl: split the sink interface

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -89,7 +89,7 @@ const (
 // emitResolvedTimestamp emits a changefeed-level resolved timestamp to the
 // sink.
 func emitResolvedTimestamp(
-	ctx context.Context, encoder Encoder, sink Sink, resolved hlc.Timestamp,
+	ctx context.Context, encoder Encoder, sink ResolvedTimestampSink, resolved hlc.Timestamp,
 ) error {
 	// TODO(dan): Emit more fine-grained (table level) resolved
 	// timestamps.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -65,7 +65,7 @@ type changeAggregator struct {
 	encoder Encoder
 	// sink is the Sink to write rows to. Resolved timestamps are never written
 	// by changeAggregator.
-	sink Sink
+	sink EventSink
 	// changedRowBuf, if non-nil, contains changed rows to be emitted. Anything
 	// queued in `resolvedSpanBuf` is dependent on these having been emitted, so
 	// this one must be empty before moving on to that one.
@@ -266,7 +266,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		return
 	}
 
-	ca.sink, err = getSink(ctx, ca.flowCtx.Cfg, ca.spec.Feed, timestampOracle,
+	ca.sink, err = getEventSink(ctx, ca.flowCtx.Cfg, ca.spec.Feed, timestampOracle,
 		ca.spec.User(), ca.spec.JobID, ca.sliMetrics)
 
 	if err != nil {
@@ -686,7 +686,7 @@ type changeFrontier struct {
 	encoder Encoder
 	// sink is the Sink to write resolved timestamps to. Rows are never written
 	// by changeFrontier.
-	sink Sink
+	sink ResolvedTimestampSink
 	// freqEmitResolved, if >= 0, is a lower bound on the duration between
 	// resolved timestamp emits.
 	freqEmitResolved time.Duration
@@ -915,7 +915,7 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 		return
 	}
 	cf.sliMetrics = sli
-	cf.sink, err = getSink(ctx, cf.flowCtx.Cfg, cf.spec.Feed, nilOracle,
+	cf.sink, err = getResolvedTimestampSink(ctx, cf.flowCtx.Cfg, cf.spec.Feed, nilOracle,
 		cf.spec.User(), cf.spec.JobID, sli)
 
 	if err != nil {

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -37,7 +37,7 @@ type kvEventToRowConsumer struct {
 	frontier  *span.Frontier
 	encoder   Encoder
 	scratch   bufalloc.ByteAllocator
-	sink      Sink
+	sink      EventSink
 	cursor    hlc.Timestamp
 	knobs     TestingKnobs
 	decoder   cdcevent.Decoder
@@ -55,7 +55,7 @@ func newKVEventToRowConsumer(
 	evalCtx *eval.Context,
 	frontier *span.Frontier,
 	cursor hlc.Timestamp,
-	sink Sink,
+	sink EventSink,
 	encoder Encoder,
 	details ChangefeedConfig,
 	expr execinfrapb.Expression,


### PR DESCRIPTION
There are some out-of-date comments in sink.go implying
that the sink that emits resolved timestamps shares
in-memory state with the sink that emits other messages.
Nope. Flush() and EmitRow() are only called by the
Aggregator, and EmitResolvedTimestamp() is only called
by the Frontier.

To help with the tasks in #84647, this PR splits up the
Sink interface into one for the frontier and one with
the aggregator. No functional changes yet, but in
subsequent PRs we can set different config for the
two sinks.

Release note: None