### PR TITLE
ui: set up eslint-plugin-crdb for db-console

### DIFF
--- a/pkg/ui/workspaces/db-console/.eslintrc.json
+++ b/pkg/ui/workspaces/db-console/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "root": true,
   "extends": "@cockroachlabs/eslint-config",
+  "plugins": ["@cockroachlabs/eslint-plugin-crdb"],
   "ignorePatterns": ["protos.d.ts", "protos.js"],
   "rules": {
     "@typescript-eslint/no-inferrable-types": "off",
@@ -12,6 +13,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "no-restricted-imports": ["error", {
       "patterns": ["@cockroachlabs/cluster-ui/src/*"]
-    }]
+    }],
+    "@cockroachlabs/crdb/require-antd-style-import": "error"
   }
 }

--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -241,6 +241,7 @@ eslint_test(
         "ccl",
         "prettier.config.js",
         "src",
+        "//pkg/ui/workspaces/eslint-plugin-crdb",
         "@npm_db_console//@cockroachlabs/eslint-config",
         "@npm_db_console//@typescript-eslint/eslint-plugin",
         "@npm_db_console//@typescript-eslint/parser",

--- a/pkg/ui/workspaces/db-console/package.json
+++ b/pkg/ui/workspaces/db-console/package.json
@@ -23,6 +23,7 @@
     "@cockroachlabs/crdb-protobuf-client": "link:./src/js",
     "@cockroachlabs/crdb-protobuf-client-ccl": "link:./ccl/src/js",
     "@cockroachlabs/design-tokens": "0.4.5",
+    "@cockroachlabs/eslint-plugin-crdb": "link:../eslint-plugin-crdb",
     "@cockroachlabs/icons": "0.5.2",
     "@cockroachlabs/ui-components": "0.2.20",
     "analytics-node": "^3.5.0",

--- a/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez/tracez.tsx
@@ -38,6 +38,7 @@ import {
 } from "src/util/api";
 import { CaretRight } from "@cockroachlabs/icons";
 import { Switch } from "antd";
+import "antd/lib/switch/style";
 import ISnapshotInfo = cockroach.server.serverpb.ISnapshotInfo;
 import ITracingSpan = cockroach.server.serverpb.ITracingSpan;
 import GetTracingSnapshotRequest = cockroach.server.serverpb.GetTracingSnapshotRequest;

--- a/pkg/ui/workspaces/db-console/yarn.lock
+++ b/pkg/ui/workspaces/db-console/yarn.lock
@@ -1379,6 +1379,10 @@
     "@typescript-eslint/parser" "^2.34.0"
     eslint-config-prettier "^6.11.0"
 
+"@cockroachlabs/eslint-plugin-crdb@link:../eslint-plugin-crdb":
+  version "0.0.0"
+  uid ""
+
 "@cockroachlabs/icons@0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.5.2.tgz#ddf87eba8e173f7ee6c787e178f460a0a1872b80"


### PR DESCRIPTION
When the custom eslint-plugin-crdb was added to this repo [1], it was
accidentally only configured in the cluster-ui subproject. Add
eslint-plugin-crdb to the db-console subproject, fixing a lint failure
in the process.

[1] ba68179282 (ui: use esbuild-loader in webpack configs, 2022-05-26)

Release note: None