### PR TITLE
acceptance: skip `TestComposeGSS`

### DIFF
--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -21,11 +21,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 const composeDir = "compose"
 
 func TestComposeGSS(t *testing.T) {
+	skip.WithIssue(t, 84978)
 	testCompose(t, filepath.Join("gss", "docker-compose.yml"), "psql")
 }
 


### PR DESCRIPTION
Touches #84981.

Release note: None