### PR TITLE
batcheval: handle MVCC range tombstones in `RevertRange`

### DIFF
--- a/pkg/kv/kvserver/batcheval/testutils_test.go
+++ b/pkg/kv/kvserver/batcheval/testutils_test.go
@@ -10,13 +10,32 @@
 
 package batcheval_test
 
-import "github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
+)
 
 type kvs = storageutils.KVs
 
 var (
 	pointKV            = storageutils.PointKV
 	pointKVWithLocalTS = storageutils.PointKVWithLocalTS
+	rangeKey           = storageutils.RangeKey
 	rangeKV            = storageutils.RangeKV
 	rangeKVWithLocalTS = storageutils.RangeKVWithLocalTS
+	wallTS             = storageutils.WallTS
+	scanEngine         = storageutils.ScanEngine
 )
+
+type wrappedBatch struct {
+	storage.Batch
+	clearIterCount int
+}
+
+func (wb *wrappedBatch) ClearMVCCIteratorRange(
+	start, end roachpb.Key, pointKeys, rangeKeys bool,
+) error {
+	wb.clearIterCount++
+	return wb.Batch.ClearMVCCIteratorRange(start, end, pointKeys, rangeKeys)
+}

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -355,7 +355,7 @@ func (m mvccClearTimeRangeOp) run(ctx context.Context) string {
 		return "no-op due to no non-conflicting key range"
 	}
 	span, err := storage.MVCCClearTimeRange(ctx, m.m.engine, &enginepb.MVCCStats{}, m.key, m.endKey,
-		m.startTime, m.endTime, math.MaxInt64, math.MaxInt64, math.MaxInt64)
+		m.startTime, m.endTime, nil, nil, math.MaxInt64, math.MaxInt64, math.MaxInt64)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -355,7 +355,7 @@ func (m mvccClearTimeRangeOp) run(ctx context.Context) string {
 		return "no-op due to no non-conflicting key range"
 	}
 	span, err := storage.MVCCClearTimeRange(ctx, m.m.engine, &enginepb.MVCCStats{}, m.key, m.endKey,
-		m.startTime, m.endTime, math.MaxInt64, math.MaxInt64)
+		m.startTime, m.endTime, math.MaxInt64, math.MaxInt64, math.MaxInt64)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2322,23 +2322,29 @@ func MVCCMerge(
 	return err
 }
 
-// MVCCClearTimeRange clears all MVCC versions within the span [key, endKey)
-// which have timestamps in the span (startTime, endTime]. This can have the
-// apparent effect of "reverting" the range to startTime if all of the older
-// revisions of cleared keys are still available (i.e. have not been GC'ed).
+// MVCCClearTimeRange clears all MVCC versions (point keys and range keys)
+// within the span [key, endKey) which have timestamps in the span
+// (startTime, endTime]. This can have the apparent effect of "reverting" the
+// range to startTime if all of the older revisions of cleared keys are still
+// available (i.e. have not been GC'ed).
 //
-// Long runs of keys that all qualify for clearing will be cleared via a single
-// clear-range operation, as specified by clearRangeThreshold. Once maxBatchSize
-// Clear and ClearRange operations are hit during iteration, the next matching
-// key is instead returned in the resumeSpan. It is possible to exceed
-// maxBatchSize by up to the size of the buffer of keys selected for deletion
-// but not yet flushed (as done to detect long runs for cleaning in a single
-// ClearRange).
+// Long runs of point keys that all qualify for clearing will be cleared via a
+// single clear-range operation, as specified by clearRangeThreshold. Once
+// maxBatchSize Clear and ClearRange operations are hit during iteration, the
+// next matching key is instead returned in the resumeSpan. It is possible to
+// exceed maxBatchSize by up to the size of the buffer of keys selected for
+// deletion but not yet flushed (as done to detect long runs for cleaning in a
+// single ClearRange).
 //
 // Limiting the number of keys or ranges of keys processed can still cause a
 // batch that is too large -- in number of bytes -- for raft to replicate if the
 // keys are very large. So if the total length of the keys or key spans cleared
 // exceeds maxBatchByteSize it will also stop and return a resume span.
+//
+// leftPeekBound and rightPeekBound are bounds that will be used to peek for
+// surrounding MVCC range keys that may be merged or fragmented by our range key
+// clears. They should correspond to the latches held by the command, and not
+// exceed the Raft range boundaries.
 //
 // This function handles the stats computations to determine the correct
 // incremental deltas of clearing these keys (and correctly determining if it
@@ -2347,13 +2353,17 @@ func MVCCMerge(
 // If the underlying iterator encounters an intent with a timestamp in the span
 // (startTime, endTime], or any inline meta, this method will return an error.
 //
-// TODO(erikgrinaker): This needs to handle MVCC range tombstones (stats too).
+// TODO(erikgrinaker): endTime does not actually work here -- if there are keys
+// above endTime then the stats do not properly account for them. We probably
+// don't need those semantics, so consider renaming this to MVCCRevertRange and
+// removing the endTime parameter.
 func MVCCClearTimeRange(
 	_ context.Context,
 	rw ReadWriter,
 	ms *enginepb.MVCCStats,
 	key, endKey roachpb.Key,
 	startTime, endTime hlc.Timestamp,
+	leftPeekBound, rightPeekBound roachpb.Key,
 	clearRangeThreshold int,
 	maxBatchSize, maxBatchByteSize int64,
 ) (roachpb.Key, error) {
@@ -2368,6 +2378,14 @@ func MVCCClearTimeRange(
 	}
 	if maxBatchByteSize == 0 {
 		maxBatchByteSize = math.MaxInt64
+	}
+	if rightPeekBound == nil {
+		rightPeekBound = keys.MaxKey
+	}
+
+	// Since we're setting up multiple iterators, we require consistent iterators.
+	if !rw.ConsistentIterators() {
+		return nil, errors.AssertionFailedf("requires consistent iterators")
 	}
 
 	// When iterating, instead of immediately clearing a matching key we can
@@ -2444,6 +2462,89 @@ func MVCCClearTimeRange(
 		return nil
 	}
 
+	// We also buffer the range key stack to clear, and flush it when we hit a new
+	// stack.
+	//
+	// TODO(erikgrinaker): For now, we remove individual range keys. We could do
+	// something similar to point keys and keep track of long runs to remove, but
+	// we expect them to be rare so this should be fine for now.
+	var clearRangeKeys MVCCRangeKeyStack
+
+	flushRangeKeys := func(resumeKey roachpb.Key) error {
+		if clearRangeKeys.IsEmpty() {
+			return nil
+		}
+		if len(resumeKey) > 0 {
+			if resumeKey.Compare(clearRangeKeys.Bounds.Key) <= 0 {
+				return nil
+			} else if resumeKey.Compare(clearRangeKeys.Bounds.EndKey) <= 0 {
+				clearRangeKeys.Bounds.EndKey = resumeKey
+			}
+		}
+
+		// Fetch the existing range keys (if any), to adjust MVCC stats. We set up
+		// a new iterator for every batch, which both sees our own writes as well as
+		// any range keys outside of the time bounds.
+		rkIter := rw.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+			KeyTypes:   IterKeyTypeRangesOnly,
+			LowerBound: leftPeekBound,
+			UpperBound: rightPeekBound,
+		})
+		defer rkIter.Close()
+
+		cmp, remaining, err := PeekRangeKeysRight(rkIter, clearRangeKeys.Bounds.Key)
+		if err != nil {
+			return err
+		} else if cmp > 0 || !remaining.Bounds.Contains(clearRangeKeys.Bounds) {
+			return errors.AssertionFailedf("did not find expected range key at %s", clearRangeKeys.Bounds)
+		} else if !remaining.IsEmpty() {
+			// Truncate the bounds to the cleared span, so that stats operate on the
+			// post-fragmented state (if relevant).
+			remaining.Bounds = clearRangeKeys.Bounds
+		}
+
+		// Clear the range keys.
+		for _, v := range clearRangeKeys.Versions {
+			rangeKey := clearRangeKeys.AsRangeKey(v)
+			if err := rw.ClearMVCCRangeKey(rangeKey); err != nil {
+				return err
+			}
+			batchSize++
+			batchByteSize += int64(rangeKey.EncodedSize())
+
+			if ms != nil {
+				ms.Add(updateStatsOnRangeKeyClearVersion(remaining, v))
+			}
+			if _, ok := remaining.Remove(v.Timestamp); !ok {
+				return errors.AssertionFailedf("did not find expected range key %s", rangeKey)
+			}
+		}
+		remaining = remaining.Clone()
+
+		// Update stats for any fragmentation or merging caused by the clears around
+		// the bounds.
+		if ms != nil {
+			if cmp, lhs, err := PeekRangeKeysLeft(rkIter, clearRangeKeys.Bounds.Key); err != nil {
+				return err
+			} else if cmp > 0 {
+				ms.Add(UpdateStatsOnRangeKeySplit(clearRangeKeys.Bounds.Key, lhs.Versions))
+			} else if cmp == 0 && lhs.CanMergeRight(remaining) {
+				ms.Add(updateStatsOnRangeKeyMerge(clearRangeKeys.Bounds.Key, lhs.Versions))
+			}
+
+			if cmp, rhs, err := PeekRangeKeysRight(rkIter, clearRangeKeys.Bounds.EndKey); err != nil {
+				return err
+			} else if cmp < 0 {
+				ms.Add(UpdateStatsOnRangeKeySplit(clearRangeKeys.Bounds.EndKey, rhs.Versions))
+			} else if cmp == 0 && remaining.CanMergeRight(rhs) {
+				ms.Add(updateStatsOnRangeKeyMerge(clearRangeKeys.Bounds.EndKey, rhs.Versions))
+			}
+		}
+
+		clearRangeKeys = MVCCRangeKeyStack{}
+		return nil
+	}
+
 	// Using the IncrementalIterator with the time-bound iter optimization could
 	// potentially be a big win here -- the expected use-case for this is to run
 	// over an entire table's span with a very recent timestamp, rolling back just
