### PR TITLE
ccl/streamingccl/streamingest: skip TestTenantStreamingPauseResumeIngestion

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -356,6 +356,7 @@ func TestTenantStreamingProducerJobTimedOut(t *testing.T) {
 
 func TestTenantStreamingPauseResumeIngestion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 84414, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// TODO(casper): now this has the same race issue with


### PR DESCRIPTION
Refs: #84414

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None