### PR TITLE
kvserver: add metrics to track snapshot queueing and application

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -669,6 +669,42 @@ var (
 		Measurement: "Bytes",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRangeSnapshotSendQueueLength = metric.Metadata{
+		Name:        "range.snapshots.send-queue",
+		Help:        "Number of snapshots queued to send",
+		Measurement: "Snapshots",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRangeSnapshotRecvQueueLength = metric.Metadata{
+		Name:        "range.snapshots.recv-queue",
+		Help:        "Number of snapshots queued to receive",
+		Measurement: "Snapshots",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRangeSnapshotSendInProgress = metric.Metadata{
+		Name:        "range.snapshots.send-in-progress",
+		Help:        "Number of non-empty snapshots being sent",
+		Measurement: "Snapshots",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRangeSnapshotRecvInProgress = metric.Metadata{
+		Name:        "range.snapshots.recv-in-progress",
+		Help:        "Number of non-empty snapshots being received",
+		Measurement: "Snapshots",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRangeSnapshotSendTotalInProgress = metric.Metadata{
+		Name:        "range.snapshots.send-total-in-progress",
+		Help:        "Number of total snapshots being sent",
+		Measurement: "Snapshots",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRangeSnapshotRecvTotalInProgress = metric.Metadata{
+		Name:        "range.snapshots.recv-total-in-progress",
+		Help:        "Number of total snapshots being received",
+		Measurement: "Snapshots",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaRangeRaftLeaderTransfers = metric.Metadata{
 		Name:        "range.raftleadertransfers",
 		Help:        "Number of raft leader transfers",
@@ -1681,6 +1717,14 @@ type StoreMetrics struct {
 	RangeSnapshotRebalancingRcvdBytes            *metric.Counter
 	RangeSnapshotRebalancingSentBytes            *metric.Counter
 
+	// Range snapshot queue metrics.
+	RangeSnapshotSendQueueLength     *metric.Gauge
+	RangeSnapshotRecvQueueLength     *metric.Gauge
+	RangeSnapshotSendInProgress      *metric.Gauge
+	RangeSnapshotRecvInProgress      *metric.Gauge
+	RangeSnapshotSendTotalInProgress *metric.Gauge
+	RangeSnapshotRecvTotalInProgress *metric.Gauge
+
 	// Raft processing metrics.
 	RaftTicks                 *metric.Counter
 	RaftQuotaPoolPercentUsed  *metric.Histogram
@@ -2169,6 +2213,12 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RangeSnapshotRecoverySentBytes:               metric.NewCounter(metaRangeSnapshotRecoverySentBytes),
 		RangeSnapshotRebalancingRcvdBytes:            metric.NewCounter(metaRangeSnapshotRebalancingRcvdBytes),
 		RangeSnapshotRebalancingSentBytes:            metric.NewCounter(metaRangeSnapshotRebalancingSentBytes),
+		RangeSnapshotSendQueueLength:                 metric.NewGauge(metaRangeSnapshotSendQueueLength),
+		RangeSnapshotRecvQueueLength:                 metric.NewGauge(metaRangeSnapshotRecvQueueLength),
+		RangeSnapshotSendInProgress:                  metric.NewGauge(metaRangeSnapshotSendInProgress),
+		RangeSnapshotRecvInProgress:                  metric.NewGauge(metaRangeSnapshotRecvInProgress),
+		RangeSnapshotSendTotalInProgress:             metric.NewGauge(metaRangeSnapshotSendTotalInProgress),
+		RangeSnapshotRecvTotalInProgress:             metric.NewGauge(metaRangeSnapshotRecvTotalInProgress),
 		RangeRaftLeaderTransfers:                     metric.NewCounter(metaRangeRaftLeaderTransfers),
 		RangeLossOfQuorumRecoveries:                  metric.NewCounter(metaRangeLossOfQuorumRecoveries),
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2937,7 +2937,7 @@ func TestReserveSnapshotThrottling(t *testing.T) {
 	tc.Start(ctx, t, stopper)
 	s := tc.store
 
-	cleanupNonEmpty1, err := s.reserveSnapshot(ctx, &kvserverpb.SnapshotRequest_Header{
+	cleanupNonEmpty1, err := s.reserveReceiveSnapshot(ctx, &kvserverpb.SnapshotRequest_Header{
 		RangeSize: 1,
 	})
 	if err != nil {
@@ -2946,9 +2946,15 @@ func TestReserveSnapshotThrottling(t *testing.T) {
 	if n := s.ReservationCount(); n != 1 {
 		t.Fatalf("expected 1 reservation, but found %d", n)
 	}
+	require.Equal(t, int64(0), s.Metrics().RangeSnapshotRecvQueueLength.Value(),
+		"unexpected snapshot queue length")
+	require.Equal(t, int64(1), s.Metrics().RangeSnapshotRecvInProgress.Value(),
+		"unexpected snapshots in progress")
+	require.Equal(t, int64(1), s.Metrics().RangeSnapshotRecvTotalInProgress.Value(),
+		"unexpected snapshots in progress")
 
 	// Ensure we allow a concurrent empty snapshot.
-	cleanupEmpty, err := s.reserveSnapshot(ctx, &kvserverpb.SnapshotRequest_Header{})
+	cleanupEmpty, err := s.reserveReceiveSnapshot(ctx, &kvserverpb.SnapshotRequest_Header{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2957,6 +2963,12 @@ func TestReserveSnapshotThrottling(t *testing.T) {
 	if n := s.ReservationCount(); n != 1 {
 		t.Fatalf("expected 1 reservation, but found %d", n)
 	}
+	require.Equal(t, int64(0), s.Metrics().RangeSnapshotRecvQueueLength.Value(),
+		"unexpected snapshot queue length")
+	require.Equal(t, int64(1), s.Metrics().RangeSnapshotRecvInProgress.Value(),
+		"unexpected snapshots in progress")
+	require.Equal(t, int64(2), s.Metrics().RangeSnapshotRecvTotalInProgress.Value(),
+		"unexpected snapshots in progress")
 	cleanupEmpty()
 
 	if n := s.ReservationCount(); n != 1 {
@@ -2970,18 +2982,38 @@ func TestReserveSnapshotThrottling(t *testing.T) {
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		if atomic.LoadInt32(&boom) == 0 {
+			if s.Metrics().RangeSnapshotRecvQueueLength.Value() != int64(1) {
+				t.Errorf("unexpected snapshot queue length; expected: %d, got: %d", 1,
+					s.Metrics().RangeSnapshotRecvQueueLength.Value())
+			}
+			if s.Metrics().RangeSnapshotRecvInProgress.Value() != int64(1) {
+				t.Errorf("unexpected snapshots in progress; expected: %d, got: %d", 1,
+					s.Metrics().RangeSnapshotRecvInProgress.Value())
+			}
 			cleanupNonEmpty1()
+		} else {
+			t.Errorf("next snapshot acquired reservation before previous called cleanup()")
 		}
 	}()
 
-	cleanupNonEmpty3, err := s.reserveSnapshot(ctx, &kvserverpb.SnapshotRequest_Header{
+	cleanupNonEmpty3, err := s.reserveReceiveSnapshot(ctx, &kvserverpb.SnapshotRequest_Header{
 		RangeSize: 1,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	atomic.StoreInt32(&boom, 1)
+	require.Equal(t, int64(0), s.Metrics().RangeSnapshotRecvQueueLength.Value(),
+		"unexpected snapshot queue length")
+	require.Equal(t, int64(1), s.Metrics().RangeSnapshotRecvInProgress.Value(),
+		"unexpected snapshots in progress")
+	require.Equal(t, int64(1), s.Metrics().RangeSnapshotRecvTotalInProgress.Value(),
+		"unexpected snapshots in progress")
 	cleanupNonEmpty3()
+	require.Equal(t, int64(0), s.Metrics().RangeSnapshotRecvInProgress.Value(),
+		"unexpected snapshots in progress")
+	require.Equal(t, int64(0), s.Metrics().RangeSnapshotRecvTotalInProgress.Value(),
+		"unexpected snapshots in progress")
 
 	if n := s.ReservationCount(); n != 0 {
 		t.Fatalf("expected 0 reservations, but found %d", n)
@@ -3017,7 +3049,7 @@ func TestReserveSnapshotFullnessLimit(t *testing.T) {
 	}
 
 	// A snapshot should be allowed.
-	cleanupAccepted, err := s.reserveSnapshot(ctx, &kvserverpb.SnapshotRequest_Header{
+	cleanupAccepted, err := s.reserveReceiveSnapshot(ctx, &kvserverpb.SnapshotRequest_Header{
 		RangeSize: 1,
 	})
 	if err != nil {
@@ -3091,7 +3123,7 @@ func TestReserveSnapshotQueueTimeoutAvoidsStarvation(t *testing.T) {
 				if err := func() error {
 					snapCtx, cancel := context.WithTimeout(ctx, timeout)
 					defer cancel()
-					cleanup, err := s.reserveSnapshot(snapCtx, &kvserverpb.SnapshotRequest_Header{RangeSize: 1})
+					cleanup, err := s.reserveReceiveSnapshot(snapCtx, &kvserverpb.SnapshotRequest_Header{RangeSize: 1})
 					if err != nil {
 						if errors.Is(err, context.DeadlineExceeded) {
 							return nil

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -609,6 +609,17 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Snapshot Queues",
+				Metrics: []string{
+					"range.snapshots.send-queue",
+					"range.snapshots.recv-queue",
+					"range.snapshots.send-in-progress",
+					"range.snapshots.recv-in-progress",
+					"range.snapshots.send-total-in-progress",
+					"range.snapshots.recv-total-in-progress",
+				},
+			},
+			{
 				Title: "Snapshot Bytes",
 				Metrics: []string{
 					"range.snapshots.rcvd-bytes",


### PR DESCRIPTION
While we previously had one metric to track "in-progress" snapshots,
`replicas.reserved`, this metric is used by both senders and receivers,
and does not track the number of snapshots queued on its semaphore. This
change adds the following new metrics, separated by sender and receiver:
```
range.snapshots.send-queue
range.snapshots.recv-queue
range.snapshots.send-in-progress
range.snapshots.recv-in-progress
range.snapshots.send-total-in-progress
range.snapshots.recv-total-in-progress
```

These metrics specifically track the number of queued non-empty
snapshots on a sender or receiver store, as well as the number of
snapshots currently being sent or received by a given store. The
first four metrics specifically only track non-empty snapshots, because
empty snapshots are not throttled at all, and thus do not compete for the
semaphore. The final two metrics track all snapshots, including empty
ones.

Release note (ops change): Added new metrics
`range.snapshots.(send|recv)-queue` and
`range.snapshots.(send|recv)-in-progress` to track the number of queued
and in-progress snapshots being sent or received on a store.