@@ -2462,22 +2563,29 @@ func MVCCClearTimeRange(
 	// _expect_ to hit this since the RevertRange is only intended for non-live
 	// key spans, but there could be an intent leftover.
 	iter := NewMVCCIncrementalIterator(rw, MVCCIncrementalIterOptions{
+		KeyTypes:  IterKeyTypePointsAndRanges,
+		StartKey:  key,
 		EndKey:    endKey,
 		StartTime: startTime,
 		EndTime:   endTime,
 	})
 	defer iter.Close()
 
-	// clearedMetaKey is the latest surfaced key that will get cleared
+	// clearedMetaKey is the latest surfaced key that will get cleared.
 	var clearedMetaKey MVCCKey
 
-	// clearedMeta contains metadata on the clearedMetaKey
+	// clearedMeta contains metadata on the clearedMetaKey.
 	var clearedMeta enginepb.MVCCMetadata
 
 	// restoredMeta contains metadata on the previous version the clearedMetaKey.
 	// Once the key in clearedMetaKey is cleared, the key represented in
 	// restoredMeta becomes the latest version of this MVCC key.
 	var restoredMeta enginepb.MVCCMetadata
+
+	// rangeKeyStart contains the start bound of the current range key, if any.
+	// This allows skipping range keys that we've already seen and processed.
+	var rangeKeyStart roachpb.Key
+
 	iter.SeekGE(MVCCKey{Key: key})
 	for {
 		if ok, err := iter.Valid(); err != nil {
@@ -2487,15 +2595,49 @@ func MVCCClearTimeRange(
 		}
 
 		k := iter.UnsafeKey()
+
+		// If we encounter a new range key stack, flush the previous range keys (if
+		// any) and buffer these for clearing.
+		if bounds := iter.RangeBounds(); !bounds.Key.Equal(rangeKeyStart) {
+			rangeKeyStart = append(rangeKeyStart[:0], bounds.Key...)
+
+			if err := flushRangeKeys(nil); err != nil {
+				return nil, err
+			}
+			if batchSize >= maxBatchSize || batchByteSize >= maxBatchByteSize {
+				resumeKey = k.Key.Clone()
+				break
+			}
+
+			// Because we're using NextIgnoringTime() to look for older keys, it's
+			// possible that the iterator will surface range keys outside of the time
+			// bounds, so we need to do additional filtering here.
+			//
+			// TODO(erikgrinaker): Consider a Clone() variant that can reuse a buffer.
+			// See also TODO in Clone() to use a single allocation for all byte
+			// slices.
+			rangeKeys := iter.RangeKeys()
+			rangeKeys.Trim(startTime.Next(), endTime)
+			clearRangeKeys = rangeKeys.Clone()
+		}
+
+		if hasPoint, _ := iter.HasPointAndRange(); !hasPoint {
+			// If we landed on a bare range tombstone, we need to check if it revealed
+			// anything below the time bounds as well.
+			iter.NextIgnoringTime()
+			continue
+		}
+
 		vRaw := iter.UnsafeValue()
 		v, err := DecodeMVCCValue(vRaw)
 		if err != nil {
 			return nil, err
 		}
 
+		// First, account for the point key that we cleared previously.
 		if len(clearedMetaKey.Key) > 0 {
 			metaKeySize := int64(clearedMetaKey.EncodedSize())
-			if bytes.Equal(clearedMetaKey.Key, k.Key) {
+			if clearedMetaKey.Key.Equal(k.Key) {
 				// Since the key matches, our previous clear "restored" this revision of
 				// the this key, so update the stats with this as the "restored" key.
 				restoredMeta.KeyBytes = MVCCVersionTimestampSize
@@ -2503,24 +2645,69 @@ func MVCCClearTimeRange(
 				restoredMeta.Deleted = v.IsTombstone()
 				restoredMeta.Timestamp = k.Timestamp.ToLegacyTimestamp()
 
+				// If there was an MVCC range tombstone between this version and the
+				// cleared key, then we didn't restore it after all, but we must still
+				// adjust the stats for the range tombstone.
+				if !restoredMeta.Deleted {
+					if v, ok := iter.RangeKeys().FirstAbove(k.Timestamp); ok {
+						if v.Timestamp.LessEq(clearedMeta.Timestamp.ToTimestamp()) {
+							restoredMeta.Deleted = true
+							restoredMeta.KeyBytes = 0
+							restoredMeta.ValBytes = 0
+							restoredMeta.Timestamp = v.Timestamp.ToLegacyTimestamp()
+						}
+					}
+				}
+
 				if ms != nil {
 					ms.Add(updateStatsOnClear(clearedMetaKey.Key, metaKeySize, 0, metaKeySize, 0,
-						&clearedMeta, &restoredMeta, k.Timestamp.WallTime))
+						&clearedMeta, &restoredMeta, restoredMeta.Timestamp.WallTime))
 				}
 			} else {
-				// We cleared a revision of a different key, so nothing was "restored".
 				if ms != nil {
 					ms.Add(updateStatsOnClear(clearedMetaKey.Key, metaKeySize, 0, 0, 0, &clearedMeta, nil, 0))
 				}
 			}
-			clearedMetaKey.Key = clearedMetaKey.Key[:0]
 		}
 
-		if startTime.Less(k.Timestamp) && k.Timestamp.LessEq(endTime) {
-			if batchSize >= maxBatchSize || batchByteSize >= maxBatchByteSize {
-				resumeKey = k.Key.Clone()
-				break
+		// Eagerly check whether we've exceeded the batch size. If we return a
+		// resumeKey we may truncate the buffered MVCC range tombstone clears
+		// at the current key, in which case we can't record the current point
+		// key as restored by the range tombstone clear below.
+		if batchSize >= maxBatchSize || batchByteSize >= maxBatchByteSize {
+			resumeKey = k.Key.Clone()
+			clearedMetaKey.Key = clearedMetaKey.Key[:0]
+			break
+		}
+
+		// Check if the current key was restored by a range tombstone clear, and
+		// adjust stats accordingly. We've already accounted for the clear of the
+		// previous point key above. We must also check that the clear actually
+		// revealed the key, since it may have been covered by the point key that
+		// we cleared or a different range tombstone below the one we cleared.
+		if !v.IsTombstone() {
+			if v, ok := clearRangeKeys.FirstAbove(k.Timestamp); ok {
+				// TODO(erikgrinaker): We have to fetch the complete set of range keys
+				// as seen by this key -- these may or may not be filtered by timestamp
+				// depending on whether we did a NextIgnoringTime(), so we have to fetch
+				// the entire set rather than using clearedRangeKeys. We should optimize
+				// this somehow.
+				if !clearedMetaKey.Key.Equal(k.Key) ||
+					!clearedMeta.Timestamp.ToTimestamp().LessEq(v.Timestamp) {
+					if !iter.RangeKeys().HasBetween(v.Timestamp.Prev(), k.Timestamp) {
+						ms.Add(enginepb.MVCCStats{
+							LastUpdateNanos: v.Timestamp.WallTime,
+							LiveCount:       1,
+							LiveBytes:       int64(k.EncodedSize()) + int64(len(vRaw)),
+						})
+					}
+				}
 			}
+		}
+
+		clearedMetaKey.Key = clearedMetaKey.Key[:0]
+
+		if startTime.Less(k.Timestamp) && k.Timestamp.LessEq(endTime) {
 			clearMatchingKey(k)
 			clearedMetaKey.Key = append(clearedMetaKey.Key[:0], k.Key...)
 			clearedMeta.KeyBytes = MVCCVersionTimestampSize
@@ -2548,8 +2735,14 @@ func MVCCClearTimeRange(
 			// Move the incremental iterator to the next valid key that can be rolled
 			// back. If TBI was enabled when initializing the incremental iterator,
 			// this step could jump over large swaths of keys that do not qualify for
-			// clearing.
-			iter.Next()
+			// clearing. However, if we've cleared any range keys, then we need to
+			// skip to the next key ignoring time, because it may not have been
+			// revealed.
+			if !clearRangeKeys.IsEmpty() {
+				iter.NextKeyIgnoringTime()
+			} else {
+				iter.Next()
+			}
 		}
 	}
 
@@ -2560,7 +2753,15 @@ func MVCCClearTimeRange(
 		ms.Add(updateStatsOnClear(clearedMetaKey.Key, origMetaKeySize, 0, 0, 0, &clearedMeta, nil, 0))
 	}
 
-	return resumeKey, flushClearedKeys(MVCCKey{Key: endKey})
+	if err := flushRangeKeys(resumeKey); err != nil {
+		return nil, err
+	}
+
+	flushKey := endKey
+	if len(resumeKey) > 0 {
+		flushKey = resumeKey
+	}
+	return resumeKey, flushClearedKeys(MVCCKey{Key: flushKey})
 }
 
 // MVCCDeleteRange deletes the range of key/value pairs specified by start and

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2328,11 +2328,12 @@ func MVCCMerge(
 // revisions of cleared keys are still available (i.e. have not been GC'ed).
 //
 // Long runs of keys that all qualify for clearing will be cleared via a single
-// clear-range operation. Once maxBatchSize Clear and ClearRange operations are
-// hit during iteration, the next matching key is instead returned in the
-// resumeSpan. It is possible to exceed maxBatchSize by up to the size of the
-// buffer of keys selected for deletion but not yet flushed (as done to detect
-// long runs for cleaning in a single ClearRange).
+// clear-range operation, as specified by clearRangeThreshold. Once maxBatchSize
+// Clear and ClearRange operations are hit during iteration, the next matching
+// key is instead returned in the resumeSpan. It is possible to exceed
+// maxBatchSize by up to the size of the buffer of keys selected for deletion
+// but not yet flushed (as done to detect long runs for cleaning in a single
+// ClearRange).
 //
 // Limiting the number of keys or ranges of keys processed can still cause a
 // batch that is too large -- in number of bytes -- for raft to replicate if the
@@ -2353,37 +2354,39 @@ func MVCCClearTimeRange(
 	ms *enginepb.MVCCStats,
 	key, endKey roachpb.Key,
 	startTime, endTime hlc.Timestamp,
+	clearRangeThreshold int,
 	maxBatchSize, maxBatchByteSize int64,
-) (*roachpb.Span, error) {
-	var batchSize int64
-	var batchByteSize int64
-	var resume *roachpb.Span
+) (roachpb.Key, error) {
+	var batchSize, batchByteSize int64
+	var resumeKey roachpb.Key
+
+	if clearRangeThreshold == 0 {
+		clearRangeThreshold = 2
+	}
+	if maxBatchSize == 0 {
+		maxBatchSize = math.MaxInt64
+	}
+	if maxBatchByteSize == 0 {
+		maxBatchByteSize = math.MaxInt64
+	}
 
 	// When iterating, instead of immediately clearing a matching key we can
-	// accumulate it in buf until either a) useRangeClearThreshold is reached and
+	// accumulate it in buf until either a) clearRangeThreshold is reached and
 	// we discard the buffer, instead just keeping track of where the span of keys
 	// matching started or b) a non-matching key is seen and we flush the buffer
 	// keys one by one as Clears. Once we switch to just tracking where the run
 	// started, on seeing a non-matching key we flush the run via one ClearRange.
 	// This can be a big win for reverting bulk-ingestion of clustered data as the
 	// entire span may likely match and thus could be cleared in one ClearRange
-	// instead of hundreds of thousands of individual Clears. This constant hasn't
-	// been tuned here at all, but was just borrowed from `clearRangeData` where
-	// where this strategy originated.
-	const useClearRangeThreshold = 64
-	var buf [useClearRangeThreshold]MVCCKey
+	// instead of hundreds of thousands of individual Clears.
+	buf := make([]MVCCKey, clearRangeThreshold)
 	var bufSize int
 	var clearRangeStart MVCCKey
 
-	if ms == nil {
-		return nil, errors.AssertionFailedf(
-			"MVCCStats passed in to MVCCClearTimeRange must be non-nil to ensure proper stats" +
-				" computation during Clear operations")
-	}
 	clearMatchingKey := func(k MVCCKey) {
 		if len(clearRangeStart.Key) == 0 {
 			// Currently buffering keys to clear one-by-one.
-			if bufSize < useClearRangeThreshold {
+			if bufSize < clearRangeThreshold {
 				buf[bufSize].Key = append(buf[bufSize].Key[:0], k.Key...)
 				buf[bufSize].Timestamp = k.Timestamp
 				bufSize++
@@ -2500,23 +2503,22 @@ func MVCCClearTimeRange(
 				restoredMeta.Deleted = v.IsTombstone()
 				restoredMeta.Timestamp = k.Timestamp.ToLegacyTimestamp()
 
-				ms.Add(updateStatsOnClear(
-					clearedMetaKey.Key, metaKeySize, 0, metaKeySize, 0, &clearedMeta, &restoredMeta, k.Timestamp.WallTime,
-				))
+				if ms != nil {
+					ms.Add(updateStatsOnClear(clearedMetaKey.Key, metaKeySize, 0, metaKeySize, 0,
+						&clearedMeta, &restoredMeta, k.Timestamp.WallTime))
+				}
 			} else {
 				// We cleared a revision of a different key, so nothing was "restored".
-				ms.Add(updateStatsOnClear(clearedMetaKey.Key, metaKeySize, 0, 0, 0, &clearedMeta, nil, 0))
+				if ms != nil {
+					ms.Add(updateStatsOnClear(clearedMetaKey.Key, metaKeySize, 0, 0, 0, &clearedMeta, nil, 0))
+				}
 			}
 			clearedMetaKey.Key = clearedMetaKey.Key[:0]
 		}
 
 		if startTime.Less(k.Timestamp) && k.Timestamp.LessEq(endTime) {
-			if batchSize >= maxBatchSize {
-				resume = &roachpb.Span{Key: append([]byte{}, k.Key...), EndKey: endKey}
-				break
-			}
-			if batchByteSize > maxBatchByteSize {
-				resume = &roachpb.Span{Key: append([]byte{}, k.Key...), EndKey: endKey}
+			if batchSize >= maxBatchSize || batchByteSize >= maxBatchByteSize {
+				resumeKey = k.Key.Clone()
 				break
 			}
 			clearMatchingKey(k)
@@ -2551,14 +2553,14 @@ func MVCCClearTimeRange(
 		}
 	}
 
-	if len(clearedMetaKey.Key) > 0 {
+	if len(clearedMetaKey.Key) > 0 && ms != nil {
 		// If we cleared on the last iteration, no older revision of that key was
 		// "restored", since otherwise we would have iterated over it.
 		origMetaKeySize := int64(clearedMetaKey.EncodedSize())
 		ms.Add(updateStatsOnClear(clearedMetaKey.Key, origMetaKeySize, 0, 0, 0, &clearedMeta, nil, 0))
 	}
 
-	return resume, flushClearedKeys(MVCCKey{Key: endKey})
+	return resumeKey, flushClearedKeys(MVCCKey{Key: endKey})
 }
 
 // MVCCDeleteRange deletes the range of key/value pairs specified by start and

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -2012,11 +2012,11 @@ func TestMVCCClearTimeRange(t *testing.T) {
 				sz int64,
 				byteLimit int64,
 			) int {
-				resume, err := MVCCClearTimeRange(ctx, rw, ms, key, endKey, ts, endTs, sz, byteLimit)
+				resume, err := MVCCClearTimeRange(ctx, rw, ms, key, endKey, ts, endTs, 64, sz, byteLimit)
 				require.NoError(t, err)
 				attempts := 1
 				for resume != nil {
-					resume, err = MVCCClearTimeRange(ctx, rw, ms, resume.Key, resume.EndKey, ts, endTs, sz, byteLimit)
+					resume, err = MVCCClearTimeRange(ctx, rw, ms, resume, endKey, ts, endTs, 64, sz, byteLimit)
 					require.NoError(t, err)
 					attempts++
 				}
@@ -2025,7 +2025,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts0", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts0, ts5, 10, 1<<10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts0, ts5, 64, 10, 1<<10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts0, ts0Content)
 				assertKVs(t, e, ts1, ts0Content)
@@ -2035,7 +2035,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts1 ", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 10, kb)
+				attempts := resumingClear(t, ctx, e, nil, localMax, keyMax, ts1, ts5, 10, kb)
 				require.Equal(t, 1, attempts)
 				assertKVs(t, e, ts1, ts1Content)
 				assertKVs(t, e, ts2, ts1Content)
@@ -2044,7 +2044,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts1 count-size batch", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 1, kb)
+				attempts := resumingClear(t, ctx, e, nil, localMax, keyMax, ts1, ts5, 1, kb)
 				require.Equal(t, 2, attempts)
 				assertKVs(t, e, ts1, ts1Content)
 				assertKVs(t, e, ts2, ts1Content)
@@ -2054,7 +2054,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts1 byte-size batch", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts5, 10, 1)
+				attempts := resumingClear(t, ctx, e, nil, localMax, keyMax, ts1, ts5, 10, 1)
 				require.Equal(t, 2, attempts)
 				assertKVs(t, e, ts1, ts1Content)
 				assertKVs(t, e, ts2, ts1Content)
@@ -2064,7 +2064,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts2", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				attempts := resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts2, ts5, 10, kb)
+				attempts := resumingClear(t, ctx, e, nil, localMax, keyMax, ts2, ts5, 10, kb)
 				require.Equal(t, 1, attempts)
 				assertKVs(t, e, ts2, ts2Content)
 				assertKVs(t, e, ts5, ts2Content)
@@ -2073,7 +2073,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts3", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts3, ts5, 10, kb)
+				resumingClear(t, ctx, e, nil, localMax, keyMax, ts3, ts5, 10, kb)
 				assertKVs(t, e, ts3, ts3Content)
 				assertKVs(t, e, ts5, ts3Content)
 			})
@@ -2081,7 +2081,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts4, ts5, 10, kb)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts4, ts5, 64, 10, kb)
 				require.NoError(t, err)
 				assertKVs(t, e, ts4, ts4Content)
 				assertKVs(t, e, ts5, ts4Content)
@@ -2090,7 +2090,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts5 (nothing)", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts5, ts5, 10, kb)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts5, ts5, 64, 10, kb)
 				require.NoError(t, err)
 				assertKVs(t, e, ts4, ts4Content)
 				assertKVs(t, e, ts5, ts4Content)
@@ -2099,7 +2099,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear up to k5 to ts0", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				resumingClear(t, ctx, e, &enginepb.MVCCStats{}, testKey1, testKey5, ts0, ts5, 10, kb)
+				resumingClear(t, ctx, e, nil, testKey1, testKey5, ts0, ts5, 10, kb)
 				assertKVs(t, e, ts2, []roachpb.KeyValue{{Key: testKey5, Value: v2}})
 				assertKVs(t, e, ts5, []roachpb.KeyValue{{Key: testKey5, Value: v4}})
 			})
@@ -2107,7 +2107,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts0 in empty span (nothing)", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey5, ts0, ts5, 10, kb)
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey5, ts0, ts5, 64, 10, kb)
 				require.NoError(t, err)
 				assertKVs(t, e, ts2, ts2Content)
 				assertKVs(t, e, ts5, ts4Content)
@@ -2116,7 +2116,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear > ts0 in empty span [k3,k5) (nothing)", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey5, ts0, ts5, 10, 1<<10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey5, ts0, ts5, 64, 10, 1<<10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts2, ts2Content)
 				assertKVs(t, e, ts5, ts4Content)
@@ -2125,7 +2125,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			t.Run("clear k3 and up in ts0 > x >= ts1 (nothing)", func(t *testing.T) {
 				e := setupKVs(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, keyMax, ts0, ts1, 10, 1<<10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, keyMax, ts0, ts1, 64, 10, 1<<10)
 				require.NoError(t, err)
 				assertKVs(t, e, ts2, ts2Content)
 				assertKVs(t, e, ts5, ts4Content)
@@ -2135,27 +2135,27 @@ func TestMVCCClearTimeRange(t *testing.T) {
 			txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, ts3, 1, 1)
 			setupKVsWithIntent := func(t *testing.T) Engine {
 				e := setupKVs(t)
-				require.NoError(t, MVCCPut(ctx, e, &enginepb.MVCCStats{}, testKey3, ts3, hlc.ClockTimestamp{}, value3, &txn))
+				require.NoError(t, MVCCPut(ctx, e, nil, testKey3, ts3, hlc.ClockTimestamp{}, value3, &txn))
 				return e
 			}
 			t.Run("clear everything hitting intent fails", func(t *testing.T) {
 				e := setupKVsWithIntent(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts0, ts5, 10, 1<<10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts0, ts5, 64, 10, 1<<10)
 				require.EqualError(t, err, "conflicting intents on \"/db3\"")
 			})
 
 			t.Run("clear exactly hitting intent fails", func(t *testing.T) {
 				e := setupKVsWithIntent(t)
 				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, &enginepb.MVCCStats{}, testKey3, testKey4, ts2, ts3, 10, 1<<10)
+				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey4, ts2, ts3, 64, 10, 1<<10)
 				require.EqualError(t, err, "conflicting intents on \"/db3\"")
 			})
 
 			t.Run("clear everything above intent", func(t *testing.T) {
 				e := setupKVsWithIntent(t)
 				defer e.Close()
-				resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts3, ts5, 10, kb)
+				resumingClear(t, ctx, e, nil, localMax, keyMax, ts3, ts5, 10, kb)
 				assertKVs(t, e, ts2, ts2Content)
 
 				// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
@@ -2179,7 +2179,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 				e := setupKVsWithIntent(t)
 				defer e.Close()
 				assertKVs(t, e, ts2, ts2Content)
-				resumingClear(t, ctx, e, &enginepb.MVCCStats{}, localMax, keyMax, ts1, ts2, 10, kb)
+				resumingClear(t, ctx, e, nil, localMax, keyMax, ts1, ts2, 10, kb)
 				assertKVs(t, e, ts2, ts1Content)
 			})
 		})
@@ -2291,6 +2291,7 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 			sort.Ints(reverts)
 			const byteLimit = 1000
 			const keyLimit = 100
+			const clearRangeThreshold = 64
 			keyLen := int64(len(roachpb.Key(fmt.Sprintf("%05d", 1)))) + MVCCVersionTimestampSize
 			maxAttempts := (numKVs * keyLen) / byteLimit
 			var attempts int64
@@ -2303,15 +2304,11 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 
 					// Revert to the revert time.
 					startKey := localMax
-					for {
+					for len(startKey) > 0 {
 						attempts++
-						resume, err := MVCCClearTimeRange(ctx, e, &ms, startKey, keyMax, revertTo, now,
-							keyLimit, byteLimit)
+						startKey, err = MVCCClearTimeRange(ctx, e, &ms, startKey, keyMax, revertTo, now,
+							clearRangeThreshold, keyLimit, byteLimit)
 						require.NoError(t, err)
-						if resume == nil {
-							break
-						}
-						startKey = resume.Key
 					}
 
 					require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -1938,252 +1938,245 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	for _, engineImpl := range mvccEngineImpls {
-		t.Run(engineImpl.name, func(t *testing.T) {
 
-			ts0 := hlc.Timestamp{WallTime: 0}
-			ts0Content := []roachpb.KeyValue{}
-			ts1 := hlc.Timestamp{WallTime: 10}
-			v1 := value1
-			v1.Timestamp = ts1
-			ts1Content := []roachpb.KeyValue{{Key: testKey2, Value: v1}}
-			ts2 := hlc.Timestamp{WallTime: 20}
-			v2 := value2
-			v2.Timestamp = ts2
-			ts2Content := []roachpb.KeyValue{{Key: testKey2, Value: v2}, {Key: testKey5, Value: v2}}
-			ts3 := hlc.Timestamp{WallTime: 30}
-			v3 := value3
-			v3.Timestamp = ts3
-			ts3Content := []roachpb.KeyValue{
-				{Key: testKey1, Value: v3}, {Key: testKey2, Value: v2}, {Key: testKey5, Value: v2},
-			}
-			ts4 := hlc.Timestamp{WallTime: 40}
-			v4 := value4
-			v4.Timestamp = ts4
-			ts4Content := []roachpb.KeyValue{
-				{Key: testKey1, Value: v3}, {Key: testKey2, Value: v4}, {Key: testKey5, Value: v4},
-			}
-			ts5 := hlc.Timestamp{WallTime: 50}
-
-			// setupKVs will generate an engine with the key-time space as follows:
-			//    50 -
-			//       |
-			//    40 -      v4          v4
-			//       |
-			//    30 -  v3
-			// time  |
-			//    20 -      v2          v2
-			//       |
-			//    10 -      v1
-			//       |
-			//     0 -----------------------
-			//          k1  k2  k3  k4  k5
-			//                 keys
-			// This returns a new, populated engine since we can't just setup one and use
-			// a new batch in each subtest, since batches don't reflect ClearRange results
-			// when read.
-			setupKVs := func(t *testing.T) Engine {
-				engine := engineImpl.create()
-				require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts1, hlc.ClockTimestamp{}, value1, nil))
-				require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts2, hlc.ClockTimestamp{}, value2, nil))
-				require.NoError(t, MVCCPut(ctx, engine, nil, testKey5, ts2, hlc.ClockTimestamp{}, value2, nil))
-				require.NoError(t, MVCCPut(ctx, engine, nil, testKey1, ts3, hlc.ClockTimestamp{}, value3, nil))
-				require.NoError(t, MVCCPut(ctx, engine, nil, testKey5, ts4, hlc.ClockTimestamp{}, value4, nil))
-				require.NoError(t, MVCCPut(ctx, engine, nil, testKey2, ts4, hlc.ClockTimestamp{}, value4, nil))
-				return engine
-			}
-
-			assertKVs := func(t *testing.T, reader Reader, at hlc.Timestamp, expected []roachpb.KeyValue) {
-				t.Helper()
-				res, err := MVCCScan(ctx, reader, localMax, keyMax, at, MVCCScanOptions{})
-				require.NoError(t, err)
-				require.Equal(t, expected, res.KVs)
-			}
-
-			const kb = 1024
-
-			resumingClear := func(
-				t *testing.T,
-				ctx context.Context,
-				rw ReadWriter,
-				ms *enginepb.MVCCStats,
-				key, endKey roachpb.Key,
-				ts, endTs hlc.Timestamp,
-				sz int64,
-				byteLimit int64,
-			) int {
-				resume, err := MVCCClearTimeRange(ctx, rw, ms, key, endKey, ts, endTs, 64, sz, byteLimit)
-				require.NoError(t, err)
-				attempts := 1
-				for resume != nil {
-					resume, err = MVCCClearTimeRange(ctx, rw, ms, resume, endKey, ts, endTs, 64, sz, byteLimit)
-					require.NoError(t, err)
-					attempts++
-				}
-				return attempts
-			}
-			t.Run("clear > ts0", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts0, ts5, 64, 10, 1<<10)
-				require.NoError(t, err)
-				assertKVs(t, e, ts0, ts0Content)
-				assertKVs(t, e, ts1, ts0Content)
-				assertKVs(t, e, ts5, ts0Content)
-			})
-
-			t.Run("clear > ts1 ", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				attempts := resumingClear(t, ctx, e, nil, localMax, keyMax, ts1, ts5, 10, kb)
-				require.Equal(t, 1, attempts)
-				assertKVs(t, e, ts1, ts1Content)
-				assertKVs(t, e, ts2, ts1Content)
-				assertKVs(t, e, ts5, ts1Content)
-			})
-			t.Run("clear > ts1 count-size batch", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				attempts := resumingClear(t, ctx, e, nil, localMax, keyMax, ts1, ts5, 1, kb)
-				require.Equal(t, 2, attempts)
-				assertKVs(t, e, ts1, ts1Content)
-				assertKVs(t, e, ts2, ts1Content)
-				assertKVs(t, e, ts5, ts1Content)
-			})
-
-			t.Run("clear > ts1 byte-size batch", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				attempts := resumingClear(t, ctx, e, nil, localMax, keyMax, ts1, ts5, 10, 1)
-				require.Equal(t, 2, attempts)
-				assertKVs(t, e, ts1, ts1Content)
-				assertKVs(t, e, ts2, ts1Content)
-				assertKVs(t, e, ts5, ts1Content)
-			})
-
-			t.Run("clear > ts2", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				attempts := resumingClear(t, ctx, e, nil, localMax, keyMax, ts2, ts5, 10, kb)
-				require.Equal(t, 1, attempts)
-				assertKVs(t, e, ts2, ts2Content)
-				assertKVs(t, e, ts5, ts2Content)
-			})
-
-			t.Run("clear > ts3", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				resumingClear(t, ctx, e, nil, localMax, keyMax, ts3, ts5, 10, kb)
-				assertKVs(t, e, ts3, ts3Content)
-				assertKVs(t, e, ts5, ts3Content)
-			})
-
-			t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts4, ts5, 64, 10, kb)
-				require.NoError(t, err)
-				assertKVs(t, e, ts4, ts4Content)
-				assertKVs(t, e, ts5, ts4Content)
-			})
-
-			t.Run("clear > ts5 (nothing)", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts5, ts5, 64, 10, kb)
-				require.NoError(t, err)
-				assertKVs(t, e, ts4, ts4Content)
-				assertKVs(t, e, ts5, ts4Content)
-			})
-
-			t.Run("clear up to k5 to ts0", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				resumingClear(t, ctx, e, nil, testKey1, testKey5, ts0, ts5, 10, kb)
-				assertKVs(t, e, ts2, []roachpb.KeyValue{{Key: testKey5, Value: v2}})
-				assertKVs(t, e, ts5, []roachpb.KeyValue{{Key: testKey5, Value: v4}})
-			})
-
-			t.Run("clear > ts0 in empty span (nothing)", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey5, ts0, ts5, 64, 10, kb)
-				require.NoError(t, err)
-				assertKVs(t, e, ts2, ts2Content)
-				assertKVs(t, e, ts5, ts4Content)
-			})
-
-			t.Run("clear > ts0 in empty span [k3,k5) (nothing)", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey5, ts0, ts5, 64, 10, 1<<10)
-				require.NoError(t, err)
-				assertKVs(t, e, ts2, ts2Content)
-				assertKVs(t, e, ts5, ts4Content)
-			})
-
-			t.Run("clear k3 and up in ts0 > x >= ts1 (nothing)", func(t *testing.T) {
-				e := setupKVs(t)
-				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, keyMax, ts0, ts1, 64, 10, 1<<10)
-				require.NoError(t, err)
-				assertKVs(t, e, ts2, ts2Content)
-				assertKVs(t, e, ts5, ts4Content)
-			})
-
-			// Add an intent at k3@ts3.
-			txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, ts3, 1, 1)
-			setupKVsWithIntent := func(t *testing.T) Engine {
-				e := setupKVs(t)
-				require.NoError(t, MVCCPut(ctx, e, nil, testKey3, ts3, hlc.ClockTimestamp{}, value3, &txn))
-				return e
-			}
-			t.Run("clear everything hitting intent fails", func(t *testing.T) {
-				e := setupKVsWithIntent(t)
-				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, localMax, keyMax, ts0, ts5, 64, 10, 1<<10)
-				require.EqualError(t, err, "conflicting intents on \"/db3\"")
-			})
-
-			t.Run("clear exactly hitting intent fails", func(t *testing.T) {
-				e := setupKVsWithIntent(t)
-				defer e.Close()
-				_, err := MVCCClearTimeRange(ctx, e, nil, testKey3, testKey4, ts2, ts3, 64, 10, 1<<10)
-				require.EqualError(t, err, "conflicting intents on \"/db3\"")
-			})
-
-			t.Run("clear everything above intent", func(t *testing.T) {
-				e := setupKVsWithIntent(t)
-				defer e.Close()
-				resumingClear(t, ctx, e, nil, localMax, keyMax, ts3, ts5, 10, kb)
-				assertKVs(t, e, ts2, ts2Content)
-
-				// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
-				// value as of ts3 (i.e. v4 was cleared to expose v2).
-				res, err := MVCCScan(ctx, e, localMax, testKey3, ts5, MVCCScanOptions{})
-				require.NoError(t, err)
-				require.Equal(t, ts3Content[:2], res.KVs)
-
-				// Verify the intent was left alone.
-				_, err = MVCCScan(ctx, e, testKey3, testKey4, ts5, MVCCScanOptions{})
-				require.Error(t, err)
-
-				// Scan (> k3 to avoid intent) to confirm that k5 was indeed reverted to
-				// value as of ts3 (i.e. v4 was cleared to expose v2).
-				res, err = MVCCScan(ctx, e, testKey4, keyMax, ts5, MVCCScanOptions{})
-				require.NoError(t, err)
-				require.Equal(t, ts3Content[2:], res.KVs)
-			})
-
-			t.Run("clear below intent", func(t *testing.T) {
-				e := setupKVsWithIntent(t)
-				defer e.Close()
-				assertKVs(t, e, ts2, ts2Content)
-				resumingClear(t, ctx, e, nil, localMax, keyMax, ts1, ts2, 10, kb)
-				assertKVs(t, e, ts2, ts1Content)
-			})
-		})
+	ts0 := hlc.Timestamp{WallTime: 0}
+	ts0Content := []roachpb.KeyValue{}
+	ts1 := hlc.Timestamp{WallTime: 10}
+	v1 := value1
+	v1.Timestamp = ts1
+	ts1Content := []roachpb.KeyValue{{Key: testKey2, Value: v1}}
+	ts2 := hlc.Timestamp{WallTime: 20}
+	v2 := value2
+	v2.Timestamp = ts2
+	ts2Content := []roachpb.KeyValue{{Key: testKey2, Value: v2}, {Key: testKey5, Value: v2}}
+	ts3 := hlc.Timestamp{WallTime: 30}
+	v3 := value3
+	v3.Timestamp = ts3
+	ts3Content := []roachpb.KeyValue{
+		{Key: testKey1, Value: v3}, {Key: testKey2, Value: v2}, {Key: testKey5, Value: v2},
 	}
