### PR TITLE
kvserver: honor lease preferences in store balance

### DIFF
--- a/pkg/kv/kvserver/allocator/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "@com_github_cockroachdb_errors//:errors",
+        "@io_etcd_go_etcd_raft_v3//:raft",
     ],
 )
 

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -1682,6 +1682,9 @@ func (r *mockRepl) GetFirstIndex() uint64 {
 func (r *mockRepl) StoreID() roachpb.StoreID {
 	return r.storeID
 }
+func (r *mockRepl) Desc() *roachpb.RangeDescriptor {
+	return &roachpb.RangeDescriptor{}
+}
 
 func (r *mockRepl) GetRangeID() roachpb.RangeID {
 	return roachpb.RangeID(0)

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -3544,8 +3545,7 @@ func (r *Replica) adminScatter(
 	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
 		desc := r.Desc()
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
-			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, false, /* excludeLeaseRepl */
-		)
+			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
 		if len(potentialLeaseTargets) > 0 {
 			newLeaseholderIdx := rand.Intn(len(potentialLeaseTargets))
 			targetStoreID := potentialLeaseTargets[newLeaseholderIdx].StoreID


### PR DESCRIPTION
Previously, lease preferences were not considered when selecting a
voter to become the leaseholder after replica rebalancing. Instead, the
voter on the store with the least QPS was selected.

This patch introduces a check to try and satisfy the lease preference
from the rebalanced voting set of replicas, if possible. Among voters
satisfying the preference, the one on a store with the least QPS is
selected to be the leaseholder.

When not possible, where none of the voting replicas satisfy the lease
preference, the store rebalancer will pick the miminum QPS store, as
before.

resolves: https://github.com/cockroachdb/cockroach/issues/83951

Release note: None