### PR TITLE
sql: Secondary Region Followup

### DIFF
--- a/docs/generated/sql/bnf/alter_database_drop_secondary_region.bnf
+++ b/docs/generated/sql/bnf/alter_database_drop_secondary_region.bnf
@@ -1,2 +1,3 @@
 alter_database_drop_secondary_region ::=
 	'ALTER' 'DATABASE' database_name 'DROP' 'SECONDARY' 'REGION'
+	| 'ALTER' 'DATABASE' database_name 'DROP' 'SECONDARY' 'REGION' 'IF' 'EXISTS'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2093,6 +2093,7 @@ alter_database_set_secondary_region_stmt ::=
 
 alter_database_drop_secondary_region ::=
 	'ALTER' 'DATABASE' database_name 'DROP' 'SECONDARY' 'REGION'
+	| 'ALTER' 'DATABASE' database_name 'DROP' 'SECONDARY' 'REGION' 'IF' 'EXISTS'
 
 alter_zone_range_stmt ::=
 	'ALTER' 'RANGE' a_expr set_zone_config

--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -404,3 +404,55 @@ PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" 
                                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                  voter_constraints = '{+region=ca-central-1: 2}',
                                                  lease_preferences = '[[+region=ca-central-1]]'
+
+
+# Verify super region interactions
+statement ok
+SET enable_super_regions = 'on'
+
+# Primary in super region
+statement ok
+CREATE DATABASE mr1 PRIMARY REGION "us-east-1" REGIONS "ap-southeast-2", "us-central-1","ca-central-1", "us-west-1"
+
+statement ok
+ALTER DATABASE mr1 ADD SUPER REGION "test1" VALUES "us-east-1", "us-west-1"
+
+statement error pq: the secondary region must be in the same super region as the current primary region
+ALTER DATABASE mr1 SET SECONDARY REGION "ap-southeast-2"
+
+statement ok
+ALTER DATABASE mr1 SET SECONDARY REGION "us-west-1"
+
+# Primary outside super region
+statement ok
+CREATE DATABASE mr2 PRIMARY REGION "ap-southeast-2" REGIONS "ap-southeast-2", "us-central-1","ca-central-1", "us-east-1", "us-west-1"
+
+statement ok
+ALTER DATABASE mr2 ADD SUPER REGION "test1" VALUES "us-east-1", "us-west-1"
+
+statement error pq: the secondary region can not be in a super region, unless the primary is also within a super region
+ALTER DATABASE mr2 SET SECONDARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE mr2 SET SECONDARY REGION "ca-central-1"
+
+# Multiple super region
+statement ok
+CREATE DATABASE mr3 PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-central-1","ca-central-1", "us-east-1", "us-west-1"
+
+statement ok
+ALTER DATABASE mr3 ADD SUPER REGION "test1" VALUES "us-east-1", "us-west-1"
+
+statement ok
+ALTER DATABASE mr3 ADD SUPER REGION "test2" VALUES "us-central-1", "ca-central-1"
+
+statement error pq: the secondary region must be in the same super region as the current primary region
+ALTER DATABASE mr3 SET SECONDARY REGION "us-east-1"
+
+statement ok
+ALTER DATABASE mr3 SET SECONDARY REGION "us-central-1"
+
+
+# Make sure a secondary region can not be removed from a super region
+statement error pq: the secondary region must be in the same super region as the current primary region
+ALTER DATABASE mr1 ALTER SUPER REGION "test1" VALUES "us-east-1"

--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -366,6 +366,12 @@ ALTER DATABASE db DROP SECONDARY REGION
 statement error pq: database .* doesn't have a secondary region defined
 ALTER DATABASE db DROP SECONDARY REGION
 
+query T noticetrace
+ALTER DATABASE db DROP SECONDARY REGION IF EXISTS
+----
+ NOTICE: No secondary region is not defined on the database; skipping
+
+
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_us_east
 ----

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1368,7 +1368,7 @@ func (n *alterDatabaseAddSuperRegion) startExec(params runParams) error {
 		)
 	}
 
-	// Check if the primary and secondary regions are members of this super region
+	// Check if the primary and secondary regions are members of this super region.
 	regionConfig, err := SynthesizeRegionConfig(
 		params.ctx, params.p.txn, n.desc.ID, params.p.Descriptors(),
 	)
