### PR TITLE
kvserver: add an interface for replica changes for the store rebalancer

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -851,6 +851,8 @@ func (r *Replica) requestLeaseLocked(
 // blocks until the transfer is done. If a transfer is already in progress, this
 // method joins in waiting for it to complete if it's transferring to the same
 // replica. Otherwise, a NotLeaseHolderError is returned.
+//
+// AdminTransferLease implements the ReplicaLeaseMover interface.
 func (r *Replica) AdminTransferLease(ctx context.Context, target roachpb.StoreID) error {
 	// initTransferHelper inits a transfer if no extension is in progress.
 	// It returns a channel for waiting for the result of a pending


### PR DESCRIPTION
In order to simulate the store rebalancer, we need an interface that
can be used for lease transfers and replica moves. This PR wraps existing
code with a new interface, which will also be implemented in the asim package.

Release note: None