### PR TITLE
kvserver: send range GC requests when point requests are absent

### DIFF
--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -486,7 +486,7 @@ func (r *replicaGCer) SetGCThreshold(ctx context.Context, thresh gc.Threshold) e
 func (r *replicaGCer) GC(
 	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
 ) error {
-	if len(keys) == 0 {
+	if len(keys) == 0 && len(rangeKeys) == 0 {
 		return nil
 	}
 	req := r.template()


### PR DESCRIPTION
Previously range GC requests were not sent if point GC keys were not requested as well.
This patch fixes the problem by checking that any of parameters could be specified.

Release note: None