### PR TITLE
release: submit version update PRs

### DIFF
--- a/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
@@ -12,7 +12,7 @@ release_bucket=release-automation-dev
 
 # override dev defaults with production values
 if [[ -z "${DRY_RUN}" ]] ; then
-  echo "Dry run"
+  echo "Setting production values"
   google_credentials="$METADATA_PUBLISHER_GOOGLE_CREDENTIALS_PROD"
   to=releases@cockroachlabs.com
   qualify_bucket=release-automation-prod

--- a/build/teamcity/internal/cockroach/release/process/update_versions.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run Update Versions Release Phase"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e VERSION -e SMTP_PASSWORD -e GH_TOKEN" \
+  run_bazel build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
+tc_end_block "Run Update Versions Release Phase"

--- a/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+to=dev-inf+release-dev@cockroachlabs.com
+# override dev defaults with production values
+if [[ -z "${DRY_RUN}" ]] ; then
+  echo "Setting production values"
+  to=release-engineering-team@cockroachlabs.com
+fi
+
+# run git fetch in order to get all remote branches
+git fetch -q origin
+
+# install gh
+wget -O /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz
+echo "9e833e02428cd49e0af73bc7dc4cafa329fe3ecba1bfe92f0859bf5b11916401  /tmp/gh.tar.gz" | sha256sum -c -
+tar --strip-components 1 -xf /tmp/gh.tar.gz
+export PATH=$PWD/bin:$PATH
+
+bazel build --config=crosslinux //pkg/cmd/release
+
+$(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
+  update-versions \
+  --version=$VERSION \
+  --template-dir=pkg/cmd/release/templates \
+  --smtp-user=cronjob@cockroachlabs.com \
+  --smtp-host=smtp.gmail.com \
+  --smtp-port=587 \
+  --to=$to

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -15,11 +15,13 @@ go_library(
         "sender.go",
         "sentry.go",
         "templates.go",
+        "update_versions.go",
         "versionmap.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/release",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/util/timeutil",
         "@com_github_andygrunwald_go_jira//:go-jira",
         "@com_github_google_go_github_v42//github",
         "@com_github_jordan_wright_email//:email",
@@ -41,13 +43,17 @@ go_test(
     srcs = [
         "blockers_test.go",
         "sender_test.go",
+        "versionmap_test.go",
     ],
     data = glob([
         "templates/**",
         "testdata/**",
     ]),
     embed = [":release_lib"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "@com_github_masterminds_semver_v3//:semver",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/cmd/release/main.go
+++ b/pkg/cmd/release/main.go
@@ -41,4 +41,5 @@ func init() {
 	rootCmd.AddCommand(cancelReleaseSeriesDateCmd)
 	rootCmd.AddCommand(setOrchestrationVersionCmd)
 	rootCmd.AddCommand(versionMapCmd)
+	rootCmd.AddCommand(updateVersionsCmd)
 }

--- a/pkg/cmd/release/orchestration.go
+++ b/pkg/cmd/release/orchestration.go
@@ -53,6 +53,8 @@ func init() {
 }
 
 func setOrchestrationVersion(_ *cobra.Command, _ []string) error {
+	// make sure we have the leading "v" in the version
+	orchestrationFlags.version = "v" + strings.TrimPrefix(orchestrationFlags.version, "v")
 	dirInfo, err := os.Stat(orchestrationFlags.templatesDir)
 	if err != nil {
 		return fmt.Errorf("cannot stat templates directory: %w", err)

--- a/pkg/cmd/release/sender.go
+++ b/pkg/cmd/release/sender.go
@@ -31,6 +31,7 @@ const (
 	templatePrefixPostBlockersPastPrep      = "post-blockers.past-prep"
 
 	templatePrefixTemplateBlockers = "template-blockers"
+	templatePrefixUpdateVersions   = "update-versions"
 )
 
 type messageDataPickSHA struct {
@@ -39,6 +40,11 @@ type messageDataPickSHA struct {
 	TrackingIssue    string
 	TrackingIssueURL htmltemplate.URL
 	DiffURL          htmltemplate.URL
+}
+
+type messageDataUpdateVersions struct {
+	Version string
+	PRs     []htmltemplate.URL
 }
 
 // ProjectBlocker lists the number of blockers per project.
@@ -201,6 +207,18 @@ func sendMailPickSHA(args messageDataPickSHA, opts sendOpts) error {
 	template := messageTemplates{
 		SubjectPrefix: templatePrefixPickSHA,
 		BodyPrefixes:  []string{templatePrefixPickSHA},
+	}
+	msg, err := newMessage(opts.templatesDir, template, args)
+	if err != nil {
+		return fmt.Errorf("newMessage: %w", err)
+	}
+	return sendmail(msg, opts)
+}
+
+func sendMailUpdateVersions(args messageDataUpdateVersions, opts sendOpts) error {
+	template := messageTemplates{
+		SubjectPrefix: templatePrefixUpdateVersions,
+		BodyPrefixes:  []string{templatePrefixUpdateVersions},
 	}
 	msg, err := newMessage(opts.templatesDir, template, args)
 	if err != nil {

--- a/pkg/cmd/release/templates/update-versions.gohtml
+++ b/pkg/cmd/release/templates/update-versions.gohtml
@@ -1,0 +1,15 @@
+<html>
+  <body>
+  <p>Pull requests for <strong>{{ .Version }}</strong> are waiting for your review and merge. Please approve the
+    following PRs and merge them.</p>
+    <ul>
+      {{ range .PRs }}
+      <li><a href="{{ . }}">{{ . }}</a></li>
+      {{ end }}
+    </ul>
+    <p>
+      Thanks,<br />
+      Release Engineering
+    </p>
+  </body>
+</html>

--- a/pkg/cmd/release/templates/update-versions.subject
+++ b/pkg/cmd/release/templates/update-versions.subject
@@ -1,0 +1,1 @@
+Release {{ .Version }}: Please approve PRs

--- a/pkg/cmd/release/templates/update-versions.txt
+++ b/pkg/cmd/release/templates/update-versions.txt
@@ -1,0 +1,8 @@
+Pull requests for {{ .Version }} are waiting for your review and merge. Please approve the following PRs and merge them.
+
+{{ range .PRs }}
+	* {{ . }}
+{{ end }}
+
+Thanks,
+Release Engineering

--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -1,0 +1,372 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/spf13/cobra"
+)
+
+const commitTemplate = `release: update CockroachDB version to %s
+
+Release note: None
+`
+
+var updateVersionsFlags = struct {
+	versionStr     string
+	templatesDir   string
+	smtpUser       string
+	smtpHost       string
+	smtpPort       int
+	emailAddresses []string
+}{}
+
+var updateVersionsCmd = &cobra.Command{
+	Use:   "update-versions",
+	Short: "Update CRDB version in various repos",
+	Long:  "Updates CRDB version in various repos",
+	RunE:  updateVersions,
+}
+
+func init() {
+	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.versionStr, versionFlag, "", "cockroachdb version")
+	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.templatesDir, templatesDir, "", "templates directory")
+	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.smtpUser, smtpUser, os.Getenv(envSMTPUser), "SMTP user name")
+	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.smtpHost, smtpHost, "", "SMTP host")
+	updateVersionsCmd.Flags().IntVar(&updateVersionsFlags.smtpPort, smtpPort, 0, "SMTP port")
+	updateVersionsCmd.Flags().StringArrayVar(&updateVersionsFlags.emailAddresses, emailAddresses, []string{}, "email addresses")
+	requiredFlags := []string{
+		versionFlag,
+		smtpUser,
+		smtpHost,
+		smtpPort,
+		emailAddresses,
+	}
+	for _, flag := range requiredFlags {
+		if err := updateVersionsCmd.MarkFlagRequired(flag); err != nil {
+			panic(err)
+		}
+	}
+	// Export some environment variables that affect git metadata.
+	// Using environment variables instead of `git config` makes the changes temporary and doesn't touch any
+	// configuration files.
+	_ = os.Setenv("GIT_AUTHOR_NAME", "Justin Beaver")
+	_ = os.Setenv("GIT_COMMITTER_NAME", "Justin Beaver")
+	_ = os.Setenv("GIT_AUTHOR_EMAIL", "teamcity@cockroachlabs.com")
+	_ = os.Setenv("GIT_COMMITTER_EMAIL", "teamcity@cockroachlabs.com")
+}
+
+type prRepo struct {
+	owner string
+	repo  string
+	// what branch should be used as the PR base
+	branch         string
+	commitMessage  string
+	githubUsername string
+	prBranch       string
+	// commands to run in order to modify the repo
+	commands []*exec.Cmd
+}
+
+func (r prRepo) name() string {
+	return r.owner + "/" + r.repo
+}
+
+func (r prRepo) pushURL() string {
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		return fmt.Sprintf("https://%s:%s@github.com/%s/%s", r.githubUsername, token, r.githubUsername, r.repo)
+	}
+	return fmt.Sprintf("git@github.com:%s/%s.git", r.githubUsername, r.repo)
+}
+
+func updateVersions(_ *cobra.Command, _ []string) error {
+	smtpPassword := os.Getenv("SMTP_PASSWORD")
+	if smtpPassword == "" {
+		return fmt.Errorf("SMTP_PASSWORD environment variable should be set")
+	}
+	// make sure we have the leading "v" in the version
+	updateVersionsFlags.versionStr = "v" + strings.TrimPrefix(updateVersionsFlags.versionStr, "v")
+	version, err := semver.NewVersion(updateVersionsFlags.versionStr)
+	if err != nil {
+		return fmt.Errorf("cannot parse version %s: %w", updateVersionsFlags.versionStr, err)
+	}
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return fmt.Errorf("cannot create a temporary directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	var prs []string
+	repos, err := productionRepos(version)
+	if err != nil {
+		return fmt.Errorf("cannot list repos: %w", err)
+	}
+	// The first for loop combines all local commands that we can run without pushing the changes.
+	// This way we can fail early and avoid unnecessary work closing the PRs we were able to create.
+	for _, repo := range repos {
+		dest := path.Join(dir, repo.name())
+		fmt.Printf("Cloning repo %s to %s", repo.name(), dest)
+		if err := cloneRepo(repo, dest); err != nil {
+			return fmt.Errorf("cannot clone %s: %w", repo.name(), err)
+		}
+		fmt.Printf("Branching repo %s to %s", repo.name(), dest)
+		if err := createBranch(repo, dest); err != nil {
+			return fmt.Errorf("cannot create branch %s: %w", repo.name(), err)
+		}
+		fmt.Printf("Munging repo %s in %s", repo.name(), dest)
+		if err := applyCommands(repo, dest); err != nil {
+			return fmt.Errorf("cannot mutate repo %s: %w", repo.name(), err)
+		}
+		fmt.Printf("commiting changes to repo %s in %s", repo.name(), dest)
+		if err := commitChanges(repo, dest); err != nil {
+			return fmt.Errorf("cannot commit changes in repo %s: %w", repo.name(), err)
+		}
+	}
+	// Now that our local changes are staged, we can try and publish them.
+	for _, repo := range repos {
+		dest := path.Join(dir, repo.name())
+		fmt.Printf("pushing changes to repo %s in %s", repo.name(), dest)
+		if err := pushChanges(repo, dest); err != nil {
+			return fmt.Errorf("cannot push changes for %s: %w", repo.name(), err)
+		}
+		fmt.Printf("creating pull request for %s in %s", repo.name(), dest)
+		pr, err := createPullRequest(repo, dest)
+		if err != nil {
+			return fmt.Errorf("cannot push changes for %s: %w", repo.name(), err)
+		}
+		fmt.Printf("Created PR: %s\n", pr)
+		prs = append(prs, pr)
+	}
+
+	if err := sendPrReport(version, prs, smtpPassword); err != nil {
+		return fmt.Errorf("cannot send email: %w", err)
+	}
+	return nil
+}
+
+func cloneRepo(repo prRepo, dest string) error {
+	cmd := exec.Command("gh", "repo", "clone", repo.name(), dest)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed cloning %s with message '%s': %w", repo.name(), string(out), err)
+	}
+	fmt.Printf("cloned %s to %s: %s\n", repo.name(), dest, string(out))
+	return nil
+}
+
+func createBranch(repo prRepo, dest string) error {
+	cmd := exec.Command("git", "checkout", "-b", repo.prBranch, "origin/"+repo.branch)
+	cmd.Dir = dest
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed running `%s` with output '%s': %w", cmd.String(), string(out), err)
+	}
+	fmt.Printf("created `%s` branch based on `%s` in `%s`: %s\n", repo.prBranch, repo.branch, dest, string(out))
+	return nil
+}
+
+func applyCommands(repo prRepo, dest string) error {
+	for _, cmd := range repo.commands {
+		cmd.Dir = dest
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed running '%s' with message '%s': %w", cmd.String(), string(out), err)
+		}
+		fmt.Printf("ran '%s': %s\n", cmd.String(), string(out))
+	}
+	cmd := exec.Command("git", "diff")
+	cmd.Dir = dest
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed diffing by '%s' with message '%s': %w", cmd.String(), string(out), err)
+	}
+	fmt.Printf("ran '%s':\n%s\n", cmd.String(), string(out))
+
+	return nil
+}
+
+func commitChanges(repo prRepo, dest string) error {
+	cmd := exec.Command("git", "commit", "-a", "-m", repo.commitMessage)
+	cmd.Dir = dest
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed commiting to %s with message '%s': %w", repo.name(), string(out), err)
+	}
+	fmt.Printf("changes committed to %s in %s: %s\n", repo.name(), dest, string(out))
+	return nil
+}
+
+func pushChanges(repo prRepo, dest string) error {
+	cmd := exec.Command("git", "push", repo.pushURL(), fmt.Sprintf("%s:%s", repo.prBranch, repo.prBranch))
+	cmd.Dir = dest
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed pushing %s with message '%s': %w", repo.prBranch, string(out), err)
+	}
+	fmt.Printf("changes pushed to %s in %s: %s\n", repo.name(), dest, string(out))
+	return nil
+}
+
+func createPullRequest(repo prRepo, dest string) (string, error) {
+	args := []string{"pr", "create", "--base", repo.branch, "--fill", "--head",
+		fmt.Sprintf("%s:%s", repo.githubUsername, repo.prBranch)}
+	cmd := exec.Command("gh", args...)
+	cmd.Dir = dest
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed creating pull request via `%s` with message '%s': %w", cmd.String(), string(out), err)
+	}
+	fmt.Printf("PR created in %s in %s: %s\n", repo.name(), dest, string(out))
+	return strings.TrimSpace(string(out)), nil
+}
+
+func sendPrReport(version *semver.Version, prs []string, smtpPassword string) error {
+	fmt.Println("========================================================")
+	fmt.Println("The following PRs are created:")
+	for i, pr := range prs {
+		fmt.Printf("%d. %s\n", i+1, pr)
+	}
+	fmt.Println("========================================================")
+	args := messageDataUpdateVersions{
+		Version: version.Original(),
+	}
+	for _, pr := range prs {
+		args.PRs = append(args.PRs, template.URL(pr))
+	}
+	opts := sendOpts{
+		templatesDir: updateVersionsFlags.templatesDir,
+		from:         fmt.Sprintf(fromEmailFormat, updateVersionsFlags.smtpUser),
+		host:         updateVersionsFlags.smtpHost,
+		port:         updateVersionsFlags.smtpPort,
+		user:         updateVersionsFlags.smtpUser,
+		password:     smtpPassword,
+		to:           updateVersionsFlags.emailAddresses,
+	}
+	fmt.Println("Sending email")
+	if err := sendMailUpdateVersions(args, opts); err != nil {
+		return fmt.Errorf("cannot send email: %w", err)
+	}
+	return nil
+}
+func randomString(n int) string {
+	rand.Seed(timeutil.Now().UnixNano())
+	var alphanumerics = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = alphanumerics[rand.Intn(len(alphanumerics))]
+	}
+	return string(s)
+}
+
+func productionRepos(version *semver.Version) ([]prRepo, error) {
+	defaultCommitMessage := fmt.Sprintf(commitTemplate, version)
+	// Add a random 4-letter string to the end of the branch name to make it unique.
+	// This simplifies recovery in case something goes wrong with pushes or PR creation.
+	defaultPrBranch := fmt.Sprintf("update-versions-%s-%s", version, randomString(4))
+	latest, err := isLatestStableBranch(version)
+	if err != nil {
+		return []prRepo{}, fmt.Errorf("cannot get branch info: %w", err)
+	}
+	nextBranch, err := nextReleaseBranch(version)
+	if err != nil {
+		return []prRepo{}, fmt.Errorf("cannot get next branch info: %w", err)
+	}
+	fmt.Printf("Using %s as next branch for %s\n", nextBranch, version.Original())
+	self, err := os.Executable()
+	if err != nil {
+		return []prRepo{}, fmt.Errorf("cannot get executable name")
+	}
+	crdbRepo := prRepo{
+		owner: "cockroachdb",
+		repo:  "cockroach",
+		// the PR will be created against the "next" branch: for latest stable versions it is "master",
+		// for other versions it is the next release version's branch.
+		branch:         nextBranch,
+		prBranch:       defaultPrBranch,
+		githubUsername: "cockroach-teamcity",
+		commitMessage:  defaultCommitMessage,
+		commands: []*exec.Cmd{
+			exec.Command(self, "update-version-map", "--version", version.Original()),
+		},
+	}
+	if latest {
+		// Combine 2 PRs (commands) in one. Applicable for latest stable releases only.
+		crdbRepo.commands = append(crdbRepo.commands,
+			exec.Command(self, "set-orchestration-version", "--template-dir", "./cloud/kubernetes/templates",
+				"--output-dir", "./cloud/kubernetes/", "--version", version.Original()))
+	}
+	repos := []prRepo{crdbRepo}
+
+	// Repos to change for the latest stable releases only
+	if latest {
+		repos = append(repos, prRepo{
+			owner:          "cockroachdb",
+			repo:           "homebrew-tap",
+			branch:         "master",
+			githubUsername: "cockroach-teamcity",
+			prBranch:       defaultPrBranch,
+			commitMessage:  defaultCommitMessage,
+			commands: []*exec.Cmd{
+				exec.Command("make", fmt.Sprintf("VERSION=%s", version), "PRODUCT=cockroach"),
+			},
+		})
+		repos = append(repos, prRepo{
+			owner:          "cockroachdb",
+			repo:           "helm-charts",
+			branch:         "master",
+			githubUsername: "cockroach-teamcity",
+			prBranch:       defaultPrBranch,
+			commitMessage:  defaultCommitMessage,
+			commands: []*exec.Cmd{
+				exec.Command("bazel", "build", "//build"),
+				exec.Command("sh", "-c", fmt.Sprintf("$(bazel info bazel-bin)/build/build_/build %s", version.Original())),
+			},
+		})
+	}
+	return repos, nil
+}
+
+func isLatestStableBranch(version *semver.Version) (bool, error) {
+	// Here we ignore pre-releases (alphas and betas), because we still want to run these operations.
+	// This way we exclude greater pre-release versions from this decision.
+	latestRelease, err := findPreviousRelease("", true)
+	if err != nil {
+		return false, fmt.Errorf("cannot find latest version: %w", err)
+	}
+	fmt.Printf("The latest released version is %s\n", latestRelease)
+	latestVersion, err := semver.NewVersion(latestRelease)
+	if err != nil {
+		return false, fmt.Errorf("cannot parse latest version: %w", err)
+	}
+	return version.GreaterThan(latestVersion), nil
+}
+
+func nextReleaseBranch(version *semver.Version) (string, error) {
+	next := nextReleaseSeries(version)
+	potentialReleaseBranch := "release-" + next
+	cmd := exec.Command("git", "rev-parse", "--quiet", "--verify", "origin/"+potentialReleaseBranch)
+	if err := cmd.Run(); err != nil {
+		//nolint:returnerrcheck
+		return "master", nil
+	}
+	return potentialReleaseBranch, nil
+}

--- a/pkg/cmd/release/versionmap_test.go
+++ b/pkg/cmd/release/versionmap_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func Test_nextReleaseSeries(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{"21.1.0", "21.2"},
+		{"21.1.9", "21.2"},
+		{"21.2.0", "22.1"},
+		{"21.2.111", "22.1"},
+		{"21.6.0", "22.1"},
+		{"21.6.12", "22.1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			ver, err := semver.NewVersion(tt.version)
+			if err != nil {
+				t.Errorf("cannot parse %s", tt.version)
+			}
+			if got := nextReleaseSeries(ver); got != tt.want {
+				t.Errorf("nextReleaseSeries(%s) = %v, want %v", ver, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, as a part of release process, the release driver person
would create all necessary PRs according to the runbook on their laptop.
After the steps are complete, the release driving person would need to
request approval from someone else.

This process has been error prone (some commands are skipped for some
releases) and required other people to review the PRs.

With automation in place, the process becomes a "one-click" action, that
still requires reviewing the PRs, but the release driver can review and
merge them.

Also:
* Refactor: Use semver instead of string if possible.
* Make sure to add the leading "v" in versions if necessary.

Release note: None