### PR TITLE
cli,server: unix socket bug fixes

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -6170,6 +6170,16 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_nightlyone_lockfile",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/nightlyone/lockfile",
+        sha256 = "0abd22d55b704c18426167732414806b2a70d99bce65fa9f943cb88c185689ad",
+        strip_prefix = "github.com/nightlyone/lockfile@v1.0.0",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/nightlyone/lockfile/com_github_nightlyone_lockfile-v1.0.0.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_nishanths_predeclared",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/nishanths/predeclared",

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -641,6 +641,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/ncw/swift/com_github_ncw_swift-v1.0.47.zip": "38cc53277c66456f267963ad9613cd168f252d9bef58de95dcee5202ceecb3e3",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/ngdinhtoan/glide-cleanup/com_github_ngdinhtoan_glide_cleanup-v0.2.0.zip": "e008e980d1a5335baaae1d10df2786ea1aea0d9774f8a46d19886a828edde4f3",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/niemeyer/pretty/com_github_niemeyer_pretty-v0.0.0-20200227124842-a10e7caefd8e.zip": "2dcb7053faf11c28cad7d84fcfa3dd7f93e3d236b39d83cff0934f691f860d7a",
+    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/nightlyone/lockfile/com_github_nightlyone_lockfile-v1.0.0.zip": "0abd22d55b704c18426167732414806b2a70d99bce65fa9f943cb88c185689ad",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/nishanths/predeclared/com_github_nishanths_predeclared-v0.0.0-20200524104333-86fad755b4d3.zip": "f3a40ab7d3e0570570e7bc41a6cc7b08b3e23df5ef5f08553ef622a3752d6e03",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/nkovacs/streamquote/com_github_nkovacs_streamquote-v0.0.0-20170412213628-49af9bddb229.zip": "679a789b4b1409ea81054cb12e5f8441199f5fb17d4a2d3510c51f3aa5f3f0cc",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/nxadm/tail/com_github_nxadm_tail-v1.4.4.zip": "c9bb9d05b3afd1bacc35e7d305a22b07cd7db38f5fabd4ccd95a9227c5709890",

--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.0
 	github.com/mmatczuk/go_generics v0.0.0-20181212143635-0aaa050f9bab
 	github.com/montanaflynn/stats v0.6.3
