### PR TITLE
bazel: bump size of `gc` test

### DIFF
--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -32,7 +32,7 @@ go_library(
 
 go_test(
     name = "gc_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "data_distribution_test.go",
         "gc_iterator_test.go",


### PR DESCRIPTION
This has timed out in CI.

Release note: None