### PR TITLE
clusterversion,storage: add explicit version for split user keys

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -283,4 +283,4 @@ trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	22.1-28	set the active cluster version in the format '<major>.<minor>'
+version	version	22.1-30	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -214,6 +214,6 @@
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.span_registry.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://<ui>/#/debug/tracez</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>22.1-28</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>22.1-30</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -289,6 +289,10 @@ const (
 
 	// LocalTimestamps enables the use of local timestamps in MVCC values.
 	LocalTimestamps
+	// PebbleFormatSplitUserKeysMarkedCompacted updates the Pebble format
+	// version that recombines all user keys that may be split across multiple
+	// files into a single table.
+	PebbleFormatSplitUserKeysMarkedCompacted
 	// EnsurePebbleFormatVersionRangeKeys is the first step of a two-part
 	// migration that bumps Pebble's format major version to a version that
 	// supports range keys.
@@ -517,52 +521,56 @@ var versionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 4},
 	},
 	{
-		Key:     EnsurePebbleFormatVersionRangeKeys,
+		Key:     PebbleFormatSplitUserKeysMarkedCompacted,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 6},
 	},
 	{
-		Key:     EnablePebbleFormatVersionRangeKeys,
+		Key:     EnsurePebbleFormatVersionRangeKeys,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 8},
 	},
 	{
-		Key:     TrigramInvertedIndexes,
+		Key:     EnablePebbleFormatVersionRangeKeys,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 10},
 	},
 	{
-		Key:     RemoveGrantPrivilege,
+		Key:     TrigramInvertedIndexes,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 12},
 	},
 	{
-		Key:     MVCCRangeTombstones,
+		Key:     RemoveGrantPrivilege,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 14},
 	},
 	{
-		Key:     UpgradeSequenceToBeReferencedByID,
+		Key:     MVCCRangeTombstones,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 16},
 	},
 	{
-		Key:     SampledStmtDiagReqs,
+		Key:     UpgradeSequenceToBeReferencedByID,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 18},
 	},
 	{
-		Key:     AddSSTableTombstones,
+		Key:     SampledStmtDiagReqs,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 20},
 	},
 	{
-		Key:     SystemPrivilegesTable,
+		Key:     AddSSTableTombstones,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 22},
 	},
 	{
-		Key:     EnablePredicateProjectionChangefeed,
+		Key:     SystemPrivilegesTable,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 24},
 	},
 	{
-		Key:     AlterSystemSQLInstancesAddLocality,
+		Key:     EnablePredicateProjectionChangefeed,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 26},
 	},
 	{
-		Key:     SystemExternalConnectionsTable,
+		Key:     AlterSystemSQLInstancesAddLocality,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 28},
+	},
+	{
+		Key:     SystemExternalConnectionsTable,
+		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 30},
 	},
 
 	// *************************************************

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -46,23 +46,24 @@ func _() {
 	_ = x[V22_1-35]
 	_ = x[Start22_2-36]
 	_ = x[LocalTimestamps-37]
-	_ = x[EnsurePebbleFormatVersionRangeKeys-38]
-	_ = x[EnablePebbleFormatVersionRangeKeys-39]
-	_ = x[TrigramInvertedIndexes-40]
-	_ = x[RemoveGrantPrivilege-41]
-	_ = x[MVCCRangeTombstones-42]
-	_ = x[UpgradeSequenceToBeReferencedByID-43]
-	_ = x[SampledStmtDiagReqs-44]
-	_ = x[AddSSTableTombstones-45]
-	_ = x[SystemPrivilegesTable-46]
-	_ = x[EnablePredicateProjectionChangefeed-47]
-	_ = x[AlterSystemSQLInstancesAddLocality-48]
-	_ = x[SystemExternalConnectionsTable-49]
+	_ = x[PebbleFormatSplitUserKeysMarkedCompacted-38]
+	_ = x[EnsurePebbleFormatVersionRangeKeys-39]
+	_ = x[EnablePebbleFormatVersionRangeKeys-40]
+	_ = x[TrigramInvertedIndexes-41]
+	_ = x[RemoveGrantPrivilege-42]
+	_ = x[MVCCRangeTombstones-43]
+	_ = x[UpgradeSequenceToBeReferencedByID-44]
+	_ = x[SampledStmtDiagReqs-45]
+	_ = x[AddSSTableTombstones-46]
+	_ = x[SystemPrivilegesTable-47]
+	_ = x[EnablePredicateProjectionChangefeed-48]
+	_ = x[AlterSystemSQLInstancesAddLocality-49]
+	_ = x[SystemExternalConnectionsTable-50]
 }
 
