### PR TITLE
storage: add `Writer.PutRawMVCCRangeKey`

### DIFF
--- a/docs/tech-notes/mvcc-range-tombstones.md
+++ b/docs/tech-notes/mvcc-range-tombstones.md
@@ -195,7 +195,12 @@ as conflict checks and stats updates, similarly to other `Writer` methods.
   at all timestamps) between the given key bounds using a Pebble range
   tombstone. Can remove sections of range keys, or several range keys. Does
   not affect point keys.
-  
+
+* `PutRawMVCCRangeKey(MVCCRangeKey, []byte)`:  Like `PutMVCCRangeKey`, but
+  takes an already-encoded `MVCCValue`. Can be used to avoid unnecessary
+  decode/encode roundtrips when copying range keys, but should otherwise be
+  avoided due to the lack of type safety.
+
 * `PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte)`: Writes
   a raw range key directly to Pebble. Only for specialized low-level use.
 

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -418,11 +418,7 @@ func EvalAddSSTable(
 				break
 			}
 			for _, rkv := range rangeIter.RangeKeys() {
-				mvccValue, err := storage.DecodeMVCCValue(rkv.Value)
-				if err != nil {
-					return result.Result{}, err
-				}
-				if err = readWriter.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+				if err = readWriter.PutRawMVCCRangeKey(rkv.RangeKey, rkv.Value); err != nil {
 					return result.Result{}, err
 				}
 				if sstToReqTS.IsSet() {

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -625,6 +625,13 @@ func (s spanSetWriter) PutMVCCRangeKey(
 	return s.w.PutMVCCRangeKey(rangeKey, value)
 }
 
+func (s spanSetWriter) PutRawMVCCRangeKey(rangeKey storage.MVCCRangeKey, value []byte) error {
+	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
+		return err
+	}
+	return s.w.PutRawMVCCRangeKey(rangeKey, value)
+}
+
 func (s spanSetWriter) PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error {
 	if !s.spansOnly {
 		panic("cannot do timestamp checking for PutEngineRangeKey")

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -716,6 +716,14 @@ type Writer interface {
 	// https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md
 	PutMVCCRangeKey(MVCCRangeKey, MVCCValue) error
 
+	// PutRawMVCCRangeKey is like PutMVCCRangeKey, but accepts an encoded
+	// MVCCValue. It can be used to avoid decoding and immediately re-encoding an
+	// MVCCValue, but should generally be avoided due to the lack of type safety.
+	//
+	// It is safe to modify the contents of the arguments after PutRawMVCCRangeKey
+	// returns.
+	PutRawMVCCRangeKey(MVCCRangeKey, []byte) error
+
 	// PutEngineRangeKey sets the given range key to the values provided. This is
 	// a general-purpose and low-level method that should be used sparingly, only
 	// when the other Put* methods are not applicable.

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -415,14 +415,7 @@ func UpdateSSTTimestamps(
 					rkv.RangeKey.Timestamp, from, rkv.RangeKey)
 			}
 			rkv.RangeKey.Timestamp = to
-			mvccValue, ok, err := tryDecodeSimpleMVCCValue(rkv.Value)
-			if !ok && err == nil {
-				mvccValue, err = decodeExtendedMVCCValue(rkv.Value)
-			}
-			if err != nil {
-				return nil, err
-			}
-			if err = writer.PutMVCCRangeKey(rkv.RangeKey, mvccValue); err != nil {
+			if err = writer.PutRawMVCCRangeKey(rkv.RangeKey, rkv.Value); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
This patch adds `Writer.PutRawMVCCRangeKey()`, which can be used to
write a range key with an already-encoded `MVCCValue`. This is useful to
avoid unnecessary decode/encode roundtrips when copying range keys.

Resolves #84896.

Release note: None