### PR TITLE
sql/sem/tree: ALTER PRIMARY KEY node formatter formats storage params

### DIFF
--- a/pkg/sql/paramparse/validation.go
+++ b/pkg/sql/paramparse/validation.go
@@ -43,9 +43,9 @@ func ValidateUniqueConstraintParams(
 			)
 		default:
 			if ctx.IsPrimaryKey {
-				return pgerror.Newf(pgcode.InvalidParameterValue, "invalid storage param %q on primary key", params[0].Key)
+				return pgerror.Newf(pgcode.InvalidParameterValue, "invalid storage param %q on primary key", param.Key)
 			}
-			return pgerror.Newf(pgcode.InvalidParameterValue, "invalid storage param %q on unique index", params[0].Key)
+			return pgerror.Newf(pgcode.InvalidParameterValue, "invalid storage param %q on unique index", param.Key)
 		}
 	}
 	return nil

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -274,6 +274,11 @@ func (node *AlterTableAlterPrimaryKey) Format(ctx *FmtCtx) {
 	if node.Sharded != nil {
 		ctx.FormatNode(node.Sharded)
 	}
+	if node.StorageParams != nil {
+		ctx.WriteString(" WITH (")
+		ctx.FormatNode(&node.StorageParams)
+		ctx.WriteString(")")
+	}
 }
 
 // AlterTableDropColumn represents a DROP COLUMN command.


### PR DESCRIPTION
Previously, the Format method of a AlterPrimaryKey node ignores the
storage params field, which causes the "round-trip" of serializing a
tree.Statement to lose information on storage params, as described in
GH issue #84907.

This PR fixes this and also another minor bug in validating storage
parmas for unique constraint.

fixed: #84907
Release note: None