### PR TITLE
multitenant: Cleanup changefeed tests in #76378

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -456,6 +456,9 @@ func TestChangefeedTenants(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	kvServer, kvSQLdb, cleanup := startTestFullServer(t, feedTestOptions{argsFn: func(args *base.TestServerArgs) {
+		// This test leverages a test tenant explicitly. No need to do so
+		// probabilistically.
+		args.DisableDefaultTestTenant = true
 		args.ExternalIODirConfig.DisableOutbound = true
 	}})
 	defer cleanup()
@@ -1432,7 +1435,11 @@ func TestChangefeedLaggingSpanCheckpointing(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	rnd, _ := randutil.NewPseudoRand()
 
-	s, db, stopServer := startTestFullServer(t, feedTestOptions{})
+	s, db, stopServer := startTestFullServer(t, feedTestOptions{argsFn: func(args *base.TestServerArgs) {
+		// This test uses SPLIT AT which isn't currently supported within
+		// tenants. Tracked with #76378.
+		args.DisableDefaultTestTenant = true
+	}})
 	defer stopServer()
 	sqlDB := sqlutils.MakeSQLRunner(db)
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -379,7 +379,7 @@ func startTestFullServer(
 	args := base.TestServerArgs{
 		Knobs: knobs,
 		// This test suite is already probabilistically running with
-		// tenants. No need for the test tenant.
+		// tenants. No need for the default test tenant.
 		DisableDefaultTestTenant: true,
 		UseDatabase:              `d`,
 		ExternalIODir:            options.externalIODir,


### PR DESCRIPTION
The original work to enable probabilistic testing of tenants was overly
pesimistic about which changefeed tests could run successfully withint tenants.
This commit enables more tenant-level testing, and identifies the few remaining
tests which can't run within tenants (due to their use of SPLIT AT).

Release note: None