-const _Key_name = "V21_2Start22_1PebbleFormatBlockPropertyCollectorProbeRequestPublicSchemasWithDescriptorsEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLogAlterSystemProtectedTimestampAddColumnEnableProtectedTimestampsForTenantDeleteCommentsWithDroppedIndexesRemoveIncompatibleDatabasePrivilegesAddRaftAppliedIndexTermMigrationPostAddRaftAppliedIndexTermMigrationDontProposeWriteTimestampForLeaseTransfersEnablePebbleFormatVersionBlockPropertiesMVCCIndexBackfillerEnableLeaseHolderRemovalLooselyCoupledRaftLogTruncationChangefeedIdlenessBackupDoesNotOverwriteLatestAndCheckpointEnableDeclarativeSchemaChangerRowLevelTTLPebbleFormatSplitUserKeysMarkedIncrementalBackupSubdirEnableNewStoreRebalancerClusterLocksVirtualTableAutoStatsTableSettingsSuperRegionsEnableNewChangefeedOptionsSpanCountTablePreSeedSpanCountTableSeedSpanCountTableV22_1Start22_2LocalTimestampsEnsurePebbleFormatVersionRangeKeysEnablePebbleFormatVersionRangeKeysTrigramInvertedIndexesRemoveGrantPrivilegeMVCCRangeTombstonesUpgradeSequenceToBeReferencedByIDSampledStmtDiagReqsAddSSTableTombstonesSystemPrivilegesTableEnablePredicateProjectionChangefeedAlterSystemSQLInstancesAddLocalitySystemExternalConnectionsTable"
+const _Key_name = "V21_2Start22_1PebbleFormatBlockPropertyCollectorProbeRequestPublicSchemasWithDescriptorsEnsureSpanConfigReconciliationEnsureSpanConfigSubscriptionEnableSpanConfigStoreSCRAMAuthenticationUnsafeLossOfQuorumRecoveryRangeLogAlterSystemProtectedTimestampAddColumnEnableProtectedTimestampsForTenantDeleteCommentsWithDroppedIndexesRemoveIncompatibleDatabasePrivilegesAddRaftAppliedIndexTermMigrationPostAddRaftAppliedIndexTermMigrationDontProposeWriteTimestampForLeaseTransfersEnablePebbleFormatVersionBlockPropertiesMVCCIndexBackfillerEnableLeaseHolderRemovalLooselyCoupledRaftLogTruncationChangefeedIdlenessBackupDoesNotOverwriteLatestAndCheckpointEnableDeclarativeSchemaChangerRowLevelTTLPebbleFormatSplitUserKeysMarkedIncrementalBackupSubdirEnableNewStoreRebalancerClusterLocksVirtualTableAutoStatsTableSettingsSuperRegionsEnableNewChangefeedOptionsSpanCountTablePreSeedSpanCountTableSeedSpanCountTableV22_1Start22_2LocalTimestampsPebbleFormatSplitUserKeysMarkedCompactedEnsurePebbleFormatVersionRangeKeysEnablePebbleFormatVersionRangeKeysTrigramInvertedIndexesRemoveGrantPrivilegeMVCCRangeTombstonesUpgradeSequenceToBeReferencedByIDSampledStmtDiagReqsAddSSTableTombstonesSystemPrivilegesTableEnablePredicateProjectionChangefeedAlterSystemSQLInstancesAddLocalitySystemExternalConnectionsTable"
 
-var _Key_index = [...]uint16{0, 5, 14, 48, 60, 88, 118, 146, 167, 186, 220, 258, 292, 324, 360, 392, 428, 470, 510, 529, 553, 584, 602, 643, 673, 684, 715, 738, 762, 786, 808, 820, 846, 860, 881, 899, 904, 913, 928, 962, 996, 1018, 1038, 1057, 1090, 1109, 1129, 1150, 1185, 1219, 1249}
+var _Key_index = [...]uint16{0, 5, 14, 48, 60, 88, 118, 146, 167, 186, 220, 258, 292, 324, 360, 392, 428, 470, 510, 529, 553, 584, 602, 643, 673, 684, 715, 738, 762, 786, 808, 820, 846, 860, 881, 899, 904, 913, 928, 968, 1002, 1036, 1058, 1078, 1097, 1130, 1149, 1169, 1190, 1225, 1259, 1289}
 
 func (i Key) String() string {
 	if i < 0 || i >= Key(len(_Key_index)-1) {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1810,6 +1810,10 @@ func (p *Pebble) SetMinVersion(version roachpb.Version) error {
 		if formatVers < pebble.FormatRangeKeys {
 			formatVers = pebble.FormatRangeKeys
 		}
+	case !version.Less(clusterversion.ByKey(clusterversion.PebbleFormatSplitUserKeysMarkedCompacted)):
+		if formatVers < pebble.FormatMarkedCompacted {
+			formatVers = pebble.FormatMarkedCompacted
+		}
 	case !version.Less(clusterversion.ByKey(clusterversion.PebbleFormatSplitUserKeysMarked)):
 		if formatVers < pebble.FormatSplitUserKeysMarked {
 			formatVers = pebble.FormatSplitUserKeysMarked


### PR DESCRIPTION
Pebble ceased splitting user keys across multiple sstables in a single
level in cockroachdb/pebble@a860bbad. A Pebble format major version was
added in 22.1 to mark existing tables with split user that formed an
"atomic compaction unit" for compaction. The compaction to recombine the
split keys happens at a low priority within Pebble, so there is no
guarantee that these tables have been recombined.

Pebble range key support depends on having split user keys recombined.
As such, the Pebble migration to upgrade to a version that support range
keys must first perform a blocking migration to compact tables with
split user keys.

Currently, the Cockroach cluster version
`EnsurePebbleFormatVersionRangeKeys` ratchets the Pebble version through
both the split user keys migration, up to the version that supports
range keys. Strictly speaking, the Pebble format version migration will
take care of the sequencing.

However, to provide better visibility into the various Pebble
migrations, and to cater for the fact that the split user keys migration
may take some time to recombine the necessary tables, a dedicated
cluster version for the split keys migration is added. This dedicated
cluster version makes it unambiguous what's blocking the Cockroach
version finalization.

Release note (backward-incompatible change, ops change): A cluster
version is added to allow Pebble to recombine certain SSTables
(specifically, user keys that are split across multiple files in a level
of the LSM). Recombining the split user keys is required for supporting
the range keys feature.  The migration to recombine the SSTables is
expected to be short (split user keys are rare in practice), but will
block subsequent migrations until all tables have been recombined. The
`storage.marked-for-compaction-files` time series metric can show the
progress of the migration.

Close #84012.