### PR TITLE
externalconn,nodelocal: add `external` ExternalStorage provider

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -413,6 +413,12 @@ func TestDataDriven(t *testing.T) {
 				}
 				return ""
 
+			case "switch-server":
+				var name string
+				d.ScanArgs(t, "name", &name)
+				lastCreatedServer = name
+				return ""
+
 			case "exec-sql":
 				server := lastCreatedServer
 				user := "root"

--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections
@@ -1,0 +1,216 @@
+new-server name=s1
+----
+
+subtest basic-backup-nodelocal
+
+exec-sql
+CREATE EXTERNAL CONNECTION 'conn-foo' AS 'nodelocal://1/foo';
+----
+
+exec-sql
+CREATE DATABASE d;
+CREATE SCHEMA d.schema;
+CREATE TABLE d.schema.foo (id INT PRIMARY KEY);
+INSERT INTO d.schema.foo VALUES (1), (2), (3);
+----
+
+# Cluster backup.
+exec-sql
+BACKUP INTO 'external://conn-foo/cluster';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN
+'external://conn-foo/cluster'] ORDER BY object_name;
+----
+bank table full
+comments table full
+d database full
+data database full
+database_role_settings table full
+defaultdb database full
+external_connections table full
+foo table full
+locations table full
+postgres database full
+public schema full
+public schema full
+public schema full
+public schema full
+role_members table full
+role_options table full
+scheduled_jobs table full
+schema schema full
+settings table full
+system database full
+tenant_settings table full
+ui table full
+users table full
+zones table full
+
+# Database backup.
+exec-sql
+BACKUP DATABASE d INTO 'external://conn-foo/database';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN
+'external://conn-foo/database'] ORDER BY object_name;
+----
+d database full
+foo table full
+public schema full
+schema schema full
+
+# Table backup.
+exec-sql
+BACKUP TABLE d.schema.foo INTO 'external://conn-foo/table';
+----
+
+exec-sql
+INSERT INTO d.schema.foo VALUES (4), (5), (6);
+----
+
+# Incremental table backup.
+exec-sql
+BACKUP TABLE d.schema.foo INTO LATEST IN 'external://conn-foo/table';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN
+'external://conn-foo/table'] ORDER BY (object_name, backup_type);
+----
+d database full
+d database incremental
+foo table full
+foo table incremental
+schema schema full
+schema schema incremental
+
+subtest end
+
+subtest basic-restore-nodelocal
+
+new-server name=s2 share-io-dir=s1
+----
+
+# Cluster restore.
+exec-sql
+CREATE EXTERNAL CONNECTION 'conn-foo' AS 'nodelocal://1/foo';
+----
+
+exec-sql
+RESTORE FROM LATEST IN 'external://conn-foo/cluster';
+----
+
+query-sql
+SELECT * FROM d.schema.foo
+----
+1
+2
+3
+
+exec-sql
+DROP DATABASE d CASCADE
+----
+
+# Cluster restore.
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'external://conn-foo/database'
+----
+
+query-sql
+SELECT * FROM d.schema.foo
+----
+1
+2
+3
+
+exec-sql
+DROP DATABASE d CASCADE
+----
+
+# Cluster restore.
+exec-sql
+RESTORE TABLE d.schema.foo FROM LATEST IN 'external://conn-foo/table' WITH into_db = 'defaultdb'
+----
+
+query-sql
+SELECT * FROM defaultdb.schema.foo
+----
+1
+2
+3
+4
+5
+6
+
+exec-sql
+DROP DATABASE d CASCADE
+----
+pq: database "d" does not exist
+
+subtest end
+
+subtest incremental-location-backup-restore-nodelocal
+
+switch-server name=s1
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION full AS 'nodelocal://1/full'
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION inc AS 'nodelocal://1/inc'
+----
+
+# Take a full backup.
+exec-sql
+BACKUP DATABASE d INTO 'external://full';
+----
+
+# Take an incremental with an explicit location.
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'external://full' WITH incremental_location = 'external://inc';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN 'external://full' WITH
+incremental_location = 'external://inc'] ORDER BY (object_name, backup_type);
+----
+d database full
+d database incremental
+foo table full
+foo table incremental
+public schema full
+public schema incremental
+schema schema full
+schema schema incremental
+
+# Ensure you can also specify an incremental location as a path to the same
+# external connection URI.
+exec-sql
+BACKUP DATABASE d INTO 'external://full/nested';
+----
+
+# Take an incremental with an explicit location that is a subdir of the external
+# connection endpoint.
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'external://full/nested' WITH incremental_location = 'external://inc/nested';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN 'external://full/nested'
+WITH incremental_location = 'external://inc/nested'] ORDER BY (object_name, backup_type);
+----
+d database full
+d database incremental
+foo table full
+foo table incremental
+public schema full
+public schema incremental
+schema schema full
+schema schema incremental
+
+subtest end

