### PR TITLE
storage: fix `pebbleIterator` leaks on construction errors

### DIFF
--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -97,6 +97,7 @@ func newPebbleIteratorByCloning(
 		RefreshBatchView: true,
 	})
 	if err != nil {
+		p.Close()
 		panic(err)
 	}
 	return p
@@ -124,7 +125,6 @@ func (p *pebbleIterator) init(
 ) {
 	*p = pebbleIterator{
 		iter:               iter,
-		inuse:              true,
 		keyBuf:             p.keyBuf,
 		lowerBoundBuf:      p.lowerBoundBuf,
 		upperBoundBuf:      p.upperBoundBuf,
@@ -133,6 +133,7 @@ func (p *pebbleIterator) init(
 		supportsRangeKeys:  supportsRangeKeys,
 	}
 	p.setOptions(opts, durability)
+	p.inuse = true // after setOptions(), so panic won't cause reader to panic too
 }
 
 // initReuseOrCreate is a convenience method that (re-)initializes an existing
@@ -164,6 +165,7 @@ func (p *pebbleIterator) initReuseOrCreate(
 			RefreshBatchView: true,
 		})
 		if err != nil {
+			p.Close()
 			panic(err)
 		}
 	}


### PR DESCRIPTION
When `pebbleIterator` construction fails, the iterator could leak since
it was not properly closed and returned to the pool. Furthermore, a
panic during construction (i.e. in `setOptions`) could cause the
iterator to have been prematurely marked as `inuse`, which would cause
further panics when the reader was closed with what it thought were
active iterators.

This patch properly closes the iterator during construction, and also
avoids marking the iterator as in use prior to calling `setOptions`.

Release note: None