### PR TITLE
sql: don't embed NodeInfo into ExecutorConfig

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -492,7 +492,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 
 		// Collect telemetry, once per backup after resolving its destination.
 		lic := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().LogicalClusterID(), p.ExecCfg().Organization(), "",
+			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), p.ExecCfg().Organization(), "",
 		) != nil
 		collectTelemetry(m, details, details, lic)
 	}
@@ -761,10 +761,10 @@ func (b *backupResumer) readManifestOnResume(
 		}
 	}
 
-	if !desc.ClusterID.Equal(cfg.LogicalClusterID()) {
+	if !desc.ClusterID.Equal(cfg.NodeInfo.LogicalClusterID()) {
 		mem.Shrink(ctx, memSize)
 		return nil, 0, errors.Newf("cannot resume backup started on another cluster (%s != %s)",
-			desc.ClusterID, cfg.LogicalClusterID())
+			desc.ClusterID, cfg.NodeInfo.LogicalClusterID())
 	}
 	return &desc, memSize, nil
 }

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -366,7 +366,7 @@ func checkPrivilegesForBackup(
 
 func requireEnterprise(execCfg *sql.ExecutorConfig, feature string) error {
 	if err := utilccl.CheckEnterpriseEnabled(
-		execCfg.Settings, execCfg.LogicalClusterID(), execCfg.Organization(),
+		execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), execCfg.Organization(),
 		fmt.Sprintf("BACKUP with %s", feature),
 	); err != nil {
 		return err
@@ -1144,7 +1144,7 @@ func getBackupDetailAndManifest(
 		// IDs are how we identify tables, and those are only meaningful in the
 		// context of their own cluster, so we need to ensure we only allow
 		// incremental previous backups that we created.
-		if fromCluster := prevBackup.ClusterID; !fromCluster.Equal(execCfg.LogicalClusterID()) {
+		if fromCluster := prevBackup.ClusterID; !fromCluster.Equal(execCfg.NodeInfo.LogicalClusterID()) {
 			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Newf("previous BACKUP belongs to cluster %s", fromCluster.String())
 		}
 
@@ -1379,7 +1379,7 @@ func createBackupManifest(
 		FormatVersion:       backupinfo.BackupFormatDescriptorTrackingVersion,
 		BuildInfo:           build.GetInfo(),
 		ClusterVersion:      execCfg.Settings.Version.ActiveVersion(ctx).Version,
-		ClusterID:           execCfg.LogicalClusterID(),
+		ClusterID:           execCfg.NodeInfo.LogicalClusterID(),
 		StatisticsFilenames: statsFiles,
 		DescriptorCoverage:  coverage,
 	}

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -780,7 +780,7 @@ func makeScheduledBackupEval(
 	}
 
 	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().LogicalClusterID(), p.ExecCfg().Organization(),
+		p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), p.ExecCfg().Organization(),
 		"BACKUP INTO LATEST")
 	eval.isEnterpriseUser = enterpriseCheckErr == nil
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -492,7 +492,7 @@ func createChangefeedJobRecord(
 
 	if scope, ok := opts.GetMetricScope(); ok {
 		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().LogicalClusterID(), p.ExecCfg().Organization(), "CHANGEFEED",
+			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), p.ExecCfg().Organization(), "CHANGEFEED",
 		); err != nil {
 			return nil, errors.Wrapf(err,
 				"use of %q option requires enterprise license.", changefeedbase.OptMetricsScope)
@@ -525,7 +525,7 @@ func createChangefeedJobRecord(
 	}
 
 	if err := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().LogicalClusterID(), p.ExecCfg().Organization(), "CHANGEFEED",
+		p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), p.ExecCfg().Organization(), "CHANGEFEED",
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -107,7 +107,7 @@ func authGSS(
 		// their GSS configuration is correct. That is, the presence of this error
 		// message means they have a correctly functioning GSS/Kerberos setup,
 		// but now need to enable enterprise features.
-		return utilccl.CheckEnterpriseEnabled(execCfg.Settings, execCfg.LogicalClusterID(), execCfg.Organization(), "GSS authentication")
+		return utilccl.CheckEnterpriseEnabled(execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), execCfg.Organization(), "GSS authentication")
 	})
 	return behaviors, nil
 }

