### PR TITLE
sql: fix migrating empty prepared statement

### DIFF
--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -258,8 +258,14 @@ func unaryNegation(e tree.Expr) tree.Expr {
 
 // Parse parses a sql statement string and returns a list of Statements.
 func Parse(sql string) (Statements, error) {
+	return ParseWithInt(sql, defaultNakedIntType)
+}
+
+// ParseWithInt parses a sql statement string and returns a list of
+// Statements. The INT token will result in the specified TInt type.
+func ParseWithInt(sql string, nakedIntType *types.T) (Statements, error) {
 	var p Parser
-	return p.parseWithDepth(1, sql, defaultNakedIntType)
+	return p.parseWithDepth(1, sql, nakedIntType)
 }
 
 // ParseOne parses a sql statement string, ensuring that it contains only a

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -33,6 +33,13 @@ wire_prepare s4
 INSERT INTO t2 VALUES($1, $2)
 ----
 
+wire_prepare s_empty
+;
+----
+
+wire_exec s_empty
+----
+
 wire_exec s2 1 cat 2022-02-10
 ----
 ERROR: relation "t" does not exist (SQLSTATE 42P01)
@@ -73,6 +80,9 @@ query
 EXECUTE s1
 ----
 1
+
+wire_exec s_empty
+----
 
 # The s2 and s3 statements should experience the same errors that they did
 # before the session migration.


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/84640

Release note (bug fix): The crdb_internal.deserialize_session builtin
function no longer causes an error when handling an empty preprared
statement.