+	github.com/nightlyone/lockfile v1.0.0
 	github.com/olekukonko/tablewriter v0.0.5-0.20200416053754-163badb3bac6
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/otan/gopgkrb5 v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -1720,6 +1720,8 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96d
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/ngdinhtoan/glide-cleanup v0.2.0/go.mod h1:UQzsmiDOb8YV3nOsCxK/c9zPpCZVNoHScRE3EO9pVMM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
+github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -205,6 +205,11 @@ type Config struct {
 	// This is computed from SQLAddr if specified otherwise Addr.
 	SQLAdvertiseAddr string
 
+	// SocketFile, if non-empty, sets up a TLS-free local listener using
+	// a unix datagram socket at the specified path for SQL clients.
+	// This is auto-populated from SQLAddr if it initially ends with '.0'.
+	SocketFile string
+
 	// HTTPAddr is the configured HTTP listen address.
 	HTTPAddr string
 
@@ -265,6 +270,7 @@ func (cfg *Config) InitDefaults() {
 	cfg.SplitListenSQL = false
 	cfg.SQLAddr = defaultSQLAddr
 	cfg.SQLAdvertiseAddr = cfg.SQLAddr
+	cfg.SocketFile = ""
 	cfg.SSLCertsDir = DefaultCertsDirectory
 	cfg.RPCHeartbeatInterval = defaultRPCHeartbeatInterval
 	cfg.ClusterName = ""

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -125,7 +125,6 @@ func setServerContextDefaults() {
 
 	serverCfg.TenantKVAddrs = []string{"127.0.0.1:26257"}
 
-	serverCfg.SQLConfig.SocketFile = ""
 	// Attempt to default serverCfg.MemoryPoolSize to 25% if possible.
 	if bytes, _ := memoryPercentResolver(25); bytes != 0 {
 		serverCfg.SQLConfig.MemoryPoolSize = bytes

--- a/pkg/cli/interactive_tests/test_socket_name.tcl
+++ b/pkg/cli/interactive_tests/test_socket_name.tcl
@@ -5,6 +5,7 @@ source [file join [file dirname $argv0] common.tcl]
 set longname "this-is-a-very-long-directory-name-the-point-is-to-be-more-than-one-hundred-and-twenty-three-characters/and-we-also-need-to-break-it-into-two-parts"
 
 spawn /bin/bash
+set shell1_spawn_id $spawn_id
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
@@ -12,7 +13,7 @@ send "mkdir -p $longname\r"
 eexpect ":/# "
 
 start_test "Check derived Unix socket name is printed in server output"
-send "$argv start-single-node --insecure --listen-addr=:0 --socket-dir=.\r"
+send "$argv start-single-node --insecure --listen-addr=`cat /etc/hostname`:0 --pid-file=logs/server_pid --socket-dir=.\r"
 eexpect "CockroachDB node starting"
 expect {
     -re "sql:.*@\[^:\]*:(\[^/\]*)/" { set sql_port $expect_out(1,string) }
@@ -23,9 +24,40 @@ expect {
     timeout { handle_timeout "socket name" }
 }
 system "test -S .s.PGSQL.$sql_port"
-interrupt
+system "test -r .s.PGSQL.$sql_port.lock"
+end_test
+
+spawn /bin/bash
+set shell2_spawn_id $spawn_id
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+start_test "Check that the socket is locked from reuse while the server is running."
+# We use 127.0.0.1 so as to not overlap with the default address 0.0.0.0 selected above.
+# We also need a different data directory to avoid a conflict there.
+send "$argv start-single-node --insecure --listen-addr=127.0.0.1:$sql_port --http-addr=:0 --socket-dir=. -s=path=logs/other\r"
+eexpect ERROR
+eexpect "Socket appears locked by process"
 eexpect ":/# "
 end_test
+
+start_test "Check that stopping the first process abruptly enables the 2nd process to start"
+system "kill -9 `cat logs/server_pid`"
+send "$argv start-single-node --insecure --listen-addr=127.0.0.1:$sql_port --http-addr=:0 --socket-dir=. -s=path=logs/other\r"
+eexpect "CockroachDB node starting"
+system "test -S .s.PGSQL.$sql_port"
+system "test -r .s.PGSQL.$sql_port.lock"
+end_test
+
+# Stop the server that was started above.
+interrupt
+eexpect ":/# "
+send "exit\r"
+eexpect eof
+
+set spawn_id $shell1_spawn_id
+interrupt
+eexpect ":/# "
 
 start_test "Check that the socket-dir flag checks the length of the directory."
 send "$argv start-single-node --insecure --socket-dir=$longname\r"

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -277,6 +277,7 @@ go_library(
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@com_github_grpc_ecosystem_grpc_gateway//utilities:go_default_library",
         "@com_github_marusama_semaphore//:semaphore",
+        "@com_github_nightlyone_lockfile//:lockfile",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_etcd_go_etcd_raft_v3//:raft",
         "@org_golang_google_grpc//:go_default_library",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -365,10 +365,6 @@ type SQLConfig struct {
 	// The tenant that the SQL server runs on the behalf of.
 	TenantID roachpb.TenantID
 
-	// SocketFile, if non-empty, sets up a TLS-free local listener using
-	// a unix datagram socket at the specified path.
-	SocketFile string
-
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.
 	TempStorageConfig base.TempStorageConfig

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1566,7 +1566,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 		s.cfg.TestingKnobs,
 		connManager,
 		pgL,
-		s.cfg.SocketFile,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
 		return err
@@ -1619,7 +1618,7 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 		s.stopper,
 		s.sqlServer.connManager,
 		s.sqlServer.pgL,
-		s.cfg.SocketFile,
+		&s.cfg.SocketFile,
 	); err != nil {
 		return err
 	}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -108,6 +109,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -1205,7 +1207,6 @@ func (s *SQLServer) preStart(
 	knobs base.TestingKnobs,
 	connManager netutil.Server,
 	pgL net.Listener,
-	socketFile string,
 	orphanedLeasesTimeThresholdNanos int64,
 ) error {
 	// The sqlliveness and sqlinstance subsystem should be started first to ensure
@@ -1392,7 +1393,7 @@ func (s *SQLServer) startServeSQL(
 	stopper *stop.Stopper,
 	connManager netutil.Server,
 	pgL net.Listener,
-	socketFile string,
+	socketFileCfg *string,
 ) error {
 	log.Ops.Info(ctx, "serving sql connections")
 	// Start servicing SQL connections.
@@ -1415,7 +1416,30 @@ func (s *SQLServer) startServeSQL(
 		})
 
 	// If a unix socket was requested, start serving there too.
+	socketFile := ""
+	if socketFileCfg != nil {
+		socketFile = *socketFileCfg
+	}
 	if len(socketFile) != 0 {
+		if strings.HasSuffix(socketFile, ".0") {
+			// Either a test explicitly set the SocketFile parameter to "xxx.0", or
+			// the top-level 'start'  command was given a port number 0 to --listen-addr
+			// (means: auto-allocate TCP port number).
+			// In either case, this is an instruction for us to generate
+			// a socket name after the TCP port automatically.
+			tcpAddr := pgL.Addr()
+			_, port, err := addr.SplitHostPort(tcpAddr.String(), "")
+			if err != nil {
+				return errors.Wrapf(err, "extracting port from SQL addr %q", tcpAddr)
+			}
+			socketFile = socketFile[:len(socketFile)-1] + port
+			if socketFileCfg != nil {
+				// Remember the computed value for reporting in the top-level
+				// start command.
+				*socketFileCfg = socketFile
+			}
+		}
+
 		log.Ops.Infof(ctx, "starting postgres server at unix:%s", socketFile)
 
 		// Unix socket enabled: postgres protocol only.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1440,7 +1440,7 @@ func (s *SQLServer) startServeSQL(
 			}
 		}
 
-		log.Ops.Infof(ctx, "starting postgres server at unix:%s", socketFile)
+		log.Ops.Infof(ctx, "starting postgres server at unix: %s", socketFile)
 
 		// Unix socket enabled: postgres protocol only.
 		unixLn, err := net.Listen("unix", socketFile)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -118,7 +118,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingservicepb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/marusama/semaphore"
+	"github.com/nightlyone/lockfile"
 	"google.golang.org/grpc"
 )
 
@@ -1415,36 +1417,19 @@ func (s *SQLServer) startServeSQL(
 			netutil.FatalIfUnexpected(err)
 		})
 
-	// If a unix socket was requested, start serving there too.
-	socketFile := ""
-	if socketFileCfg != nil {
-		socketFile = *socketFileCfg
+	socketFile, socketLock, err := prepareUnixSocket(pgCtx, pgL, socketFileCfg)
+	if err != nil {
+		return err
 	}
-	if len(socketFile) != 0 {
-		if strings.HasSuffix(socketFile, ".0") {
-			// Either a test explicitly set the SocketFile parameter to "xxx.0", or
-			// the top-level 'start'  command was given a port number 0 to --listen-addr
-			// (means: auto-allocate TCP port number).
-			// In either case, this is an instruction for us to generate
-			// a socket name after the TCP port automatically.
-			tcpAddr := pgL.Addr()
-			_, port, err := addr.SplitHostPort(tcpAddr.String(), "")
-			if err != nil {
-				return errors.Wrapf(err, "extracting port from SQL addr %q", tcpAddr)
-			}
-			socketFile = socketFile[:len(socketFile)-1] + port
-			if socketFileCfg != nil {
-				// Remember the computed value for reporting in the top-level
-				// start command.
-				*socketFileCfg = socketFile
-			}
-		}
 
+	// If a unix socket was requested, start serving there too.
+	if len(socketFile) != 0 {
 		log.Ops.Infof(ctx, "starting postgres server at unix: %s", socketFile)
 
 		// Unix socket enabled: postgres protocol only.
 		unixLn, err := net.Listen("unix", socketFile)
 		if err != nil {
+			err = errors.CombineErrors(err, socketLock.Unlock())
 			return err
 		}
 
@@ -1455,7 +1440,10 @@ func (s *SQLServer) startServeSQL(
 			// only when the listener closes. In other words, the listener needs
 			// to close when quiescing starts to allow that worker to shut down.
 			if err := unixLn.Close(); err != nil {
-				log.Ops.Fatalf(ctx, "%v", err)
+				log.Ops.Warningf(ctx, "closing unix socket: %v", err)
+			}
+			if err := socketLock.Unlock(); err != nil {
+				log.Ops.Warningf(ctx, "removing unix socket lock: %v", err)
 			}
 		}
 		if err := stopper.RunAsyncTaskEx(ctx,
@@ -1485,6 +1473,80 @@ func (s *SQLServer) startServeSQL(
 	s.isReady.Set(true)
 
 	return nil
+}
+
+const noLock lockfile.Lockfile = ""
+
+func prepareUnixSocket(
+	ctx context.Context, pgL net.Listener, socketFileCfg *string,
+) (socketFile string, socketLock lockfile.Lockfile, err error) {
+	socketFile = ""
+	if socketFileCfg != nil {
+		socketFile = *socketFileCfg
+	}
+	if len(socketFile) == 0 {
+		// No socket configured. Nothing to do.
+		return "", noLock, nil
+	}
+
+	if strings.HasSuffix(socketFile, ".0") {
+		// Either a test explicitly set the SocketFile parameter to "xxx.0", or
+		// the top-level 'start'  command was given a port number 0 to --listen-addr
+		// (means: auto-allocate TCP port number).
+		// In either case, this is an instruction for us to generate
+		// a socket name after the TCP port automatically.
+		tcpAddr := pgL.Addr()
+		_, port, err := addr.SplitHostPort(tcpAddr.String(), "")
+		if err != nil {
+			return "", noLock, errors.Wrapf(err, "extracting port from SQL addr %q", tcpAddr)
+		}
+		socketFile = socketFile[:len(socketFile)-1] + port
+		if socketFileCfg != nil {
+			// Remember the computed value for reporting in the top-level
+			// start command.
+			*socketFileCfg = socketFile
+		}
+	}
+
+	// Use a socket lock mechanism to ensure we reuse the socket only
+	// if it's safe to do so (there's no owner any more).
+	lockPath := socketFile + ".lock"
+	// The lockfile package wants an absolute path.
+	absLockPath, err := filepath.Abs(lockPath)
+	if err != nil {
+		return "", noLock, errors.Wrap(err, "computing absolute path for unix socket")
+	}
+	socketLock, err = lockfile.New(absLockPath)
+	if err != nil {
+		// This should only fail on non-absolute paths, but we
+		// just made it absolute above.
+		return "", noLock, errors.NewAssertionErrorWithWrappedErrf(err, "creating lock")
+	}
+	if err := socketLock.TryLock(); err != nil {
+		if owner, ownerErr := socketLock.GetOwner(); ownerErr == nil {
+			err = errors.WithHintf(err, "Socket appears locked by process %d.", owner.Pid)
+		}
+		return "", noLock, errors.Wrapf(err, "locking unix socket %q", socketFile)
+	}
+
+	// Now the lock has succeeded, we can delete the previous socket
+	// if it exists.
+	if _, err := os.Stat(socketFile); err != nil {
+		if !oserror.IsNotExist(err) {
+			// Socket exists but there's some file access error.
+			// we probably can't remove it.
+			return "", noLock, errors.CombineErrors(err, socketLock.Unlock())
+		}
+	} else {
+		// Socket file existed already.
+		if err := os.Remove(socketFile); err != nil {
+			return "", noLock, errors.CombineErrors(
+				errors.Wrap(err, "removing previous socket file"),
+				socketLock.Unlock())
+		}
+	}
+
+	return socketFile, socketLock, nil
 }
 
 // LogicalClusterID retrieves the logical (tenant-level) cluster ID

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -303,9 +303,6 @@ func startTenantInternal(
 		baseCfg.SQLAdvertiseAddr,  // sql addr
 	)
 
-	const (
-		socketFile = "" // no unix socket
-	)
 	orphanedLeasesTimeThresholdNanos := args.clock.Now().WallTime
 
 	// TODO(tbg): the log dir is not configurable at this point
@@ -326,7 +323,6 @@ func startTenantInternal(
 		args.TestingKnobs,
 		connManager,
 		pgL,
-		socketFile,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
 		return nil, nil, nil, "", "", err
@@ -355,7 +351,7 @@ func startTenantInternal(
 		args.stopper,
 		s.connManager,
 		s.pgL,
-		socketFile); err != nil {
+		nil /* socketFile */); err != nil {
 		return nil, nil, nil, "", "", err
 	}
 


### PR DESCRIPTION
Fixes #84658
Fixes #49664

cc @a-robinson 

Release note (bug fix): The SQL unix socket, when requested,
now contains a port number compatible with the connection URL
when `--listen-addr` is configured to auto-allocate a port number.
This bug had existed since CockroachDB v1.0.

Release note (bug fix): Previously, if a unix socket was requested but
it already existed on disk, CockroachDB would exit with an error even
if the original owner process was not running any more.  This
limitation would e.g. prevent reuse of a unix socket after an abnormal
shutdown. It had been present since CockroachDB v1.0. This limitation
was lifted.