--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -6,7 +6,7 @@ CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo/bar';
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
 
 # Try to create another External Connection with the same name.
 exec-sql
@@ -21,8 +21,8 @@ CREATE EXTERNAL CONNECTION bar123 AS 'nodelocal://1/baz';
 
 inspect-system-table
 ----
-bar123 STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/baz"}}}
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+bar123 STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/baz"}}, "provider": "nodelocal"}
+foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
 
 # Drop an External Connection that does not exist.
 exec-sql
@@ -35,7 +35,7 @@ DROP EXTERNAL CONNECTION bar123;
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
 
 exec-sql
 DROP EXTERNAL CONNECTION foo;
@@ -67,7 +67,7 @@ CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
 
 inspect-system-table
 ----
-privileged STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo"}}}
+privileged STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo"}}, "provider": "nodelocal"}
 
 exec-sql
 REVOKE SYSTEM EXTERNALCONNECTION FROM testuser;

--- a/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
@@ -9,7 +9,7 @@ CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo/bar';
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
 
 # Try to create another External Connection with the same name.
 exec-sql
@@ -24,8 +24,8 @@ CREATE EXTERNAL CONNECTION bar123 AS 'nodelocal://1/baz';
 
 inspect-system-table
 ----
-bar123 STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/baz"}}}
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+bar123 STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/baz"}}, "provider": "nodelocal"}
+foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
 
 # Drop an External Connection that does not exist.
 exec-sql
@@ -38,7 +38,7 @@ DROP EXTERNAL CONNECTION bar123;
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}}
+foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
 
 exec-sql
 DROP EXTERNAL CONNECTION foo;
@@ -70,7 +70,7 @@ CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
 
 inspect-system-table
 ----
-privileged STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo"}}}
+privileged STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo"}}, "provider": "nodelocal"}
 
 exec-sql
 REVOKE SYSTEM EXTERNALCONNECTION FROM testuser;

