### PR TITLE
acceptance: bump GSS Dockerfile to Go 1.18

### DIFF
--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -1,5 +1,5 @@
 # Build the test binary in a multistage build.
-FROM golang:1.17 AS builder
+FROM golang:1.18 AS builder
 WORKDIR /workspace
 COPY . .
 # go 1.16 requires go.mod to be present unless GO111MODULE is set to off


### PR DESCRIPTION
This is now required by `github.com/jcmturner/gofork/encoding/asn1`.
Ideally, we should use `go.mod` for these tests, but this will unbreak
CI for now. Fixes build errors of the form:

```
Step 5/10 : RUN GO111MODULE=off go test -v -c -tags gss_compose -o gss.test
 ---> Running in e80775fb9678
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:698:14: undefined: any
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:703:17: cannot assign string to result in multiple assignment
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:705:17: cannot assign string to result in multiple assignment
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:707:17: cannot assign string to result in multiple assignment
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:710:17: cannot assign string to result in multiple assignment
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:712:17: cannot assign string to result in multiple assignment
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:1092:30: undefined: any
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:1115:40: undefined: any
/go/src/github.com/jcmturner/gofork/encoding/asn1/marshal.go:738:18: undefined: any
/go/src/github.com/jcmturner/gofork/encoding/asn1/marshal.go:744:28: undefined: any
/go/src/github.com/jcmturner/gofork/encoding/asn1/asn1.go:712:17: too many errors
```

Touches #84981.

Release note: None