+	ts4 := hlc.Timestamp{WallTime: 40}
+	v4 := value4
+	v4.Timestamp = ts4
+	ts4Content := []roachpb.KeyValue{
+		{Key: testKey1, Value: v3}, {Key: testKey2, Value: v4}, {Key: testKey5, Value: v4},
+	}
+	ts5 := hlc.Timestamp{WallTime: 50}
+
+	// Set up an engine with the key-time space as follows:
+	//    50 -
+	//       |
+	//    40 -      v4          v4
+	//       |
+	//    30 -  v3
+	// time  |
+	//    20 -      v2          v2
+	//       |
+	//    10 -      v1
+	//       |
+	//     0 -----------------------
+	//          k1  k2  k3  k4  k5
+	//                 keys
+	eng := NewDefaultInMemForTesting()
+	defer eng.Close()
+	require.NoError(t, MVCCPut(ctx, eng, nil, testKey2, ts1, hlc.ClockTimestamp{}, value1, nil))
+	require.NoError(t, MVCCPut(ctx, eng, nil, testKey2, ts2, hlc.ClockTimestamp{}, value2, nil))
+	require.NoError(t, MVCCPut(ctx, eng, nil, testKey5, ts2, hlc.ClockTimestamp{}, value2, nil))
+	require.NoError(t, MVCCPut(ctx, eng, nil, testKey1, ts3, hlc.ClockTimestamp{}, value3, nil))
+	require.NoError(t, MVCCPut(ctx, eng, nil, testKey5, ts4, hlc.ClockTimestamp{}, value4, nil))
+	require.NoError(t, MVCCPut(ctx, eng, nil, testKey2, ts4, hlc.ClockTimestamp{}, value4, nil))
+
+	assertKVs := func(t *testing.T, reader Reader, at hlc.Timestamp, expected []roachpb.KeyValue) {
+		t.Helper()
+		res, err := MVCCScan(ctx, reader, localMax, keyMax, at, MVCCScanOptions{})
+		require.NoError(t, err)
+		require.Equal(t, expected, res.KVs)
+	}
+
+	const kb = 1024
+
+	resumingClear := func(
+		t *testing.T,
+		ctx context.Context,
+		rw ReadWriter,
+		ms *enginepb.MVCCStats,
+		key, endKey roachpb.Key,
+		ts, endTs hlc.Timestamp,
+		sz int64,
+		byteLimit int64,
+	) int {
+		resume, err := MVCCClearTimeRange(ctx, rw, ms, key, endKey, ts, endTs, nil, nil, 64, sz, byteLimit)
+		require.NoError(t, err)
+		attempts := 1
+		for resume != nil {
+			resume, err = MVCCClearTimeRange(ctx, rw, ms, resume, endKey, ts, endTs, nil, nil, 64, sz, byteLimit)
+			require.NoError(t, err)
+			attempts++
+		}
+		return attempts
+	}
+	t.Run("clear > ts0", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		_, err := MVCCClearTimeRange(ctx, b, nil, localMax, keyMax, ts0, ts5, nil, nil, 64, 10, 1<<10)
+		require.NoError(t, err)
+		assertKVs(t, b, ts0, ts0Content)
+		assertKVs(t, b, ts1, ts0Content)
+		assertKVs(t, b, ts5, ts0Content)
+	})
+
+	t.Run("clear > ts1 ", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		attempts := resumingClear(t, ctx, b, nil, localMax, keyMax, ts1, ts5, 10, kb)
+		require.Equal(t, 1, attempts)
+		assertKVs(t, b, ts1, ts1Content)
+		assertKVs(t, b, ts2, ts1Content)
+		assertKVs(t, b, ts5, ts1Content)
+	})
+	t.Run("clear > ts1 count-size batch", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		attempts := resumingClear(t, ctx, b, nil, localMax, keyMax, ts1, ts5, 1, kb)
+		require.Equal(t, 2, attempts)
+		assertKVs(t, b, ts1, ts1Content)
+		assertKVs(t, b, ts2, ts1Content)
+		assertKVs(t, b, ts5, ts1Content)
+	})
+
+	t.Run("clear > ts1 byte-size batch", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		attempts := resumingClear(t, ctx, b, nil, localMax, keyMax, ts1, ts5, 10, 1)
+		require.Equal(t, 2, attempts)
+		assertKVs(t, b, ts1, ts1Content)
+		assertKVs(t, b, ts2, ts1Content)
+		assertKVs(t, b, ts5, ts1Content)
+	})
+
+	t.Run("clear > ts2", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		attempts := resumingClear(t, ctx, b, nil, localMax, keyMax, ts2, ts5, 10, kb)
+		require.Equal(t, 1, attempts)
+		assertKVs(t, b, ts2, ts2Content)
+		assertKVs(t, b, ts5, ts2Content)
+	})
+
+	t.Run("clear > ts3", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		resumingClear(t, ctx, b, nil, localMax, keyMax, ts3, ts5, 10, kb)
+		assertKVs(t, b, ts3, ts3Content)
+		assertKVs(t, b, ts5, ts3Content)
+	})
+
+	t.Run("clear > ts4 (nothing) ", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		_, err := MVCCClearTimeRange(ctx, b, nil, localMax, keyMax, ts4, ts5, nil, nil, 64, 10, kb)
+		require.NoError(t, err)
+		assertKVs(t, b, ts4, ts4Content)
+		assertKVs(t, b, ts5, ts4Content)
+	})
+
+	t.Run("clear > ts5 (nothing)", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		_, err := MVCCClearTimeRange(ctx, b, nil, localMax, keyMax, ts5, ts5, nil, nil, 64, 10, kb)
+		require.NoError(t, err)
+		assertKVs(t, b, ts4, ts4Content)
+		assertKVs(t, b, ts5, ts4Content)
+	})
+
+	t.Run("clear up to k5 to ts0", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		resumingClear(t, ctx, b, nil, testKey1, testKey5, ts0, ts5, 10, kb)
+		assertKVs(t, b, ts2, []roachpb.KeyValue{{Key: testKey5, Value: v2}})
+		assertKVs(t, b, ts5, []roachpb.KeyValue{{Key: testKey5, Value: v4}})
+	})
+
+	t.Run("clear > ts0 in empty span (nothing)", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		_, err := MVCCClearTimeRange(ctx, b, nil, testKey3, testKey5, ts0, ts5, nil, nil, 64, 10, kb)
+		require.NoError(t, err)
+		assertKVs(t, b, ts2, ts2Content)
+		assertKVs(t, b, ts5, ts4Content)
+	})
+
+	t.Run("clear > ts0 in empty span [k3,k5) (nothing)", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		_, err := MVCCClearTimeRange(ctx, b, nil, testKey3, testKey5, ts0, ts5, nil, nil, 64, 10, 1<<10)
+		require.NoError(t, err)
+		assertKVs(t, b, ts2, ts2Content)
+		assertKVs(t, b, ts5, ts4Content)
+	})
+
+	t.Run("clear k3 and up in ts0 > x >= ts1 (nothing)", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		_, err := MVCCClearTimeRange(ctx, b, nil, testKey3, keyMax, ts0, ts1, nil, nil, 64, 10, 1<<10)
+		require.NoError(t, err)
+		assertKVs(t, b, ts2, ts2Content)
+		assertKVs(t, b, ts5, ts4Content)
+	})
+
+	// Add an intent at k3@ts3.
+	txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, ts3, 1, 1)
+	addIntent := func(t *testing.T, rw ReadWriter) {
+		require.NoError(t, MVCCPut(ctx, rw, nil, testKey3, ts3, hlc.ClockTimestamp{}, value3, &txn))
+	}
+	t.Run("clear everything hitting intent fails", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		addIntent(t, b)
+		_, err := MVCCClearTimeRange(ctx, b, nil, localMax, keyMax, ts0, ts5, nil, nil, 64, 10, 1<<10)
+		require.EqualError(t, err, "conflicting intents on \"/db3\"")
+	})
+
+	t.Run("clear exactly hitting intent fails", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		addIntent(t, b)
+		_, err := MVCCClearTimeRange(ctx, b, nil, testKey3, testKey4, ts2, ts3, nil, nil, 64, 10, 1<<10)
+		require.EqualError(t, err, "conflicting intents on \"/db3\"")
+	})
+
+	t.Run("clear everything above intent", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		addIntent(t, b)
+		resumingClear(t, ctx, b, nil, localMax, keyMax, ts3, ts5, 10, kb)
+		assertKVs(t, b, ts2, ts2Content)
+
+		// Scan (< k3 to avoid intent) to confirm that k2 was indeed reverted to
+		// value as of ts3 (i.e. v4 was cleared to expose v2).
+		res, err := MVCCScan(ctx, b, localMax, testKey3, ts5, MVCCScanOptions{})
+		require.NoError(t, err)
+		require.Equal(t, ts3Content[:2], res.KVs)
+
+		// Verify the intent was left alone.
+		_, err = MVCCScan(ctx, b, testKey3, testKey4, ts5, MVCCScanOptions{})
+		require.Error(t, err)
+
+		// Scan (> k3 to avoid intent) to confirm that k5 was indeed reverted to
+		// value as of ts3 (i.e. v4 was cleared to expose v2).
+		res, err = MVCCScan(ctx, b, testKey4, keyMax, ts5, MVCCScanOptions{})
+		require.NoError(t, err)
+		require.Equal(t, ts3Content[2:], res.KVs)
+	})
+
+	t.Run("clear below intent", func(t *testing.T) {
+		b := eng.NewBatch()
+		defer b.Close()
+		addIntent(t, b)
+		assertKVs(t, b, ts2, ts2Content)
+		resumingClear(t, ctx, b, nil, localMax, keyMax, ts1, ts2, 10, kb)
+		assertKVs(t, b, ts2, ts1Content)
+	})
 }
 
 func computeStats(
@@ -2218,110 +2211,108 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	rng, _ := randutil.NewTestRand()
-
 	ctx := context.Background()
 
-	for _, engineImpl := range mvccEngineImpls {
-		t.Run(engineImpl.name, func(t *testing.T) {
-			e := engineImpl.create()
-			defer e.Close()
+	e := NewDefaultInMemForTesting()
+	defer e.Close()
 
-			now := hlc.Timestamp{WallTime: 100000000}
+	now := hlc.Timestamp{WallTime: 100000000}
 
-			var ms enginepb.MVCCStats
+	var ms enginepb.MVCCStats
 
-			// Setup numKVs random kv by writing to random keys [0, keyRange) except for
-			// the span [swathStart, swathEnd). Then fill in that swath with kvs all
-			// having the same ts, to ensure they all revert at the same time, thus
-			// triggering the ClearRange optimization path.
-			const numKVs = 10000
-			const keyRange, swathStart, swathEnd = 5000, 3500, 4000
-			const swathSize = swathEnd - swathStart
-			const randTimeRange = 1000
+	// Setup numKVs random kv by writing to random keys [0, keyRange) except for
+	// the span [swathStart, swathEnd). Then fill in that swath with kvs all
+	// having the same ts, to ensure they all revert at the same time, thus
+	// triggering the ClearRange optimization path.
+	const numKVs = 10000
+	const keyRange, swathStart, swathEnd = 5000, 3500, 4000
+	const swathSize = swathEnd - swathStart
+	const randTimeRange = 1000
 
-			wrote := make(map[int]int64, keyRange)
-			for i := 0; i < numKVs-swathSize; i++ {
-				k := rng.Intn(keyRange - swathSize)
-				if k >= swathStart {
-					k += swathSize
-				}
+	wrote := make(map[int]int64, keyRange)
+	for i := 0; i < numKVs-swathSize; i++ {
+		k := rng.Intn(keyRange - swathSize)
+		if k >= swathStart {
+			k += swathSize
+		}
 
-				ts := int64(rng.Intn(randTimeRange))
-				// Ensure writes to a given key are increasing in time.
-				if ts <= wrote[k] {
-					ts = wrote[k] + 1
-				}
-				wrote[k] = ts
+		ts := int64(rng.Intn(randTimeRange))
+		// Ensure writes to a given key are increasing in time.
+		if ts <= wrote[k] {
+			ts = wrote[k] + 1
+		}
+		wrote[k] = ts
 
-				key := roachpb.Key(fmt.Sprintf("%05d", k))
-				if rand.Float64() > 0.8 {
-					require.NoError(t, MVCCDelete(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, hlc.ClockTimestamp{}, nil))
-				} else {
-					v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-					require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, hlc.ClockTimestamp{}, v, nil))
-				}
+		key := roachpb.Key(fmt.Sprintf("%05d", k))
+		if rand.Float64() > 0.8 {
+			require.NoError(t, MVCCDelete(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, hlc.ClockTimestamp{}, nil))
+		} else {
+			v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
+			require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: ts}, hlc.ClockTimestamp{}, v, nil))
+		}
+	}
+	swathTime := rand.Intn(randTimeRange-100) + 100
+	for i := swathStart; i < swathEnd; i++ {
+		key := roachpb.Key(fmt.Sprintf("%05d", i))
+		v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
+		require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(swathTime)}, hlc.ClockTimestamp{}, v, nil))
+	}
+
+	// Add another swath of keys above to exercise an after-iteration range flush.
+	for i := keyRange; i < keyRange+200; i++ {
+		key := roachpb.Key(fmt.Sprintf("%05d", i))
+		v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
+		require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(randTimeRange + 1)}, hlc.ClockTimestamp{}, v, nil))
+	}
+
+	ms.AgeTo(2000)
+
+	// Sanity check starting stats.
+	require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
+
+	// Pick timestamps to which we'll revert, and sort them so we can go back
+	// though them in order. The largest will still be less than randTimeRange so
+	// the initial revert will be assured to use ClearRange.
+	reverts := make([]int, 5)
+	for i := range reverts {
+		reverts[i] = rand.Intn(randTimeRange)
+	}
+	reverts[0] = swathTime - 1
+	sort.Ints(reverts)
+	const byteLimit = 1000
+	const keyLimit = 100
+	const clearRangeThreshold = 64
+	keyLen := int64(len(roachpb.Key(fmt.Sprintf("%05d", 1)))) + MVCCVersionTimestampSize
+	maxAttempts := (numKVs * keyLen) / byteLimit
+	var attempts int64
+	for i := len(reverts) - 1; i >= 0; i-- {
+		t.Run(fmt.Sprintf("revert-%d", i), func(t *testing.T) {
+			revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
+			// MVCC-Scan at the revert time.
+			resBefore, err := MVCCScan(ctx, e, localMax, keyMax, revertTo, MVCCScanOptions{MaxKeys: numKVs})
+			require.NoError(t, err)
+
+			// Revert to the revert time.
+			startKey := localMax
+			for len(startKey) > 0 {
+				attempts++
+				batch := e.NewBatch()
+				startKey, err = MVCCClearTimeRange(ctx, batch, &ms, startKey, keyMax, revertTo, now,
+					nil, nil, clearRangeThreshold, keyLimit, byteLimit)
+				require.NoError(t, err)
+				require.NoError(t, batch.Commit(false))
+				batch.Close()
 			}
-			swathTime := rand.Intn(randTimeRange-100) + 100
-			for i := swathStart; i < swathEnd; i++ {
-				key := roachpb.Key(fmt.Sprintf("%05d", i))
-				v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-				require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(swathTime)}, hlc.ClockTimestamp{}, v, nil))
-			}
 
