### PR TITLE
sql,catalog: make owner privileges implicit rather than explicit

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -946,25 +946,45 @@ func showPrivileges(descriptor *descpb.Descriptor) string {
 	if privDesc == nil {
 		return ""
 	}
-	for _, userPriv := range privDesc.Show(objectType) {
+	for _, userPriv := range privDesc.Show(objectType, false /* showImplicitOwnerPrivs */) {
 		privs := userPriv.Privileges
 		if len(privs) == 0 {
 			continue
 		}
-		privStringBuilder.WriteString("GRANT ")
-
-		for j, priv := range privs {
-			if j != 0 {
-				privStringBuilder.WriteString(", ")
+		var privsWithGrantOption []string
+		for _, priv := range privs {
+			if priv.GrantOption {
+				privsWithGrantOption = append(privsWithGrantOption, priv.Kind.String())
 			}
-			privStringBuilder.WriteString(priv.Kind.String())
 		}
-		privStringBuilder.WriteString(" ON ")
-		privStringBuilder.WriteString(strings.ToUpper(string(objectType)) + " ")
-		privStringBuilder.WriteString(descpb.GetDescriptorName(descriptor))
-		privStringBuilder.WriteString(" TO ")
-		privStringBuilder.WriteString(userPriv.User.SQLIdentifier())
-		privStringBuilder.WriteString("; ")
+		if len(privsWithGrantOption) > 0 {
+			privStringBuilder.WriteString("GRANT ")
+			privStringBuilder.WriteString(strings.Join(privsWithGrantOption, ", "))
+			privStringBuilder.WriteString(" ON ")
+			privStringBuilder.WriteString(strings.ToUpper(string(objectType)) + " ")
+			privStringBuilder.WriteString(descpb.GetDescriptorName(descriptor))
+			privStringBuilder.WriteString(" TO ")
+			privStringBuilder.WriteString(userPriv.User.SQLIdentifier())
+			privStringBuilder.WriteString(" WITH GRANT OPTION; ")
+		}
+
+		var privsWithoutGrantOption []string
+		for _, priv := range privs {
+			if !priv.GrantOption {
+				privsWithoutGrantOption = append(privsWithoutGrantOption, priv.Kind.String())
+			}
+
+		}
+		if len(privsWithoutGrantOption) > 0 {
+			privStringBuilder.WriteString("GRANT ")
+			privStringBuilder.WriteString(strings.Join(privsWithoutGrantOption, ", "))
+			privStringBuilder.WriteString(" ON ")
+			privStringBuilder.WriteString(strings.ToUpper(string(objectType)) + " ")
+			privStringBuilder.WriteString(descpb.GetDescriptorName(descriptor))
+			privStringBuilder.WriteString(" TO ")
+			privStringBuilder.WriteString(userPriv.User.SQLIdentifier())
+			privStringBuilder.WriteString("; ")
+		}
 	}
 
 	return privStringBuilder.String()

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -413,19 +413,33 @@ GRANT UPDATE ON top_secret TO agent_bond;
 		sqlDB.Exec(t, `BACKUP DATABASE mi5 TO $1;`, showPrivs)
 
 		want := [][]string{
-			{`mi5`, `database`, `GRANT ALL ON DATABASE mi5 TO admin; GRANT ALL ON DATABASE mi5 TO agents; GRANT CONNECT ON DATABASE mi5 TO public; GRANT ALL ON DATABASE mi5 TO root; `, `root`},
-			{`public`, `schema`, `GRANT ALL ON SCHEMA public TO admin; GRANT CREATE, USAGE ON SCHEMA public TO public; GRANT ALL ON SCHEMA public TO root; `, `admin`},
-			{`locator`, `schema`, `GRANT ALL ON SCHEMA locator TO admin; GRANT CREATE ON SCHEMA locator TO agent_bond; GRANT ALL ON SCHEMA locator TO m; ` +
-				`GRANT ALL ON SCHEMA locator TO root; `, `root`},
-			{`continent`, `type`, `GRANT ALL ON TYPE continent TO admin; GRANT ALL ON TYPE continent TO m; GRANT USAGE ON TYPE continent TO public; GRANT ALL ON TYPE continent TO root; `, `root`},
-			{`_continent`, `type`, `GRANT ALL ON TYPE _continent TO admin; GRANT USAGE ON TYPE _continent TO public; GRANT ALL ON TYPE _continent TO root; `, `root`},
-			{`agent_locations`, `table`, `GRANT ALL ON TABLE agent_locations TO admin; ` +
-				`GRANT SELECT ON TABLE agent_locations TO agent_bond; GRANT UPDATE ON TABLE agent_locations TO agents; ` +
-				`GRANT ALL ON TABLE agent_locations TO m; GRANT ALL ON TABLE agent_locations TO root; `,
-				`root`},
-			{`top_secret`, `table`, `GRANT ALL ON TABLE top_secret TO admin; ` +
-				`GRANT SELECT, UPDATE ON TABLE top_secret TO agent_bond; GRANT INSERT ON TABLE top_secret TO agents; ` +
-				`GRANT ALL ON TABLE top_secret TO m; GRANT ALL ON TABLE top_secret TO root; `, `root`},
+			{`mi5`, `database`, `GRANT ALL ON DATABASE mi5 TO admin WITH GRANT OPTION; ` +
+				`GRANT ALL ON DATABASE mi5 TO agents; ` +
+				`GRANT CONNECT ON DATABASE mi5 TO public; ` +
+				`GRANT ALL ON DATABASE mi5 TO root WITH GRANT OPTION; `, `root`},
+			{`public`, `schema`, `GRANT ALL ON SCHEMA public TO admin WITH GRANT OPTION; ` +
+				`GRANT CREATE, USAGE ON SCHEMA public TO public; ` +
+				`GRANT ALL ON SCHEMA public TO root WITH GRANT OPTION; `, `admin`},
+			{`locator`, `schema`, `GRANT ALL ON SCHEMA locator TO admin WITH GRANT OPTION; ` +
+				`GRANT CREATE ON SCHEMA locator TO agent_bond; ` +
+				`GRANT ALL ON SCHEMA locator TO m; ` +
+				`GRANT ALL ON SCHEMA locator TO root WITH GRANT OPTION; `, `root`},
+			{`continent`, `type`, `GRANT ALL ON TYPE continent TO admin WITH GRANT OPTION; ` +
+				`GRANT ALL ON TYPE continent TO m; ` +
+				`GRANT USAGE ON TYPE continent TO public; ` +
+				`GRANT ALL ON TYPE continent TO root WITH GRANT OPTION; `, `root`},
+			{`_continent`, `type`, `GRANT ALL ON TYPE _continent TO admin WITH GRANT OPTION; ` +
+				`GRANT USAGE ON TYPE _continent TO public; ` +
+				`GRANT ALL ON TYPE _continent TO root WITH GRANT OPTION; `, `root`},
+			{`agent_locations`, `table`, `GRANT ALL ON TABLE agent_locations TO admin WITH GRANT OPTION; ` +
+				`GRANT SELECT ON TABLE agent_locations TO agent_bond; ` +
+				`GRANT UPDATE ON TABLE agent_locations TO agents; ` +
+				`GRANT ALL ON TABLE agent_locations TO m; ` +
+				`GRANT ALL ON TABLE agent_locations TO root WITH GRANT OPTION; `, `root`},
+			{`top_secret`, `table`, `GRANT ALL ON TABLE top_secret TO admin WITH GRANT OPTION; ` +
+				`GRANT SELECT, UPDATE ON TABLE top_secret TO agent_bond; ` +
+				`GRANT INSERT ON TABLE top_secret TO agents; GRANT ALL ON TABLE top_secret TO m; ` +
+				`GRANT ALL ON TABLE top_secret TO root WITH GRANT OPTION; `, `root`},
 		}
 
 		showQuery := fmt.Sprintf(`SELECT object_name, object_type, privileges, owner FROM [SHOW BACKUP '%s' WITH privileges]`, showPrivs)

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -297,6 +297,7 @@ SHOW GRANTS ON TYPE testuser_db.greeting_usage;
 ----
 testuser_db public greeting_usage admin ALL true
 testuser_db public greeting_usage root ALL true
+testuser_db public greeting_usage testuser ALL true
 
 query-sql
 SHOW GRANTS ON testuser_db.testtable_greeting_usage;
@@ -515,54 +516,63 @@ SHOW GRANTS ON DATABASE testdb
 testdb admin ALL true
 testdb public CONNECT false
 testdb root ALL true
+testdb testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.testtable_simple
 ----
 testdb public testtable_simple admin ALL true
 testdb public testtable_simple root ALL true
+testdb public testtable_simple testuser ALL true
 
 query-sql
 SHOW GRANTS ON SCHEMA testdb.sc
 ----
 testdb sc admin ALL true
 testdb sc root ALL true
+testdb sc testuser ALL true
 
 query-sql
 SHOW GRANTS ON SCHEMA testdb.public
 ----
 testdb public admin ALL true
 testdb public root ALL true
+testdb public testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.sc.othertable
 ----
 testdb sc othertable admin ALL true
 testdb sc othertable root ALL true
+testdb sc othertable testuser ALL true
 
 query-sql
 SHOW GRANTS ON TYPE greeting_usage;
 ----
 testdb public greeting_usage admin ALL true
 testdb public greeting_usage root ALL true
+testdb public greeting_usage testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.testtable_greeting_usage;
 ----
 testdb public testtable_greeting_usage admin ALL true
 testdb public testtable_greeting_usage root ALL true
+testdb public testtable_greeting_usage testuser ALL true
 
 query-sql
 SHOW GRANTS ON TYPE greeting_owner;
 ----
 testdb public greeting_owner admin ALL true
 testdb public greeting_owner root ALL true
+testdb public greeting_owner testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.testtable_greeting_owner;
 ----
 testdb public testtable_greeting_owner admin ALL true
 testdb public testtable_greeting_owner root ALL true
+testdb public testtable_greeting_owner testuser ALL true
 
 # Ensure that testuser is the owner of the restored database/schemas.
 query-sql

--- a/pkg/sql/catalog/catpb/privilege_test.go
+++ b/pkg/sql/catalog/catpb/privilege_test.go
@@ -160,7 +160,7 @@ func TestPrivilege(t *testing.T) {
 				descriptor.Revoke(tc.grantee, tc.revoke, tc.objectType, false)
 			}
 		}
-		show := descriptor.Show(tc.objectType)
+		show := descriptor.Show(tc.objectType, true /* showImplicitOwnerPrivs */)
 		if len(show) != len(tc.show) {
 			t.Fatalf("#%d: show output for descriptor %+v differs, got: %+v, expected %+v",
 				tcNum, descriptor, show, tc.show)

--- a/pkg/sql/catalog/catprivilege/default_privilege_test.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege_test.go
@@ -371,10 +371,9 @@ func TestPresetDefaultPrivilegesInSchema(t *testing.T) {
 			nonSystemDatabaseID, creatorUser, targetObject, &catpb.PrivilegeDescriptor{},
 		)
 
-		// There are no preset privileges on a default privilege descriptor defined
-		// for a schema.
-		if newPrivileges.CheckPrivilege(creatorUser, privilege.ALL) {
-			t.Errorf("creator should not have ALL privileges on %s", targetObject)
+		// The owner always has ALL privileges.
+		if !newPrivileges.CheckPrivilege(creatorUser, privilege.ALL) {
+			t.Errorf("expected creator to have ALL privileges on %s", targetObject)
 		}
 
 		if targetObject == privilege.Types {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4896,7 +4896,7 @@ CREATE TABLE crdb_internal.cluster_database_privileges (
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
-				privs := db.GetPrivileges().Show(privilege.Database)
+				privs := db.GetPrivileges().Show(privilege.Database, true /* showImplicitOwnerPrivs */)
 				dbNameStr := tree.NewDString(db.GetName())
 				// TODO(knz): This should filter for the current user, see
 				// https://github.com/cockroachdb/cockroach/issues/35572

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1026,7 +1026,7 @@ var informationSchemaTypePrivilegesTable = virtualSchemaTable{
 					typeNameStr := tree.NewDString(typeDesc.GetName())
 					// TODO(knz): This should filter for the current user, see
 					// https://github.com/cockroachdb/cockroach/issues/35572
-					privs := typeDesc.GetPrivileges().Show(privilege.Type)
+					privs := typeDesc.GetPrivileges().Show(privilege.Type, true /* showImplicitOwnerPrivs */)
 					for _, u := range privs {
 						userNameStr := tree.NewDString(u.User.Normalized())
 						for _, priv := range u.Privileges {
@@ -1062,7 +1062,7 @@ var informationSchemaSchemataTablePrivileges = virtualSchemaTable{
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
 				return forEachSchema(ctx, p, db, func(sc catalog.SchemaDescriptor) error {
-					privs := sc.GetPrivileges().Show(privilege.Schema)
+					privs := sc.GetPrivileges().Show(privilege.Schema, true /* showImplicitOwnerPrivs */)
 					dbNameStr := tree.NewDString(db.GetName())
 					scNameStr := tree.NewDString(sc.GetName())
 					// TODO(knz): This should filter for the current user, see
@@ -1371,7 +1371,7 @@ func populateTablePrivileges(
 			} else {
 				tableType = privilege.Table
 			}
-			for _, u := range table.GetPrivileges().Show(tableType) {
+			for _, u := range table.GetPrivileges().Show(tableType, true /* showImplicitOwnerPrivs */) {
 				granteeNameStr := tree.NewDString(u.User.Normalized())
 				for _, priv := range u.Privileges {
 					// We use this function to check for the grant option so that the

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
@@ -43,9 +43,10 @@ CREATE SCHEMA testuser_s2;
 query TTTTB colnames
 SHOW GRANTS ON SCHEMA testuser_s2
 ----
-database_name  schema_name  grantee  privilege_type  is_grantable
-d              testuser_s2  admin    ALL             true
-d              testuser_s2  root     ALL             true
+database_name  schema_name  grantee   privilege_type  is_grantable
+d              testuser_s2  admin     ALL             true
+d              testuser_s2  root      ALL             true
+d              testuser_s2  testuser  ALL             true
 
 user root
 
@@ -115,9 +116,10 @@ CREATE SCHEMA s4
 query TTTTB colnames
 SHOW GRANTS ON SCHEMA s4
 ----
-database_name  schema_name  grantee  privilege_type  is_grantable
-d              s4           admin    ALL             true
-d              s4           root     ALL             true
+database_name  schema_name  grantee   privilege_type  is_grantable
+d              s4           admin     ALL             true
+d              s4           root      ALL             true
+d              s4           testuser  ALL             true
 
 user root
 statement ok
@@ -141,9 +143,10 @@ CREATE SCHEMA s5
 query TTTTB colnames
 SHOW GRANTS ON SCHEMA s5
 ----
-database_name  schema_name  grantee  privilege_type  is_grantable
-d              s5           admin    ALL             true
-d              s5           root     ALL             true
+database_name  schema_name  grantee   privilege_type  is_grantable
+d              s5           admin     ALL             true
+d              s5           root      ALL             true
+d              s5           testuser  ALL             true
 
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO testuser, testuser2

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
@@ -32,9 +32,10 @@ CREATE SEQUENCE testuser_s2;
 query TTTTTB colnames
 SHOW GRANTS ON testuser_s2
 ----
-database_name  schema_name  table_name   grantee  privilege_type  is_grantable
-d              public       testuser_s2  admin    ALL             true
-d              public       testuser_s2  root     ALL             true
+database_name  schema_name  table_name   grantee   privilege_type  is_grantable
+d              public       testuser_s2  admin     ALL             true
+d              public       testuser_s2  root      ALL             true
+d              public       testuser_s2  testuser  ALL             true
 
 user root
 
@@ -128,9 +129,10 @@ CREATE SEQUENCE s4
 query TTTTTB colnames
 SHOW GRANTS ON s4
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-d              public       s4          admin    ALL             true
-d              public       s4          root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+d              public       s4          admin     ALL             true
+d              public       s4          root      ALL             true
+d              public       s4          testuser  ALL             true
 
 user root
 statement ok
@@ -153,6 +155,7 @@ CREATE SEQUENCE s5
 query TTTTTB colnames
 SHOW GRANTS ON s5
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-d              public       s5          admin    ALL             true
-d              public       s5          root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+d              public       s5          admin     ALL             true
+d              public       s5          root      ALL             true
+d              public       s5          testuser  ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
@@ -47,9 +47,10 @@ CREATE TABLE testuser_t2();
 query TTTTTB colnames
 SHOW GRANTS ON testuser_t2
 ----
-database_name  schema_name  table_name   grantee  privilege_type  is_grantable
-d              public       testuser_t2  admin    ALL             true
-d              public       testuser_t2  root     ALL             true
+database_name  schema_name  table_name   grantee   privilege_type  is_grantable
+d              public       testuser_t2  admin     ALL             true
+d              public       testuser_t2  root      ALL             true
+d              public       testuser_t2  testuser  ALL             true
 
 user root
 
@@ -196,7 +197,7 @@ SHOW GRANTS ON t5
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 d              public       t5          admin      ALL             true
 d              public       t5          root       ALL             true
-d              public       t5          testuser   SELECT          true
+d              public       t5          testuser   ALL             true
 d              public       t5          testuser2  SELECT          false
 
 user root
@@ -218,9 +219,10 @@ CREATE TABLE t6()
 query TTTTTB colnames
 SHOW GRANTS ON t6
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-d              public       t6          admin    ALL             true
-d              public       t6          root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+d              public       t6          admin     ALL             true
+d              public       t6          root      ALL             true
+d              public       t6          testuser  ALL             true
 
 user root
 
@@ -308,6 +310,7 @@ SHOW GRANTS ON t10
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 d              public       t10         admin      ALL             true
 d              public       t10         root       ALL             true
+d              public       t10         testuser   ALL             true
 d              public       t10         testuser2  SELECT          false
 d              public       t10         testuser3  SELECT          false
 
@@ -334,9 +337,10 @@ CREATE TABLE t12()
 query TTTTTB colnames
 SHOW GRANTS ON t12
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-d              public       t12         admin    ALL             true
-d              public       t12         root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+d              public       t12         admin     ALL             true
+d              public       t12         root      ALL             true
+d              public       t12         testuser  ALL             true
 
 # Cannot specify PUBLIC as the target role.
 statement error pq: user or role public does not exist

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type
@@ -33,9 +33,10 @@ CREATE TYPE testuser_t2 AS ENUM();
 query TTTTTB colnames
 SHOW GRANTS ON TYPE testuser_t2
 ----
-database_name  schema_name  type_name    grantee  privilege_type  is_grantable
-d              public       testuser_t2  admin    ALL             true
-d              public       testuser_t2  root     ALL             true
+database_name  schema_name  type_name    grantee   privilege_type  is_grantable
+d              public       testuser_t2  admin     ALL             true
+d              public       testuser_t2  root      ALL             true
+d              public       testuser_t2  testuser  ALL             true
 
 user root
 
@@ -105,9 +106,10 @@ CREATE TYPE t4 AS ENUM()
 query TTTTTB colnames
 SHOW GRANTS ON TYPE t4
 ----
-database_name  schema_name  type_name  grantee  privilege_type  is_grantable
-d              public       t4         admin    ALL             true
-d              public       t4         root     ALL             true
+database_name  schema_name  type_name  grantee   privilege_type  is_grantable
+d              public       t4         admin     ALL             true
+d              public       t4         root      ALL             true
+d              public       t4         testuser  ALL             true
 
 user root
 statement ok
@@ -129,6 +131,7 @@ CREATE TYPE t5 AS ENUM()
 query TTTTTB colnames
 SHOW GRANTS ON TYPE t5
 ----
-database_name  schema_name  type_name  grantee  privilege_type  is_grantable
-d              public       t5         admin    ALL             true
-d              public       t5         root     ALL             true
+database_name  schema_name  type_name  grantee   privilege_type  is_grantable
+d              public       t5         admin     ALL             true
+d              public       t5         root      ALL             true
+d              public       t5         testuser  ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
@@ -187,6 +187,7 @@ SHOW GRANTS ON t11
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t11         admin      ALL             true
 test           public       t11         root       ALL             true
+test           public       t11         testuser   ALL             true
 test           public       t11         testuser2  SELECT          false
 
 # Default privileges for schemas have no defaults - no privileges are defined
@@ -206,9 +207,10 @@ CREATE TABLE s2.t12()
 query TTTTTB colnames
 SHOW GRANTS ON s2.t12
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-test           s2           t12         admin    ALL             true
-test           s2           t12         root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+test           s2           t12         admin     ALL             true
+test           s2           t12         root      ALL             true
+test           s2           t12         testuser  ALL             true
 
 query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE schema_name IS NOT NULL

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
@@ -259,6 +259,7 @@ SHOW GRANTS ON TABLE t13
 database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 test           public       t13         admin     ALL             true
 test           public       t13         root      ALL             true
+test           public       t13         testuser  ALL             true
 
 statement ok
 GRANT ALL PRIVILEGES ON TABLE t13 TO testuser
@@ -299,6 +300,7 @@ SHOW GRANTS ON TABLE t14;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t14         admin      ALL             true
 test           public       t14         root       ALL             true
+test           public       t14         testuser   ALL             true
 test           public       t14         testuser2  INSERT          true
 test           public       t14         testuser2  SELECT          false
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -173,3 +173,24 @@ owner_grant_option  admin                     ALL             true
 owner_grant_option  owner_grant_option_child  CONNECT         true
 owner_grant_option  public                    CONNECT         false
 owner_grant_option  root                      ALL             true
+owner_grant_option  testuser                  ALL             true
+
+# Verify that is_grantable moves to the new owner.
+
+user root
+
+statement ok
+CREATE ROLE other_owner
+
+statement ok
+ALTER DATABASE owner_grant_option OWNER TO other_owner
+
+query TTTB colnames
+SHOW GRANTS ON DATABASE owner_grant_option
+----
+database_name       grantee                   privilege_type  is_grantable
+owner_grant_option  admin                     ALL             true
+owner_grant_option  other_owner               ALL             true
+owner_grant_option  owner_grant_option_child  CONNECT         false
+owner_grant_option  public                    CONNECT         false
+owner_grant_option  root                      ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -524,6 +524,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t1          admin      ALL             true
 test           public       t1          root       ALL             true
+test           public       t1          testuser   ALL             true
 test           public       t1          testuser2  SELECT          false
 
 # even though testuser doesn't have privileges on table t1, it can still grant
@@ -540,6 +541,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t1          admin      ALL             true
 test           public       t1          root       ALL             true
+test           public       t1          testuser   ALL             true
 test           public       t1          testuser2  ALL             true
 
 query TTTTTB colnames
@@ -548,6 +550,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t1          admin      ALL             true
 test           public       t1          root       ALL             true
+test           public       t1          testuser   ALL             true
 test           public       t1          testuser2  ALL             true
 
 # owner can give privileges back to themself
@@ -631,3 +634,22 @@ test           public       owner_grant_option  admin                     ALL   
 test           public       owner_grant_option  owner_grant_option_child  SELECT          true
 test           public       owner_grant_option  root                      ALL             true
 test           public       owner_grant_option  testuser                  ALL             true
+
+# Verify that is_grantable moves to the new owner.
+
+user root
+
+statement ok
+CREATE ROLE other_owner
+
+statement ok
+ALTER TABLE owner_grant_option OWNER TO other_owner
+
+query TTTTTB colnames
+SHOW GRANTS ON TABLE owner_grant_option
+----
+database_name  schema_name  table_name          grantee                   privilege_type  is_grantable
+test           public       owner_grant_option  admin                     ALL             true
+test           public       owner_grant_option  other_owner               ALL             true
+test           public       owner_grant_option  owner_grant_option_child  SELECT          false
+test           public       owner_grant_option  root                      ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -104,8 +104,8 @@ public     test           public              USAGE           NO
 root       test           public              ALL             YES
 admin      test           s                   ALL             YES
 root       test           s                   ALL             YES
-testuser   test           s                   ALL             YES
 testuser2  test           s                   CREATE          NO
+testuser   test           s                   ALL             YES
 
 # Check grants for testuser2, which should inherit from the public role.
 query TBB colnames rowsort
@@ -153,3 +153,22 @@ test           owner_grant_option  admin                     ALL             tru
 test           owner_grant_option  owner_grant_option_child  USAGE           true
 test           owner_grant_option  root                      ALL             true
 test           owner_grant_option  testuser                  ALL             true
+
+# Verify that is_grantable moves to the new owner.
+
+user root
+
+statement ok
+CREATE ROLE other_owner
+
+statement ok
+ALTER SCHEMA owner_grant_option OWNER TO other_owner
+
+query TTTTB colnames
+SHOW GRANTS ON SCHEMA owner_grant_option
+----
+database_name  schema_name         grantee                   privilege_type  is_grantable
+test           owner_grant_option  admin                     ALL             true
+test           owner_grant_option  other_owner               ALL             true
+test           owner_grant_option  owner_grant_option_child  USAGE           false
+test           owner_grant_option  root                      ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_type
+++ b/pkg/sql/logictest/testdata/logic_test/grant_type
@@ -106,3 +106,23 @@ test           public       owner_grant_option  owner_grant_option_child  USAGE 
 test           public       owner_grant_option  public                    USAGE           false
 test           public       owner_grant_option  root                      ALL             true
 test           public       owner_grant_option  testuser                  ALL             true
+
+# Verify that is_grantable moves to the new owner.
+
+user root
+
+statement ok
+CREATE ROLE other_owner
+
+statement ok
+ALTER TYPE owner_grant_option OWNER TO other_owner
+
+query TTTTTB colnames
+SHOW GRANTS ON TYPE owner_grant_option
+----
+database_name  schema_name  type_name           grantee                   privilege_type  is_grantable
+test           public       owner_grant_option  admin                     ALL             true
+test           public       owner_grant_option  other_owner               ALL             true
+test           public       owner_grant_option  owner_grant_option_child  USAGE           false
+test           public       owner_grant_option  public                    USAGE           false
+test           public       owner_grant_option  root                      ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1944,7 +1944,7 @@ Schema change plan for DROP INDEX ‹test›.public.‹parent›@‹idx› CASCA
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 19 elements transitioning toward ABSENT
+      │    ├── 18 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 265, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 265, ColumnID: 1, IndexID: 2}
       │    │    ├── VALIDATED  → DELETE_ONLY SecondaryIndex:{DescID: 265, IndexID: 2, ConstraintID: 2}
@@ -1952,7 +1952,6 @@ Schema change plan for DROP INDEX ‹test›.public.‹parent›@‹idx› CASCA
       │    │    ├── PUBLIC     → ABSENT      Owner:{DescID: 266}
       │    │    ├── PUBLIC     → ABSENT      UserPrivileges:{DescID: 266, Name: admin}
       │    │    ├── PUBLIC     → ABSENT      UserPrivileges:{DescID: 266, Name: root}
-      │    │    ├── PUBLIC     → ABSENT      UserPrivileges:{DescID: 266, Name: testuser}
       │    │    ├── OFFLINE    → DROPPED     View:{DescID: 266}
       │    │    ├── PUBLIC     → ABSENT      ObjectParent:{DescID: 266, ReferencedDescID: 105}
       │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 266, ColumnID: 1}
@@ -1994,6 +1993,7 @@ Schema change plan for DROP INDEX ‹test›.public.‹parent›@‹idx› CASCA
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":265}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":266}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}
+
 
 statement ok
 SET use_declarative_schema_changer = 'on'

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2658,7 +2658,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html`,
 		if err = forEachTableDesc(ctx, p, dbContext, virtualMany,
 			func(db catalog.DatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
 				owner := table.GetPrivileges().Owner()
-				for _, u := range table.GetPrivileges().Show(privilege.Table) {
+				for _, u := range table.GetPrivileges().Show(privilege.Table, true /* showImplicitOwnerPrivs */) {
 					if err := addSharedDependency(
 						dbOid(db.GetID()),       // dbid
 						pgClassOid,              // classid
@@ -2680,7 +2680,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html`,
 		if err = forEachDatabaseDesc(ctx, p, nil /*all databases*/, false, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
 				owner := db.GetPrivileges().Owner()
-				for _, u := range db.GetPrivileges().Show(privilege.Database) {
+				for _, u := range db.GetPrivileges().Show(privilege.Database, true /* showImplicitOwnerPrivs */) {
 					if err := addSharedDependency(
 						tree.NewDOid(0),   // dbid
 						pgDatabaseOid,     // classid

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_owned_by
@@ -26,8 +26,6 @@ DROP OWNED BY r
   {descriptorId: 105, owner: r}
 - [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC]
   {descriptorId: 105, privileges: 2, userName: admin}
-- [[UserPrivileges:{DescID: 105, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 105, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 105, privileges: 2, userName: root}
 - [[Schema:{DescID: 105}, ABSENT], PUBLIC]
@@ -42,8 +40,6 @@ DROP OWNED BY r
   {descriptorId: 106, owner: r}
 - [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC]
   {descriptorId: 106, privileges: 2, userName: admin}
-- [[UserPrivileges:{DescID: 106, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 106, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 106, privileges: 2, userName: root}
 - [[Sequence:{DescID: 106}, ABSENT], PUBLIC]
@@ -56,8 +52,6 @@ DROP OWNED BY r
   {descriptorId: 109, owner: r}
 - [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC]
   {descriptorId: 109, privileges: 2, userName: admin}
-- [[UserPrivileges:{DescID: 109, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 109, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 109, privileges: 2, userName: root}
 - [[Table:{DescID: 109}, ABSENT], PUBLIC]
@@ -114,8 +108,6 @@ DROP OWNED BY r
   {descriptorId: 107, owner: r}
 - [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC]
   {descriptorId: 107, privileges: 2, userName: admin}
-- [[UserPrivileges:{DescID: 107, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 107, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 107, privileges: 2, userName: root}
 - [[Sequence:{DescID: 107}, ABSENT], PUBLIC]
@@ -128,8 +120,6 @@ DROP OWNED BY r
   {descriptorId: 108, owner: r}
 - [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC]
   {descriptorId: 108, privileges: 2, userName: admin}
-- [[UserPrivileges:{DescID: 108, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 108, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 108, privileges: 2, userName: root}
 - [[Table:{DescID: 108}, ABSENT], PUBLIC]
@@ -186,8 +176,6 @@ DROP OWNED BY r
   {descriptorId: 110, owner: r}
 - [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC]
   {descriptorId: 110, privileges: 2, userName: admin}
-- [[UserPrivileges:{DescID: 110, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 110, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 110, privileges: 2, userName: root}
 - [[View:{DescID: 110}, ABSENT], PUBLIC]
@@ -220,8 +208,6 @@ DROP OWNED BY r
   {descriptorId: 111, privileges: 2, userName: admin}
 - [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC]
   {descriptorId: 111, privileges: 512, userName: public}
-- [[UserPrivileges:{DescID: 111, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 111, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 111, privileges: 2, userName: root}
 - [[EnumType:{DescID: 111}, ABSENT], PUBLIC]
@@ -238,8 +224,6 @@ DROP OWNED BY r
   {descriptorId: 112, privileges: 2, userName: admin}
 - [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC]
   {descriptorId: 112, privileges: 512, userName: public}
-- [[UserPrivileges:{DescID: 112, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 112, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 112, privileges: 2, userName: root}
 - [[AliasType:{DescID: 112}, ABSENT], PUBLIC]
@@ -252,8 +236,6 @@ DROP OWNED BY r
   {descriptorId: 113, owner: r}
 - [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC]
   {descriptorId: 113, privileges: 2, userName: admin}
-- [[UserPrivileges:{DescID: 113, Name: r}, ABSENT], PUBLIC]
-  {descriptorId: 113, privileges: 2, userName: r}
 - [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 113, privileges: 2, userName: root}
 - [[View:{DescID: 113}, ABSENT], PUBLIC]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
@@ -140,7 +140,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 46 MutationType ops
     [[Namespace:{DescID: 105, Name: s, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Schema:{DescID: 105}, ABSENT], OFFLINE] -> DROPPED
     [[SchemaParent:{DescID: 105, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
@@ -148,14 +147,12 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 46 MutationType ops
     [[Namespace:{DescID: 106, Name: sq, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 106, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 106}, ABSENT], OFFLINE] -> DROPPED
     [[ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 109, Name: t, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 109, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Table:{DescID: 109}, ABSENT], OFFLINE] -> DROPPED
     [[ObjectParent:{DescID: 109, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
@@ -184,14 +181,12 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 46 MutationType ops
     [[Namespace:{DescID: 107, Name: sq, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 107, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 107}, ABSENT], OFFLINE] -> DROPPED
     [[ObjectParent:{DescID: 107, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 108, Name: t, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 108, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Table:{DescID: 108}, ABSENT], OFFLINE] -> DROPPED
     [[ObjectParent:{DescID: 108, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
@@ -220,7 +215,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 46 MutationType ops
     [[Namespace:{DescID: 110, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 110, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[View:{DescID: 110}, ABSENT], OFFLINE] -> DROPPED
     [[ObjectParent:{DescID: 110, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
@@ -237,7 +231,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 46 MutationType ops
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: public}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 111, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[EnumType:{DescID: 111}, ABSENT], OFFLINE] -> DROPPED
     [[EnumTypeValue:{DescID: 111, Name: a}, ABSENT], PUBLIC] -> ABSENT
@@ -246,14 +239,12 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 46 MutationType ops
     [[Owner:{DescID: 112}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 112, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[AliasType:{DescID: 112}, ABSENT], OFFLINE] -> DROPPED
     [[ObjectParent:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 113, Name: r}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[View:{DescID: 113}, ABSENT], OFFLINE] -> DROPPED
     [[ObjectParent:{DescID: 113, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT


### PR DESCRIPTION
Previously, the privileges for an object owner would be explicitly
granted at the time of object creation. However, this is a bug, since if
the owner is changed, the original owner no longer should have
priveleges, and the new owner should have them instead. It's fixed by
relying on the CheckPrivilege functions checking for ownership, and the
privileges.Show function returning the implicit owner privs at
introspection time.

Release note (bug fix): Fixed a bug where the priveleges for an object
owner would not be correctly transferred when the owner is changed.