--- a/pkg/ccl/multiregionccl/multiregion.go
+++ b/pkg/ccl/multiregionccl/multiregion.go
@@ -118,7 +118,7 @@ func initializeMultiRegionMetadata(
 func CheckClusterSupportsMultiRegion(execCfg *sql.ExecutorConfig) error {
 	return utilccl.CheckEnterpriseEnabled(
 		execCfg.Settings,
-		execCfg.LogicalClusterID(),
+		execCfg.NodeInfo.LogicalClusterID(),
 		execCfg.Organization(),
 		"multi-region features",
 	)
@@ -129,7 +129,7 @@ func getMultiRegionEnumAddValuePlacement(
 ) (tree.AlterTypeAddValue, error) {
 	if err := utilccl.CheckEnterpriseEnabled(
 		execCfg.Settings,
-		execCfg.LogicalClusterID(),
+		execCfg.NodeInfo.LogicalClusterID(),
 		execCfg.Organization(),
 		"ADD REGION",
 	); err != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -52,7 +52,7 @@ func newStreamIngestManagerWithPrivilegesCheck(
 
 	execCfg := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
 	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		execCfg.Settings, execCfg.LogicalClusterID(), execCfg.Organization(), "REPLICATION")
+		execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), execCfg.Organization(), "REPLICATION")
 	if enterpriseCheckErr != nil {
 		return nil, pgerror.Wrap(enterpriseCheckErr,
 			pgcode.InsufficientPrivilege, "replication requires enterprise license")

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -110,7 +110,7 @@ func ingestionPlanHook(
 		defer span.Finish()
 
 		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().LogicalClusterID(), p.ExecCfg().Organization(),
+			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), p.ExecCfg().Organization(),
 			"RESTORE FROM REPLICATION STREAM",
 		); err != nil {
 			return err

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -126,7 +126,7 @@ func distStreamIngest(
 	)
 
 	execCfg := execCtx.ExecCfg()
-	gatewayNodeID, err := execCfg.NodeID.OptionalNodeIDErr(48274)
+	gatewayNodeID, err := execCfg.NodeInfo.NodeID.OptionalNodeIDErr(48274)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager.go
@@ -72,7 +72,7 @@ func newReplicationStreamManagerWithPrivilegesCheck(
 
 	execCfg := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
 	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		execCfg.Settings, execCfg.LogicalClusterID(), execCfg.Organization(), "REPLICATION")
+		execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), execCfg.Organization(), "REPLICATION")
 	if enterpriseCheckErr != nil {
 		return nil, pgerror.Wrap(enterpriseCheckErr,
 			pgcode.InsufficientPrivilege, "replication requires enterprise license")

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1265,7 +1265,7 @@ func (s *SQLServer) preStart(
 		&migrationsExecutor,
 		s.execCfg.Clock,
 		mmKnobs,
-		s.execCfg.NodeID.SQLInstanceID().String(),
+		s.execCfg.NodeInfo.NodeID.SQLInstanceID().String(),
 		s.execCfg.Settings,
 		s.jobRegistry,
 	)
@@ -1461,5 +1461,5 @@ func (s *SQLServer) startServeSQL(
 // LogicalClusterID retrieves the logical (tenant-level) cluster ID
 // for this server.
 func (s *SQLServer) LogicalClusterID() uuid.UUID {
-	return s.execCfg.LogicalClusterID()
+	return s.execCfg.NodeInfo.LogicalClusterID()
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -505,7 +505,7 @@ func (ts *TestServer) TenantStatusServer() interface{} {
 // capabilities.
 func (ts *TestServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 	org := sql.ClusterOrganization.Get(&ts.st.SV)
-	clusterID := ts.sqlServer.execCfg.LogicalClusterID
+	clusterID := ts.sqlServer.execCfg.NodeInfo.LogicalClusterID
 	if err := base.CheckEnterpriseEnabled(ts.st, clusterID(), org, "SQL servers"); err != nil {
 		// If not enterprise enabled, we won't be able to use SQL Servers so eat
 		// the error and return without creating/starting a SQL server.

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -56,7 +56,7 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 	}()
 
 	execCtx := execCtxI.(sql.JobExecContext)
-	if !execCtx.ExecCfg().LogicalClusterID().Equal(r.job.Payload().CreationClusterID) {
+	if !execCtx.ExecCfg().NodeInfo.LogicalClusterID().Equal(r.job.Payload().CreationClusterID) {
 		// When restoring a cluster, we don't want to end up with two instances of
 		// the singleton reconciliation job.
 		//
@@ -64,7 +64,7 @@ func (r *resumer) Resume(ctx context.Context, execCtxI interface{}) (jobErr erro
 		// ID; comparing cluster IDs during restore doesn't help when we're
 		// restoring into the same cluster the backup was run from.
 		log.Infof(ctx, "duplicate restored job (source-cluster-id=%s, dest-cluster-id=%s); exiting",
-			r.job.Payload().CreationClusterID, execCtx.ExecCfg().LogicalClusterID())
+			r.job.Payload().CreationClusterID, execCtx.ExecCfg().NodeInfo.LogicalClusterID())
 		return nil
 	}
 

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -304,7 +304,7 @@ func runPlanInsidePlan(params runParams, plan *planComponents, resultWriter rowR
 	evalCtx := params.p.ExtendedEvalContextCopy()
 	plannerCopy := *params.p
 	distributePlan := getPlanDistribution(
-		params.ctx, &plannerCopy, plannerCopy.execCfg.NodeID, plannerCopy.SessionData().DistSQLMode, plan.main,
+		params.ctx, &plannerCopy, plannerCopy.execCfg.NodeInfo.NodeID, plannerCopy.SessionData().DistSQLMode, plan.main,
 	)
 	distributeType := DistributionType(DistributionTypeNone)
 	if distributePlan.WillDistribute() {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -407,7 +407,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		InternalExecutor:        &sqlStatsInternalExecutor,
 		InternalExecutorMonitor: sqlStatsInternalExecutorMonitor,
 		KvDB:                    cfg.DB,
-		SQLIDContainer:          cfg.NodeID,
+		SQLIDContainer:          cfg.NodeInfo.NodeID,
 		JobRegistry:             s.cfg.JobRegistry,
 		Knobs:                   cfg.SQLStatsTestingKnobs,
 		FlushCounter:            serverMetrics.StatsMetrics.SQLStatsFlushStarted,
@@ -880,7 +880,7 @@ func (s *Server) newConnExecutor(
 		-1 /* increment */, noteworthyMemoryUsageBytes, s.cfg.Settings,
 	)
 
-	nodeIDOrZero, _ := s.cfg.NodeID.OptionalNodeID()
+	nodeIDOrZero, _ := s.cfg.NodeInfo.NodeID.OptionalNodeID()
 	ex := &connExecutor{
 		server:              s,
 		metrics:             srvMetrics,
@@ -960,7 +960,7 @@ func (s *Server) newConnExecutor(
 	ex.extraTxnState.descCollection = s.cfg.CollectionFactory.MakeCollection(ctx, descs.NewTemporarySchemaProvider(sdMutIterator.sds), ex.sessionMon)
 	ex.extraTxnState.txnRewindPos = -1
 	ex.extraTxnState.schemaChangeJobRecords = make(map[descpb.ID]*jobs.Record)
-	ex.queryCancelKey = pgwirecancel.MakeBackendKeyData(ex.rng, ex.server.cfg.NodeID.SQLInstanceID())
+	ex.queryCancelKey = pgwirecancel.MakeBackendKeyData(ex.rng, ex.server.cfg.NodeInfo.NodeID.SQLInstanceID())
 	ex.mu.ActiveQueries = make(map[clusterunique.ID]*queryMeta)
 	ex.machine = fsm.MakeMachine(TxnStateTransitions, stateNoTxn{}, &ex.state)
 
@@ -2477,7 +2477,7 @@ func stmtHasNoData(stmt tree.Statement) bool {
 // HLC timestamp. These IDs are either scoped at the query level or at the
 // session level.
 func (ex *connExecutor) generateID() clusterunique.ID {
-	return clusterunique.GenerateID(ex.server.cfg.Clock.Now(), ex.server.cfg.NodeID.SQLInstanceID())
+	return clusterunique.GenerateID(ex.server.cfg.Clock.Now(), ex.server.cfg.NodeInfo.NodeID.SQLInstanceID())
 }
 
 // commitPrepStmtNamespace deallocates everything in

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1101,7 +1101,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	ex.sessionTracing.TracePlanCheckStart(ctx)
 	distributePlan := getPlanDistribution(
-		ctx, planner, planner.execCfg.NodeID, ex.sessionData().DistSQLMode, planner.curPlan.main,
+		ctx, planner, planner.execCfg.NodeInfo.NodeID, ex.sessionData().DistSQLMode, planner.curPlan.main,
 	)
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan.WillDistribute())
 

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -692,7 +692,7 @@ func (p *planner) preparePlannerForCopy(
 	stmtTs := txnOpt.stmtTimestamp
 	autoCommit := false
 	if txn == nil {
-		nodeID, _ := p.execCfg.NodeID.OptionalNodeID()
+		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID()
 		// The session data stack in the planner is not set up at this point, so use
 		// the default Normal QoSLevel.
 		txn = kv.NewTxnWithSteppingEnabled(ctx, p.execCfg.DB, nodeID, sessiondatapb.Normal)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -186,12 +186,12 @@ CREATE TABLE crdb_internal.node_build_info (
 )`,
 	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		execCfg := p.ExecCfg()
-		nodeID, _ := execCfg.NodeID.OptionalNodeID() // zero if not available
+		nodeID, _ := execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 
 		info := build.GetInfo()
 		for k, v := range map[string]string{
 			"Name":         "CockroachDB",
-			"ClusterID":    execCfg.LogicalClusterID().String(),
+			"ClusterID":    execCfg.NodeInfo.LogicalClusterID().String(),
 			"Organization": execCfg.Organization(),
 			"Build":        info.Short(),
 			"Version":      info.Tag,
@@ -733,7 +733,7 @@ CREATE TABLE crdb_internal.leases (
 	populate: func(
 		ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
 	) (err error) {
-		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
+		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 		p.LeaseMgr().VisitLeases(func(desc catalog.Descriptor, takenOffline bool, _ int, expiration tree.DTimestamp) (wantMore bool) {
 			if p.CheckAnyPrivilege(ctx, desc) != nil {
 				// TODO(ajwerner): inspect what type of error got returned.
@@ -1120,7 +1120,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 			return err
 		}
 
-		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
+		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 
 		statementVisitor := func(_ context.Context, stats *roachpb.CollectedStatementStatistics) error {
 			anonymized := tree.DNull
@@ -1264,7 +1264,7 @@ CREATE TABLE crdb_internal.node_transaction_statistics (
 			return err
 		}
 
-		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
+		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 
 		transactionVisitor := func(_ context.Context, stats *roachpb.CollectedTransactionStatistics) error {
 			stmtFingerprintIDsDatum := tree.NewDArray(types.String)
@@ -1338,7 +1338,7 @@ CREATE TABLE crdb_internal.node_txn_stats (
 			return err
 		}
 
-		nodeID, _ := p.execCfg.NodeID.OptionalNodeID() // zero if not available
+		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 
 		appTxnStatsVisitor := func(appName string, stats *roachpb.TxnStats) error {
 			return addRow(

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1275,7 +1275,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	defer subqueryMemAccount.Close(ctx)
 
 	distributeSubquery := getPlanDistribution(
-		ctx, planner, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
+		ctx, planner, planner.execCfg.NodeInfo.NodeID, planner.SessionData().DistSQLMode, subqueryPlan.plan,
 	).WillDistribute()
 	distribute := DistributionType(DistributionTypeNone)
 	if distributeSubquery {
@@ -1628,7 +1628,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	defer postqueryMemAccount.Close(ctx)
 
 	distributePostquery := getPlanDistribution(
-		ctx, planner, planner.execCfg.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
+		ctx, planner, planner.execCfg.NodeInfo.NodeID, planner.SessionData().DistSQLMode, postqueryPlan,
 	).WillDistribute()
 	distribute := DistributionType(DistributionTypeNone)
 	if distributePostquery {

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -358,7 +358,7 @@ func (p *planner) dropIndexByName(
 		if s.IndexID != uint32(idx.GetID()) {
 			_, err = GenerateSubzoneSpans(
 				p.ExecCfg().Settings,
-				p.ExecCfg().LogicalClusterID(),
+				p.ExecCfg().NodeInfo.LogicalClusterID(),
 				p.ExecCfg().Codec,
 				tableDesc,
 				zone.Subzones,

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -252,8 +252,8 @@ func logEventInternalForSchemaChanges(
 	return insertEventRecords(
 		ctx, execCfg.InternalExecutor,
 		txn,
-		int32(execCfg.NodeID.SQLInstanceID()), /* reporter ID */
-		1,                                     /* depth: use this function as origin */
+		int32(execCfg.NodeInfo.NodeID.SQLInstanceID()), /* reporter ID */
+		1, /* depth: use this function as origin */
 		eventLogOptions{dst: LogEverywhere},
 		eventLogEntry{
 			targetID: int32(descID),
@@ -303,10 +303,10 @@ func logEventInternalForSQLStatements(
 		ctx,
 		execCfg.InternalExecutor,
 		txn,
-		int32(execCfg.NodeID.SQLInstanceID()), /* reporter ID */
-		1+depth,                               /* depth */
-		opts,                                  /* eventLogOptions */
-		entries...,                            /* ...eventLogEntry */
+		int32(execCfg.NodeInfo.NodeID.SQLInstanceID()), /* reporter ID */
+		1+depth,    /* depth */
+		opts,       /* eventLogOptions */
+		entries..., /* ...eventLogEntry */
 	)
 }
 
@@ -354,12 +354,12 @@ func (l schemaChangerEventLogger) LogEventForSchemaChange(
 	if !ok {
 		return errors.AssertionFailedf("unknown event type: %T", event)
 	}
-	scCommon.CommonSchemaChangeDetails().InstanceID = int32(l.execCfg.NodeID.SQLInstanceID())
+	scCommon.CommonSchemaChangeDetails().InstanceID = int32(l.execCfg.NodeInfo.NodeID.SQLInstanceID())
 	return insertEventRecords(
 		ctx, l.execCfg.InternalExecutor,
 		l.txn,
-		int32(l.execCfg.NodeID.SQLInstanceID()), /* reporter ID */
-		1,                                       /* depth: use this function as origin */
+		int32(l.execCfg.NodeInfo.NodeID.SQLInstanceID()), /* reporter ID */
+		1, /* depth: use this function as origin */
 		eventLogOptions{dst: LogEverywhere},
 		eventLogEntry{
 			targetID: int32(descID),
@@ -402,8 +402,8 @@ func LogEventForJobs(
 	return insertEventRecords(
 		ctx, execCfg.InternalExecutor,
 		txn,
-		int32(execCfg.NodeID.SQLInstanceID()), /* reporter ID */
-		1,                                     /* depth: use this function for vmodule filtering */
+		int32(execCfg.NodeInfo.NodeID.SQLInstanceID()), /* reporter ID */
+		1, /* depth: use this function for vmodule filtering */
 		eventLogOptions{dst: LogEverywhere},
 		eventLogEntry{event: event},
 	)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1147,8 +1147,8 @@ type nodeStatusGenerator interface {
 // All fields holding a pointer or an interface are required to create
 // an Executor; the rest will have sane defaults set if omitted.
 type ExecutorConfig struct {
-	Settings *cluster.Settings
-	NodeInfo
+	Settings          *cluster.Settings
+	NodeInfo          NodeInfo
 	Codec             keys.SQLCodec
 	DefaultZoneConfig *zonepb.ZoneConfig
 	Locality          roachpb.Locality

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -60,8 +60,8 @@ func setExplainBundleResult(
 			"Statement diagnostics bundle generated. Download from the Admin UI (Advanced",
 			"Debug -> Statement Diagnostics History), via the direct link below, or using",
 			"the SQL shell or command line.",
-			fmt.Sprintf("Admin UI: %s", execCfg.AdminURL()),
-			fmt.Sprintf("Direct link: %s/_admin/v1/stmtbundle/%d", execCfg.AdminURL(), bundle.diagID),
+			fmt.Sprintf("Admin UI: %s", execCfg.NodeInfo.AdminURL()),
+			fmt.Sprintf("Direct link: %s/_admin/v1/stmtbundle/%d", execCfg.NodeInfo.AdminURL(), bundle.diagID),
 			fmt.Sprintf("SQL shell: \\statement-diag download %d", bundle.diagID),
 			fmt.Sprintf("Command line: cockroach statement-diag download %d", bundle.diagID),
 		}

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -62,7 +62,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		// after the plan is finalized (when the physical plan is successfully
 		// created).
 		distribution := getPlanDistribution(
-			params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeID,
+			params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeInfo.NodeID,
 			params.extendedEvalCtx.SessionData().DistSQLMode, plan.main,
 		)
 

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -43,7 +43,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	n.run.values = make(tree.Datums, 1)
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	distribution := getPlanDistribution(
-		params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeID,
+		params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeInfo.NodeID,
 		params.extendedEvalCtx.SessionData().DistSQLMode, n.plan.main,
 	)
 	outerSubqueries := params.p.curPlan.subqueryPlans

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -535,7 +535,7 @@ INSERT INTO foo VALUES (1), (10), (100);
 
 		// Run the index backfill
 		changer := sql.NewSchemaChangerForTesting(
-			tableID, 1, execCfg.NodeID.SQLInstanceID(), s0.DB(), lm, jr, &execCfg, settings)
+			tableID, 1, execCfg.NodeInfo.NodeID.SQLInstanceID(), s0.DB(), lm, jr, &execCfg, settings)
 		changer.SetJob(j)
 		spans := []roachpb.Span{table.IndexSpan(keys.SystemSQLCodec, test.indexToBackfill)}
 		require.NoError(t, changer.TestingDistIndexBackfill(ctx, table.GetVersion(), spans,

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -730,7 +730,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn, socketType Socket
 	defer onCloseFn()
 
 	connDetails := eventpb.CommonConnectionDetails{
-		InstanceID:    int32(s.execCfg.NodeID.SQLInstanceID()),
+		InstanceID:    int32(s.execCfg.NodeInfo.NodeID.SQLInstanceID()),
 		Network:       conn.RemoteAddr().Network(),
 		RemoteAddress: conn.RemoteAddr().String(),
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -116,9 +116,9 @@ func (evalCtx *extendedEvalContext) copyFromExecCfg(execCfg *ExecutorConfig) {
 	evalCtx.SQLLivenessReader = execCfg.SQLLiveness
 	evalCtx.CompactEngineSpan = execCfg.CompactEngineSpanFunc
 	evalCtx.TestingKnobs = execCfg.EvalContextTestingKnobs
-	evalCtx.ClusterID = execCfg.LogicalClusterID()
+	evalCtx.ClusterID = execCfg.NodeInfo.LogicalClusterID()
 	evalCtx.ClusterName = execCfg.RPCContext.ClusterName()
-	evalCtx.NodeID = execCfg.NodeID
+	evalCtx.NodeID = execCfg.NodeInfo.NodeID
 	evalCtx.Locality = execCfg.Locality
 	evalCtx.NodesStatusServer = execCfg.NodesStatusServer
 	evalCtx.RegionsServer = execCfg.RegionsServer
@@ -383,9 +383,9 @@ func newInternalPlanner(
 	p.extendedEvalCtx.Tenant = p
 	p.extendedEvalCtx.Regions = p
 	p.extendedEvalCtx.JoinTokenCreator = p
-	p.extendedEvalCtx.ClusterID = execCfg.LogicalClusterID()
+	p.extendedEvalCtx.ClusterID = execCfg.NodeInfo.LogicalClusterID()
 	p.extendedEvalCtx.ClusterName = execCfg.RPCContext.ClusterName()
-	p.extendedEvalCtx.NodeID = execCfg.NodeID
+	p.extendedEvalCtx.NodeID = execCfg.NodeInfo.NodeID
 	p.extendedEvalCtx.Locality = execCfg.Locality
 
 	p.sessionDataMutatorIterator = smi

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -64,7 +64,7 @@ func (p *planner) SchemaChange(ctx context.Context, stmt tree.Statement) (planNo
 	scs := p.extendedEvalCtx.SchemaChangerState
 	scs.stmts = append(scs.stmts, p.stmt.SQL)
 	deps := scdeps.NewBuilderDependencies(
-		p.ExecCfg().LogicalClusterID(),
+		p.ExecCfg().NodeInfo.LogicalClusterID(),
 		p.ExecCfg().Codec,
 		p.Txn(),
 		p.Descriptors(),
@@ -190,7 +190,7 @@ func (s *schemaChangePlanNode) startExec(params runParams) error {
 	// phase was not executed.
 	if !reflect.DeepEqual(s.lastState.Current, scs.state.Current) {
 		deps := scdeps.NewBuilderDependencies(
-			p.ExecCfg().LogicalClusterID(),
+			p.ExecCfg().NodeInfo.LogicalClusterID(),
 			p.ExecCfg().Codec,
 			p.Txn(),
 			p.Descriptors(),

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -355,7 +355,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			}
 
 			isLocal := !getPlanDistribution(
-				ctx, localPlanner, localPlanner.execCfg.NodeID,
+				ctx, localPlanner, localPlanner.execCfg.NodeInfo.NodeID,
 				localPlanner.extendedEvalCtx.SessionData().DistSQLMode,
 				localPlanner.curPlan.main,
 			).WillDistribute()
@@ -2487,9 +2487,9 @@ func createSchemaChangeEvalCtx(
 			Regions:            &faketreeeval.DummyRegionOperator{},
 			Settings:           execCfg.Settings,
 			TestingKnobs:       execCfg.EvalContextTestingKnobs,
-			ClusterID:          execCfg.LogicalClusterID(),
+			ClusterID:          execCfg.NodeInfo.LogicalClusterID(),
 			ClusterName:        execCfg.RPCContext.ClusterName(),
-			NodeID:             execCfg.NodeID,
+			NodeID:             execCfg.NodeInfo.NodeID,
 			Codec:              execCfg.Codec,
 			Locality:           execCfg.Locality,
 			Tracer:             execCfg.AmbientCtx.Tracer,
@@ -2560,7 +2560,7 @@ func (r schemaChangeResumer) Resume(ctx context.Context, execCtx interface{}) er
 			descID:               descID,
 			mutationID:           mutationID,
 			droppedDatabaseID:    droppedDatabaseID,
-			sqlInstanceID:        p.ExecCfg().NodeID.SQLInstanceID(),
+			sqlInstanceID:        p.ExecCfg().NodeInfo.NodeID.SQLInstanceID(),
 			db:                   p.ExecCfg().DB,
 			leaseMgr:             p.ExecCfg().LeaseManager,
 			testingKnobs:         p.ExecCfg().SchemaChangerTestingKnobs,
@@ -2748,7 +2748,7 @@ func (r schemaChangeResumer) OnFailOrCancel(ctx context.Context, execCtx interfa
 	sc := SchemaChanger{
 		descID:               details.DescID,
 		mutationID:           details.TableMutationID,
-		sqlInstanceID:        p.ExecCfg().NodeID.SQLInstanceID(),
+		sqlInstanceID:        p.ExecCfg().NodeInfo.NodeID.SQLInstanceID(),
 		db:                   p.ExecCfg().DB,
 		leaseMgr:             p.ExecCfg().LeaseManager,
 		testingKnobs:         p.ExecCfg().SchemaChangerTestingKnobs,

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -101,7 +101,7 @@ func TestSchemaChangeProcess(t *testing.T) {
 	require.NoError(t, err)
 	leaseMgr := lease.NewLeaseManager(
 		s.AmbientCtx(),
-		execCfg.NodeID,
+		execCfg.NodeInfo.NodeID,
 		execCfg.DB,
 		execCfg.Clock,
 		execCfg.InternalExecutor,

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -73,7 +73,7 @@ func WithBuilderDependenciesFromTestServer(
 	// changer will allow non-fully implemented operations.
 	planner.SessionData().NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafe
 	fn(scdeps.NewBuilderDependencies(
-		execCfg.LogicalClusterID(),
+		execCfg.NodeInfo.LogicalClusterID(),
 		execCfg.Codec,
 		planner.Txn(),
 		planner.Descriptors(),

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -149,7 +149,7 @@ func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, erro
 		if err != nil {
 			return nil, err
 		}
-		id := clusterunique.GenerateID(evalCtx.ExecCfg.Clock.Now(), evalCtx.ExecCfg.NodeID.SQLInstanceID())
+		id := clusterunique.GenerateID(evalCtx.ExecCfg.Clock.Now(), evalCtx.ExecCfg.NodeInfo.NodeID.SQLInstanceID())
 		stmt := makeStatement(parserStmt, id)
 
 		var placeholderTypes tree.PlaceholderTypes

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -86,7 +86,7 @@ var supportedZoneConfigOptions = map[tree.Name]struct {
 			}
 			return base.CheckEnterpriseEnabled(
 				execCfg.Settings,
-				execCfg.LogicalClusterID(),
+				execCfg.NodeInfo.LogicalClusterID(),
 				execCfg.Organization(),
 				"global_reads",
 			)
@@ -1071,7 +1071,7 @@ func prepareZoneConfigWrites(
 	if len(zone.Subzones) > 0 {
 		st := execCfg.Settings
 		zone.SubzoneSpans, err = GenerateSubzoneSpans(
-			st, execCfg.LogicalClusterID(), execCfg.Codec, table, zone.Subzones, hasNewSubzones)
+			st, execCfg.NodeInfo.LogicalClusterID(), execCfg.Codec, table, zone.Subzones, hasNewSubzones)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This patch turns an embedded struct into a field. With the NodeInfo
being embedded, it was hard to grep for all the places that uses its
member fields, and I found myself wanting to know that.

Release note: None