-			// Add another swath of keys above to exercise an after-iteration range flush.
-			for i := keyRange; i < keyRange+200; i++ {
-				key := roachpb.Key(fmt.Sprintf("%05d", i))
-				v := roachpb.MakeValueFromString(fmt.Sprintf("v-%d", i))
-				require.NoError(t, MVCCPut(ctx, e, &ms, key, hlc.Timestamp{WallTime: int64(randTimeRange + 1)}, hlc.ClockTimestamp{}, v, nil))
-			}
-
-			ms.AgeTo(2000)
-
-			// Sanity check starting stats.
 			require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
-
-			// Pick timestamps to which we'll revert, and sort them so we can go back
-			// though them in order. The largest will still be less than randTimeRange so
-			// the initial revert will be assured to use ClearRange.
-			reverts := make([]int, 5)
-			for i := range reverts {
-				reverts[i] = rand.Intn(randTimeRange)
-			}
-			reverts[0] = swathTime - 1
-			sort.Ints(reverts)
-			const byteLimit = 1000
-			const keyLimit = 100
-			const clearRangeThreshold = 64
-			keyLen := int64(len(roachpb.Key(fmt.Sprintf("%05d", 1)))) + MVCCVersionTimestampSize
-			maxAttempts := (numKVs * keyLen) / byteLimit
-			var attempts int64
-			for i := len(reverts) - 1; i >= 0; i-- {
-				t.Run(fmt.Sprintf("revert-%d", i), func(t *testing.T) {
-					revertTo := hlc.Timestamp{WallTime: int64(reverts[i])}
-					// MVCC-Scan at the revert time.
-					resBefore, err := MVCCScan(ctx, e, localMax, keyMax, revertTo, MVCCScanOptions{MaxKeys: numKVs})
-					require.NoError(t, err)
-
-					// Revert to the revert time.
-					startKey := localMax
-					for len(startKey) > 0 {
-						attempts++
-						startKey, err = MVCCClearTimeRange(ctx, e, &ms, startKey, keyMax, revertTo, now,
-							clearRangeThreshold, keyLimit, byteLimit)
-						require.NoError(t, err)
-					}
-
-					require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
-					// Scanning at "now" post-revert should yield the same result as scanning
-					// at revert-time pre-revert.
-					resAfter, err := MVCCScan(ctx, e, localMax, keyMax, now, MVCCScanOptions{MaxKeys: numKVs})
-					require.NoError(t, err)
-					require.Equal(t, resBefore.KVs, resAfter.KVs)
-				})
-			}
-			require.LessOrEqual(t, attempts, maxAttempts)
+			// Scanning at "now" post-revert should yield the same result as scanning
+			// at revert-time pre-revert.
+			resAfter, err := MVCCScan(ctx, e, localMax, keyMax, now, MVCCScanOptions{MaxKeys: numKVs})
+			require.NoError(t, err)
+			require.Equal(t, resBefore.KVs, resAfter.KVs)
 		})
 	}