--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -25,12 +25,27 @@ enum ExternalStorageProvider {
   reserved 6;
   userfile = 7;
   null = 8;
+  external = 9;
 }
 
 message LocalFileConfig {
   string path = 1;
   uint32 node_id = 2 [(gogoproto.customname) = "NodeID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
+}
+
+// ExternalConnectionConfig is the ExternalStorage configuration for the
+// `external` provider.
+message ExternalConnectionConfig {
+  // Name identifies the External Connection object.
+  string name = 1;
+  // User interacting with the external storage. This is used to check access
+  // privileges of the external connection object.
+  string user = 2;
+  // Path will be appended to the endpoint of the resource represented by the
+  // external connection object. It is used to access subdirectories/buckets of
+  // the external resource.
+  string path = 3;
 }
 
 message ExternalStorage {
@@ -120,5 +135,6 @@ message ExternalStorage {
   Azure AzureConfig = 6;
   reserved 7;
   FileTable FileTableConfig = 8 [(gogoproto.nullable) = false];
+  ExternalConnectionConfig external_connection_config = 9 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -154,6 +154,8 @@ type ExternalStorageContext struct {
 	BlobClientFactory blobs.BlobClientFactory
 	InternalExecutor  sqlutil.InternalExecutor
 	DB                *kv.DB
+	Options           []ExternalStorageOption
+	Limiters          Limiters
 }
 
 // ExternalStorageOptions holds dependencies and values that can be

--- a/pkg/cloud/externalconn/BUILD.bazel
+++ b/pkg/cloud/externalconn/BUILD.bazel
@@ -5,12 +5,15 @@ go_library(
     name = "externalconn",
     srcs = [
         "connection.go",
+        "connection_storage.go",
         "impl_registry.go",
         "record.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud/externalconn",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cloud",
+        "//pkg/cloud/cloudpb",
         "//pkg/cloud/externalconn/connectionpb",
         "//pkg/kv",
         "//pkg/security/username",

--- a/pkg/cloud/externalconn/connection.go
+++ b/pkg/cloud/externalconn/connection.go
@@ -14,19 +14,36 @@ import (
 	"context"
 	"net/url"
 
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 )
+
+// Connection is a marker interface for objects that support interaction with an
+// external resource.
+type Connection interface{}
 
 // ConnectionDetails is the interface to the external resource represented by an
 // External Connection object.
 type ConnectionDetails interface {
+	// Dial establishes a connection to the external resource.
+	//
+	// A non-empty subdir results in a `Connection` to the joined path of the
+	// endpoint represented by the external connection and subdir.
+	Dial(ctx context.Context, args cloud.ExternalStorageContext, subdir string) (Connection, error)
 	// ConnectionProto prepares the ConnectionDetails for serialization.
 	ConnectionProto() *connectionpb.ConnectionDetails
 	// ConnectionType returns the type of the connection.
 	ConnectionType() connectionpb.ConnectionType
 }
 
-// ConnectionDetailsFromURIFactory is the factory method that takes in an
-// endpoint URI for an external resource, and returns a ConnectionDetails
-// interface to interact with it.
-type ConnectionDetailsFromURIFactory func(ctx context.Context, uri *url.URL) (ConnectionDetails, error)
+// connectionParserFactory is the factory method that takes in an endpoint URI
+// for an external resource, and returns the ConnectionDetails proto
+// representation of that URI.
+type connectionParserFactory func(ctx context.Context,
+	uri *url.URL) (connectionpb.ConnectionDetails, error)
+
+// connectionDetailsFactory is the factory method that returns a
+// ConnectionDetails interface to interact with the underlying External
+// Connection object.
+type connectionDetailsFactory func(ctx context.Context,
+	details connectionpb.ConnectionDetails) ConnectionDetails

--- a/pkg/cloud/externalconn/connection_storage.go
+++ b/pkg/cloud/externalconn/connection_storage.go
@@ -1,0 +1,99 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package externalconn
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/errors"
+)
+
+func makeExternalConnectionConfig(
+	uri *url.URL, args cloud.ExternalStorageURIContext,
+) (cloudpb.ExternalConnectionConfig, error) {
+	externalConnCfg := cloudpb.ExternalConnectionConfig{}
+	if uri.Host == "" {
+		return externalConnCfg, errors.Newf("host component of an external URI must refer to an "+
+			"existing External Connection object: %s", uri.String())
+	}
+	if args.CurrentUser.Undefined() {
+		return externalConnCfg, errors.Errorf("user creating the external connection storage must be specified")
+	}
+	normUser := args.CurrentUser.Normalized()
+	externalConnCfg.User = normUser
+	externalConnCfg.Name = uri.Host
+	externalConnCfg.Path = uri.Path
+	return externalConnCfg, nil
+}
+
+func parseExternalConnectionURL(
+	args cloud.ExternalStorageURIContext, uri *url.URL,
+) (cloudpb.ExternalStorage, error) {
+	conf := cloudpb.ExternalStorage{}
+	conf.Provider = cloudpb.ExternalStorageProvider_external
+	var err error
+	conf.ExternalConnectionConfig, err = makeExternalConnectionConfig(uri, args)
+	return conf, err
+}
+
+func makeExternalConnectionStorage(
+	ctx context.Context, args cloud.ExternalStorageContext, dest cloudpb.ExternalStorage,
+) (cloud.ExternalStorage, error) {
+	cfg := dest.ExternalConnectionConfig
+	if cfg.Name == "" {
+		return nil, errors.New("invalid ExternalConnectionConfig with an empty name")
+	}
+
+	// TODO(adityamaru): Use the `user` in `cfg` to perform privilege checks on
+	// the external connection object we are about to retrieve.
+
+	// Retrieve the external connection object from the system table.
+	var ec *ExternalConnection
+	if err := args.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		var err error
+		ec, err = LoadExternalConnection(ctx, cfg.Name, args.InternalExecutor,
+			username.MakeSQLUsernameFromPreNormalizedString(cfg.User), txn)
+		return err
+	}); err != nil {
+		return nil, errors.Wrap(err, "failed to load external connection object")
+	}
+
+	// Construct an ExternalStorage handle for the underlying resource represented
+	// by the external connection object.
+	details := ec.ConnectionDetails()
+	connDetails, err := MakeConnectionDetails(ctx, *details)
+	if err != nil {
+		return nil, err
+	}
+	connection, err := connDetails.Dial(ctx, args, cfg.Path)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to Dial external connection")
+	}
+
+	var es cloud.ExternalStorage
+	var ok bool
+	if es, ok = connection.(cloud.ExternalStorage); !ok {
+		return nil, errors.AssertionFailedf("cannot convert Connection to cloud.ExternalStorage")
+	}
+
+	return es, nil
+}
+
+func init() {
+	scheme := "external"
+	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_external, parseExternalConnectionURL,
+		makeExternalConnectionStorage, cloud.RedactedParams(), scheme)
+}

