### PR TITLE
dev: v45

### DIFF
--- a/dev
+++ b/dev
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=44
+DEV_VERSION=45
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
./dev's version wasn't properly incremented in PR 84766 [1] due to a
last-minute rebase, in which someone else increased the version as well.
Bump dev's version to force a rebuild.

[1] https://github.com/cockroachdb/cockroach/pull/84766

Release note: None