### PR TITLE
release-22.1: changefeedccl, backupresolver: refactor to hold on to mapping of target to descriptor

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -760,7 +760,7 @@ func backupPlanHook(
 		switch backupStmt.Coverage() {
 		case tree.RequestedDescriptors:
 			var err error
-			targetDescs, completeDBs, err = backupresolver.ResolveTargetsToDescriptors(ctx, p, endTime, backupStmt.Targets)
+			targetDescs, completeDBs, _, err = backupresolver.ResolveTargetsToDescriptors(ctx, p, endTime, backupStmt.Targets)
 			if err != nil {
 				return errors.Wrap(err, "failed to resolve targets specified in the BACKUP stmt")
 			}

--- a/pkg/ccl/backupccl/backupresolver/targets_test.go
+++ b/pkg/ccl/backupccl/backupresolver/targets_test.go
@@ -282,6 +282,12 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 				if !reflect.DeepEqual(test.expectedDBs, matchedDBNames) {
 					t.Fatalf("expected %q got %q", test.expectedDBs, matchedDBNames)
 				}
+				for _, p := range targets.Tables {
+					_, ok := matched.DescsByTablePattern[p]
+					if !ok {
+						t.Fatalf("no entry in %q for %q", matched.DescsByTablePattern, p)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Backport 1/1 commits from #79260.

/cc @cockroachdb/release

A production issue was reported recently involving a `could not match %v to a fetched descriptor` error, which should never happen. It's likely due to some mismatch between name resolution in the changefeed and resolver, so we should backport the change to make that logic shared.

---


Changefeed statements need to resolve a bunch of table names at once,
 but unlike backups and grants they need to know which returned
descriptor corresponded to which input because they (now) take
target-specific options. We were reconstructing this awkwardly on
the calling side. This PR adds an optional parameter to the
 backupresolver method being used so that it can track which
 descriptor belongs to which input.

I'm probably being overly polite by making this optional,
but hey, it is a little extra memory footprint and not my package.

Release note: None

Release justification: Bug fix.