+	require.LessOrEqual(t, attempts, maxAttempts)
 }
 
 func TestMVCCInitPut(t *testing.T) {

--- a/pkg/storage/testdata/mvcc_histories/clear_time_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_time_range
@@ -1,0 +1,1041 @@
+# Tests MVCCClearTimeRange.
+#
+# All tests set up the following dataset, where x is tombstone, o-o is range
+# tombstone, [] is intent. The dataset is recreated for every test.
+#
+#  T
+#  6                      f6
+#  5          o-------------------o           k5
+#  4  x   x       d4          x      x
+#  3      o-------o   e3  x   o------oi3              o---o
+#  2  a2          d2      f2  g2
+#  1  o---------------------------------------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n
+
+# Clear the entire span.
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0
+stats: key_count=-8 key_bytes=-184 val_count=-14 val_bytes=-63 range_key_count=-8 range_key_bytes=-167 range_val_count=-15 range_val_bytes=-13 live_count=-2 live_bytes=-42 gc_bytes_age=-37212
+>> at end:
+<no data>
+stats: 
+
+# Clear individual timestamps 7-1.
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=6
+----
+>> clear_time_range k=a end=z ts=7 targetTs=6
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=8 key_bytes=184 val_count=14 val_bytes=63 range_key_count=8 range_key_bytes=167 range_val_count=15 range_val_bytes=13 live_count=2 live_bytes=42 gc_bytes_age=37212
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=5
+----
+>> clear_time_range k=a end=z ts=6 targetTs=5
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 live_count=-1 live_bytes=-21 gc_bytes_age=+194
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=8 key_bytes=172 val_count=13 val_bytes=56 range_key_count=8 range_key_bytes=167 range_val_count=15 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=37406
+
+run stats ok
+clear_time_range k=a end=z ts=5 targetTs=4
+----
+>> clear_time_range k=a end=z ts=5 targetTs=4
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-2 range_key_bytes=-71 range_val_count=-7 live_count=+1 live_bytes=+21 gc_bytes_age=-10827
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=7 key_bytes=158 val_count=12 val_bytes=49 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=2 live_bytes=42 gc_bytes_age=26579
+
+run stats ok
+clear_time_range k=a end=z ts=4 targetTs=3
+----
+>> clear_time_range k=a end=z ts=4 targetTs=3
+stats: key_count=-1 key_bytes=-62 val_count=-5 val_bytes=-7 live_count=+2 live_bytes=+42 gc_bytes_age=-10654
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=15925
+
+run stats ok
+clear_time_range k=a end=z ts=3 targetTs=2
+----
+>> clear_time_range k=a end=z ts=3 targetTs=2
+stats: key_count=-2 key_bytes=-40 val_count=-3 val_bytes=-14 range_key_count=-5 range_key_bytes=-83 range_val_count=-7 range_val_bytes=-13 gc_bytes_age=-14638
+>> at end:
+rangekey: {a-k}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+stats: key_count=4 key_bytes=56 val_count=4 val_bytes=28 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=4 live_bytes=84 gc_bytes_age=1287
+
+run stats ok
+clear_time_range k=a end=z ts=2 targetTs=1
+----
+>> clear_time_range k=a end=z ts=2 targetTs=1
+stats: key_count=-4 key_bytes=-56 val_count=-4 val_bytes=-28 live_count=-4 live_bytes=-84
+>> at end:
+rangekey: {a-k}/[1.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1287
+
+run stats ok
+clear_time_range k=a end=z ts=1 targetTs=0
+----
+>> clear_time_range k=a end=z ts=1 targetTs=0
+stats: range_key_count=-1 range_key_bytes=-13 range_val_count=-1 gc_bytes_age=-1287
+>> at end:
+<no data>
+stats: 
+
+# Clear individual keys a-n for times 3-6.
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=b ts=6 targetTs=3
+----
+>> clear_time_range k=a end=b ts=6 targetTs=3
+stats: key_bytes=-12 val_count=-1 live_count=+1 live_bytes=+21 gc_bytes_age=-3168
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=8 key_bytes=172 val_count=13 val_bytes=63 range_key_count=8 range_key_bytes=167 range_val_count=15 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=34044
+
+run stats ok
+clear_time_range k=b end=c ts=6 targetTs=3
+----
+>> clear_time_range k=b end=c ts=6 targetTs=3
+stats: key_count=-1 key_bytes=-14 val_count=-1 gc_bytes_age=-1344
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=158 val_count=12 val_bytes=63 range_key_count=8 range_key_bytes=167 range_val_count=15 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=32700
+
+run stats ok
+clear_time_range k=c end=d ts=6 targetTs=3
+----
+>> clear_time_range k=c end=d ts=6 targetTs=3
+stats: range_key_count=-1 range_key_bytes=-31 range_val_count=-3 gc_bytes_age=-2999
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=158 val_count=12 val_bytes=63 range_key_count=7 range_key_bytes=136 range_val_count=12 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=29701
+
+run stats ok
+clear_time_range k=d end=e ts=6 targetTs=3
+----
+>> clear_time_range k=d end=e ts=6 targetTs=3
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=+1 live_bytes=+21 gc_bytes_age=-2532
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-e}/[1.000000000,0=/<empty>]
+rangekey: {e-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=146 val_count=11 val_bytes=56 range_key_count=8 range_key_bytes=149 range_val_count=13 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=27169
+
+run stats ok
+clear_time_range k=e end=f ts=6 targetTs=3
+----
+>> clear_time_range k=e end=f ts=6 targetTs=3
+stats: live_count=+1 live_bytes=+21 gc_bytes_age=-1995
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[1.000000000,0=/<empty>]
+rangekey: {f-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=146 val_count=11 val_bytes=56 range_key_count=8 range_key_bytes=149 range_val_count=13 range_val_bytes=13 live_count=5 live_bytes=105 gc_bytes_age=25174
+
+run stats ok
+clear_time_range k=f end=g ts=6 targetTs=3
+----
+>> clear_time_range k=f end=g ts=6 targetTs=3
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-22 range_val_count=-2 live_count=-1 live_bytes=-21 gc_bytes_age=-1932
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=134 val_count=10 val_bytes=49 range_key_count=7 range_key_bytes=127 range_val_count=11 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=23242
+
+run stats ok
+clear_time_range k=g end=h ts=6 targetTs=3
+----
+>> clear_time_range k=g end=h ts=6 targetTs=3
+stats: key_bytes=-12 val_count=-1 range_key_count=-1 range_key_bytes=-31 range_val_count=-3 gc_bytes_age=-4149
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=122 val_count=9 val_bytes=49 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=19093
+
+run stats ok
+clear_time_range k=h end=i ts=6 targetTs=3
+----
+>> clear_time_range k=h end=i ts=6 targetTs=3
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=122 val_count=9 val_bytes=49 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=19093
+
+run stats ok
+clear_time_range k=i end=j ts=6 targetTs=3
+----
+>> clear_time_range k=i end=j ts=6 targetTs=3
+stats: key_bytes=-12 val_count=-1 live_count=+1 live_bytes=+21 gc_bytes_age=-3168
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=110 val_count=8 val_bytes=49 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=5 live_bytes=105 gc_bytes_age=15925
+
+run stats ok
+clear_time_range k=j end=k ts=6 targetTs=3
+----
+>> clear_time_range k=j end=k ts=6 targetTs=3
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=110 val_count=8 val_bytes=49 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=5 live_bytes=105 gc_bytes_age=15925
+
+run stats ok
+clear_time_range k=k end=l ts=6 targetTs=3
+----
+>> clear_time_range k=k end=l ts=6 targetTs=3
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 live_count=-1 live_bytes=-21
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=15925
+
+run stats ok
+clear_time_range k=l end=m ts=6 targetTs=3
+----
+>> clear_time_range k=l end=m ts=6 targetTs=3
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=15925
+
+run stats ok
+clear_time_range k=m end=n ts=6 targetTs=3
+----
+>> clear_time_range k=m end=n ts=6 targetTs=3
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=15925
+
+# Clear individual keys n-a for times 0-3.
+run stats ok
+clear_time_range k=m end=n ts=3 targetTs=0
+----
+>> clear_time_range k=m end=n ts=3 targetTs=0
+stats: range_key_count=-1 range_key_bytes=-13 range_val_count=-1 range_val_bytes=-13 gc_bytes_age=-2522
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=5 range_key_bytes=83 range_val_count=7 live_count=4 live_bytes=84 gc_bytes_age=13403
+
+run stats ok
+clear_time_range k=l end=m ts=3 targetTs=0
+----
+>> clear_time_range k=l end=m ts=3 targetTs=0
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=5 range_key_bytes=83 range_val_count=7 live_count=4 live_bytes=84 gc_bytes_age=13403
+
+run stats ok
+clear_time_range k=k end=l ts=3 targetTs=0
+----
+>> clear_time_range k=k end=l ts=3 targetTs=0
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=5 range_key_bytes=83 range_val_count=7 live_count=4 live_bytes=84 gc_bytes_age=13403
+
+run stats ok
+clear_time_range k=j end=k ts=3 targetTs=0
+----
+>> clear_time_range k=j end=k ts=3 targetTs=0
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-j}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=5 range_key_bytes=83 range_val_count=7 live_count=4 live_bytes=84 gc_bytes_age=13403
+
+run stats ok
+clear_time_range k=i end=j ts=3 targetTs=0
+----
+>> clear_time_range k=i end=j ts=3 targetTs=0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 live_count=-1 live_bytes=-21 gc_bytes_age=-1287
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+stats: key_count=5 key_bytes=82 val_count=6 val_bytes=35 range_key_count=4 range_key_bytes=70 range_val_count=6 live_count=3 live_bytes=63 gc_bytes_age=12116
+
+run stats ok
+clear_time_range k=h end=i ts=3 targetTs=0
+----
+>> clear_time_range k=h end=i ts=3 targetTs=0
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+stats: key_count=5 key_bytes=82 val_count=6 val_bytes=35 range_key_count=4 range_key_bytes=70 range_val_count=6 live_count=3 live_bytes=63 gc_bytes_age=12116
+
+run stats ok
+clear_time_range k=g end=h ts=3 targetTs=0
+----
+>> clear_time_range k=g end=h ts=3 targetTs=0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-22 range_val_count=-2 gc_bytes_age=-4189
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+stats: key_count=4 key_bytes=68 val_count=5 val_bytes=28 range_key_count=3 range_key_bytes=48 range_val_count=4 live_count=3 live_bytes=63 gc_bytes_age=7927
+
+run stats ok
+clear_time_range k=f end=g ts=3 targetTs=0
+----
+>> clear_time_range k=f end=g ts=3 targetTs=0
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3201
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+stats: key_count=3 key_bytes=42 val_count=3 val_bytes=21 range_key_count=3 range_key_bytes=48 range_val_count=4 live_count=3 live_bytes=63 gc_bytes_age=4726
+
+run stats ok
+clear_time_range k=e end=f ts=3 targetTs=0
+----
+>> clear_time_range k=e end=f ts=3 targetTs=0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 live_count=-1 live_bytes=-21
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-e}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=14 range_key_count=3 range_key_bytes=48 range_val_count=4 live_count=2 live_bytes=42 gc_bytes_age=4726
+
+run stats ok
+clear_time_range k=d end=e ts=3 targetTs=0
+----
+>> clear_time_range k=d end=e ts=3 targetTs=0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 live_count=-1 live_bytes=-21 gc_bytes_age=-1287
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=21 gc_bytes_age=3439
+
+run stats ok
+clear_time_range k=c end=d ts=3 targetTs=0
+----
+>> clear_time_range k=c end=d ts=3 targetTs=0
+stats: no change
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=1 live_bytes=21 gc_bytes_age=3439
+
+run stats ok
+clear_time_range k=b end=c ts=3 targetTs=0
+----
+>> clear_time_range k=b end=c ts=3 targetTs=0
+stats: range_key_count=-1 range_key_bytes=-22 range_val_count=-2 gc_bytes_age=-2152
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=1 live_bytes=21 gc_bytes_age=1287
+
+run stats ok
+clear_time_range k=a end=b ts=3 targetTs=0
+----
+>> clear_time_range k=a end=b ts=3 targetTs=0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 live_count=-1 live_bytes=-21 gc_bytes_age=-1287
+>> at end:
+<no data>
+stats: 
+
+# Clear a few arbitrary keys and arbitrary timestamps.
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=ccc end=foobar ts=6 targetTs=3
+----
+>> clear_time_range k=ccc end=foobar ts=6 targetTs=3
+stats: key_bytes=-24 val_count=-2 val_bytes=-14 range_key_count=+2 range_key_bytes=+49 range_val_count=+3 live_count=+1 live_bytes=+21 gc_bytes_age=-827
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: c{-cc}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {ccc-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-foobar}/[1.000000000,0=/<empty>]
+rangekey: {foobar-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=8 key_bytes=160 val_count=12 val_bytes=49 range_key_count=10 range_key_bytes=216 range_val_count=18 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=36385
+
+run stats ok
+clear_time_range k=a+ end=b+ ts=4 targetTs=0
+----
+>> clear_time_range k=a+ end=b+ ts=4 targetTs=0
+stats: key_count=-1 key_bytes=-14 val_count=-1 range_key_bytes=+2 gc_bytes_age=-1148
+>> at end:
+rangekey: a{-+}/[1.000000000,0=/<empty>]
+rangekey: {b+-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: c{-cc}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {ccc-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-foobar}/[1.000000000,0=/<empty>]
+rangekey: {foobar-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=146 val_count=11 val_bytes=49 range_key_count=10 range_key_bytes=218 range_val_count=18 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=35237
+
+run stats ok
+clear_time_range k=foo end=i ts=6 targetTs=2
+----
+>> clear_time_range k=foo end=i ts=6 targetTs=2
+stats: key_bytes=-12 val_count=-1 range_key_count=-4 range_key_bytes=-98 range_val_count=-8 live_count=+1 live_bytes=+21 gc_bytes_age=-12721
+>> at end:
+rangekey: a{-+}/[1.000000000,0=/<empty>]
+rangekey: {b+-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: c{-cc}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {ccc-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=134 val_count=10 val_bytes=49 range_key_count=6 range_key_bytes=120 range_val_count=10 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=22516
+
+run stats ok
+clear_time_range k=k end=mmm ts=6 targetTs=0
+----
+>> clear_time_range k=k end=mmm ts=6 targetTs=0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_bytes=+2 live_count=-1 live_bytes=-21 gc_bytes_age=+194
+>> at end:
+rangekey: a{-+}/[1.000000000,0=/<empty>]
+rangekey: {b+-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: c{-cc}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {ccc-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-k}/[1.000000000,0=/<empty>]
+rangekey: {mmm-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=120 val_count=9 val_bytes=42 range_key_count=6 range_key_bytes=122 range_val_count=10 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=22710
+
+run stats ok
+clear_time_range k=c+ end=cc+ ts=6 targetTs=3
+----
+>> clear_time_range k=c+ end=cc+ ts=6 targetTs=3
+stats: range_key_count=+2 range_key_bytes=+59 range_val_count=+5 gc_bytes_age=+5727
+>> at end:
+rangekey: a{-+}/[1.000000000,0=/<empty>]
+rangekey: {b+-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: c{-+}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: c{+-c+}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: cc{+-c}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {ccc-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-k}/[1.000000000,0=/<empty>]
+rangekey: {mmm-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=120 val_count=9 val_bytes=42 range_key_count=8 range_key_bytes=181 range_val_count=15 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=28437
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=3
+----
+>> clear_time_range k=a end=z ts=6 targetTs=3
+stats: key_bytes=-24 val_count=-2 range_key_count=-4 range_key_bytes=-116 range_val_count=-10 live_count=+2 live_bytes=+42 gc_bytes_age=-17598
+>> at end:
+rangekey: a{-+}/[1.000000000,0=/<empty>]
+rangekey: {b+-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-k}/[1.000000000,0=/<empty>]
+rangekey: {mmm-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=4 range_key_bytes=65 range_val_count=5 range_val_bytes=13 live_count=5 live_bytes=105 gc_bytes_age=10839
+
+run stats ok
+clear_time_range k=ccc end=mmm ts=6 targetTs=0
+----
+>> clear_time_range k=ccc end=mmm ts=6 targetTs=0
+stats: key_count=-5 key_bytes=-82 val_count=-6 val_bytes=-35 range_key_count=-1 range_key_bytes=-11 range_val_count=-1 live_count=-4 live_bytes=-84 gc_bytes_age=-4294
+>> at end:
+rangekey: a{-+}/[1.000000000,0=/<empty>]
+rangekey: {b+-ccc}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {mmm-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 range_key_count=3 range_key_bytes=54 range_val_count=4 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=6545
+
+run stats ok
+clear_time_range k=a end=a+ ts=6 targetTs=0
+----
+>> clear_time_range k=a end=a+ ts=6 targetTs=0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 live_count=-1 live_bytes=-21 gc_bytes_age=-1386
+>> at end:
+rangekey: {b+-ccc}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {mmm-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+stats: range_key_count=2 range_key_bytes=40 range_val_count=3 range_val_bytes=13 gc_bytes_age=5159
+
+run stats ok
+clear_time_range k=b+ end=n ts=3 targetTs=0
+----
+>> clear_time_range k=b+ end=n ts=3 targetTs=0
+stats: range_key_count=-2 range_key_bytes=-40 range_val_count=-3 range_val_bytes=-13 gc_bytes_age=-5159
+>> at end:
+<no data>
+stats: 

--- a/pkg/storage/testdata/mvcc_histories/clear_time_range_limits
+++ b/pkg/storage/testdata/mvcc_histories/clear_time_range_limits
@@ -1,0 +1,713 @@
+# Tests MVCCClearTimeRange limits.
+#
+# NB: The behavior here is a bit wonky, in that the batch size is only updated
+# (and thus the limits are only checked) after we _flush_ any data, and we're
+# allowed to buffer keys up to clearRangeThreshold. Thus, we'll typically only
+# flush the buffer when we encounter a non-matching key or a new range key.
+# Luckily, we limit the size of the buffer to 64 items for RevertRange, which
+# keeps the size from blowing up completely. We keep the current behavior for
+# now.
+#
+# All tests set up the following dataset, where x is tombstone, o-o is range
+# tombstone, [] is intent. The dataset is recreated for every test.
+#
+#  T
+#  6                      f6
+#  5          o-------------------o           k5
+#  4  x   x       d4          x      x
+#  3      o-------o   e3  x   o------oi3              o---o
+#  2  a2          d2      f2  g2
+#  1  o---------------------------------------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n
+
+# Clear the entire span using clearRangeThreshold=1, clearRangeThreshold=2, and
+# clearRangeThreshold=1000.
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=2
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=2
+stats: key_count=-8 key_bytes=-184 val_count=-14 val_bytes=-63 range_key_count=-8 range_key_bytes=-167 range_val_count=-15 range_val_bytes=-13 live_count=-2 live_bytes=-42 gc_bytes_age=-37212
+>> at end:
+<no data>
+stats: 
+
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000
+stats: key_count=-8 key_bytes=-184 val_count=-14 val_bytes=-63 range_key_count=-8 range_key_bytes=-167 range_val_count=-15 range_val_bytes=-13 live_count=-2 live_bytes=-42 gc_bytes_age=-37212
+>> at end:
+<no data>
+stats: 
+
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1
+stats: key_count=-8 key_bytes=-184 val_count=-14 val_bytes=-63 range_key_count=-8 range_key_bytes=-167 range_val_count=-15 range_val_bytes=-13 live_count=-2 live_bytes=-42 gc_bytes_age=-37212
+>> at end:
+<no data>
+stats: 
+
+# Clear the entire span using clearRangeThreshold=1000 and maxBatchSize=3.
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+clear_time_range: resume="c"
+stats: key_count=-2 key_bytes=-40 val_count=-3 val_bytes=-7 range_key_count=-2 range_key_bytes=-35 range_val_count=-3 gc_bytes_age=-7951
+>> at end:
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=6 key_bytes=144 val_count=11 val_bytes=56 range_key_count=6 range_key_bytes=132 range_val_count=12 range_val_bytes=13 live_count=2 live_bytes=42 gc_bytes_age=29261
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+clear_time_range: resume="d"
+stats: range_key_count=-1 range_key_bytes=-31 range_val_count=-3 gc_bytes_age=-2999
+>> at end:
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=6 key_bytes=144 val_count=11 val_bytes=56 range_key_count=5 range_key_bytes=101 range_val_count=9 range_val_bytes=13 live_count=2 live_bytes=42 gc_bytes_age=26262
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+clear_time_range: resume="h"
+stats: key_count=-4 key_bytes=-104 val_count=-8 val_bytes=-42 range_key_count=-2 range_key_bytes=-53 range_val_count=-5 live_count=-1 live_bytes=-21 gc_bytes_age=-17133
+>> at end:
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=14 range_key_count=3 range_key_bytes=48 range_val_count=4 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=9129
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+clear_time_range: resume="k"
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 range_key_count=-2 range_key_bytes=-35 range_val_count=-3 gc_bytes_age=-6607
+>> at end:
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 range_key_count=1 range_key_bytes=13 range_val_count=1 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=2522
+
+run stats ok
+clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+----
+>> clear_time_range k=a end=z ts=7 targetTs=0 clearRangeThreshold=1000 maxBatchSize=3
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 range_val_bytes=-13 live_count=-1 live_bytes=-21 gc_bytes_age=-2522
+>> at end:
+<no data>
+stats: 
+
+# Clear timestamps 4-6 using clearRangeThreshold=1000 and maxBatchSize=3,
+# and then the remainder using maxBatchByteSize=1.
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=3 clearRangeThreshold=1000 maxBatchSize=3
+----
+>> clear_time_range k=a end=z ts=6 targetTs=3 clearRangeThreshold=1000 maxBatchSize=3
+clear_time_range: resume="e"
+stats: key_count=-1 key_bytes=-38 val_count=-3 val_bytes=-7 range_key_bytes=-18 range_val_count=-2 live_count=+2 live_bytes=+42 gc_bytes_age=-10043
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-e}/[1.000000000,0=/<empty>]
+rangekey: {e-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=146 val_count=11 val_bytes=56 range_key_count=8 range_key_bytes=149 range_val_count=13 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=27169
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=3 clearRangeThreshold=1000 maxBatchSize=3
+----
+>> clear_time_range k=a end=z ts=6 targetTs=3 clearRangeThreshold=1000 maxBatchSize=3
+clear_time_range: resume="h"
+stats: key_bytes=-24 val_count=-2 val_bytes=-7 range_key_count=-2 range_key_bytes=-53 range_val_count=-5 gc_bytes_age=-8076
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=122 val_count=9 val_bytes=49 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=19093
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=3 clearRangeThreshold=1000 maxBatchSize=3
+----
+>> clear_time_range k=a end=z ts=6 targetTs=3 clearRangeThreshold=1000 maxBatchSize=3
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3168
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=6 key_bytes=96 val_count=7 val_bytes=42 range_key_count=6 range_key_bytes=96 range_val_count=8 range_val_bytes=13 live_count=4 live_bytes=84 gc_bytes_age=15925
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+clear_time_range: resume="b"
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 live_count=-1 live_bytes=-21 gc_bytes_age=-1287
+>> at end:
+rangekey: {b-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=5 key_bytes=82 val_count=6 val_bytes=35 range_key_count=5 range_key_bytes=83 range_val_count=7 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=14638
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+clear_time_range: resume="d"
+stats: range_key_count=-1 range_key_bytes=-22 range_val_count=-2 gc_bytes_age=-2152
+>> at end:
+rangekey: {d-g}/[1.000000000,0=/<empty>]
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=5 key_bytes=82 val_count=6 val_bytes=35 range_key_count=4 range_key_bytes=61 range_val_count=5 range_val_bytes=13 live_count=3 live_bytes=63 gc_bytes_age=12486
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+clear_time_range: resume="g"
+stats: key_count=-3 key_bytes=-54 val_count=-4 val_bytes=-21 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 live_count=-2 live_bytes=-42 gc_bytes_age=-4488
+>> at end:
+rangekey: {g-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=14 range_key_count=3 range_key_bytes=48 range_val_count=4 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=7998
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+clear_time_range: resume="i"
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-22 range_val_count=-2 gc_bytes_age=-4189
+>> at end:
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "i"/3.000000000,0 -> /BYTES/i3
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 range_key_count=2 range_key_bytes=26 range_val_count=2 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=3809
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+clear_time_range: resume="m"
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 live_count=-1 live_bytes=-21 gc_bytes_age=-1287
+>> at end:
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 range_val_bytes=13 gc_bytes_age=2522
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchSize=1
+stats: range_key_count=-1 range_key_bytes=-13 range_val_count=-1 range_val_bytes=-13 gc_bytes_age=-2522
+>> at end:
+<no data>
+stats: 
+
+# Clear the entire span using clearRangeThreshold=1000 and maxBatchByteSize=1.
+run ok
+put_rangekey k=a end=k ts=1
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=d ts=2 v=d2
+put_rangekey k=b end=d ts=3
+del k=b ts=4
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+del k=f ts=3
+put k=g ts=2 v=g2
+put_rangekey k=g end=i ts=3
+del k=g ts=4
+put_rangekey k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=i ts=3 v=i3
+del k=i ts=4
+put k=k ts=5 v=k5
+put_rangekey k=m end=n ts=3 localTs=2
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+clear_time_range: resume="b"
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 gc_bytes_age=-4455
+>> at end:
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=7 key_bytes=158 val_count=12 val_bytes=56 range_key_count=7 range_key_bytes=154 range_val_count=14 range_val_bytes=13 live_count=2 live_bytes=42 gc_bytes_age=32757
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+clear_time_range: resume="c"
+stats: key_count=-1 key_bytes=-14 val_count=-1 range_key_count=-1 range_key_bytes=-22 range_val_count=-2 gc_bytes_age=-3496
+>> at end:
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=6 key_bytes=144 val_count=11 val_bytes=56 range_key_count=6 range_key_bytes=132 range_val_count=12 range_val_bytes=13 live_count=2 live_bytes=42 gc_bytes_age=29261
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+clear_time_range: resume="d"
+stats: range_key_count=-1 range_key_bytes=-31 range_val_count=-3 gc_bytes_age=-2999
+>> at end:
+rangekey: {d-g}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/3.000000000,0 -> /<empty>
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=6 key_bytes=144 val_count=11 val_bytes=56 range_key_count=5 range_key_bytes=101 range_val_count=9 range_val_bytes=13 live_count=2 live_bytes=42 gc_bytes_age=26262
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+clear_time_range: resume="g"
+stats: key_count=-3 key_bytes=-78 val_count=-6 val_bytes=-35 range_key_count=-1 range_key_bytes=-22 range_val_count=-2 live_count=-1 live_bytes=-21 gc_bytes_age=-10947
+>> at end:
+rangekey: {g-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=3 key_bytes=66 val_count=5 val_bytes=21 range_key_count=4 range_key_bytes=79 range_val_count=7 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=15315
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+clear_time_range: resume="h"
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 range_key_count=-1 range_key_bytes=-31 range_val_count=-3 gc_bytes_age=-6186
+>> at end:
+rangekey: {h-i}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=14 range_key_count=3 range_key_bytes=48 range_val_count=4 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=9129
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+clear_time_range: resume="i"
+stats: range_key_count=-1 range_key_bytes=-22 range_val_count=-2 gc_bytes_age=-2152
+>> at end:
+rangekey: {i-k}/[1.000000000,0=/<empty>]
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "i"/4.000000000,0 -> /<empty>
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=14 range_key_count=2 range_key_bytes=26 range_val_count=2 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=6977
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+clear_time_range: resume="k"
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 gc_bytes_age=-4455
+>> at end:
+rangekey: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+data: "k"/5.000000000,0 -> /BYTES/k5
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 range_key_count=1 range_key_bytes=13 range_val_count=1 range_val_bytes=13 live_count=1 live_bytes=21 gc_bytes_age=2522
+
+run stats ok
+clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+----
+>> clear_time_range k=a end=z ts=6 targetTs=0 clearRangeThreshold=1000 maxBatchByteSize=1
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 range_val_bytes=-13 live_count=-1 live_bytes=-21 gc_bytes_age=-2522
+>> at end:
+<no data>
+stats: 


### PR DESCRIPTION
**storage: tweak `MVCCClearTimeRange` parameters**

This patch tweaks `MVCCClearTimeRange` parameters, for testing and
consistency. There are no behavioral changes.

Release note: None
  
**batcheval: handle MVCC range tombstones in `RevertRange`**

This patch adds removal of MVCC range tombstones in `RevertRange` and
the underlying `MVCCClearTimeRange()`, with additional tests in
`TestMVCCHistories`. This is a correct but unoptimized implementation,
optimizations will be addressed separately.

MVCC range tombstones will only exist once the `MVCCRangeTombstones`
version gate is enabled, so there are no further mixed version concerns
here.

Resolves #83407.

Release note: None