### PR TITLE
backupccl: handle range keys in BACKUP

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/rangekeys
+++ b/pkg/ccl/backupccl/testdata/backup-restore/rangekeys
@@ -1,0 +1,84 @@
+# Tests that Backups without Revisions History and Restore properly handle
+# range keys
+
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE orig;
+USE orig;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foo VALUES (1, 'x'),(2,'y');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (11, 'xx'),(22,'yy');
+----
+
+# Ensure a full backup properly captures range keys
+# - with foo, delete then insert, and ensure no original data surfaces in restore
+# - with baz: chill for now
+
+kv request=DeleteRange target=foo
+----
+
+exec-sql
+INSERT INTO foo VALUES (3,'z');
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://0/test-root/';
+----
+
+exec-sql
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' with new_db_name='orig1';
+----
+
+query-sql
+SELECT count(*) from orig1.foo;
+----
+1
+
+query-sql
+SELECT count(*) from orig1.baz;
+----
+2
+
+exec-sql
+DROP DATABASE orig1 CASCADE
+----
+
+# Ensure incremental backup without revision history
+# handles range tombstones:
+# - with foo, insert and ensure latest data from previous backup surfaces in RESTORE
+# - with baz, delete then insert, and ensure no data from previous backup surfaces in RESTORE
+
+exec-sql
+INSERT INTO foo VALUES (4,'a'),(5,'b');
+----
+
+kv request=DeleteRange target=baz
+----
+
+exec-sql
+INSERT INTO baz VALUES (33,'zz');
+----
+
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/test-root/';
+----
+
+exec-sql
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' with new_db_name='orig1';
+----
+
+query-sql
+SELECT count(*) from orig1.foo
+----
+3
+
+query-sql
+SELECT count(*) from orig1.baz
+----
+1
+
+
+

--- a/pkg/ccl/backupccl/testdata/backup-restore/rangekeys-revision-history
+++ b/pkg/ccl/backupccl/testdata/backup-restore/rangekeys-revision-history
@@ -1,0 +1,148 @@
+# Tests that Backups with Revisions History and As Of System Time
+# Restore properly handle range keys in tables foo and baz
+# - t0: inital dataset
+# - t1: delrange on foo
+# - t2: one insert in foo
+# - full backup
+# - t3: 2 inserts in foo; delrange on baz
+# - t4: one insert in baz
+# - incremental backup
+
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE orig;
+USE orig;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foo VALUES (1, 'x'),(2,'y');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (11, 'xx'),(22,'yy');
+----
+
+save-cluster-ts tag=t0
+----
+
+kv request=DeleteRange target=foo
+----
+
+save-cluster-ts tag=t1
+----
+
+exec-sql
+INSERT INTO foo VALUES (3,'z');
+----
+
+save-cluster-ts tag=t2
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://0/test-root/' with revision_history;
+----
+
+exec-sql
+INSERT INTO foo VALUES (4,'a'),(5,'b');
+----
+
+kv request=DeleteRange target=baz
+----
+
+save-cluster-ts tag=t3
+----
+
+exec-sql
+INSERT INTO baz VALUES (33,'zz');
+----
+
+save-cluster-ts tag=t4
+----
+
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/test-root/' with revision_history;
+----
+
+restore aost=t0
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t0 WITH new_db_name='orig1';
+----
+
+query-sql
+SELECT count(*) from orig1.foo
+----
+2
+
+query-sql
+SELECT count(*) from orig1.baz
+----
+2
+
+exec-sql
+DROP DATABASE orig1 CASCADE
+----
+
+restore aost=t1
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t1 WITH new_db_name='orig1';
+----
+
+query-sql
+SELECT count(*) from orig1.foo
+----
+0
+
+query-sql
+SELECT count(*) from orig1.baz
+----
+2
+
+exec-sql
+DROP DATABASE orig1 CASCADE
+----
+
+restore aost=t2
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t2 WITH new_db_name='orig1';
+----
+
+query-sql
+SELECT count(*) from orig1.foo
+----
+1
+
+query-sql
+SELECT count(*) from orig1.baz
+----
+2
+
+exec-sql
+DROP DATABASE orig1 CASCADE
+----
+
+restore aost=t3
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t3 WITH new_db_name='orig1';
+----
+
+query-sql
+SELECT count(*) from orig1.foo
+----
+3
+
+query-sql
+SELECT count(*) from orig1.baz
+----
+0
+
+exec-sql
+DROP DATABASE orig1 CASCADE
+----
+
+restore aost=t4
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t4 WITH new_db_name='orig1';
+----
+
+query-sql
+SELECT count(*) from orig1.foo
+----
+3
+
+query-sql
+SELECT count(*) from orig1.baz
+----
+1

--- a/pkg/kv/kvclient/revision_reader.go
+++ b/pkg/kv/kvclient/revision_reader.go
@@ -48,7 +48,12 @@ func GetAllRevisions(
 
 	var res []VersionedValues
 	for _, file := range resp.(*roachpb.ExportResponse).Files {
-		iter, err := storage.NewMemSSTIterator(file.SST, false)
+		iterOpts := storage.IterOptions{
+			KeyTypes:   storage.IterKeyTypePointsOnly,
+			LowerBound: file.Span.Key,
+			UpperBound: file.Span.EndKey,
+		}
+		iter, err := storage.NewPebbleMemSSTIterator(file.SST, true, iterOpts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously BACKUP would not back up range tombstones. With this patch, BACKUPs
with revision_history will backup range tombstones. Non-revision history backups
are not affected by this diff because MVCCExportToSST filters all tombstones
out of the backup already.

Specifically, this patch replaces the iterators used in the backup_processor
with the pebbleIterator, which has baked in range key support. This refactor
introduces a 5% regression in backup runtime, even when the backup has no range
keys, though https://github.com/cockroachdb/cockroach/issues/83051 hopes to address this gap. See details below on the
benchmark experiment.

At this point a backup with range keys is restorable, thanks to https://github.com/cockroachdb/cockroach/pull/84214. Note
that the restore codebase still touches iterators that are not range key aware.
This is not a problem because restored data does not have range keys, nor do
the empty ranges restore dumps data into. These iterators (e.g. in SSTBatcher
and in CheckSSTConflicts) will be updated when https://github.com/cockroachdb/cockroach/issues/70428 gets fixed.

Fixes https://github.com/cockroachdb/cockroach/issues/71155

Release note: none

To benchmark this diff, the following commands were used on the following sha
https://github.com/cockroachdb/cockroach/commit/a5ccdc3a49a73ce8791a133297e70871223f3d7e, with and without this commit, over
three trials:
```
roachprod create -n 5 --gce-machine-type=n2-standard-16 $CLUSTER
roachprod put $CLUSTER [build] cockroach

roachprod wipe $CLUSTER; roachprod start $CLUSTER;
roachprod run $CLUSTER:1 -- "./cockroach workload init bank --rows 1000000000"
roachprod sql $CLUSTER:1 -- -e "BACKUP INTO 'gs://somebucket/michael-rangkey?AUTH=implicit'"
```

The backup on the control binary took on average 478 seconds with a stdev of 13
seconds, while the backup with the treatment binary took on average 499 seconds
with stddev of 8 seconds.