--- a/pkg/cloud/externalconn/connectionpb/connection.proto
+++ b/pkg/cloud/externalconn/connectionpb/connection.proto
@@ -15,6 +15,11 @@ option go_package = "connectionpb";
 import "gogoproto/gogo.proto";
 import "cloud/cloudpb/external_storage.proto";
 
+enum ConnectionProvider {
+  Unknown = 0;
+  nodelocal = 1;
+}
+
 enum ConnectionType {
   option (gogoproto.goproto_enum_prefix) = false;
 
@@ -23,6 +28,8 @@ enum ConnectionType {
 }
 
 message ConnectionDetails {
+  ConnectionProvider provider = 1;
+
   oneof details {
     NodelocalConnectionDetails nodelocal = 2;
   }

--- a/pkg/cloud/impl/BUILD.bazel
+++ b/pkg/cloud/impl/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//pkg/cloud/amazon",
         "//pkg/cloud/azure",
+        "//pkg/cloud/externalconn",
         "//pkg/cloud/gcp",
         "//pkg/cloud/httpsink",
         "//pkg/cloud/nodelocal",

--- a/pkg/cloud/impl/external_storage.go
+++ b/pkg/cloud/impl/external_storage.go
@@ -19,6 +19,7 @@ import (
 	// Import all the cloud provider packages to register them.
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/amazon"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/azure"
+	_ "github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/gcp"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/httpsink"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"

--- a/pkg/cloud/nodelocal/BUILD.bazel
+++ b/pkg/cloud/nodelocal/BUILD.bazel
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "nodelocal",
-    srcs = ["nodelocal_storage.go"],
+    srcs = [
+        "nodelocal_connection.go",
+        "nodelocal_storage.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud/nodelocal",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/cloud/nodelocal/nodelocal_connection.go
+++ b/pkg/cloud/nodelocal/nodelocal_connection.go
@@ -1,0 +1,89 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package nodelocal
+
+import (
+	"context"
+	"net/url"
+	"path"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
+	"github.com/cockroachdb/errors"
+)
+
+var _ externalconn.ConnectionDetails = &localFileConnectionDetails{}
+
+type localFileConnectionDetails struct {
+	connectionpb.ConnectionDetails
+}
+
+// Dial implements the external.ConnectionDetails interface.
+func (l *localFileConnectionDetails) Dial(
+	ctx context.Context, args cloud.ExternalStorageContext, subdir string,
+) (externalconn.Connection, error) {
+	cfg := l.GetNodelocal().Cfg
+	cfg.Path = path.Join(cfg.Path, subdir)
+	externalStorageConf := cloudpb.ExternalStorage{
+		Provider:        cloudpb.ExternalStorageProvider_nodelocal,
+		LocalFileConfig: cfg,
+	}
+	es, err := cloud.MakeExternalStorage(ctx, externalStorageConf, args.IOConf, args.Settings,
+		args.BlobClientFactory, args.InternalExecutor, args.DB, args.Limiters, args.Options...)
+	if err != nil {
+		return nil, errors.Wrap(err,
+			"failed to construct `nodelocal` ExternalStorage while resolving external connection")
+	}
+
+	return es, nil
+}
+
+// ConnectionType implements the external.ConnectionDetails interface.
+func (l *localFileConnectionDetails) ConnectionType() connectionpb.ConnectionType {
+	return connectionpb.TypeStorage
+}
+
+// ConnectionProto implements the external.ConnectionDetails interface.
+func (l *localFileConnectionDetails) ConnectionProto() *connectionpb.ConnectionDetails {
+	return &l.ConnectionDetails
+}
+
+func parseLocalFileConnectionURI(
+	_ context.Context, uri *url.URL,
+) (connectionpb.ConnectionDetails, error) {
+	connDetails := connectionpb.ConnectionDetails{
+		Provider: connectionpb.ConnectionProvider_nodelocal,
+		Details: &connectionpb.ConnectionDetails_Nodelocal{
+			Nodelocal: &connectionpb.NodelocalConnectionDetails{},
+		},
+	}
+	var err error
+	connDetails.GetNodelocal().Cfg, err = makeLocalFileConfig(uri)
+	return connDetails, err
+}
+
+func makeLocalFileConnectionDetails(
+	_ context.Context, details connectionpb.ConnectionDetails,
+) externalconn.ConnectionDetails {
+	return &localFileConnectionDetails{ConnectionDetails: details}
+}
+
+func init() {
+	const scheme = "nodelocal"
+	externalconn.RegisterConnectionDetailsFromURIFactory(
+		connectionpb.ConnectionProvider_nodelocal,
+		scheme,
+		parseLocalFileConnectionURI,
+		makeLocalFileConnectionDetails,
+	)
+}

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -114,10 +114,6 @@ type EvalContext interface {
 	// requests on the range.
 	GetCurrentReadSummary(ctx context.Context) rspb.ReadSummary
 
-	GetExternalStorage(ctx context.Context, dest cloudpb.ExternalStorage) (cloud.ExternalStorage, error)
-	GetExternalStorageFromURI(ctx context.Context, uri string, user username.SQLUsername) (cloud.ExternalStorage,
-		error)
-
 	// RevokeLease stops the replica from using its current lease, if that lease
 	// matches the provided lease sequence. All future calls to leaseStatus on
 	// this node with the current lease will now return a PROSCRIBED status.

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -13,8 +13,6 @@ package kvserver
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/cloud"
-	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
@@ -23,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -232,21 +229,6 @@ func (rec *SpanSetReplicaEvalContext) GetCurrentClosedTimestamp(ctx context.Cont
 // interface.
 func (rec *SpanSetReplicaEvalContext) GetClosedTimestampOlderThanStorageSnapshot() hlc.Timestamp {
 	return rec.i.GetClosedTimestampOlderThanStorageSnapshot()
-}
-
-// GetExternalStorage returns an ExternalStorage object, based on
-// information parsed from a URI, stored in `dest`.
-func (rec *SpanSetReplicaEvalContext) GetExternalStorage(
-	ctx context.Context, dest cloudpb.ExternalStorage,
-) (cloud.ExternalStorage, error) {
-	return rec.i.GetExternalStorage(ctx, dest)
-}
-
-// GetExternalStorageFromURI returns an ExternalStorage object, based on the given URI.
-func (rec *SpanSetReplicaEvalContext) GetExternalStorageFromURI(
-	ctx context.Context, uri string, user username.SQLUsername,
-) (cloud.ExternalStorage, error) {
-	return rec.i.GetExternalStorageFromURI(ctx, uri, user)
 }
 
 // RevokeLease stops the replica from using its current lease.


### PR DESCRIPTION
In #84310 we added the ability to create an external connection
to represent a `nodelocal` endpoint. This diff is the second piece
of the puzzle that allows systems in CRDB to interact with the
external connection object.

We introduce an `external` URI scheme to the `ExternalStorage`
registry. URIs with an `external` scheme are required to contain a
host component referring to the unique name of an existing extenral
connection object. Optionally, the URI can also contain a path
component that will be appended to the endpoint that was specified
at the time the external connection object was created. This is necessary
for operations such as backup and restore that read/write to subdirectories
in the endpoint inputted by the user. A nice UX win is the abilility to
have a single external connection object for the base bucket, and then
interact with all the subdirectories without having to create an object
for each directory. In the future we may want to clamp down on this, and
allow the user to specify which objects permit subdirectory access.

The `external://<object-name>/<optional-path>` URI is parsed and the
underlying object is fetched from the `system.external_connections` table.
The resource represented by the object is then `Dial()`ed to return an
`ExternalStorage` handle that can be used to read, write, list etc. With
this change all bulk operations and cdc are able to use external connections
to represent a `nodelocal` endpoint. For example, a backup can now be run as:

```
CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo';
BACKUP INTO 'external://foo';
RESTORE FROM LATEST IN 'external://foo';
```

Gradually, we will add support for all other external storage endpoints
as well.

Note, we do not register limiter settings for the `external` provider
`ExternalStorage` interface, nor do we wrap it with an ioRecorder. This is
because the underlying resource of the external connection object will already
have its registered limiters and recorder.

Informs: #84753

Release note (sql change): Bulk operations and CDC will accept an `external`
scheme URI that points to a previously created External Connection object,
These operations can then interact with the underlying resource represented by
the object as they did before.