@@ -1376,11 +1376,10 @@ func (n *alterDatabaseAddSuperRegion) startExec(params runParams) error {
 		return err
 	}
 
-	if regionConfig.SecondaryRegion() != catpb.RegionName(tree.SecondaryRegionNotSpecifiedName) {
+	if regionConfig.HasSecondaryRegion() {
 		primaryRegion := regionConfig.PrimaryRegionString()
-		primaryInSuper := tree.NameList(n.n.Regions).Contains(tree.Name(primaryRegion))
 		regions := nameToRegionName(n.n.Regions)
-		err := validateSecondaryRegion(regionConfig, regionConfig.SecondaryRegion(), regions, primaryInSuper)
+		err := validateSecondaryRegion(catpb.RegionName(primaryRegion), regionConfig.SecondaryRegion(), regions)
 		if err != nil {
 			return err
 		}
@@ -1617,10 +1616,9 @@ func (n *alterDatabaseAlterSuperRegion) startExec(params runParams) error {
 		return err
 	}
 
-	if regionConfig.SecondaryRegion() != catpb.RegionName(tree.SecondaryRegionNotSpecifiedName) {
-		primaryInSuper := tree.NameList(n.n.Regions).Contains(tree.Name(regionConfig.PrimaryRegion()))
+	if regionConfig.HasSecondaryRegion() {
 		regions := nameToRegionName(n.n.Regions)
-		err = validateSecondaryRegion(regionConfig, typeDesc.RegionConfig.SecondaryRegion, regions, primaryInSuper)
+		err = validateSecondaryRegion(regionConfig.PrimaryRegion(), typeDesc.RegionConfig.SecondaryRegion, regions)
 		if err != nil {
 			return err
 		}
@@ -1784,19 +1782,16 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 		)
 	}
 
-	regions, err := prevRegionConfig.GetSuperRegionRegionsForRegion(prevRegionConfig.PrimaryRegion())
+	regions, ok := prevRegionConfig.GetSuperRegionRegionsForRegion(prevRegionConfig.PrimaryRegion())
+	if !ok && prevRegionConfig.IsMemberOfExplicitSuperRegion(catpb.RegionName(n.n.SecondaryRegion)) {
+		return pgerror.New(pgcode.InvalidDatabaseDefinition,
+			"the secondary region can not be in a super region, unless the primary is also "+
+				"within a super region",
+		)
+	}
+	err = validateSecondaryRegion(prevRegionConfig.PrimaryRegion(), catpb.RegionName(n.n.SecondaryRegion), regions)
 	if err != nil {
-		if prevRegionConfig.IsMemberOfExplicitSuperRegion(catpb.RegionName(n.n.SecondaryRegion)) {
-			return pgerror.New(pgcode.InvalidDatabaseDefinition,
-				"the secondary region can not be in a super region, unless the primary is also "+
-					"within a super region",
-			)
-		}
-	} else {
-		err = validateSecondaryRegion(prevRegionConfig, catpb.RegionName(n.n.SecondaryRegion), regions, true)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
 	// Get the type descriptor for the multi-region enum.
@@ -1896,6 +1891,13 @@ func (n *alterDatabaseDropSecondaryRegion) startExec(params runParams) error {
 	}
 
 	if n.desc.RegionConfig.SecondaryRegion == "" {
+		if n.n.IfExists {
+			params.p.BufferClientNotice(
+				params.ctx,
+				pgnotice.Newf("No secondary region is not defined on the database; skipping"),
+			)
+			return nil
+		}
 		return pgerror.Newf(pgcode.UndefinedParameter,
 			"database %s doesn't have a secondary region defined", n.desc.GetName(),
 		)
@@ -1959,20 +1961,19 @@ func (n *alterDatabaseDropSecondaryRegion) startExec(params runParams) error {
 // are both inside or both outside a super region. The primary region and secondary
 // region should also be within the same super region.
 func validateSecondaryRegion(
-	prevRegionConfig multiregion.RegionConfig,
-	secondaryRegion catpb.RegionName,
-	regions catpb.RegionNames,
-	primaryInCurrSuper bool,
+	primaryRegion catpb.RegionName, secondaryRegion catpb.RegionName, regions catpb.RegionNames,
 ) error {
 
-	secondaryInCurrSuper := false
+	secondaryInCurrSuper, primaryInCurrSuper := false, false
 	for _, region := range regions {
 		if region == secondaryRegion {
 			secondaryInCurrSuper = true
 		}
+		if region == primaryRegion {
+			primaryInCurrSuper = true
+		}
 	}
-	// TODO(embrown): Might be helpful to return the name of the super region in the case
-	// of multiple super region
+
 	if primaryInCurrSuper == secondaryInCurrSuper {
 		return nil
 	}

--- a/pkg/sql/catalog/multiregion/region_config.go
+++ b/pkg/sql/catalog/multiregion/region_config.go
@@ -86,15 +86,15 @@ func (r *RegionConfig) IsMemberOfExplicitSuperRegion(region catpb.RegionName) bo
 // error.
 func (r *RegionConfig) GetSuperRegionRegionsForRegion(
 	region catpb.RegionName,
-) (catpb.RegionNames, error) {
+) (catpb.RegionNames, bool) {
 	for _, superRegion := range r.SuperRegions() {
 		for _, regionOfSuperRegion := range superRegion.Regions {
 			if region == regionOfSuperRegion {
-				return superRegion.Regions, nil
+				return superRegion.Regions, true
 			}
 		}
 	}
-	return nil, errors.AssertionFailedf("region %s is not part of a super region", region)
+	return nil, false
 }
 
 // IsValidRegionNameString implements the tree.DatabaseRegionConfig interface.

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1977,12 +1977,21 @@ alter_database_set_secondary_region_stmt:
    }
 
 alter_database_drop_secondary_region:
-  ALTER DATABASE database_name DROP SECONDARY REGION
-  {
-    $$.val = &tree.AlterDatabaseDropSecondaryRegion{
-      DatabaseName: tree.Name($3),
+    ALTER DATABASE database_name DROP SECONDARY REGION
+    {
+      $$.val = &tree.AlterDatabaseDropSecondaryRegion{
+        DatabaseName: tree.Name($3),
+        IfExists: false,
+      }
     }
-  }
+
+  | ALTER DATABASE database_name DROP SECONDARY REGION IF EXISTS
+    {
+      $$.val = &tree.AlterDatabaseDropSecondaryRegion{
+        DatabaseName: tree.Name($3),
+        IfExists: true,
+      }
+    }
 
 // %Help: ALTER RANGE - change the parameters of a range
 // %Category: DDL

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -179,9 +179,9 @@ func zoneConfigForMultiRegionDatabase(
 func addConstraintsForSuperRegion(
 	zc *zonepb.ZoneConfig, regionConfig multiregion.RegionConfig, affinityRegion catpb.RegionName,
 ) error {
-	regions, err := regionConfig.GetSuperRegionRegionsForRegion(affinityRegion)
-	if err != nil {
-		return err
+	regions, ok := regionConfig.GetSuperRegionRegionsForRegion(affinityRegion)
+	if !ok {
+		return errors.AssertionFailedf("region %s is not part of a super region", affinityRegion)
 	}
 	_, numReplicas := getNumVotersAndNumReplicas(regionConfig.WithRegions(regions))
 

--- a/pkg/sql/sem/tree/alter_database.go
+++ b/pkg/sql/sem/tree/alter_database.go
@@ -200,6 +200,7 @@ func (node *AlterDatabaseSecondaryRegion) Format(ctx *FmtCtx) {
 // ALTER DATABASE DROP SECONDARY REGION statement.
 type AlterDatabaseDropSecondaryRegion struct {
 	DatabaseName Name
+	IfExists     bool
 }
 
 var _ Statement = &AlterDatabaseDropSecondaryRegion{}
@@ -209,4 +210,7 @@ func (node *AlterDatabaseDropSecondaryRegion) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
 	ctx.FormatNode(&node.DatabaseName)
 	ctx.WriteString(" DROP SECONDARY REGION ")
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
 }


### PR DESCRIPTION
Resolves #68358

For 22.2 we've decided that secondary and super regions should have
minimal interaction. Secondary regions are tied to the primary region,
both wither have to be outside of inside of a super region. In the case
of multiple super regions, the primary and secondary region must be within
the same super region.

Release note (sql change): Secondary regions, like the primary regions can
either be set inside or outside of a super region. In order to move a
secondary region `alter_primary_region_super_region_override` must be enabled
and the primary region moved.

Release justification: Low-risk update to new functionality