### PR TITLE
storage: add `MVCCRangeKeyStack` for range keys

### DIFF
--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -363,8 +363,9 @@ func (s *fileSSTSink) copyRangeKeys(dataSST []byte) error {
 		} else if !ok {
 			break
 		}
-		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
-			if err := s.sst.PutRawMVCCRangeKey(rkv.RangeKey, rkv.Value); err != nil {
+		rangeKeys := iter.RangeKeys()
+		for _, v := range rangeKeys.Versions {
+			if err := s.sst.PutRawMVCCRangeKey(rangeKeys.AsRangeKey(v), v.Value); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -363,7 +363,7 @@ func (s *fileSSTSink) copyRangeKeys(dataSST []byte) error {
 		} else if !ok {
 			break
 		}
-		for _, rkv := range iter.RangeKeys() {
+		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
 			if err := s.sst.PutRawMVCCRangeKey(rkv.RangeKey, rkv.Value); err != nil {
 				return err
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -417,15 +417,16 @@ func EvalAddSSTable(
 			} else if !ok {
 				break
 			}
-			for _, rkv := range rangeIter.RangeKeys().AsRangeKeyValues() {
-				if err = readWriter.PutRawMVCCRangeKey(rkv.RangeKey, rkv.Value); err != nil {
+			rangeKeys := rangeIter.RangeKeys()
+			for _, v := range rangeKeys.Versions {
+				if err = readWriter.PutRawMVCCRangeKey(rangeKeys.AsRangeKey(v), v.Value); err != nil {
 					return result.Result{}, err
 				}
 				if sstToReqTS.IsSet() {
 					readWriter.LogLogicalOp(storage.MVCCDeleteRangeOpType, storage.MVCCLogicalOpDetails{
-						Key:       rkv.RangeKey.StartKey,
-						EndKey:    rkv.RangeKey.EndKey,
-						Timestamp: rkv.RangeKey.Timestamp,
+						Key:       rangeKeys.Bounds.Key,
+						EndKey:    rangeKeys.Bounds.EndKey,
+						Timestamp: v.Timestamp,
 					})
 				}
 			}
@@ -517,26 +518,28 @@ func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.M
 			break
 		}
 
-		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
-			if err := rkv.RangeKey.Validate(); err != nil {
+		rangeKeys := iter.RangeKeys()
+		for _, v := range rangeKeys.Versions {
+			rangeKey := rangeKeys.AsRangeKey(v)
+			if err := rangeKey.Validate(); err != nil {
 				return errors.NewAssertionErrorWithWrappedErrf(err, "SST contains invalid range key")
 			}
-			if sstTimestamp.IsSet() && rkv.RangeKey.Timestamp != sstTimestamp {
+			if sstTimestamp.IsSet() && v.Timestamp != sstTimestamp {
 				return errors.AssertionFailedf(
 					"SST has unexpected timestamp %s (expected %s) for range key %s",
-					rkv.RangeKey.Timestamp, sstTimestamp, rkv.RangeKey)
+					v.Timestamp, sstTimestamp, rangeKeys.Bounds)
 			}
-			value, err := storage.DecodeMVCCValue(rkv.Value)
+			value, err := storage.DecodeMVCCValue(v.Value)
 			if err != nil {
 				return errors.NewAssertionErrorWithWrappedErrf(err,
-					"SST contains invalid range key value for range key %s", rkv.RangeKey)
+					"SST contains invalid range key value for range key %s", rangeKey)
 			}
 			if !value.IsTombstone() {
-				return errors.AssertionFailedf("SST contains non-tombstone range key %s", rkv.RangeKey)
+				return errors.AssertionFailedf("SST contains non-tombstone range key %s", rangeKey)
 			}
 			if value.MVCCValueHeader != (enginepb.MVCCValueHeader{}) {
 				return errors.AssertionFailedf("SST contains non-empty MVCC value header for range key %s",
-					rkv.RangeKey)
+					rangeKey)
 			}
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -417,7 +417,7 @@ func EvalAddSSTable(
 			} else if !ok {
 				break
 			}
-			for _, rkv := range rangeIter.RangeKeys() {
+			for _, rkv := range rangeIter.RangeKeys().AsRangeKeyValues() {
 				if err = readWriter.PutRawMVCCRangeKey(rkv.RangeKey, rkv.Value); err != nil {
 					return result.Result{}, err
 				}
@@ -517,7 +517,7 @@ func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.M
 			break
 		}
 
-		for _, rkv := range iter.RangeKeys() {
+		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
 			if err := rkv.RangeKey.Validate(); err != nil {
 				return errors.NewAssertionErrorWithWrappedErrf(err, "SST contains invalid range key")
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -186,7 +186,7 @@ func TestEvalAddSSTable(t *testing.T) {
 			toReqTS: 1,
 			sst:     kvs{pointKV("a", 1, "a1"), rangeKV("c", "d", 2, "")},
 			expectErr: []string{
-				`unexpected timestamp 0.000000002,0 (expected 0.000000001,0) for range key {c-d}/0.000000002,0`,
+				`unexpected timestamp 0.000000002,0 (expected 0.000000001,0) for range key {c-d}`,
 				`key has suffix "\x00\x00\x00\x00\x00\x00\x00\x02\t", expected "\x00\x00\x00\x00\x00\x00\x00\x01\t"`,
 			},
 		},

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -218,9 +218,9 @@ func computeStatsDelta(
 				if ok, err := iter.Valid(); err != nil {
 					return err
 				} else if ok && iter.RangeBounds().Key.Compare(bound) < 0 {
-					for i, rkv := range iter.RangeKeys().AsRangeKeyValues() {
-						keyBytes := int64(storage.EncodedMVCCTimestampSuffixLength(rkv.RangeKey.Timestamp))
-						valBytes := int64(len(rkv.Value))
+					for i, v := range iter.RangeKeys().Versions {
+						keyBytes := int64(storage.EncodedMVCCTimestampSuffixLength(v.Timestamp))
+						valBytes := int64(len(v.Value))
 						if i == 0 {
 							delta.RangeKeyCount--
 							keyBytes += 2 * int64(storage.EncodedMVCCKeyPrefixLength(bound))
@@ -229,7 +229,7 @@ func computeStatsDelta(
 						delta.RangeValCount--
 						delta.RangeValBytes -= valBytes
 						delta.GCBytesAge -= (keyBytes + valBytes) *
-							(delta.LastUpdateNanos/1e9 - rkv.RangeKey.Timestamp.WallTime/1e9)
+							(delta.LastUpdateNanos/1e9 - v.Timestamp.WallTime/1e9)
 					}
 				}
 				return nil

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -218,7 +218,7 @@ func computeStatsDelta(
 				if ok, err := iter.Valid(); err != nil {
 					return err
 				} else if ok && iter.RangeBounds().Key.Compare(bound) < 0 {
-					for i, rkv := range iter.RangeKeys() {
+					for i, rkv := range iter.RangeKeys().AsRangeKeyValues() {
 						keyBytes := int64(storage.EncodedMVCCTimestampSuffixLength(rkv.RangeKey.Timestamp))
 						valBytes := int64(len(rkv.Value))
 						if i == 0 {

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -306,7 +306,7 @@ func checkPredicateDeleteRange(t *testing.T, engine storage.Reader, rKeyInfo sto
 			// PredicateDeleteRange should not have written any delete tombstones;
 			// therefore, any range key tombstones in the span should have been
 			// written before the request was issued.
-			for _, rKey := range iter.RangeKeys() {
+			for _, rKey := range iter.RangeKeys().AsRangeKeyValues() {
 				require.Equal(t, true, rKey.RangeKey.Timestamp.Less(rKeyInfo.Timestamp))
 			}
 			continue
@@ -337,7 +337,7 @@ func checkDeleteRangeTombstone(
 			break
 		}
 		require.True(t, ok)
-		for _, rkv := range iter.RangeKeys() {
+		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
 			if rkv.RangeKey.Timestamp.Equal(rangeKey.Timestamp) {
 				if len(seen.RangeKey.StartKey) == 0 {
 					seen = rkv.Clone()

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -306,8 +306,8 @@ func checkPredicateDeleteRange(t *testing.T, engine storage.Reader, rKeyInfo sto
 			// PredicateDeleteRange should not have written any delete tombstones;
 			// therefore, any range key tombstones in the span should have been
 			// written before the request was issued.
-			for _, rKey := range iter.RangeKeys().AsRangeKeyValues() {
-				require.Equal(t, true, rKey.RangeKey.Timestamp.Less(rKeyInfo.Timestamp))
+			for _, v := range iter.RangeKeys().Versions {
+				require.True(t, v.Timestamp.Less(rKeyInfo.Timestamp))
 			}
 			continue
 		}
@@ -337,13 +337,14 @@ func checkDeleteRangeTombstone(
 			break
 		}
 		require.True(t, ok)
-		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
-			if rkv.RangeKey.Timestamp.Equal(rangeKey.Timestamp) {
+		rangeKeys := iter.RangeKeys()
+		for _, v := range rangeKeys.Versions {
+			if v.Timestamp.Equal(rangeKey.Timestamp) {
 				if len(seen.RangeKey.StartKey) == 0 {
-					seen = rkv.Clone()
+					seen = rangeKeys.AsRangeKeyValue(v).Clone()
 				} else {
-					seen.RangeKey.EndKey = rkv.RangeKey.EndKey.Clone()
-					require.Equal(t, seen.Value, rkv.Value)
+					seen.RangeKey.EndKey = rangeKeys.Bounds.EndKey.Clone()
+					require.Equal(t, seen.Value, v.Value)
 				}
 				break
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1315,9 +1315,9 @@ func computeSplitRangeKeyStatsDelta(
 	// contribution of the range key fragmentation. The naïve calculation would be
 	// rhs.EncodedSize() - (keyLen(rhs.EndKey) - keyLen(lhs.EndKey))
 	// which simplifies to 2 * keyLen(rhs.StartKey) + tsLen(rhs.Timestamp).
-	for i, rkv := range iter.RangeKeys().AsRangeKeyValues() {
-		keyBytes := int64(storage.EncodedMVCCTimestampSuffixLength(rkv.RangeKey.Timestamp))
-		valBytes := int64(len(rkv.Value))
+	for i, v := range iter.RangeKeys().Versions {
+		keyBytes := int64(storage.EncodedMVCCTimestampSuffixLength(v.Timestamp))
+		valBytes := int64(len(v.Value))
 		if i == 0 {
 			delta.RangeKeyCount++
 			keyBytes += 2 * int64(storage.EncodedMVCCKeyPrefixLength(splitKey))
@@ -1325,7 +1325,7 @@ func computeSplitRangeKeyStatsDelta(
 		delta.RangeKeyBytes += keyBytes
 		delta.RangeValCount++
 		delta.RangeValBytes += valBytes
-		delta.GCBytesAge += (keyBytes + valBytes) * (nowNanos/1e9 - rkv.RangeKey.Timestamp.WallTime/1e9)
+		delta.GCBytesAge += (keyBytes + valBytes) * (nowNanos/1e9 - v.Timestamp.WallTime/1e9)
 	}
 
 	return delta, nil

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1315,7 +1315,7 @@ func computeSplitRangeKeyStatsDelta(
 	// contribution of the range key fragmentation. The naïve calculation would be
 	// rhs.EncodedSize() - (keyLen(rhs.EndKey) - keyLen(lhs.EndKey))
 	// which simplifies to 2 * keyLen(rhs.StartKey) + tsLen(rhs.Timestamp).
-	for i, rkv := range iter.RangeKeys() {
+	for i, rkv := range iter.RangeKeys().AsRangeKeyValues() {
 		keyBytes := int64(storage.EncodedMVCCTimestampSuffixLength(rkv.RangeKey.Timestamp))
 		valBytes := int64(len(rkv.Value))
 		if i == 0 {

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
@@ -93,12 +93,8 @@ func refreshRange(
 		key := iter.UnsafeKey().Clone()
 
 		if _, hasRange := iter.HasPointAndRange(); hasRange {
-			rangeKVs := iter.RangeKeys().AsRangeKeyValues()
-			if len(rangeKVs) == 0 { // defensive
-				return errors.Errorf("expected range key at %s not found", key)
-			}
 			return roachpb.NewRefreshFailedError(roachpb.RefreshFailedError_REASON_COMMITTED_VALUE,
-				key.Key, rangeKVs[0].RangeKey.Timestamp)
+				key.Key, iter.RangeKeys().Versions[0].Timestamp)
 		}
 
 		if !key.IsValue() {

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range.go
@@ -93,7 +93,7 @@ func refreshRange(
 		key := iter.UnsafeKey().Clone()
 
 		if _, hasRange := iter.HasPointAndRange(); hasRange {
-			rangeKVs := iter.RangeKeys()
+			rangeKVs := iter.RangeKeys().AsRangeKeyValues()
 			if len(rangeKVs) == 0 { // defensive
 				return errors.Errorf("expected range key at %s not found", key)
 			}

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -855,7 +855,7 @@ func processReplicatedRangeTombstones(
 		if !ok {
 			break
 		}
-		rangeKeys := iter.RangeKeys()
+		rangeKeys := iter.RangeKeys().AsRangeKeyValues()
 
 		if idx := sort.Search(len(rangeKeys), func(i int) bool {
 			return rangeKeys[i].RangeKey.Timestamp.LessEq(gcThreshold)

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -855,6 +855,7 @@ func processReplicatedRangeTombstones(
 		if !ok {
 			break
 		}
+		// TODO(erikgrinaker): Rewrite to use MVCCRangeKeyStack.
 		rangeKeys := iter.RangeKeys().AsRangeKeyValues()
 
 		if idx := sort.Search(len(rangeKeys), func(i int) bool {

--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -195,7 +195,7 @@ func (it *gcIterator) currentRangeTS() hlc.Timestamp {
 	}
 
 	it.cachedRangeTombstoneTS = hlc.Timestamp{}
-	rangeKeys := it.it.RangeKeys()
+	rangeKeys := it.it.RangeKeys().AsRangeKeyValues()
 	if idx := sort.Search(len(rangeKeys), func(i int) bool {
 		return rangeKeys[i].RangeKey.Timestamp.LessEq(it.threshold)
 	}); idx < len(rangeKeys) {

--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -11,7 +11,6 @@
 package gc
 
 import (
-	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -193,15 +192,13 @@ func (it *gcIterator) currentRangeTS() hlc.Timestamp {
 	if rangeTombstoneStartKey.Equal(it.cachedRangeTombstoneKey) {
 		return it.cachedRangeTombstoneTS
 	}
-
-	it.cachedRangeTombstoneTS = hlc.Timestamp{}
-	rangeKeys := it.it.RangeKeys().AsRangeKeyValues()
-	if idx := sort.Search(len(rangeKeys), func(i int) bool {
-		return rangeKeys[i].RangeKey.Timestamp.LessEq(it.threshold)
-	}); idx < len(rangeKeys) {
-		it.cachedRangeTombstoneTS = rangeKeys[idx].RangeKey.Timestamp
-	}
 	it.cachedRangeTombstoneKey = append(it.cachedRangeTombstoneKey[:0], rangeTombstoneStartKey...)
+
+	if v, ok := it.it.RangeKeys().FirstBelow(it.threshold); ok {
+		it.cachedRangeTombstoneTS = v.Timestamp
+	} else {
+		it.cachedRangeTombstoneTS = hlc.Timestamp{}
+	}
 	return it.cachedRangeTombstoneTS
 }
 

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -466,7 +466,7 @@ func getExpectationsGenerator(
 						// so we will add them to history of current key for analysis.
 						// Bare range tombstones are ignored.
 						if r {
-							for _, r := range it.RangeKeys() {
+							for _, r := range it.RangeKeys().AsRangeKeyValues() {
 								history = append(history, historyItem{
 									MVCCKeyValue: storage.MVCCKeyValue{
 										Key: storage.MVCCKey{
@@ -603,7 +603,7 @@ func getKeyHistory(t *testing.T, r storage.Reader, key roachpb.Key) string {
 			break
 		}
 		if r && len(result) == 0 {
-			for _, rk := range it.RangeKeys() {
+			for _, rk := range it.RangeKeys().AsRangeKeyValues() {
 				result = append(result, fmt.Sprintf("R:%s", rk.RangeKey.String()))
 			}
 		}
@@ -624,8 +624,8 @@ func rangeFragmentsFromIt(t *testing.T, it storage.MVCCIterator) [][]storage.MVC
 		}
 		_, r := it.HasPointAndRange()
 		if r {
-			fragments := make([]storage.MVCCRangeKeyValue, len(it.RangeKeys()))
-			for i, r := range it.RangeKeys() {
+			fragments := make([]storage.MVCCRangeKeyValue, len(it.RangeKeys().AsRangeKeyValues()))
+			for i, r := range it.RangeKeys().AsRangeKeyValues() {
 				fragments[i] = r.Clone()
 			}
 			result = append(result, fragments)

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -466,12 +466,12 @@ func getExpectationsGenerator(
 						// so we will add them to history of current key for analysis.
 						// Bare range tombstones are ignored.
 						if r {
-							for _, r := range it.RangeKeys().AsRangeKeyValues() {
+							for _, r := range it.RangeKeys().AsRangeKeys() {
 								history = append(history, historyItem{
 									MVCCKeyValue: storage.MVCCKeyValue{
 										Key: storage.MVCCKey{
-											Key:       r.RangeKey.StartKey,
-											Timestamp: r.RangeKey.Timestamp,
+											Key:       r.StartKey,
+											Timestamp: r.Timestamp,
 										},
 										Value: nil,
 									},
@@ -622,13 +622,8 @@ func rangeFragmentsFromIt(t *testing.T, it storage.MVCCIterator) [][]storage.MVC
 		if !ok {
 			break
 		}
-		_, r := it.HasPointAndRange()
-		if r {
-			fragments := make([]storage.MVCCRangeKeyValue, len(it.RangeKeys().AsRangeKeyValues()))
-			for i, r := range it.RangeKeys().AsRangeKeyValues() {
-				fragments[i] = r.Clone()
-			}
-			result = append(result, fragments)
+		if _, hasRange := it.HasPointAndRange(); hasRange {
+			result = append(result, it.RangeKeys().Clone().AsRangeKeyValues())
 		}
 		it.NextKey()
 	}

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -1084,7 +1084,7 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 		_, r := rangeIt.HasPointAndRange()
 		if r {
 			span := rangeIt.RangeBounds()
-			newKeys := rangeIt.RangeKeys()
+			newKeys := rangeIt.RangeKeys().AsRangeKeyValues()
 			if lastEnd.Equal(span.Key) {
 				// Try merging keys by timestamp.
 				var newPartial []storage.MVCCRangeKey

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -1084,20 +1084,20 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 		_, r := rangeIt.HasPointAndRange()
 		if r {
 			span := rangeIt.RangeBounds()
-			newKeys := rangeIt.RangeKeys().AsRangeKeyValues()
+			newKeys := rangeIt.RangeKeys().AsRangeKeys()
 			if lastEnd.Equal(span.Key) {
 				// Try merging keys by timestamp.
 				var newPartial []storage.MVCCRangeKey
 				i, j := 0, 0
 				for i < len(newKeys) && j < len(partialRangeKeys) {
-					switch newKeys[i].RangeKey.Timestamp.Compare(partialRangeKeys[j].Timestamp) {
+					switch newKeys[i].Timestamp.Compare(partialRangeKeys[j].Timestamp) {
 					case 1:
-						newPartial = append(newPartial, newKeys[i].RangeKey.Clone())
+						newPartial = append(newPartial, newKeys[i].Clone())
 						i++
 					case 0:
 						newPartial = append(newPartial, storage.MVCCRangeKey{
 							StartKey:  partialRangeKeys[j].StartKey,
-							EndKey:    newKeys[i].RangeKey.EndKey.Clone(),
+							EndKey:    newKeys[i].EndKey.Clone(),
 							Timestamp: partialRangeKeys[j].Timestamp,
 						})
 						i++
@@ -1108,7 +1108,7 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 					}
 				}
 				for ; i < len(newKeys); i++ {
-					newPartial = append(newPartial, newKeys[i].RangeKey.Clone())
+					newPartial = append(newPartial, newKeys[i].Clone())
 				}
 				for ; j < len(partialRangeKeys); j++ {
 					newPartial = append(newPartial, partialRangeKeys[j].Clone())
@@ -1118,7 +1118,7 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 				result = append(result, makeRangeCells(partialRangeKeys)...)
 				partialRangeKeys = make([]storage.MVCCRangeKey, len(newKeys))
 				for i, rk := range newKeys {
-					partialRangeKeys[i] = rk.RangeKey.Clone()
+					partialRangeKeys[i] = rk.Clone()
 				}
 			}
 			lastEnd = span.EndKey.Clone()

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -154,15 +154,15 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 				rangeKeysStart = append(rangeKeysStart[:0], rangeBounds.Key...)
 
 				// Emit events for these MVCC range tombstones, in chronological order.
-				rangeKeys := i.RangeKeys().AsRangeKeyValues()
-				for i := len(rangeKeys) - 1; i >= 0; i-- {
+				versions := i.RangeKeys().Versions
+				for i := len(versions) - 1; i >= 0; i-- {
 					var span roachpb.Span
 					a, span.Key = a.Copy(rangeBounds.Key, 0)
 					a, span.EndKey = a.Copy(rangeBounds.EndKey, 0)
 					err := outputFn(&roachpb.RangeFeedEvent{
 						DeleteRange: &roachpb.RangeFeedDeleteRange{
 							Span:      span,
-							Timestamp: rangeKeys[i].RangeKey.Timestamp,
+							Timestamp: versions[i].Timestamp,
 						},
 					})
 					if err != nil {
@@ -271,8 +271,7 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 					// to rangeKeysStart above, because NextIgnoringTime() could reveal
 					// additional MVCC range tombstones below StartTime that cover this
 					// point. We need to find a more performant way to handle this.
-					if !hasRange || !storage.HasRangeKeyBetween(
-						i.RangeKeys().AsRangeKeyValues(), reorderBuf[l].Val.Value.Timestamp, ts) {
+					if !hasRange || !i.RangeKeys().HasBetween(ts, reorderBuf[l].Val.Value.Timestamp) {
 						// TODO(sumeer): find out if it is deliberate that we are not populating
 						// PrevValue.Timestamp.
 						reorderBuf[l].Val.PrevValue.RawBytes = val

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -154,7 +154,7 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 				rangeKeysStart = append(rangeKeysStart[:0], rangeBounds.Key...)
 
 				// Emit events for these MVCC range tombstones, in chronological order.
-				rangeKeys := i.RangeKeys()
+				rangeKeys := i.RangeKeys().AsRangeKeyValues()
 				for i := len(rangeKeys) - 1; i >= 0; i-- {
 					var span roachpb.Span
 					a, span.Key = a.Copy(rangeBounds.Key, 0)
@@ -272,7 +272,7 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 					// additional MVCC range tombstones below StartTime that cover this
 					// point. We need to find a more performant way to handle this.
 					if !hasRange || !storage.HasRangeKeyBetween(
-						i.RangeKeys(), reorderBuf[l].Val.Value.Timestamp, ts) {
+						i.RangeKeys().AsRangeKeyValues(), reorderBuf[l].Val.Value.Timestamp, ts) {
 						// TODO(sumeer): find out if it is deliberate that we are not populating
 						// PrevValue.Timestamp.
 						reorderBuf[l].Val.PrevValue.RawBytes = val

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -204,9 +204,9 @@ func (s *testIterator) RangeBounds() roachpb.Span {
 	return roachpb.Span{}
 }
 
-// RangeTombstones implements SimpleMVCCIterator.
-func (s *testIterator) RangeKeys() []storage.MVCCRangeKeyValue {
-	return []storage.MVCCRangeKeyValue{}
+// RangeKeys implements SimpleMVCCIterator.
+func (s *testIterator) RangeKeys() storage.MVCCRangeKeyStack {
+	return storage.MVCCRangeKeyStack{}
 }
 
 func TestInitResolvedTSScan(t *testing.T) {

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -341,7 +341,7 @@ func (ri *ReplicaMVCCDataIterator) UnsafeValue() []byte {
 
 // RangeKeys exposes RangeKeys from underlying iterator. See
 // storage.SimpleMVCCIterator for details.
-func (ri *ReplicaMVCCDataIterator) RangeKeys() []storage.MVCCRangeKeyValue {
+func (ri *ReplicaMVCCDataIterator) RangeKeys() storage.MVCCRangeKeyStack {
 	return ri.it.RangeKeys()
 }
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -176,7 +176,7 @@ func verifyRDReplicatedOnlyMVCCIter(
 				}
 			}
 			if r {
-				rks := iter.RangeKeys()
+				rks := iter.RangeKeys().AsRangeKeyValues()
 				if !rks[0].RangeKey.StartKey.Equal(rangeStart) {
 					if !reverse {
 						for _, rk := range rks {

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -176,19 +176,20 @@ func verifyRDReplicatedOnlyMVCCIter(
 				}
 			}
 			if r {
-				rks := iter.RangeKeys().AsRangeKeyValues()
-				if !rks[0].RangeKey.StartKey.Equal(rangeStart) {
+				rangeKeys := iter.RangeKeys().Clone()
+				if !rangeKeys.Bounds.Key.Equal(rangeStart) {
+					rangeStart = rangeKeys.Bounds.Key.Clone()
 					if !reverse {
-						for _, rk := range rks {
-							actualRanges = append(actualRanges, rk.RangeKey.Clone())
+						for _, v := range rangeKeys.Versions {
+							actualRanges = append(actualRanges, rangeKeys.AsRangeKey(v))
 						}
 					} else {
-						for i := len(rks) - 1; i >= 0; i-- {
-							actualRanges = append([]storage.MVCCRangeKey{rks[i].RangeKey.Clone()},
+						for i := rangeKeys.Len() - 1; i >= 0; i-- {
+							actualRanges = append([]storage.MVCCRangeKey{
+								rangeKeys.AsRangeKey(rangeKeys.Versions[i])},
 								actualRanges...)
 						}
 					}
-					rangeStart = rks[0].RangeKey.StartKey.Clone()
 				}
 			}
 			next()

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -186,7 +186,7 @@ func (i *MVCCIterator) RangeBounds() roachpb.Span {
 }
 
 // RangeKeys implements SimpleMVCCIterator.
-func (i *MVCCIterator) RangeKeys() []storage.MVCCRangeKeyValue {
+func (i *MVCCIterator) RangeKeys() storage.MVCCRangeKeyStack {
 	return i.i.RangeKeys()
 }
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -168,13 +168,13 @@ type SimpleMVCCIterator interface {
 	// empty span if there are none. The returned keys are only valid until the
 	// next iterator call.
 	RangeBounds() roachpb.Span
-	// RangeKeys returns all range keys (with different timestamps) at the current
-	// key position, or an empty list if there are none. When at a point key, it
-	// will return all range keys overlapping that point key. The keys are only
-	// valid until the next iterator operation. For details on range keys, see
-	// comment on SimpleMVCCIterator, or this tech note:
+	// RangeKeys returns a stack of all range keys (with different timestamps) at
+	// the current key position. When at a point key, it will return all range
+	// keys overlapping that point key. The stack is only valid until the next
+	// iterator operation. For details on range keys, see comment on
+	// SimpleMVCCIterator, or this tech note:
 	// https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md
-	RangeKeys() []MVCCRangeKeyValue
+	RangeKeys() MVCCRangeKeyStack
 }
 
 // IteratorStats is returned from {MVCCIterator,EngineIterator}.Stats.

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -2312,8 +2312,8 @@ func scanRangeKeys(t *testing.T, r Reader) []MVCCRangeKeyValue {
 		if !ok {
 			break
 		}
-		for _, rangeKey := range iter.RangeKeys() {
-			rangeKeys = append(rangeKeys, rangeKey.Clone())
+		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
+			rangeKeys = append(rangeKeys, rkv.Clone())
 		}
 	}
 	return rangeKeys
@@ -2373,8 +2373,8 @@ func scanIter(t *testing.T, iter SimpleMVCCIterator) []interface{} {
 		hasPoint, hasRange := iter.HasPointAndRange()
 		if hasRange {
 			if bounds := iter.RangeBounds(); !bounds.Key.Equal(prevRangeStart) {
-				for _, rk := range iter.RangeKeys() {
-					keys = append(keys, rk.Clone())
+				for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
+					keys = append(keys, rkv.Clone())
 				}
 				prevRangeStart = bounds.Key.Clone()
 			}

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -934,9 +934,9 @@ func (i *intentInterleavingIter) RangeBounds() roachpb.Span {
 }
 
 // RangeKeys implements SimpleMVCCIterator.
-func (i *intentInterleavingIter) RangeKeys() []MVCCRangeKeyValue {
+func (i *intentInterleavingIter) RangeKeys() MVCCRangeKeyStack {
 	if _, hasRange := i.HasPointAndRange(); !hasRange {
-		return []MVCCRangeKeyValue{}
+		return MVCCRangeKeyStack{}
 	}
 	return i.iter.RangeKeys()
 }

--- a/pkg/storage/multi_iterator.go
+++ b/pkg/storage/multi_iterator.go
@@ -106,7 +106,7 @@ func (f *multiIterator) RangeBounds() roachpb.Span {
 }
 
 // RangeKeys implements SimpleMVCCIterator.
-func (f *multiIterator) RangeKeys() []MVCCRangeKeyValue {
+func (f *multiIterator) RangeKeys() MVCCRangeKeyStack {
 	panic("not implemented")
 }
 

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -176,16 +176,17 @@ func TestMVCCHistories(t *testing.T) {
 					break
 				}
 				hasData = true
-				buf.Printf("rangekey: %s/[", iter.RangeBounds())
-				for i, rangeKV := range iter.RangeKeys() {
-					val, err := DecodeMVCCValue(rangeKV.Value)
+				rangeKeys := iter.RangeKeys()
+				buf.Printf("rangekey: %s/[", rangeKeys.Bounds)
+				for i, version := range rangeKeys.Versions {
+					val, err := DecodeMVCCValue(version.Value)
 					if err != nil {
 						t.Fatal(err)
 					}
 					if i > 0 {
 						buf.Printf(" ")
 					}
-					buf.Printf("%s=%s", rangeKV.RangeKey.Timestamp, val)
+					buf.Printf("%s=%s", version.Timestamp, val)
 				}
 				buf.Printf("]\n")
 				iter.Next()
@@ -1211,15 +1212,15 @@ func cmdExport(e *evalCtx) error {
 			if rangeBounds := iter.RangeBounds(); !rangeBounds.Key.Equal(rangeStart) {
 				rangeStart = append(rangeStart[:0], rangeBounds.Key...)
 				e.results.buf.Printf("export: %s/[", rangeBounds)
-				for i, rangeKV := range iter.RangeKeys() {
-					val, err := DecodeMVCCValue(rangeKV.Value)
+				for i, version := range iter.RangeKeys().Versions {
+					val, err := DecodeMVCCValue(version.Value)
 					if err != nil {
 						return err
 					}
 					if i > 0 {
 						e.results.buf.Printf(" ")
 					}
-					e.results.buf.Printf("%s=%s", rangeKV.RangeKey.Timestamp, val)
+					e.results.buf.Printf("%s=%s", version.Timestamp, val)
 				}
 				e.results.buf.Printf("]\n")
 			}
@@ -1627,16 +1628,17 @@ func printIter(e *evalCtx) {
 		}
 	}
 	if hasRange {
-		e.results.buf.Printf(" %s/[", e.iter.RangeBounds())
-		for i, rangeKV := range e.iter.RangeKeys() {
-			value, err := DecodeMVCCValue(rangeKV.Value)
+		rangeKeys := e.iter.RangeKeys()
+		e.results.buf.Printf(" %s/[", rangeKeys.Bounds)
+		for i, version := range rangeKeys.Versions {
+			value, err := DecodeMVCCValue(version.Value)
 			if err != nil {
 				e.Fatalf("%v", err)
 			}
 			if i > 0 {
 				e.results.buf.Printf(" ")
 			}
-			e.results.buf.Printf("%s=%s", rangeKV.RangeKey.Timestamp, value)
+			e.results.buf.Printf("%s=%s", version.Timestamp, value)
 		}
 		e.results.buf.Printf("]")
 	}

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -11,8 +11,6 @@
 package storage
 
 import (
-	"sort"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -429,7 +427,9 @@ func (i *MVCCIncrementalIterator) advance() {
 		}
 
 		// NB: Don't update i.hasRange directly -- we only change it when
-		// i.rangeKeysStart changes, to avoid unnecessary checks.
+		// i.rangeKeysStart changes, which allows us to retain i.hasRange=false if
+		// we've already determined that the current range keys are outside of the
+		// time bounds.
 		hasPoint, hasRange := i.iter.HasPointAndRange()
 		i.hasPoint = hasPoint
 
@@ -443,21 +443,10 @@ func (i *MVCCIncrementalIterator) advance() {
 		if hasRange {
 			if rangeStart := i.iter.RangeBounds().Key; !rangeStart.Equal(i.rangeKeysStart) {
 				i.rangeKeysStart = append(i.rangeKeysStart[:0], rangeStart...)
-				// Find the first range key at or below EndTime. If that's also above
-				// StartTime then we have visible range keys. We use a linear search
-				// rather than a binary search because we expect EndTime to be near the
-				// current time, so the first range key will typically be sufficient.
-				hasRange = false
-				for _, rkv := range i.iter.RangeKeys().AsRangeKeyValues() {
-					if ts := rkv.RangeKey.Timestamp; ts.LessEq(i.endTime) {
-						hasRange = i.startTime.Less(ts)
-						break
-					}
-				}
-				i.hasRange = hasRange
-				newRangeKey = hasRange
+				i.hasRange = i.iter.RangeKeys().HasBetween(i.startTime.Next(), i.endTime)
+				newRangeKey = i.hasRange
 			}
-			// else keep i.hasRange from last i.rangeKeysStart change.
+			// Else: keep i.hasRange from last i.rangeKeysStart change.
 		} else {
 			i.hasRange = false
 		}
@@ -551,38 +540,14 @@ func (i *MVCCIncrementalIterator) RangeKeys() MVCCRangeKeyStack {
 	if !i.hasRange {
 		return MVCCRangeKeyStack{}
 	}
-
 	// TODO(erikgrinaker): It may be worthwhile to clone and memoize this result
 	// for the same range key. However, callers may avoid calling RangeKeys()
 	// unnecessarily, and we may optimize parent iterators, so let's measure.
 	rangeKeys := i.iter.RangeKeys()
-
 	if i.ignoringTime {
 		return rangeKeys
 	}
-
-	// Find the first range key at or below endTime, and truncate rangeKeys. We do
-	// a linear search rather than a binary search, because we expect endTime to
-	// be near the current time, so the first element will typically match.
-	first := len(rangeKeys.Versions) - 1
-	for idx, v := range rangeKeys.Versions {
-		if v.Timestamp.LessEq(i.endTime) {
-			first = idx
-			break
-		}
-	}
-	rangeKeys.Versions = rangeKeys.Versions[first:]
-
-	// Find the first range key at or below startTime, and truncate rangeKeys.
-	if i.startTime.IsSet() {
-		if idx := sort.Search(len(rangeKeys.Versions), func(idx int) bool {
-			return rangeKeys.Versions[idx].Timestamp.LessEq(i.startTime)
-		}); idx >= 0 {
-			rangeKeys.Versions = rangeKeys.Versions[:idx]
-		}
-	}
-
-	return rangeKeys
+	return rangeKeys.Trim(i.startTime.Next(), i.endTime)
 }
 
 // UnsafeValue implements SimpleMVCCIterator.

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -11,13 +11,13 @@
 package storage
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 )
@@ -365,6 +365,11 @@ type MVCCRangeKey struct {
 	Timestamp hlc.Timestamp
 }
 
+// Bounds returns the range key bounds as a Span.
+func (k MVCCRangeKey) Bounds() roachpb.Span {
+	return roachpb.Span{Key: k.StartKey, EndKey: k.EndKey}
+}
+
 // Clone returns a copy of the range key.
 func (k MVCCRangeKey) Clone() MVCCRangeKey {
 	// k is already a copy, but byte slices must be cloned.
@@ -437,6 +442,232 @@ func (k MVCCRangeKey) Validate() (err error) {
 	default:
 		return nil
 	}
+}
+
+// MVCCRangeKeyStack represents a stack of range key fragments as returned
+// by SimpleMVCCIterator.RangeKeys(). All fragments have the same key bounds,
+// and are ordered from newest to oldest.
+type MVCCRangeKeyStack struct {
+	Bounds   roachpb.Span
+	Versions MVCCRangeKeyVersions
+}
+
+// MVCCRangeKeyVersions represents a stack of range key fragment versions.
+type MVCCRangeKeyVersions []MVCCRangeKeyVersion
+
+// MVCCRangeKeyVersion represents a single range key fragment version.
+type MVCCRangeKeyVersion struct {
+	Timestamp hlc.Timestamp
+	Value     []byte
+}
+
+// AsRangeKey returns an MVCCRangeKey for the given version. Byte slices
+// are shared with the stack.
+func (s MVCCRangeKeyStack) AsRangeKey(v MVCCRangeKeyVersion) MVCCRangeKey {
+	return MVCCRangeKey{
+		StartKey:  s.Bounds.Key,
+		EndKey:    s.Bounds.EndKey,
+		Timestamp: v.Timestamp,
+	}
+}
+
+// AsRangeKeys converts the stack into a slice of MVCCRangeKey. Byte slices
+// are shared with the stack.
+func (s MVCCRangeKeyStack) AsRangeKeys() []MVCCRangeKey {
+	rangeKeys := make([]MVCCRangeKey, 0, len(s.Versions))
+	for _, v := range s.Versions {
+		rangeKeys = append(rangeKeys, s.AsRangeKey(v))
+	}
+	return rangeKeys
+}
+
+// AsRangeKeyValue returns an MVCCRangeKeyValue for the given version. Byte
+// slices are shared with the stack.
+func (s MVCCRangeKeyStack) AsRangeKeyValue(v MVCCRangeKeyVersion) MVCCRangeKeyValue {
+	return MVCCRangeKeyValue{
+		RangeKey: s.AsRangeKey(v),
+		Value:    v.Value,
+	}
+}
+
+// AsRangeKeyValues converts the stack into a slice of MVCCRangeKeyValue. Byte
+// slices are shared with the stack.
+func (s MVCCRangeKeyStack) AsRangeKeyValues() []MVCCRangeKeyValue {
+	kvs := make([]MVCCRangeKeyValue, 0, len(s.Versions))
+	for _, v := range s.Versions {
+		kvs = append(kvs, s.AsRangeKeyValue(v))
+	}
+	return kvs
+}
+
+// CanMergeRight returns true if the current stack will merge with the given
+// right-hand stack. The key bounds must touch exactly, i.e. lhs.EndKey must
+// equal rhs.Key.
+func (s MVCCRangeKeyStack) CanMergeRight(r MVCCRangeKeyStack) bool {
+	if s.IsEmpty() || s.Len() != r.Len() || !s.Bounds.EndKey.Equal(r.Bounds.Key) {
+		return false
+	}
+	for i := range s.Versions {
+		if !s.Versions[i].Equal(r.Versions[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Clone clones the stack.
+func (s MVCCRangeKeyStack) Clone() MVCCRangeKeyStack {
+	// TODO(erikgrinaker): We can optimize this by using a single memory
+	// allocation for all byte slices in the entire stack.
+	s.Bounds = s.Bounds.Clone()
+	s.Versions = s.Versions.Clone()
+	return s
+}
+
+// Covers returns true if any range key in the stack covers the given point key.
+func (s MVCCRangeKeyStack) Covers(k MVCCKey) bool {
+	return s.Versions.Covers(k.Timestamp) && s.Bounds.ContainsKey(k.Key)
+}
+
+// CoversTimestamp returns true if any range key in the stack covers the given timestamp.
+func (s MVCCRangeKeyStack) CoversTimestamp(ts hlc.Timestamp) bool {
+	return s.Versions.Covers(ts)
+}
+
+// FirstAbove does a binary search for the first range key version at or above
+// the given timestamp. Returns false if no matching range key was found.
+func (s MVCCRangeKeyStack) FirstAbove(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
+	return s.Versions.FirstAbove(ts)
+}
+
+// FirstBelow does a binary search for the first range key version at or below
+// the given timestamp. Returns false if no matching range key was found.
+func (s MVCCRangeKeyStack) FirstBelow(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
+	return s.Versions.FirstBelow(ts)
+}
+
+// HasBetween checks whether an MVCC range key exists between the two given
+// timestamps (both inclusive, in order).
+func (s MVCCRangeKeyStack) HasBetween(lower, upper hlc.Timestamp) bool {
+	return s.Versions.HasBetween(lower, upper)
+}
+
+// IsEmpty returns true if the stack is empty (no versions).
+func (s MVCCRangeKeyStack) IsEmpty() bool {
+	return s.Versions.IsEmpty()
+}
+
+// Len returns the number of versions in the stack.
+func (s MVCCRangeKeyStack) Len() int {
+	return len(s.Versions)
+}
+
+// Timestamps returns the timestamps of all versions.
+func (s MVCCRangeKeyStack) Timestamps() []hlc.Timestamp {
+	return s.Versions.Timestamps()
+}
+
+// Trim trims the versions to the time span [from, to] (both inclusive).
+func (s MVCCRangeKeyStack) Trim(from, to hlc.Timestamp) MVCCRangeKeyStack {
+	s.Versions = s.Versions.Trim(from, to)
+	return s
+}
+
+// Clone clones the versions.
+func (v MVCCRangeKeyVersions) Clone() MVCCRangeKeyVersions {
+	c := make(MVCCRangeKeyVersions, len(v))
+	for i, version := range v {
+		c[i] = version.Clone()
+	}
+	return c
+}
+
+// Covers returns true if any version in the stack is above the given timestamp.
+func (v MVCCRangeKeyVersions) Covers(ts hlc.Timestamp) bool {
+	return !v.IsEmpty() && ts.LessEq(v[0].Timestamp)
+}
+
+// FirstAbove does a binary search for the first range key version at or above
+// the given timestamp. Returns false if no matching range key was found.
+func (v MVCCRangeKeyVersions) FirstAbove(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
+	// This is kind of odd due to sort.Search() semantics: we do a binary search
+	// for the first range key that's below the timestamp, then return the
+	// previous range key if any.
+	if i := sort.Search(len(v), func(i int) bool {
+		return v[i].Timestamp.Less(ts)
+	}); i > 0 {
+		return v[i-1], true
+	}
+	return MVCCRangeKeyVersion{}, false
+}
+
+// FirstBelow does a binary search for the first range key version at or below
+// the given timestamp. Returns false if no matching range key was found.
+func (v MVCCRangeKeyVersions) FirstBelow(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
+	if i := sort.Search(len(v), func(i int) bool {
+		return v[i].Timestamp.LessEq(ts)
+	}); i < len(v) {
+		return v[i], true
+	}
+	return MVCCRangeKeyVersion{}, false
+}
+
+// HasBetween checks whether an MVCC range key exists between the two given
+// timestamps (both inclusive, in order).
+func (v MVCCRangeKeyVersions) HasBetween(lower, upper hlc.Timestamp) bool {
+	if version, ok := v.FirstAbove(lower); ok {
+		// Consider equal timestamps to be "between". This shouldn't really happen,
+		// since MVCC enforces point and range keys can't have the same timestamp.
+		return version.Timestamp.LessEq(upper)
+	}
+	return false
+}
+
+// IsEmpty returns true if the stack is empty (no versions).
+func (v MVCCRangeKeyVersions) IsEmpty() bool {
+	return len(v) == 0
+}
+
+// Timestamps returns the timestamps of all versions.
+func (v MVCCRangeKeyVersions) Timestamps() []hlc.Timestamp {
+	timestamps := make([]hlc.Timestamp, 0, len(v))
+	for _, version := range v {
+		timestamps = append(timestamps, version.Timestamp)
+	}
+	return timestamps
+}
+
+// Trim trims the versions to the time span [from, to] (both inclusive).
+func (v MVCCRangeKeyVersions) Trim(from, to hlc.Timestamp) MVCCRangeKeyVersions {
+	// We assume that to will often be near the current time, and use a linear
+	// rather than a binary search, which will often match on the first range key.
+	start := len(v)
+	for i, version := range v {
+		if version.Timestamp.LessEq(to) {
+			start = i
+			break
+		}
+	}
+	v = v[start:]
+
+	// We then use a binary search to find the lower bound.
+	end := sort.Search(len(v), func(i int) bool {
+		return v[i].Timestamp.Less(from)
+	})
+	return v[:end]
+}
+
+// Clone clones the version.
+func (v MVCCRangeKeyVersion) Clone() MVCCRangeKeyVersion {
+	if v.Value != nil {
+		v.Value = append([]byte(nil), v.Value...)
+	}
+	return v
+}
+
+// Equal returns true if the two versions are equal.
+func (v MVCCRangeKeyVersion) Equal(o MVCCRangeKeyVersion) bool {
+	return v.Timestamp.Equal(o.Timestamp) && bytes.Equal(v.Value, o.Value)
 }
 
 // FirstRangeKeyAbove does a binary search for the first range key at or above

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -501,8 +501,8 @@ func (s MVCCRangeKeyStack) AsRangeKeyValues() []MVCCRangeKeyValue {
 }
 
 // CanMergeRight returns true if the current stack will merge with the given
-// right-hand stack. The key bounds must touch exactly, i.e. lhs.EndKey must
-// equal rhs.Key.
+// right-hand stack. The key bounds must touch exactly, i.e. the left-hand
+// EndKey must equal the right-hand Key.
 func (s MVCCRangeKeyStack) CanMergeRight(r MVCCRangeKeyStack) bool {
 	if s.IsEmpty() || s.Len() != r.Len() || !s.Bounds.EndKey.Equal(r.Bounds.Key) {
 		return false
@@ -668,41 +668,4 @@ func (v MVCCRangeKeyVersion) Clone() MVCCRangeKeyVersion {
 // Equal returns true if the two versions are equal.
 func (v MVCCRangeKeyVersion) Equal(o MVCCRangeKeyVersion) bool {
 	return v.Timestamp.Equal(o.Timestamp) && bytes.Equal(v.Value, o.Value)
-}
-
-// FirstRangeKeyAbove does a binary search for the first range key at or above
-// the given timestamp. It assumes the range keys are ordered in descending
-// timestamp order, as returned by SimpleMVCCIterator.RangeKeys(). Returns false
-// if no matching range key was found.
-//
-// TODO(erikgrinaker): Consider using a new type for []MVCCRangeKeyValue as
-// returned by SimpleMVCCIterator.RangeKeys(), and add this as a method.
-func FirstRangeKeyAbove(rangeKeys []MVCCRangeKeyValue, ts hlc.Timestamp) (MVCCRangeKeyValue, bool) {
-	// This is kind of odd due to sort.Search() semantics: we do a binary search
-	// for the first range tombstone that's below the timestamp, then return the
-	// previous range tombstone if any.
-	if i := sort.Search(len(rangeKeys), func(i int) bool {
-		return rangeKeys[i].RangeKey.Timestamp.Less(ts)
-	}); i > 0 {
-		return rangeKeys[i-1], true
-	}
-	return MVCCRangeKeyValue{}, false
-}
-
-// HasRangeKeyBetween checks whether an MVCC range key exists between the two
-// given timestamps (in order). It assumes the range keys are ordered in
-// descending timestamp order, as returned by SimpleMVCCIterator.RangeKeys().
-func HasRangeKeyBetween(rangeKeys []MVCCRangeKeyValue, upper, lower hlc.Timestamp) bool {
-	if len(rangeKeys) == 0 {
-		return false
-	}
-	if util.RaceEnabled && upper.Less(lower) {
-		panic(errors.AssertionFailedf("HasRangeKeyBetween given upper %s <= lower %s", upper, lower))
-	}
-	if rkv, ok := FirstRangeKeyAbove(rangeKeys, lower); ok {
-		// Consider equal timestamps to be "between". This shouldn't really happen,
-		// since MVCC enforces point and range keys can't have the same timestamp.
-		return rkv.RangeKey.Timestamp.LessEq(upper)
-	}
-	return false
 }

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5763,7 +5763,7 @@ func TestMVCCGarbageCollectRanges(t *testing.T) {
 						if !ok {
 							break
 						}
-						for _, rkv := range it.RangeKeys() {
+						for _, rkv := range it.RangeKeys().AsRangeKeyValues() {
 							require.Less(t, expectIndex, len(d.after), "not enough expectations; at unexpected range:", rkv.RangeKey.String())
 							require.EqualValues(t, d.after[expectIndex], rkv.RangeKey, "range key is not equal")
 							expectIndex++

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5763,9 +5763,9 @@ func TestMVCCGarbageCollectRanges(t *testing.T) {
 						if !ok {
 							break
 						}
-						for _, rkv := range it.RangeKeys().AsRangeKeyValues() {
-							require.Less(t, expectIndex, len(d.after), "not enough expectations; at unexpected range:", rkv.RangeKey.String())
-							require.EqualValues(t, d.after[expectIndex], rkv.RangeKey, "range key is not equal")
+						for _, rk := range it.RangeKeys().AsRangeKeys() {
+							require.Less(t, expectIndex, len(d.after), "not enough expectations; at unexpected range: %s", rk)
+							require.EqualValues(t, d.after[expectIndex], rk, "range key is not equal")
 							expectIndex++
 						}
 					}

--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -65,9 +65,9 @@ var pointSynthesizingIterPool = sync.Pool{
 type pointSynthesizingIter struct {
 	iter MVCCIterator
 
-	// rangeKeys contains any range keys that overlap the current key position,
-	// for which points will be synthesized.
-	rangeKeys []MVCCRangeKeyValue
+	// rangeKeys contains any range key versions that overlap the current key
+	// position, for which points will be synthesized.
+	rangeKeys MVCCRangeKeyVersions
 
 	// rangeKeysPos is the current key (along the rangeKeys span) that points will
 	// be synthesized for. It is only set if rangeKeys is non-empty, and may
@@ -172,14 +172,11 @@ func (i *pointSynthesizingIter) updateRangeKeys() {
 	if !i.iterValid {
 		i.clearRangeKeys()
 	} else if _, hasRange := i.iter.HasPointAndRange(); hasRange {
+		// TODO(erikgrinaker): Optimize this.
 		i.rangeKeysPos = append(i.rangeKeysPos[:0], i.iter.UnsafeKey().Key...)
 		if rangeStart := i.iter.RangeBounds().Key; !rangeStart.Equal(i.rangeKeysStart) {
 			i.rangeKeysStart = append(i.rangeKeysStart[:0], rangeStart...)
-			i.rangeKeys = i.rangeKeys[:0]
-			for _, rk := range i.iter.RangeKeys().AsRangeKeyValues() {
-				// TODO(erikgrinaker): We should optimize the clone cost.
-				i.rangeKeys = append(i.rangeKeys, rk.Clone())
-			}
+			i.rangeKeys = i.iter.RangeKeys().Versions.Clone()
 		}
 		if !i.reverse {
 			i.rangeKeysIdx = 0
@@ -206,10 +203,10 @@ func (i *pointSynthesizingIter) updateAtPoint() {
 	} else if !i.reverse {
 		i.atPoint = i.rangeKeysIdx >= len(i.rangeKeys) ||
 			!point.Timestamp.IsSet() ||
-			i.rangeKeys[i.rangeKeysIdx].RangeKey.Timestamp.LessEq(point.Timestamp)
+			i.rangeKeys[i.rangeKeysIdx].Timestamp.LessEq(point.Timestamp)
 	} else {
 		i.atPoint = i.rangeKeysIdx < 0 || (point.Timestamp.IsSet() &&
-			point.Timestamp.LessEq(i.rangeKeys[i.rangeKeysIdx].RangeKey.Timestamp))
+			point.Timestamp.LessEq(i.rangeKeys[i.rangeKeysIdx].Timestamp))
 	}
 }
 
@@ -341,7 +338,7 @@ func (i *pointSynthesizingIter) SeekGE(seekKey MVCCKey) {
 	// If we're seeking to a specific version, skip newer range keys.
 	if len(i.rangeKeys) > 0 && seekKey.Timestamp.IsSet() && seekKey.Key.Equal(i.rangeKeysPos) {
 		i.rangeKeysIdx = sort.Search(len(i.rangeKeys), func(idx int) bool {
-			return i.rangeKeys[idx].RangeKey.Timestamp.LessEq(seekKey.Timestamp)
+			return i.rangeKeys[idx].Timestamp.LessEq(seekKey.Timestamp)
 		})
 	}
 
@@ -492,7 +489,7 @@ func (i *pointSynthesizingIter) SeekLT(seekKey MVCCKey) {
 	// If we're seeking to a specific version, skip over older range keys.
 	if seekKey.Timestamp.IsSet() && seekKey.Key.Equal(i.rangeKeysPos) {
 		i.rangeKeysIdx = sort.Search(len(i.rangeKeys), func(idx int) bool {
-			return i.rangeKeys[idx].RangeKey.Timestamp.LessEq(seekKey.Timestamp)
+			return i.rangeKeys[idx].Timestamp.LessEq(seekKey.Timestamp)
 		}) - 1
 	}
 
@@ -569,7 +566,7 @@ func (i *pointSynthesizingIter) UnsafeKey() MVCCKey {
 	}
 	return MVCCKey{
 		Key:       i.rangeKeysPos,
-		Timestamp: i.rangeKeys[i.rangeKeysIdx].RangeKey.Timestamp,
+		Timestamp: i.rangeKeys[i.rangeKeysIdx].Timestamp,
 	}
 }
 
@@ -752,10 +749,10 @@ func (i *pointSynthesizingIter) assertInvariants() error {
 		maxIdx = i.rangeKeysIdx + 1
 	}
 	if minIdx >= 0 && minIdx < len(i.rangeKeys) {
-		minKey = MVCCKey{Key: i.rangeKeysPos, Timestamp: i.rangeKeys[minIdx].RangeKey.Timestamp}
+		minKey = MVCCKey{Key: i.rangeKeysPos, Timestamp: i.rangeKeys[minIdx].Timestamp}
 	}
 	if maxIdx >= 0 && maxIdx < len(i.rangeKeys) {
-		maxKey = MVCCKey{Key: i.rangeKeysPos, Timestamp: i.rangeKeys[maxIdx].RangeKey.Timestamp}
+		maxKey = MVCCKey{Key: i.rangeKeysPos, Timestamp: i.rangeKeys[maxIdx].Timestamp}
 	}
 
 	iterKey := i.iter.Key()

--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -176,7 +176,7 @@ func (i *pointSynthesizingIter) updateRangeKeys() {
 		if rangeStart := i.iter.RangeBounds().Key; !rangeStart.Equal(i.rangeKeysStart) {
 			i.rangeKeysStart = append(i.rangeKeysStart[:0], rangeStart...)
 			i.rangeKeys = i.rangeKeys[:0]
-			for _, rk := range i.iter.RangeKeys() {
+			for _, rk := range i.iter.RangeKeys().AsRangeKeyValues() {
 				// TODO(erikgrinaker): We should optimize the clone cost.
 				i.rangeKeys = append(i.rangeKeys, rk.Clone())
 			}
@@ -624,8 +624,8 @@ func (i *pointSynthesizingIter) RangeBounds() roachpb.Span {
 }
 
 // RangeKeys implements MVCCIterator.
-func (i *pointSynthesizingIter) RangeKeys() []MVCCRangeKeyValue {
-	return []MVCCRangeKeyValue{}
+func (i *pointSynthesizingIter) RangeKeys() MVCCRangeKeyStack {
+	return MVCCRangeKeyStack{}
 }
 
 // ComputeStats implements MVCCIterator.

--- a/pkg/storage/read_as_of_iterator.go
+++ b/pkg/storage/read_as_of_iterator.go
@@ -130,7 +130,9 @@ func (f *ReadAsOfIterator) advance() {
 			return
 		}
 
-		if !f.asOf.IsEmpty() && f.asOf.Less(f.iter.UnsafeKey().Timestamp) {
+		key := f.iter.UnsafeKey()
+
+		if f.asOf.Less(key.Timestamp) {
 			// Skip keys above the asOf timestamp, regardless of type of key (e.g. point or range)
 			f.iter.Next()
 		} else if hasPoint, hasRange := f.iter.HasPointAndRange(); !hasPoint && hasRange {
@@ -155,31 +157,25 @@ func (f *ReadAsOfIterator) advance() {
 		} else if !hasRange {
 			// On a valid key without a range key
 			return
-		} else if f.asOfRangeKeyShadows() {
+			// TODO (msbutler): ensure this caches range key values (#84379) before
+			// the 22.2 branch cut, else we face a steep perf cliff for RESTORE with
+			// range keys.
+		} else if f.iter.RangeKeys().HasBetween(key.Timestamp, f.asOf) {
 			// The latest range key, as of system time, shadows the latest point key.
 			// This key is therefore deleted as of system time.
 			f.iter.NextKey()
 		} else {
-			// On a valid key that potentially shadows range key(s)
+			// On a valid key that potentially shadows range key(s).
 			return
 		}
 	}
 }
 
-// asOfRangeKeyShadows returns true if there exists a range key at or below the asOf timestamp
-// that shadows the latest point key
-//
-// TODO (msbutler): ensure this function caches range key values (#84379) before
-// the 22.2 branch cut, else we face a steep perf cliff for RESTORE with range keys.
-func (f *ReadAsOfIterator) asOfRangeKeyShadows() (shadows bool) {
-	rangeKeys := f.iter.RangeKeys().AsRangeKeyValues()
-	if f.asOf.IsEmpty() {
-		return f.iter.UnsafeKey().Timestamp.LessEq(rangeKeys[0].RangeKey.Timestamp)
-	}
-	return HasRangeKeyBetween(rangeKeys, f.asOf, f.iter.UnsafeKey().Timestamp)
-}
-
-// NewReadAsOfIterator constructs a ReadAsOfIterator.
+// NewReadAsOfIterator constructs a ReadAsOfIterator. If asOf is not set, the
+// iterator reads the most recent data.
 func NewReadAsOfIterator(iter SimpleMVCCIterator, asOf hlc.Timestamp) *ReadAsOfIterator {
+	if asOf.IsEmpty() {
+		asOf = hlc.MaxTimestamp
+	}
 	return &ReadAsOfIterator{iter: iter, asOf: asOf}
 }

--- a/pkg/storage/read_as_of_iterator.go
+++ b/pkg/storage/read_as_of_iterator.go
@@ -110,8 +110,8 @@ func (f *ReadAsOfIterator) RangeBounds() roachpb.Span {
 }
 
 // RangeKeys is always empty since this iterator never surfaces rangeKeys.
-func (f *ReadAsOfIterator) RangeKeys() []MVCCRangeKeyValue {
-	return []MVCCRangeKeyValue{}
+func (f *ReadAsOfIterator) RangeKeys() MVCCRangeKeyStack {
+	return MVCCRangeKeyStack{}
 }
 
 // updateValid updates i.valid and i.err based on the underlying iterator, and
@@ -172,7 +172,7 @@ func (f *ReadAsOfIterator) advance() {
 // TODO (msbutler): ensure this function caches range key values (#84379) before
 // the 22.2 branch cut, else we face a steep perf cliff for RESTORE with range keys.
 func (f *ReadAsOfIterator) asOfRangeKeyShadows() (shadows bool) {
-	rangeKeys := f.iter.RangeKeys()
+	rangeKeys := f.iter.RangeKeys().AsRangeKeyValues()
 	if f.asOf.IsEmpty() {
 		return f.iter.UnsafeKey().Timestamp.LessEq(rangeKeys[0].RangeKey.Timestamp)
 	}

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -409,7 +409,7 @@ func UpdateSSTTimestamps(
 		} else if !ok {
 			break
 		}
-		for _, rkv := range iter.RangeKeys() {
+		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
 			if rkv.RangeKey.Timestamp != from {
 				return nil, errors.Errorf("unexpected timestamp %s (expected %s) for range key %s",
 					rkv.RangeKey.Timestamp, from, rkv.RangeKey)

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -409,13 +409,14 @@ func UpdateSSTTimestamps(
 		} else if !ok {
 			break
 		}
-		for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
-			if rkv.RangeKey.Timestamp != from {
+		rangeKeys := iter.RangeKeys()
+		for _, v := range rangeKeys.Versions {
+			if v.Timestamp != from {
 				return nil, errors.Errorf("unexpected timestamp %s (expected %s) for range key %s",
-					rkv.RangeKey.Timestamp, from, rkv.RangeKey)
+					v.Timestamp, from, rangeKeys.Bounds)
 			}
-			rkv.RangeKey.Timestamp = to
-			if err = writer.PutRawMVCCRangeKey(rkv.RangeKey, rkv.Value); err != nil {
+			v.Timestamp = to
+			if err = writer.PutRawMVCCRangeKey(rangeKeys.AsRangeKey(v), v.Value); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/storage/sst_iterator.go
+++ b/pkg/storage/sst_iterator.go
@@ -232,6 +232,6 @@ func (r *sstIterator) RangeBounds() roachpb.Span {
 }
 
 // RangeKeys implements SimpleMVCCIterator.
-func (r *sstIterator) RangeKeys() []MVCCRangeKeyValue {
-	return []MVCCRangeKeyValue{}
+func (r *sstIterator) RangeKeys() MVCCRangeKeyStack {
+	return MVCCRangeKeyStack{}
 }

--- a/pkg/testutils/storageutils/scan.go
+++ b/pkg/testutils/storageutils/scan.go
@@ -45,7 +45,7 @@ func ScanIter(t *testing.T, iter storage.SimpleMVCCIterator) KVs {
 		hasPoint, hasRange := iter.HasPointAndRange()
 		if hasRange {
 			if bounds := iter.RangeBounds(); !bounds.Key.Equal(prevRangeStart) {
-				for _, rkv := range iter.RangeKeys() {
+				for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
 					if len(rkv.Value) == 0 {
 						rkv.Value = nil
 					}

--- a/pkg/testutils/storageutils/scan.go
+++ b/pkg/testutils/storageutils/scan.go
@@ -45,13 +45,14 @@ func ScanIter(t *testing.T, iter storage.SimpleMVCCIterator) KVs {
 		hasPoint, hasRange := iter.HasPointAndRange()
 		if hasRange {
 			if bounds := iter.RangeBounds(); !bounds.Key.Equal(prevRangeStart) {
-				for _, rkv := range iter.RangeKeys().AsRangeKeyValues() {
-					if len(rkv.Value) == 0 {
-						rkv.Value = nil
-					}
-					kvs = append(kvs, rkv.Clone())
-				}
 				prevRangeStart = bounds.Key.Clone()
+				rangeKeys := iter.RangeKeys().Clone()
+				for _, v := range rangeKeys.Versions {
+					if len(v.Value) == 0 {
+						v.Value = nil
+					}
+					kvs = append(kvs, rangeKeys.AsRangeKeyValue(v))
+				}
 			}
 		}
 		if hasPoint {


### PR DESCRIPTION
**storage: add `MVCCRangeKeyStack` for range keys**

This patch adds `MVCCRangeKeyStack` and `MVCCRangeKeyVersion`, a new
range key representation that will be returned by `SimpleMVCCIterator`.
It is more compact, for efficiency, and comes with a set of convenience
methods to simplify common range key processing.

Resolves #83895.

Release note: None
  
**storage: return `MVCCRangeKeyStack` from `SimpleMVCCIterator`**

This patch changes `SimpleMVCCIterator.RangeKeys()` to return
`MVCCRangeKeyStack` instead of `[]MVCCRangeKeyValue`. Callers have not
been migrated to properly make use of this -- instead, they call
`AsRangeKeyValues()` and construct and use the old data structure.

The MVCC range tombstones tech note is also updated to reflect this.

Release note: None
  
**storage: migrate MVCC code to `MVCCRangeKeyStack`**

Release note: None
  
***: migrate higher-level code to `MVCCRangeKeyStack`**

Release note: None
  
**kvserver/gc: partially migrate to `MVCCRangeKeyStack`**

Some parts require invasive changes to MVCC stats helpers. These will
shortly be consolidated with other MVCC stats logic elsewhere, so the
existing logic is retained for now by using `AsRangeKeyValues()`.

Release note: None
  
**storage: remove `FirstRangeKeyAbove()` and `HasRangeKeyBetween()`**

Release note: None