### PR TITLE
gc: use delete range to remove large number of consecutive keys

### DIFF
--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -46,6 +46,18 @@ const (
 	// Raft command for each GCRequest does not significantly exceed
 	// this threshold.
 	KeyVersionChunkBytes = base.ChunkRaftCommandThresholdBytes
+	// minRangeDeleteVersions is min number of versions we will try to delete
+	// using range deletion. Thinking behind this constant is that if we have
+	// less than this count, using pebble range tombstone is more expensive
+	// than using multiple point deletions.
+	defaultMinRangeDeleteVersions = 100
+	// defaultClearRangeCooldownVerions is min number of versions of consecutive
+	// garbage (across multiple keys) needed to start collecting clear range
+	// requests.
+	defaultClearRangeCooldownVerions = 100
+	// defaultMax number of scrapped clear range attempts before abandoning
+	// attempts to use clear range for a GC run.
+	defaultClearRangeMaxRestartThreshold = 5
 )
 
 // IntentAgeThreshold is the threshold after which an extant intent
@@ -207,6 +219,9 @@ type Info struct {
 	// AffectedVersionsRangeValBytes is the number of (fully encoded) bytes deleted from values that
 	// belong to removed range keys.
 	AffectedVersionsRangeValBytes int64
+	// FullRangeDeleteOperations is 1 if fast path delete range request was successfully used to
+	// remove all replicated data from a range.
+	FullRangeDeleteOperations int64
 }
 
 // RunOptions contains collection of limits that GC run applies when performing operations
@@ -226,6 +241,22 @@ type RunOptions struct {
 	MaxTxnsPerIntentCleanupBatch int64
 	// IntentCleanupBatchTimeout is the timeout for processing a batch of intents. 0 to disable.
 	IntentCleanupBatchTimeout time.Duration
+	// DeleteRangeMinKeys is minimum count of keys to delete with a DeleteRangeKeys type request.
+	// If there's less than this number of keys to delete, GC would fall back to point deletions.
+	// 0 means default value of defaultMinRangeDeleteVersions is used.
+	DeleteRangeMinKeys int
+	// MaxKeyVersionChunkBytes is the max size of keys for all versions of objects a single gc
+	// batch would contain. This includes not only keys within the request, but also all versions
+	// covered below request keys. This is important because of the resulting raft command size
+	// generated in response to GC request.
+	MaxKeyVersionChunkBytes int64
+	// MaxClearRangeRestartCount is maximum number of unsuccessful attempts to build clear range
+	// request batcher will do before abandoning the clear range operations. If set to 0 default
+	// value is used. To disable set to -1 to avoid default and always fail restart check.
+	MaxClearRangeRestartCount int
+	// ClearRangeCooldownCount is number of consecutive garbage object versions batcher need before
+	// to start considering clear range gc request creation. If set to 0 default value is used.
+	ClearRangeCooldownCount int
 }
 
 // CleanupIntentsFunc synchronously resolves the supplied intents
@@ -271,7 +302,9 @@ func Run(
 		Threshold: newThreshold,
 	}
 
-	err := processReplicatedKeyRange(ctx, desc, snap, now, newThreshold, options.IntentAgeThreshold, gcer,
+	err := processReplicatedKeyRange(ctx, desc, snap, now, newThreshold, options.IntentAgeThreshold,
+		populateBatcherOptions(options),
+		gcer,
 		intentBatcherOptions{
 			maxIntentsPerIntentCleanupBatch:        options.MaxIntentsPerIntentCleanupBatch,
 			maxIntentKeyBytesPerIntentCleanupBatch: options.MaxIntentKeyBytesPerIntentCleanupBatch,
@@ -289,7 +322,8 @@ func Run(
 	// From now on, all keys processed are range-local and inline (zero timestamp).
 
 	// Process local range key entries (txn records, queue last processed times).
-	if err := processLocalKeyRange(ctx, snap, desc, txnExp, &info, cleanupTxnIntentsAsyncFn, gcer); err != nil {
+	if err := processLocalKeyRange(ctx, snap, desc, txnExp, &info, cleanupTxnIntentsAsyncFn,
+		gcer); err != nil {
 		if errors.Is(err, ctx.Err()) {
 			return Info{}, err
 		}
@@ -310,6 +344,28 @@ func Run(
 	return info, nil
 }
 
+func populateBatcherOptions(options RunOptions) gcKeyBatcherThresholds {
+	batcherOptions := gcKeyBatcherThresholds{
+		deleteRangeMinKeys:            options.DeleteRangeMinKeys,
+		batchGCKeysBytesThreshold:     options.MaxKeyVersionChunkBytes,
+		clearRangeCooldownThreshold:   options.ClearRangeCooldownCount,
+		clearRangeMaxRestartThreshold: options.MaxClearRangeRestartCount,
+	}
+	if batcherOptions.deleteRangeMinKeys == 0 {
+		batcherOptions.deleteRangeMinKeys = defaultMinRangeDeleteVersions
+	}
+	if batcherOptions.batchGCKeysBytesThreshold == 0 {
+		batcherOptions.batchGCKeysBytesThreshold = KeyVersionChunkBytes
+	}
+	if batcherOptions.clearRangeCooldownThreshold == 0 {
+		batcherOptions.clearRangeCooldownThreshold = defaultClearRangeCooldownVerions
+	}
+	if batcherOptions.clearRangeMaxRestartThreshold == 0 {
+		batcherOptions.clearRangeMaxRestartThreshold = defaultClearRangeMaxRestartThreshold
+	}
+	return batcherOptions
+}
+
 // processReplicatedKeyRange identifies garbage and sends GC requests to
 // remove it.
 //
@@ -322,142 +378,489 @@ func processReplicatedKeyRange(
 	now hlc.Timestamp,
 	threshold hlc.Timestamp,
 	intentAgeThreshold time.Duration,
+	batcherOptions gcKeyBatcherThresholds,
 	gcer GCer,
 	options intentBatcherOptions,
 	cleanupIntentsFn CleanupIntentsFunc,
 	info *Info,
 ) error {
-	var alloc bufalloc.ByteAllocator
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now.Add(-intentAgeThreshold.Nanoseconds(), 0)
 
-	intentBatcher := newIntentBatcher(cleanupIntentsFn, options, info)
+	return rditer.IterateMVCCReplicaKeySpans(desc, snap, rditer.IterateOptions{
+		CombineRangesAndPoints: true,
+		Reverse:                true,
+	}, func(iterator storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+		intentBatcher := newIntentBatcher(cleanupIntentsFn, options, info)
 
-	// handleIntent will deserialize transaction info and if intent is older than
-	// threshold enqueue it to batcher, otherwise ignore it.
-	handleIntent := func(keyValue *storage.MVCCKeyValue) error {
-		meta := &enginepb.MVCCMetadata{}
-		if err := protoutil.Unmarshal(keyValue.Value, meta); err != nil {
-			log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %+v", keyValue.Key, err)
+		// handleIntent will deserialize transaction info and if intent is older than
+		// threshold enqueue it to batcher, otherwise ignore it.
+		handleIntent := func(keyValue *storage.MVCCKeyValue) error {
+			meta := &enginepb.MVCCMetadata{}
+			if err := protoutil.Unmarshal(keyValue.Value, meta); err != nil {
+				log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %+v", keyValue.Key, err)
+				return nil
+			}
+			if meta.Txn != nil {
+				// Keep track of intent to resolve if older than the intent
+				// expiration threshold.
+				if meta.Timestamp.ToTimestamp().Less(intentExp) {
+					info.IntentsConsidered++
+					if err := intentBatcher.addAndMaybeFlushIntents(ctx, keyValue.Key.Key, meta); err != nil {
+						if errors.Is(err, ctx.Err()) {
+							return err
+						}
+						log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+					}
+				}
+			}
 			return nil
 		}
-		if meta.Txn != nil {
-			// Keep track of intent to resolve if older than the intent
-			// expiration threshold.
-			if meta.Timestamp.ToTimestamp().Less(intentExp) {
-				info.IntentsConsidered++
-				if err := intentBatcher.addAndMaybeFlushIntents(ctx, keyValue.Key.Key, meta); err != nil {
-					if errors.Is(err, ctx.Err()) {
-						return err
-					}
-					log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+
+		// Iterate all versions of all keys from oldest to newest. If a version is an
+		// intent it will have the highest timestamp of any versions and will be
+		// followed by a metadata entry.
+		// The loop determines if next object is garbage, non-garbage or intent and
+		// notifies batcher with its detail. Batcher is responsible for accumulating
+		// pending key data and sending sending keys to GCer as needed.
+		// It could also request the main loop to rewind to a previous point to
+		// retry (this is needed when attempt to collect a clear range batch fails
+		// in the middle of key versions).
+		it := makeGCIterator(iterator, threshold)
+
+		b := gcKeyBatcher{
+			deleteRangeMinKeys:        batcherOptions.deleteRangeMinKeys,
+			batchGCKeysBytesThreshold: batcherOptions.batchGCKeysBytesThreshold,
+			gcer:                      gcer,
+			state:                     batcherState{prevWasNewest: true},
+			rangeClearLastKey:         desc.EndKey.AsRawKey(),
+			clearRangeGate: clearRangeGate{
+				cooldownThreshold: batcherOptions.clearRangeCooldownThreshold,
+				maxRestartCount:   batcherOptions.clearRangeMaxRestartThreshold,
+			},
+		}
+
+		for ; ; it.step() {
+			var rewindKey storage.MVCCKey
+			var upd batchCounters
+			var err error
+
+			s, ok := it.state()
+			if !ok {
+				if it.err != nil {
+					return it.err
 				}
-			}
-		}
-		return nil
-	}
-
-	// Iterate all versions of all keys from oldest to newest. If a version is an
-	// intent it will have the highest timestamp of any versions and will be
-	// followed by a metadata entry. The loop will determine whether a given key
-	// has garbage and, if so, will determine the timestamp of the latest version
-	// which is garbage to be added to the current batch. If the current version
-	// pushes the size of keys to be removed above the limit, the current key will
-	// be added with that version and the batch will be sent. When the newest
-	// version for a key has been reached, if haveGarbageForThisKey, we'll add the
-	// current key to the batch with the gcTimestampForThisKey.
-	var (
-		batchGCKeys           []roachpb.GCRequest_GCKey
-		batchGCKeysBytes      int64
-		haveGarbageForThisKey bool
-		gcTimestampForThisKey hlc.Timestamp
-		sentBatchForThisKey   bool
-	)
-	it := makeGCIterator(desc, snap, threshold)
-	defer it.close()
-	for ; ; it.step() {
-		s, ok := it.state()
-		if !ok {
-			if it.err != nil {
-				return it.err
-			}
-			break
-		}
-		if s.curIsNotValue() { // Step over metadata or other system keys
-			continue
-		}
-		if s.curIsIntent() {
-			if err := handleIntent(s.next); err != nil {
-				return err
-			}
-			continue
-		}
-		// No more values in buffer or next value has different key.
-		isNewestPoint := s.curIsNewest()
-		if isGarbage(threshold, s.cur, s.next, isNewestPoint, s.firstRangeTombstoneTsAtOrBelowGC) {
-			keyBytes := int64(s.cur.Key.EncodedSize())
-			batchGCKeysBytes += keyBytes
-			haveGarbageForThisKey = true
-			gcTimestampForThisKey = s.cur.Key.Timestamp
-			info.AffectedVersionsKeyBytes += keyBytes
-			info.AffectedVersionsValBytes += int64(len(s.cur.Value))
-		}
-		// We bump how many keys were processed when we reach newest key and looking
-		// if key has garbage or if garbage for this key was included in previous
-		// batch.
-		if affected := isNewestPoint && (sentBatchForThisKey || haveGarbageForThisKey); affected {
-			info.NumKeysAffected++
-			// If we reached newest timestamp for the key then we should reset sent
-			// batch to ensure subsequent keys are not included in affected keys if
-			// they don't have garbage.
-			sentBatchForThisKey = false
-		}
-		shouldSendBatch := batchGCKeysBytes >= KeyVersionChunkBytes
-		if shouldSendBatch || isNewestPoint && haveGarbageForThisKey {
-			alloc, s.cur.Key.Key = alloc.Copy(s.cur.Key.Key, 0)
-			batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{
-				Key:       s.cur.Key.Key,
-				Timestamp: gcTimestampForThisKey,
-			})
-			haveGarbageForThisKey = false
-			gcTimestampForThisKey = hlc.Timestamp{}
-
-			// Mark that we sent a batch for this key so we know that we had garbage
-			// even if it turns out that there's no more garbage for this key.
-			// We want to count a key as affected once even if we paginate the
-			// deletion of its versions.
-			sentBatchForThisKey = shouldSendBatch && !isNewestPoint
-		}
-		// If limit was reached, delegate to GC'r to remove collected batch.
-		if shouldSendBatch {
-			if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
-				if errors.Is(err, ctx.Err()) {
+				// We need to flush last batch here just in case we'll have to rewind
+				// and start again if number of keys is too small for clear range.
+				rewindKey, upd, err = b.flushLastBatch(ctx)
+				if err != nil {
 					return err
 				}
-				// Even though we are batching the GC process, it's
-				// safe to continue because we bumped the GC
-				// thresholds. We may leave some inconsistent history
-				// behind, but nobody can read it.
-				log.Warningf(ctx, "failed to GC a batch of keys: %v", err)
+				upd.updateGcInfo(info)
+				if len(rewindKey.Key) > 0 {
+					// If last batch is a clear range but it too small, it may request a
+					// restart to use point batches.
+					it.seek(rewindKey)
+					continue
+				}
+				break
 			}
-			batchGCKeys = nil
-			batchGCKeysBytes = 0
-			alloc = bufalloc.ByteAllocator{}
+
+			isNewestPoint := s.curIsNewest()
+			switch {
+			case s.curIsNotValue():
+				rewindKey, upd, err = b.foundNonGCAbleData(ctx, s.cur, isNewestPoint, true /* isMeta */)
+			case s.curIsIntent():
+				rewindKey, upd, err = b.foundNonGCAbleData(ctx, s.cur, isNewestPoint, true /* isMeta */)
+				// Note that if we had to rewind then we will return to this key again
+				// and we don't need to process it now.
+				if len(rewindKey.Key) == 0 {
+					if err = handleIntent(s.next); err != nil {
+						return err
+					}
+				}
+			default:
+				if isGarbage(threshold, s.cur, s.next, isNewestPoint, s.firstRangeTombstoneTsAtOrBelowGC) {
+					rewindKey, upd, err = b.foundGarbage(ctx, s.cur, isNewestPoint)
+				} else {
+					rewindKey, upd, err = b.foundNonGCAbleData(ctx, s.cur, isNewestPoint, false /* isMeta */)
+				}
+			}
+			if err != nil {
+				return err
+			}
+			upd.updateGcInfo(info)
+			if len(rewindKey.Key) > 0 {
+				it.seek(rewindKey)
+			}
+		}
+
+		// We need to send out last intent cleanup batch.
+		if err := intentBatcher.maybeFlushPendingIntents(ctx); err != nil {
+			if errors.Is(err, ctx.Err()) {
+				return err
+			}
+			log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+		}
+		return nil
+	})
+}
+
+// batchCounters contain statistics about garbage that is collected for the
+// range of keys.
+type batchCounters struct {
+	keyBytes, valBytes int64
+	keysAffected       int
+}
+
+func (c batchCounters) updateGcInfo(info *Info) {
+	info.AffectedVersionsKeyBytes += c.keyBytes
+	info.AffectedVersionsValBytes += c.valBytes
+	info.NumKeysAffected += c.keysAffected
+}
+
+func (c *batchCounters) merge(other batchCounters) {
+	c.keyBytes += other.keyBytes
+	c.valBytes += other.valBytes
+	c.keysAffected += other.keysAffected
+}
+
+// batchInfo contains transient information that allows GC to rollback its
+// processing to a previous key. Includes counters already accumulated at the
+// checkpoint time and the last processed key.
+type batchInfo struct {
+	batchCounters
+	// Last processed key to use with SeekLT() upon restart.
+	lastProcessedKey storage.MVCCKey
+}
+
+func (c *batchInfo) isEmpty() bool {
+	return len(c.lastProcessedKey.Key) == 0
+}
+
+// Content of other is incorporated into current batch. Other must be more
+// recent in terms of key progress.
+func (c *batchInfo) merge(other batchInfo) {
+	c.batchCounters.merge(other.batchCounters)
+	c.lastProcessedKey = other.lastProcessedKey
+}
+
+func (c *batchInfo) clear() {
+	*c = batchInfo{}
+}
+
+// gcKeyBatcherThresholds collection configuration options.
+type gcKeyBatcherThresholds struct {
+	deleteRangeMinKeys            int
+	batchGCKeysBytesThreshold     int64
+	clearRangeCooldownThreshold   int
+	clearRangeMaxRestartThreshold int
+}
+
+// batcherState contains info about currently processed batch of keys.
+// It accounts for fully collected keys and the last key separately to allow
+// performing ClearRange operations that are key bound, not version bound.
+type batcherState struct {
+	currentBatch  batchInfo
+	lastKey       batchInfo
+	prevWasNewest bool
+}
+
+func (cp *batcherState) isEmpty() bool {
+	return cp.currentBatch.isEmpty() && cp.lastKey.isEmpty()
+}
+
+func (cp *batcherState) mergeLastKey() {
+	cp.currentBatch.merge(cp.lastKey)
+	cp.lastKey.clear()
+}
+
+func (cp *batcherState) keySize() int64 {
+	return cp.currentBatch.keyBytes + cp.lastKey.keyBytes
+}
+
+func (cp *batcherState) clear() {
+	cp.lastKey.clear()
+	cp.currentBatch.clear()
+}
+
+// gcKeyBatcher is responsibe for collecting MVCCKeys and feeding them to GCer
+// for removal.
+// It is receiving notifications if next key is garbage or not and makes decision
+// how to batch the data and weather to use point deletion requests or clear
+// range requests.
+// Internally it would start collecting point data into the batch until it
+// reaches configured batchGCKeysBytesThreshold (which limits size of the raft
+// entry that this request will create later). At this point it will decide
+// if it should switch into ClearRange mode. If decision is made to proceed with
+// clear range, current state is saved into checkpoint.
+// If later non garbage data is found, batcher looks on number of keys covered
+// by already checked range and will either:
+// - send clear range batch up to the last fully covered key, rewind to the
+//   first version after cleared key
+// - restore state from checkpoint and send point key batch, rewind to the
+//   version after the last sent key
+type gcKeyBatcher struct {
+	// Batcher configuration options.
+	deleteRangeMinKeys        int
+	batchGCKeysBytesThreshold int64
+
+	// Fields are used to accumulate point GC batch.
+	batchGCKeys []roachpb.GCRequest_GCKey
+	alloc       bufalloc.ByteAllocator
+
+	// Info about currently accumulated batch including garbage size counters,
+	// current key and state that allows detection when we advance to next key
+	// without a need to compare key values.
+	state batcherState
+	// Whenever we switch to range deletion mode, pointsKeyBatch captures state
+	// of batcher on the last eligible object so that we could rewind to that
+	// state if we decide not to proceed with range deletion.
+	checkpoint batcherState
+
+	// Ranged deletion.
+	// Point versions counter to assess feasibility of range del.
+	sequentialKeysFound int
+	// canDeleteRange is true when batch starts and turns to false if we found a
+	// non GC-able object during point batch collection.
+	canDeleteRange bool
+	// End key for potential clean range request.
+	rangeClearLastKey roachpb.Key
+	// clearRangeGate tracks found live and garbage keys to enable or disable
+	// clear range based on observed patterns.
+	clearRangeGate clearRangeGate
+
+	gcer GCer
+}
+
+func (b *gcKeyBatcher) foundNonGCAbleData(
+	ctx context.Context, cur *storage.MVCCKeyValue, isNewestPoint, isMeta bool,
+) (rewindKey storage.MVCCKey, counterUpdate batchCounters, err error) {
+	b.clearRangeGate.foundLiveData()
+
+	// Not tracking range deletion yet.
+	if b.checkpoint.isEmpty() {
+		// Range collection could still be restarted in presence of garbage if:
+		//  - batch is empty;
+		//  - we are at newest point or we are at non-value or intent.
+		if len(b.batchGCKeys) > 0 || !isNewestPoint || !isMeta {
+			b.canDeleteRange = false
+		}
+		// We also need to handle the special case where we restart range on
+		// key boundary. In this case we need to bump range clear last key to
+		// match current.
+		if len(b.batchGCKeys) == 0 && isNewestPoint {
+			b.rangeClearLastKey = cur.Key.Key.Clone()
+		}
+		if isMeta {
+			// We don't need to update anything on non-versionable object and we
+			// don't need to flush anything.
+			return storage.MVCCKey{}, batchCounters{}, nil
+		}
+		// For non-meta objects we still need to handle isNewest/prevWasNewest
+		if b.state.prevWasNewest {
+			b.state.mergeLastKey()
+			b.state.lastKey.lastProcessedKey = cur.Key.Clone()
+		}
+		b.state.prevWasNewest = isNewestPoint
+		return storage.MVCCKey{}, batchCounters{}, nil
+	}
+
+	// We are already tracking range deletion, we should try to compute end range
+	// here and also capture start position to resume future range tracking.
+	if !cur.Key.Key.Equal(b.state.lastKey.lastProcessedKey.Key) {
+		// We are already at the next key, we can use newest as previous.
+		b.state.mergeLastKey()
+	} else {
+		// If they are equal, we hit an intent and can't clean this key with range
+		// op.
+		b.sequentialKeysFound--
+	}
+	if !isMeta {
+		b.state.prevWasNewest = isNewestPoint
+	}
+	return b.maybeFlushPendingRange(ctx)
+}
+
+func (b *gcKeyBatcher) foundGarbage(
+	ctx context.Context, cur *storage.MVCCKeyValue, isNewestPoint bool,
+) (rewindKey storage.MVCCKey, counterUpdate batchCounters, err error) {
+	b.clearRangeGate.foundGarbageData()
+
+	// Aggregate last key batch into current.
+	if b.state.prevWasNewest {
+		// Check if we just started a batch and we can try to collect a range.
+		if len(b.batchGCKeys) == 0 && b.clearRangeGate.shouldRestartClearRange() {
+			b.canDeleteRange = true
+		}
+
+		b.state.mergeLastKey()
+		b.sequentialKeysFound++
+
+		// Start filling up new batch with current key garbage data.
+		b.state.lastKey.keysAffected++
+		if b.checkpoint.isEmpty() {
+			b.alloc, b.state.lastKey.lastProcessedKey.Key = b.alloc.Copy(cur.Key.Key, 0)
+		} else {
+			b.state.lastKey.lastProcessedKey = cur.Key.Clone()
 		}
 	}
-	// We need to send out last intent cleanup batch.
-	if err := intentBatcher.maybeFlushPendingIntents(ctx); err != nil {
+
+	// Accumulate pending counters for sizes.
+	b.state.lastKey.keyBytes += int64(cur.Key.EncodedSize())
+	b.state.lastKey.valBytes += int64(len(cur.Value))
+
+	// Accumulate point keys into batch if needed.
+	if b.checkpoint.isEmpty() {
+		b.state.lastKey.lastProcessedKey.Timestamp = cur.Key.Timestamp
+		// We put a key into batch when it is found for the first time in a batch
+		// e.g. if prev key was newest in its history or if batch is empty because
+		// we just flushed it.
+		// In other cases we just update its timestamp to track highest.
+		if b.state.prevWasNewest || len(b.batchGCKeys) == 0 {
+			b.batchGCKeys = append(b.batchGCKeys, roachpb.GCRequest_GCKey{
+				Key:       b.state.lastKey.lastProcessedKey.Key,
+				Timestamp: cur.Key.Timestamp,
+			})
+		} else {
+			b.batchGCKeys[len(b.batchGCKeys)-1].Timestamp = cur.Key.Timestamp
+		}
+
+		shouldFinishPointsBatch := b.state.keySize() >= b.batchGCKeysBytesThreshold
+		// We can try to restart clear range collection, but for that we need to
+		// realign start of points batch with the first version of the key.
+		if !b.canDeleteRange && b.clearRangeGate.shouldRestartClearRange() && b.state.prevWasNewest {
+			shouldFinishPointsBatch = true
+		}
+		if shouldFinishPointsBatch {
+			b.state.prevWasNewest = isNewestPoint
+			if !b.canDeleteRange {
+				// If limit was reached, delegate to GC'r to remove collected batch.
+				counterUpdate, err = b.flushPointsBatch(ctx)
+				return storage.MVCCKey{}, counterUpdate, err
+			}
+			// We now proceed with range clear operation. Save current state for
+			// potential rewind and only accumulate counters from now on.
+			b.checkpoint = b.state
+		}
+	}
+
+	b.state.prevWasNewest = isNewestPoint
+	return storage.MVCCKey{}, counterUpdate, nil
+}
+
+// Send out points batch and clean up context for current batch.
+// If we are rewinding after that, caller should be concerned with that.
+// Rewind position is lost and needs to be captured separately by caller if
+// needed.
+func (b *gcKeyBatcher) flushPointsBatch(
+	ctx context.Context,
+) (counterUpdate batchCounters, err error) {
+	if err := b.gcer.GC(ctx, b.batchGCKeys, nil, nil); err != nil {
 		if errors.Is(err, ctx.Err()) {
-			return err
+			return counterUpdate, err
 		}
-		log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+		// Even though we are batching the GC process, it's
+		// safe to continue because we bumped the GC
+		// thresholds. We may leave some inconsistent history
+		// behind, but nobody can read it.
+		log.Warningf(ctx, "failed to GC a batch of keys: %v", err)
 	}
-	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
-			return err
+	b.batchGCKeys = nil
+	b.alloc = bufalloc.ByteAllocator{}
+	b.sequentialKeysFound = 0
+
+	// After flushing the batch we need to aggregate counters for included keys
+	// which include previous keys as well as keys in the current batch.
+	// We need to preserve last processed key as current key might have more
+	// versions. We will do it using newly created alloc as it should belong to
+	// subsequent batch.
+	var savedKey roachpb.Key
+	b.alloc, savedKey = b.alloc.Copy(b.state.lastKey.lastProcessedKey.Key, 0)
+	b.state.mergeLastKey()
+	counterUpdate = b.state.currentBatch.batchCounters
+	b.state.clear()
+	b.state.lastKey.lastProcessedKey.Key = savedKey
+	// Finally update lower boundary for potential subsequent clear range operation.
+	b.rangeClearLastKey = savedKey
+	return counterUpdate, nil
+}
+
+// Make decision if range batch should be flushed and flush either range or
+// points.
+func (b *gcKeyBatcher) maybeFlushPendingRange(
+	ctx context.Context,
+) (rewindKey storage.MVCCKey, counterUpdate batchCounters, err error) {
+	// If current pending range batch is too small to send, flush last collected
+	// point batch, revert the state and request an iterator rewind.
+	// Note that we always ignore current key as we don't know it all versions
+	// were processed and we check that we have at least one full previous key.
+	if b.sequentialKeysFound < b.deleteRangeMinKeys || b.state.currentBatch.keysAffected == 0 {
+		b.clearRangeGate.abandonedClearRange()
+		// If we have to rewind to last collected points batch, then we restore
+		// to checkpoint, flush points batch and request a rewind.
+		b.state = b.checkpoint
+		b.checkpoint.clear()
+		rewindKey = b.state.lastKey.lastProcessedKey
+		cnt, err := b.flushPointsBatch(ctx)
+		b.canDeleteRange = false
+		return rewindKey, cnt, err
+	}
+	return b.flushRangeBatch(ctx)
+}
+
+// Flush range batch sends range batch and optionally reverts to last key
+// with non complete deletion.
+func (b *gcKeyBatcher) flushRangeBatch(
+	ctx context.Context,
+) (rewindKey storage.MVCCKey, counterUpdate batchCounters, err error) {
+	if err := b.gcer.GC(ctx, nil, nil, []roachpb.GCRequest_GCClearRangeKey{{
+		StartKey: b.state.currentBatch.lastProcessedKey.Key,
+		EndKey:   b.rangeClearLastKey,
+	}}); err != nil {
+		if errors.Is(err, ctx.Err()) {
+			return storage.MVCCKey{}, counterUpdate, err
 		}
+		// Even though we are batching the GC process, it's
+		// safe to continue because we bumped the GC
+		// thresholds. We may leave some inconsistent history
+		// behind, but nobody can read it.
+		log.Warningf(ctx, "failed to GC keys with clear range: %v", err)
 	}
-	return nil
+
+	// Clean up stale points key batch and its resources.
+	b.checkpoint.clear()
+	b.batchGCKeys = nil
+	b.alloc = bufalloc.ByteAllocator{}
+	b.sequentialKeysFound = 0
+
+	b.alloc, b.rangeClearLastKey = b.alloc.Copy(b.state.currentBatch.lastProcessedKey.Key, 0)
+	counterUpdate = b.state.currentBatch.batchCounters
+	rewindKey = b.state.currentBatch.lastProcessedKey
+	b.state.clear()
+
+	// Since we discard last key here and rewind to previous we should set
+	// prevWasNewest to true to allow for key capture for the next object.
+	b.state.prevWasNewest = true
+
+	return rewindKey, counterUpdate, nil
+}
+
+// When we reached the end of iteration we need to flush last batch.
+func (b *gcKeyBatcher) flushLastBatch(
+	ctx context.Context,
+) (rewindKey storage.MVCCKey, counterUpdate batchCounters, err error) {
+	if b.checkpoint.isEmpty() {
+		if len(b.batchGCKeys) > 0 {
+			counterUpdate, err = b.flushPointsBatch(ctx)
+		}
+		return rewindKey, counterUpdate, err
+	}
+	// Aggregate last key as it never had a chance to merge after isNewest.
+	if !b.state.lastKey.isEmpty() {
+		b.state.mergeLastKey()
+	}
+	return b.maybeFlushPendingRange(ctx)
 }
 
 type intentBatcher struct {
@@ -578,6 +981,63 @@ func (b *intentBatcher) maybeFlushPendingIntents(ctx context.Context) error {
 	b.pendingIntents = b.pendingIntents[:0]
 	b.collectedIntentBytes = 0
 	return err
+}
+
+// clearRangeGate tracks enabling and disabling of clear range request
+// collection within gcKeyBatcher.
+// It counts number of consecutive garbage values to see if it is worth starting
+// a clear range request.
+// When batcher scraps a clear range and rewinds clearRangeGate will ensure we
+// don't speculatively start creating more clear range requests before the live
+// data that caused previous request to stop is skipped.
+// It also counts how many scrapped clear range were made and will stop
+// attempts all together when limit is reached.
+type clearRangeGate struct {
+	// How many consecutive garbage versions gc needs to see before trying
+	// to start collecting clear range batch.
+	// If this value set to a very high value, clear range is effectively
+	// disabled.
+	cooldownThreshold int
+	// Current number of consecutive garbage versions.
+	cooldownCount int
+	// Only do cooldown if we know that there's no live data ahead.
+	cooldownDisabled bool
+
+	// Number of rewind operations to tolerate before giving up on clear range
+	// batch building.
+	maxRestartCount int
+	// Total number of rewind operations allowed before before clear range is
+	// disabled for this GC run.
+	rewindCount int
+}
+
+func (e *clearRangeGate) foundGarbageData() {
+	if !e.cooldownDisabled {
+		e.cooldownCount++
+	}
+}
+
+func (e *clearRangeGate) foundLiveData() {
+	e.cooldownCount = 0
+	e.cooldownDisabled = false
+}
+
+// abandonedClearRange is a notification from batcher that we tried to collect
+// a clear range request, but number of keys included was too low to justify
+// the operation and it was scrapped.
+func (e *clearRangeGate) abandonedClearRange() {
+	// Clear range is abandoned when we found live data and rewinded to last
+	// known points batch. This is a wasteful condition so we try to check if
+	// we have to rewind to much and disable this behaviour all together once
+	// certain threshold is crossed.
+	e.rewindCount++
+	e.cooldownDisabled = true
+}
+
+// shouldRestartClearRange tells batcher if it is worth starting new batch and
+// attempt to perform a clear range.
+func (e *clearRangeGate) shouldRestartClearRange() bool {
+	return e.cooldownCount >= e.cooldownThreshold && e.rewindCount < e.maxRestartCount
 }
 
 // isGarbage makes a determination whether a key ('cur') is garbage.

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -122,7 +122,9 @@ type Thresholder interface {
 
 // PureGCer is part of the GCer interface.
 type PureGCer interface {
-	GC(context.Context, []roachpb.GCRequest_GCKey, []roachpb.GCRequest_GCRangeKey) error
+	GC(context.Context, []roachpb.GCRequest_GCKey, []roachpb.GCRequest_GCRangeKey,
+		[]roachpb.GCRequest_GCClearRangeKey,
+	) error
 }
 
 // A GCer is an abstraction used by the MVCC GC queue to carry out chunked deletions.
@@ -141,7 +143,10 @@ func (NoopGCer) SetGCThreshold(context.Context, Threshold) error { return nil }
 
 // GC implements storage.GCer.
 func (NoopGCer) GC(
-	context.Context, []roachpb.GCRequest_GCKey, []roachpb.GCRequest_GCRangeKey,
+	context.Context,
+	[]roachpb.GCRequest_GCKey,
+	[]roachpb.GCRequest_GCRangeKey,
+	[]roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	return nil
 }
@@ -425,7 +430,7 @@ func processReplicatedKeyRange(
 		}
 		// If limit was reached, delegate to GC'r to remove collected batch.
 		if shouldSendBatch {
-			if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
+			if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
 				if errors.Is(err, ctx.Err()) {
 					return err
 				}
@@ -448,7 +453,7 @@ func processReplicatedKeyRange(
 		log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
 	}
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
 			return err
 		}
 	}
@@ -820,7 +825,7 @@ func (b *rangeKeyBatcher) flushPendingFragments(ctx context.Context) error {
 		}
 		b.pending = b.pending[:0]
 		b.pendingSize = 0
-		return b.gcer.GC(ctx, nil, toSend)
+		return b.gcer.GC(ctx, nil, toSend, nil)
 	}
 	return nil
 }
@@ -901,7 +906,7 @@ func (b *batchingInlineGCer) FlushingAdd(ctx context.Context, key roachpb.Key) {
 }
 
 func (b *batchingInlineGCer) Flush(ctx context.Context) {
-	err := b.gcer.GC(ctx, b.gcKeys, nil)
+	err := b.gcer.GC(ctx, b.gcKeys, nil, nil)
 	b.gcKeys = nil
 	b.size = 0
 	if err != nil {

--- a/pkg/kv/kvserver/gc/gc_iterator_test.go
+++ b/pkg/kv/kvserver/gc/gc_iterator_test.go
@@ -152,8 +152,14 @@ func TestGCIterator(t *testing.T) {
 			ds.setupTest(t, eng, desc)
 			snap := eng.NewSnapshot()
 			defer snap.Close()
-			it := makeGCIterator(&desc, snap, tc.gcThreshold)
-			defer it.close()
+			mvccIt := snap.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+				LowerBound: desc.StartKey.AsRawKey(),
+				UpperBound: desc.EndKey.AsRawKey(),
+				KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			})
+			mvccIt.SeekLT(storage.MVCCKey{Key: desc.EndKey.AsRawKey()})
+			defer mvccIt.Close()
+			it := makeGCIterator(mvccIt, tc.gcThreshold)
 			expectations := tc.expectations
 			for i, ex := range expectations {
 				s, ok := it.state()

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -151,7 +151,7 @@ func runGCOld(
 						if batchGCKeysBytes >= KeyVersionChunkBytes {
 							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
 
-							err := gcer.GC(ctx, batchGCKeys, nil)
+							err := gcer.GC(ctx, batchGCKeys, nil, nil)
 
 							batchGCKeys = nil
 							batchGCKeysBytes = 0
@@ -210,7 +210,7 @@ func runGCOld(
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
 			return Info{}, err
 		}
 	}

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -720,6 +720,7 @@ type fakeGCer struct {
 	// feed them into MVCCGarbageCollectRangeKeys and ranges argument should be
 	// non-overlapping.
 	gcRangeKeyBatches [][]roachpb.GCRequest_GCRangeKey
+	gcRangeDeleteKeys []roachpb.GCRequest_GCClearRangeKey
 	threshold         Threshold
 	intents           []roachpb.Intent
 	batches           [][]roachpb.Intent
@@ -740,12 +741,16 @@ func (f *fakeGCer) SetGCThreshold(ctx context.Context, t Threshold) error {
 }
 
 func (f *fakeGCer) GC(
-	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+	ctx context.Context,
+	keys []roachpb.GCRequest_GCKey,
+	rangeKeys []roachpb.GCRequest_GCRangeKey,
+	deletionKeys []roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	for _, k := range keys {
 		f.gcKeys[k.Key.String()] = k
 	}
 	f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
+	f.gcRangeDeleteKeys = append(f.gcRangeDeleteKeys, deletionKeys...)
 	return nil
 }
 

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -145,19 +145,19 @@ func TestIntentAgeThresholdSetting(t *testing.T) {
 	nowTs := hlc.Timestamp{
 		WallTime: now.Nanoseconds(),
 	}
-	fakeGCer := makeFakeGCer()
+	gcer := makeFakeGCer()
 
 	// Test GC desired behavior.
 	info, err := Run(ctx, &desc, snap, nowTs, nowTs,
-		RunOptions{IntentAgeThreshold: intentLongThreshold}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
-		fakeGCer.resolveIntentsAsync)
+		RunOptions{IntentAgeThreshold: intentLongThreshold}, gcTTL, &gcer, gcer.resolveIntents,
+		gcer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Zero(t, info.IntentsConsidered,
 		"Expected no intents considered by GC with default threshold")
 
 	info, err = Run(ctx, &desc, snap, nowTs, nowTs,
-		RunOptions{IntentAgeThreshold: intentShortThreshold}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
-		fakeGCer.resolveIntentsAsync)
+		RunOptions{IntentAgeThreshold: intentShortThreshold}, gcTTL, &gcer, gcer.resolveIntents,
+		gcer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Equal(t, 1, info.IntentsConsidered,
 		"Expected 1 intents considered by GC with short threshold")
@@ -212,22 +212,22 @@ func TestIntentCleanupBatching(t *testing.T) {
 	baseGCer.normalize()
 
 	var batchSize int64 = 7
-	fakeGCer := makeFakeGCer()
+	gcer := makeFakeGCer()
 	info, err := Run(ctx, &desc, snap, nowTs, nowTs,
 		RunOptions{IntentAgeThreshold: intentAgeThreshold, MaxIntentsPerIntentCleanupBatch: batchSize},
 		gcTTL,
-		&fakeGCer, fakeGCer.resolveIntents, fakeGCer.resolveIntentsAsync)
+		&gcer, gcer.resolveIntents, gcer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	maxIntents := 0
-	for _, batch := range fakeGCer.batches {
+	for _, batch := range gcer.batches {
 		if intents := len(batch); intents > maxIntents {
 			maxIntents = intents
 		}
 	}
 	require.Equal(t, int64(maxIntents), batchSize, "Batch size")
 	require.Equal(t, 15, info.ResolveTotal)
-	fakeGCer.normalize()
-	require.EqualValues(t, baseGCer, fakeGCer, "GC result with batching")
+	gcer.normalize()
+	require.EqualValues(t, baseGCer, gcer, "GC result with batching")
 }
 
 type testResolver [][]roachpb.Intent
@@ -683,12 +683,18 @@ var avoidMergingDifferentTs = `
  1 |
 `
 
+type testRunData struct {
+	name                 string
+	data                 string
+	deleteRangeThreshold int
+	keyBytesThreshold    int64
+	disableClearRange    bool
+	clearRangeCooldown   int
+}
+
 func TestGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	for _, d := range []struct {
-		name string
-		data string
-	}{
+	for _, d := range []testRunData{
 		{name: "single", data: singleValueData},
 		{name: "multiple_newer", data: multipleValuesNewerData},
 		{name: "multiple_older", data: multipleValuesOlderData},
@@ -708,12 +714,387 @@ func TestGC(t *testing.T) {
 		{name: "avoid_merging_different_ts", data: avoidMergingDifferentTs},
 	} {
 		t.Run(d.name, func(t *testing.T) {
-			runTest(t, d.data)
+			d.disableClearRange = true
+			runTest(t, d, nil)
 		})
 	}
 }
 
-func runTest(t *testing.T, data string) {
+var clearRangePointsSplitAtKeyBoundaries = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |
+>5 | .------------
+ 4 |            d E
+ 3 | a     cc
+ 2 |    bb
+ 1 |
+`
+
+var clearRangePointsSplitAtVersions = `
+   | a  bb ccc  d  e
+---+----------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |       A
+>5 | .-------------
+ 4 |            d  E
+ 3 | a     cc
+ 2 |    bb f    gg
+ 1 |
+`
+
+var clearRangeManySplitsPerKey = `
+   | a  bb ccc  d  e
+---+----------------
+ 9 |    K
+>8 | .-------------
+ 7 |       g
+ 6 |    i
+ 5 | l     eee
+ 4 |    h  dd 
+ 3 | a     ccc
+ 2 |    bb f
+ 1 |
+`
+
+var rangeClearInOneGo = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 | 
+>5 | .----------
+ 4 |
+ 3 | a     ccc
+ 2 |    bb
+ 1 |
+`
+
+var rangeClearAtKeyBoundary = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |    B
+>5 | .------------
+ 4 |            d
+ 3 | a     ccc  e
+ 2 |            f
+ 1 |
+`
+
+var rangeClearAtGarbageVersion = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |    H
+ 7 |
+ 6 |    B
+>5 | .------------
+ 4 |            d
+ 3 | a  g  ccc  e
+ 2 |            f
+ 1 |
+`
+
+var rangeClearAtNewest = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |    B
+>5 | .------------
+ 4 |            d
+ 3 | a  g  ccc  e
+ 2 |            f
+ 1 |
+`
+
+var rangeClearAtIntent = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |    !B
+>5 | .------------
+ 4 |            d
+ 3 | a  g  ccc  e
+ 2 |            f
+ 1 |
+`
+
+var rangeClearAtNewestUnderIntent = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |    !H
+ 7 |
+ 6 |    B
+>5 | .------------
+ 4 |            d
+ 3 | a  g  ccc  e
+ 2 |            f
+ 1 |
+`
+
+var rangeClearRestartAfterIntent = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |       !H
+ 7 |
+ 6 |
+>5 | .------------
+ 4 |
+ 3 | a  g  ccc
+ 2 |    i       f
+ 1 |
+`
+
+var rangeClearRestartAfterNewest = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |       H
+ 7 |
+ 6 |
+>5 | .------------
+ 4 |
+ 3 | a  g  ccc
+ 2 |    i       f
+ 1 |
+`
+
+var rangeClearRestartAfterMultipleVersions = `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |       H
+ 7 |
+ 6 |       J
+>5 | .------------
+ 4 |
+ 3 | a  g  ccc
+ 2 |    i       f
+ 1 |
+`
+
+var sequentialKeyCount = `
+   | a  bb ccc  d e f
+---+------------------
+ 9 | 
+ 8 | 
+ 7 |
+ 6 |    B
+>5 | .--------------
+ 4 |
+ 3 | a  d  ccc
+ 2 |    e       f g
+ 1 |
+`
+
+// This test uses cooldown, so after H batcher will send at least one point
+// batch before switching back to clear range keys.
+var reenableClearRangeCooldown = `
+   | a  bb ccc  d e f
+---+------------------
+ 9 | 
+ 8 | 
+ 7 |
+ 6 |       H
+>5 | .--------------
+ 4 |
+ 3 | a  d  ccc
+ 2 |    e       f g
+ 1 |
+`
+
+// For testing clear range we perform normal checks, but also explicitly verify
+// generated clear range spans as normal point key deletions would do the same
+// job but less efficiently.
+type clearRangeTestData struct {
+	testRunData
+	clearSpans []roachpb.Span
+}
+
+func TestGCUseClearRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	mkKey := func(key string) roachpb.Key {
+		tablePrefix := keys.SystemSQLCodec.TablePrefix(42)
+		return append(tablePrefix, key...)
+	}
+	last := keys.SystemSQLCodec.TablePrefix(42).PrefixEnd()
+
+	for _, d := range []clearRangeTestData{
+		{
+			testRunData: testRunData{
+				name:              "point batches split at key boundaries",
+				data:              clearRangePointsSplitAtKeyBoundaries,
+				disableClearRange: true,
+				keyBytesThreshold: 25,
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:              "point batches split at versions",
+				data:              clearRangePointsSplitAtVersions,
+				disableClearRange: true,
+				keyBytesThreshold: 35,
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:              "point batches multiple splits per key",
+				data:              clearRangeManySplitsPerKey,
+				disableClearRange: true,
+				keyBytesThreshold: 30,
+			},
+		},
+		{
+			testRunData: testRunData{
+				name: "clear all range data",
+				data: rangeClearInOneGo,
+			},
+			clearSpans: []roachpb.Span{{mkKey("a"), last}},
+		},
+		{
+			testRunData: testRunData{
+				name: "range clear at key boundary",
+				data: rangeClearAtKeyBoundary,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("ccc"), last},
+				{mkKey("a"), mkKey("bb")},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "range clear stop at older version",
+				data:                 rangeClearAtGarbageVersion,
+				deleteRangeThreshold: 2,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("ccc"), last},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "range clear stop at newest version",
+				data:                 rangeClearAtNewest,
+				deleteRangeThreshold: 2,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("ccc"), last},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "range clear stop at intent",
+				data:                 rangeClearAtIntent,
+				deleteRangeThreshold: 2,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("ccc"), last},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "range clear stop an newest under intent",
+				data:                 rangeClearAtNewestUnderIntent,
+				deleteRangeThreshold: 2,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("ccc"), last},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "range clear restart after intent",
+				data:                 rangeClearRestartAfterIntent,
+				deleteRangeThreshold: 2,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("a"), mkKey("ccc")},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "range clear restart after newest",
+				data:                 rangeClearRestartAfterNewest,
+				deleteRangeThreshold: 2,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("a"), mkKey("ccc")},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "range clear restart after many versions",
+				data:                 rangeClearRestartAfterMultipleVersions,
+				deleteRangeThreshold: 2,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("a"), mkKey("ccc")},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "not enough sequential keys",
+				data:                 sequentialKeyCount,
+				deleteRangeThreshold: 4,
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "just enough sequential keys",
+				data:                 sequentialKeyCount,
+				deleteRangeThreshold: 3,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("ccc"), last},
+			},
+		},
+		{
+			testRunData: testRunData{
+				name:                 "reenable clear range after non-garbage",
+				data:                 reenableClearRangeCooldown,
+				deleteRangeThreshold: 0,
+				clearRangeCooldown:   2,
+			},
+			clearSpans: []roachpb.Span{
+				{mkKey("d"), mkKey("e")},
+				{mkKey("a"), mkKey("bb")},
+			},
+		},
+	} {
+		// Defaults to enable range from first key.
+		if d.deleteRangeThreshold == 0 {
+			d.deleteRangeThreshold = 1
+		}
+		if d.keyBytesThreshold == 0 {
+			d.keyBytesThreshold = 1
+		}
+		t.Run(d.name, func(t *testing.T) {
+			runTest(t, d.testRunData, func(t *testing.T, gcer *fakeGCer) {
+				require.EqualValues(t, d.clearSpans, r2s(gcer.gcClearRangeKeys), "clear range requests")
+			})
+		})
+	}
+}
+
+type gcVerifier func(t *testing.T, gcer *fakeGCer)
+
+func runTest(t *testing.T, data testRunData, verify gcVerifier) {
 	ctx := context.Background()
 	tablePrefix := keys.SystemSQLCodec.TablePrefix(42)
 	desc := roachpb.RangeDescriptor{
@@ -724,21 +1105,45 @@ func runTest(t *testing.T, data string) {
 	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
-	dataItems, gcTS, now := readTableData(t, desc.StartKey.AsRawKey(), data)
+	dataItems, gcTS, now := readTableData(t, desc.StartKey.AsRawKey(), data.data)
 	ds := dataItems.fullDistribution()
 	stats := ds.setupTest(t, eng, desc)
 	snap := eng.NewSnapshot()
 	defer snap.Close()
 
+	restartCount := math.MaxInt
+	if data.disableClearRange {
+		restartCount = -1
+	} else if data.clearRangeCooldown == 0 {
+		// Set cooldown to 1 to override default and enable cooldown immediately.
+		data.clearRangeCooldown = 1
+	}
 	gcer := makeFakeGCer()
 	_, err := Run(ctx, &desc, snap, now, gcTS,
-		RunOptions{IntentAgeThreshold: time.Nanosecond * time.Duration(now.WallTime)}, time.Second,
+		RunOptions{
+			IntentAgeThreshold:        time.Nanosecond * time.Duration(now.WallTime),
+			MaxKeyVersionChunkBytes:   data.keyBytesThreshold,
+			DeleteRangeMinKeys:        data.deleteRangeThreshold,
+			MaxClearRangeRestartCount: restartCount,
+			ClearRangeCooldownCount:   data.clearRangeCooldown,
+		},
+		time.Second,
 		&gcer,
 		gcer.resolveIntents, gcer.resolveIntentsAsync)
+
+	if verify != nil {
+		verify(t, &gcer)
+	}
+
 	require.NoError(t, err)
 	require.Empty(t, gcer.intents, "expecting no intents")
 	require.NoError(t,
 		storage.MVCCGarbageCollect(ctx, eng, &stats, gcer.pointKeys(), gcTS))
+
+	clearRangeKeys := makeCollectableGCClearRangesFromGCRequests(desc.StartKey.AsRawKey(),
+		desc.EndKey.AsRawKey(), gcer.clearRangeKeys())
+	require.NoError(t,
+		storage.MVCCGarbageCollectWithClearRange(ctx, eng, &stats, gcTS, clearRangeKeys))
 
 	for _, batch := range gcer.rangeKeyBatches() {
 		rangeKeys := makeCollectableGCRangesFromGCRequests(desc.StartKey.AsRawKey(),
@@ -769,6 +1174,20 @@ func runTest(t *testing.T, data string) {
 	expectedStats.AgeTo(now.WallTime)
 	stats.AgeTo(now.WallTime)
 	require.Equal(t, expectedStats, stats, "mvcc stats don't match the data")
+}
+
+func r2s(cc []roachpb.GCRequest_GCClearRangeKey) (spans []roachpb.Span) {
+	if len(cc) == 0 {
+		return nil
+	}
+	spans = make([]roachpb.Span, len(cc))
+	for i, c := range cc {
+		spans[i] = roachpb.Span{
+			Key:    c.StartKey,
+			EndKey: c.EndKey,
+		}
+	}
+	return spans
 }
 
 // requireEqualReaders compares data in two readers
@@ -1439,4 +1858,61 @@ func TestRangeKeyBatching(t *testing.T) {
 			require.EqualValues(t, data.expect, gcer.rangeKeys())
 		})
 	}
+}
+
+func assertClearRangeOn(t *testing.T, g *clearRangeGate, step int, seq []bool) {
+	t.Helper()
+	if step >= len(seq) {
+		panic("Expected step must be within sequence length or -1 to ignore")
+	}
+	for i, garbage := range seq {
+		if garbage {
+			g.foundGarbageData()
+		} else {
+			g.foundLiveData()
+		}
+		if step == i {
+			require.True(t, g.shouldRestartClearRange(), "expected restart on step %d of garbage sequence %s", i, seq)
+		} else {
+			require.False(t, g.shouldRestartClearRange(), "unexpected restart on step %d (instead of %d) of garbage sequence %s", i, step, seq)
+		}
+	}
+}
+
+func TestClearRangeGateEnableOnCooldown(t *testing.T) {
+	g := clearRangeGate{
+		cooldownThreshold: 3,
+		maxRestartCount:   5,
+	}
+	assertClearRangeOn(t, &g, 2, []bool{true, true, true})
+}
+
+func TestClearRangeGateSkipInterleavedGarbage(t *testing.T) {
+	g := clearRangeGate{
+		cooldownThreshold: 3,
+		maxRestartCount:   5,
+	}
+	assertClearRangeOn(t, &g, 7, []bool{true, true, false, true, false, true, true, true})
+}
+
+func TestClearRangeSkipOverGarbage(t *testing.T) {
+	g := clearRangeGate{
+		cooldownThreshold: 3,
+		maxRestartCount:   5,
+	}
+	g.abandonedClearRange()
+	assertClearRangeOn(t, &g, 7, []bool{true, true, true, true, false, true, true, true})
+}
+
+func TestClearRangeDisableAfterRewindCountExceeded(t *testing.T) {
+	g := clearRangeGate{
+		cooldownThreshold: 3,
+		maxRestartCount:   5,
+	}
+	g.abandonedClearRange()
+	g.abandonedClearRange()
+	g.abandonedClearRange()
+	g.abandonedClearRange()
+	g.abandonedClearRange()
+	assertClearRangeOn(t, &g, -1, []bool{true, true, true, true, true, true})
 }

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -56,7 +56,10 @@ type collectingGCer struct {
 }
 
 func (c *collectingGCer) GC(
-	_ context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+	_ context.Context,
+	keys []roachpb.GCRequest_GCKey,
+	_ []roachpb.GCRequest_GCRangeKey,
+	_ []roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	c.keys = append(c.keys, keys)
 	return nil

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -484,7 +484,10 @@ func (r *replicaGCer) SetGCThreshold(ctx context.Context, thresh gc.Threshold) e
 }
 
 func (r *replicaGCer) GC(
-	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+	ctx context.Context,
+	keys []roachpb.GCRequest_GCKey,
+	rangeKeys []roachpb.GCRequest_GCRangeKey,
+	clearRangeKeys []roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	if len(keys) == 0 && len(rangeKeys) == 0 {
 		return nil
@@ -492,6 +495,7 @@ func (r *replicaGCer) GC(
 	req := r.template()
 	req.Keys = keys
 	req.RangeKeys = rangeKeys
+	req.ClearRangeKeys = clearRangeKeys
 	return r.send(ctx, req)
 }
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -148,52 +148,53 @@ func verifyRDReplicatedOnlyMVCCIter(
 			}, hlc.Timestamp{WallTime: 42})
 			readWriter = spanset.NewReadWriterAt(readWriter, &spans, hlc.Timestamp{WallTime: 42})
 		}
-		iter := NewReplicaMVCCDataIterator(desc, readWriter, ReplicaDataIteratorOptions{
-			Reverse:  reverse,
-			IterKind: storage.MVCCKeyAndIntentsIterKind,
-			KeyTypes: storage.IterKeyTypePointsAndRanges,
-		})
-		defer iter.Close()
-		next := iter.Next
-		if reverse {
-			next = iter.Prev
-		}
 		var rangeStart roachpb.Key
 		actualKeys := []storage.MVCCKey{}
 		actualRanges := []storage.MVCCRangeKey{}
-		for {
-			ok, err := iter.Valid()
-			require.NoError(t, err)
-			if !ok {
-				break
-			}
-			p, r := iter.HasPointAndRange()
-			if p {
-				if !reverse {
-					actualKeys = append(actualKeys, iter.Key())
-				} else {
-					actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
+		err := IterateMVCCReplicaKeySpans(desc, readWriter, IterateOptions{
+			CombineRangesAndPoints: false,
+			Reverse:                reverse,
+		}, func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+			for {
+				ok, err := iter.Valid()
+				require.NoError(t, err)
+				if !ok {
+					break
 				}
-			}
-			if r {
-				rangeKeys := iter.RangeKeys().Clone()
-				if !rangeKeys.Bounds.Key.Equal(rangeStart) {
-					rangeStart = rangeKeys.Bounds.Key.Clone()
+				p, r := iter.HasPointAndRange()
+				if p {
 					if !reverse {
-						for _, v := range rangeKeys.Versions {
-							actualRanges = append(actualRanges, rangeKeys.AsRangeKey(v))
-						}
+						actualKeys = append(actualKeys, iter.Key())
 					} else {
-						for i := rangeKeys.Len() - 1; i >= 0; i-- {
-							actualRanges = append([]storage.MVCCRangeKey{
-								rangeKeys.AsRangeKey(rangeKeys.Versions[i])},
-								actualRanges...)
+						actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
+					}
+				}
+				if r {
+					rangeKeys := iter.RangeKeys().Clone()
+					if !rangeKeys.Bounds.Key.Equal(rangeStart) {
+						rangeStart = rangeKeys.Bounds.Key.Clone()
+						if !reverse {
+							for _, v := range rangeKeys.Versions {
+								actualRanges = append(actualRanges, rangeKeys.AsRangeKey(v))
+							}
+						} else {
+							for i := rangeKeys.Len() - 1; i >= 0; i-- {
+								actualRanges = append([]storage.MVCCRangeKey{
+									rangeKeys.AsRangeKey(rangeKeys.Versions[i]),
+								}, actualRanges...)
+							}
 						}
 					}
 				}
+				if reverse {
+					iter.Prev()
+				} else {
+					iter.Next()
+				}
 			}
-			next()
-		}
+			return nil
+		})
+		require.NoError(t, err, "visitor failed")
 		require.Equal(t, expectedKeys, actualKeys)
 		require.Equal(t, expectedRangeKeys, actualRanges)
 	}

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -979,6 +979,17 @@ message GCRequest {
   // Threshold is the expiration timestamp.
   util.hlc.Timestamp threshold = 4 [(gogoproto.nullable) = false];
 
+  // Range deletion request.
+  message GCClearRangeKey {
+    bytes start_key = 1 [(gogoproto.casttype) = "Key"];
+    bytes end_key = 2 [(gogoproto.casttype) = "Key"];
+  }
+  // range_deletion_keys contains zero or more (typically a single) ranges
+  // that would be deleted using storage range delete operation. Note that
+  // those ranges must not have any data newer than GC threshold or the
+  // request will fail.
+  repeated GCClearRangeKey clear_range_keys = 7 [(gogoproto.nullable) = false];
+
   reserved 5;
 }
 

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5277,6 +5277,11 @@ func pt(key roachpb.Key, ts hlc.Timestamp) rangeTestDataItem {
 	return rangeTestDataItem{point: MVCCKeyValue{Key: mvccVersionKey(key, ts), Value: val}}
 }
 
+// tb creates a point tombstone.
+func tb(key roachpb.Key, ts hlc.Timestamp) rangeTestDataItem {
+	return rangeTestDataItem{point: MVCCKeyValue{Key: mvccVersionKey(key, ts)}}
+}
+
 // txn wraps point update and adds transaction to it for intent creation.
 func txn(d rangeTestDataItem) rangeTestDataItem {
 	ts := d.point.Key.Timestamp
@@ -5812,6 +5817,30 @@ func rangesFromRequests(
 	return collectableKeys
 }
 
+func clearRangesFromRequests(
+	rangeStart, rangeEnd roachpb.Key, rangeKeys []roachpb.GCRequest_GCClearRangeKey,
+) []CollectableGCClearRangeKey {
+	collectableKeys := make([]CollectableGCClearRangeKey, len(rangeKeys))
+	for i, rk := range rangeKeys {
+		leftPeekBound := rk.StartKey.Prevish(roachpb.PrevishKeyLength)
+		if leftPeekBound.Compare(rangeStart) <= 0 {
+			leftPeekBound = rangeStart
+		}
+		rightPeekBound := rk.EndKey.Next()
+		if rightPeekBound.Compare(rangeEnd) >= 0 {
+			rightPeekBound = rangeEnd
+		}
+		collectableKeys[i] = CollectableGCClearRangeKey{
+			Span: roachpb.Span{
+				Key:    rk.StartKey,
+				EndKey: rk.EndKey,
+			},
+			LatchSpan: roachpb.Span{Key: leftPeekBound, EndKey: rightPeekBound},
+		}
+	}
+	return collectableKeys
+}
+
 func TestMVCCGarbageCollectRangesFailures(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -5918,6 +5947,175 @@ func TestMVCCGarbageCollectRangesFailures(t *testing.T) {
 						"expected error '%s' found '%s'", d.error, err)
 				})
 			}
+		})
+	}
+}
+
+// TestMVCCGarbageCollectClearRange does sanity checks over data, main test
+// cases are covered by mvcc_history_test: gc_clear_range*
+func TestMVCCGarbageCollectClearRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	mkKey := func(k string) roachpb.Key {
+		return append(keys.SystemSQLCodec.TablePrefix(42), k...)
+	}
+	rangeStart := mkKey("")
+	rangeEnd := rangeStart.PrefixEnd()
+
+	// Note we use keys of different lengths so that stats accounting errors
+	// would not obviously cancel out if right and left bounds are used
+	// incorrectly.
+	keyA := mkKey("a")
+	keyB := mkKey("bb")
+	keyC := mkKey("ccc")
+	keyD := mkKey("dddd")
+	keyE := mkKey("eeeee")
+
+	mkTs := func(wallTimeSec int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: time.Second.Nanoseconds() * wallTimeSec}
+	}
+
+	ts1 := mkTs(1)
+	ts2 := mkTs(2)
+	ts3 := mkTs(3)
+	ts4 := mkTs(4)
+	tsMax := mkTs(9)
+
+	testData := []struct {
+		name string
+		// Note that range test data should be in ascending order (valid writes).
+		before  rangeTestData
+		request []roachpb.GCRequest_GCClearRangeKey
+		after   rangeTestData
+		// Optional start and end range for tests that want to restrict default
+		// key range.
+		rangeStart roachpb.Key
+		rangeEnd   roachpb.Key
+	}{
+		{
+			name: "clear over interleaved points and ranges",
+			before: rangeTestData{
+				pt(keyB, ts1),
+				rng(keyB, keyC, ts2),
+				pt(keyB, ts3),
+				rng(keyB, keyC, ts4),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyB, EndKey: keyD},
+			},
+			after: rangeTestData{},
+		},
+		{
+			name: "clear over data outside range",
+			before: rangeTestData{
+				pt(keyA, ts2),
+				pt(keyA, tsMax),
+				pt(keyE, ts3),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyB, EndKey: keyD},
+			},
+			after: rangeTestData{
+				pt(keyA, ts2),
+				pt(keyA, tsMax),
+				pt(keyE, ts3),
+			},
+		},
+	}
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			for _, d := range testData {
+				t.Run(d.name, func(t *testing.T) {
+					engine := engineImpl.create()
+					defer engine.Close()
+
+					// Populate range descriptor defaults.
+					if len(d.rangeStart) == 0 {
+						d.rangeStart = rangeStart
+					}
+					if len(d.rangeEnd) == 0 {
+						d.rangeEnd = rangeEnd
+					}
+
+					var ms enginepb.MVCCStats
+					d.before.populateEngine(t, engine, &ms)
+
+					rangeKeys := clearRangesFromRequests(rangeStart, rangeEnd, d.request)
+					require.NoError(t, MVCCGarbageCollectWithClearRange(ctx, engine, &ms, tsMax, rangeKeys),
+						"failed to run mvcc range tombstone garbage collect")
+
+					expected := engineImpl.create()
+					defer expected.Close()
+					var expMs enginepb.MVCCStats
+					d.after.populateEngine(t, expected, &expMs)
+
+					rks := scanRangeKeys(t, engine)
+					expRks := scanRangeKeys(t, expected)
+					require.EqualValues(t, rks, expRks)
+
+					ks := scanPointKeys(t, engine)
+					expKs := scanPointKeys(t, expected)
+					require.EqualValues(t, ks, expKs)
+
+					ms.AgeTo(tsMax.WallTime)
+					it := engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+						KeyTypes:   IterKeyTypePointsAndRanges,
+						LowerBound: d.rangeStart,
+						UpperBound: d.rangeEnd,
+					})
+					expMs, err := ComputeStatsForRange(it, rangeStart, rangeEnd, tsMax.WallTime)
+					require.NoError(t, err, "failed to compute stats for range")
+					require.EqualValues(t, expMs, ms, "computed range stats vs gc'd")
+				})
+			}
+		})
+	}
+}
+
+// TestMVCCGarbageCollectClearRangeFailure does sanity checks over data, main test
+// cases are covered by mvcc_history_test: gc_clear_range*
+func TestMVCCGarbageCollectClearRangeFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	mkKey := func(k string) roachpb.Key {
+		return append(keys.SystemSQLCodec.TablePrefix(42), k...)
+	}
+	rangeStart := mkKey("")
+	rangeEnd := rangeStart.PrefixEnd()
+
+	// Note we use keys of different lengths so that stats accounting errors
+	// would not obviously cancel out if right and left bounds are used
+	// incorrectly.
+	keyA := mkKey("a")
+	keyD := mkKey("dddd")
+
+	mkTs := func(wallTimeSec int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: time.Second.Nanoseconds() * wallTimeSec}
+	}
+
+	ts1 := mkTs(1)
+	tsGC := mkTs(5)
+
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			before := rangeTestData{pt(keyA, ts1)}
+			request := []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			}
+			errMessage := `attempt to clear range with data /Table/42/"a"/1.000000000,0`
+			engine := engineImpl.create()
+			defer engine.Close()
+			var ms enginepb.MVCCStats
+			before.populateEngine(t, engine, &ms)
+			rangeKeys := clearRangesFromRequests(rangeStart, rangeEnd, request)
+			err := MVCCGarbageCollectWithClearRange(ctx, engine, &ms, tsGC, rangeKeys)
+			require.Errorf(t, err, "expected error '%s' but found none", errMessage)
+			require.True(t, testutils.IsError(err, errMessage),
+				"expected error '%s' found '%s'", errMessage, err)
 		})
 	}
 }

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range
@@ -1,0 +1,231 @@
+# Each error uses distinct data set and multiple tests are combined in this file.
+# ~~~ - gc clear range ops (test case number embedded for clarity)
+#  5  ~8~~~   ~7~~~   ~6~~~   ~5~~~~~~    ~4~~~~~~    ~3~~~            ~2~~~   ~1~~~      ~9~~
+#  4  x               o---o   x   x       o---o       o-------o   o-------o           o-----------o
+#  3                          x   55      888
+#  2  1       o---o   22      3   x       o---o       o-------o   o-------o           o-----------o
+#  1                          44  6       7
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   nn  o   p   q   r   s   t   u   v   w   x
+
+run ok
+put k=a v=11 ts=2,0
+del k=a ts=4,0
+del_range_ts k=c end=d ts=2,0
+put k=e v=22 ts=2,0
+del_range_ts k=e end=f ts=4,0
+with k=g
+  put v=44 ts=1,0
+  put v=3 ts=2,0
+  del ts=3,0
+  del ts=4,0
+with k=h
+  put v=5 ts=1,0
+  del ts=2,0
+  put v=66 ts=3,0
+  del ts=4,0
+with k=j
+  put v=7 ts=1,0
+  del_range_ts end=k ts=2,0
+  put v=888 ts=3,0
+  del_range_ts end=k ts=4,0
+with k=m end=o
+  del_range_ts ts=2,0
+  del_range_ts ts=4,0
+with k=p end=q
+  del_range_ts ts=2,0
+  del_range_ts ts=4,0
+with k=u end=x
+  del_range_ts ts=2,0
+  del_range_ts ts=4,0
+----
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {j-k}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+data: "j"/3.000000000,0 -> /BYTES/888
+data: "j"/1.000000000,0 -> /BYTES/7
+
+run stats
+gc_clear_range k=s end=t ts=5,0
+----
+>> gc_clear_range k=s end=t ts=5,0
+stats: no change
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {j-k}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+data: "j"/3.000000000,0 -> /BYTES/888
+data: "j"/1.000000000,0 -> /BYTES/7
+stats: key_count=5 key_bytes=166 val_count=13 val_bytes=54 range_key_count=6 range_key_bytes=114 range_val_count=10 gc_bytes_age=32326
+
+run stats
+gc_clear_range k=q end=r ts=5,0
+----
+>> gc_clear_range k=q end=r ts=5,0
+stats: no change
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {j-k}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+data: "j"/3.000000000,0 -> /BYTES/888
+data: "j"/1.000000000,0 -> /BYTES/7
+stats: key_count=5 key_bytes=166 val_count=13 val_bytes=54 range_key_count=6 range_key_bytes=114 range_val_count=10 gc_bytes_age=32326
+
+run stats
+gc_clear_range k=m end=nn ts=5,0
+----
+>> gc_clear_range k=m end=nn ts=5,0
+stats: range_key_bytes=+1 gc_bytes_age=+96
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {j-k}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+data: "j"/3.000000000,0 -> /BYTES/888
+data: "j"/1.000000000,0 -> /BYTES/7
+stats: key_count=5 key_bytes=166 val_count=13 val_bytes=54 range_key_count=6 range_key_bytes=115 range_val_count=10 gc_bytes_age=32422
+
+run stats
+gc_clear_range k=j end=l ts=5,0
+----
+>> gc_clear_range k=j end=l ts=5,0
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-14 range_key_count=-1 range_key_bytes=-22 range_val_count=-2 gc_bytes_age=-6006
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/3.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/3
+data: "g"/1.000000000,0 -> /BYTES/44
+data: "h"/4.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/66
+data: "h"/2.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/5
+stats: key_count=4 key_bytes=140 val_count=11 val_bytes=40 range_key_count=5 range_key_bytes=93 range_val_count=8 gc_bytes_age=26416
+
+run stats
+gc_clear_range k=g end=i ts=5,0
+----
+>> gc_clear_range k=g end=i ts=5,0
+stats: key_count=-2 key_bytes=-100 val_count=-8 val_bytes=-26 gc_bytes_age=-12224
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {e-f}/[4.000000000,0=/<empty>]
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "e"/2.000000000,0 -> /BYTES/22
+stats: key_count=2 key_bytes=40 val_count=3 val_bytes=14 range_key_count=5 range_key_bytes=93 range_val_count=8 gc_bytes_age=14192
+
+run stats
+gc_clear_range k=e end=f ts=5,0
+----
+>> gc_clear_range k=e end=f ts=5,0
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 range_key_count=-1 range_key_bytes=-13 range_val_count=-1 gc_bytes_age=-3264
+>> at end:
+rangekey: {c-d}/[2.000000000,0=/<empty>]
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+stats: key_count=1 key_bytes=26 val_count=2 val_bytes=7 range_key_count=4 range_key_bytes=80 range_val_count=7 gc_bytes_age=10928
+
+run stats
+gc_clear_range k=c end=d ts=5,0
+----
+>> gc_clear_range k=c end=d ts=5,0
+stats: range_key_count=-1 range_key_bytes=-13 range_val_count=-1 gc_bytes_age=-1274
+>> at end:
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+stats: key_count=1 key_bytes=26 val_count=2 val_bytes=7 range_key_count=3 range_key_bytes=67 range_val_count=6 gc_bytes_age=9654
+
+run stats
+gc_clear_range k=a end=b ts=5,0
+----
+>> gc_clear_range k=a end=b ts=5,0
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3168
+>> at end:
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+stats: range_key_count=3 range_key_bytes=67 range_val_count=6 gc_bytes_age=6486
+
+run stats
+gc_clear_range k=v end=w ts=5,0
+----
+>> gc_clear_range k=v end=w ts=5,0
+stats: range_key_count=+1 range_key_bytes=+22 range_val_count=+2 gc_bytes_age=+2130
+>> at end:
+rangekey: {nn-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {p-q}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {u-v}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+rangekey: {w-x}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+stats: range_key_count=4 range_key_bytes=89 range_val_count=8 gc_bytes_age=8616

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
@@ -1,0 +1,122 @@
+# Each error uses distinct data set and multiple tests are combined in this file.
+#  5                  o-------o   x       v4      [v5]
+#  4
+#  3  ~~~~~   ~~~~~       ~~~~~   ~~~~~   ~~~~~   ~~~~~  Clear ranges at GC threshold
+#  2
+#  1  [v1]    v2                  v3
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o
+
+run ok
+with t=A k=a
+  txn_begin ts=1,0
+  put  v=1
+put  k=c v=2 ts=1,0
+del_range_ts  k=e end=g ts=5,0
+put  k=h v=3 ts=1,0
+del  k=h ts=5,0
+put  k=j v=4 ts=5,0
+with t=B k=l
+  txn_begin ts=5,0
+  put v=5
+----
+>> at end:
+txn: "B" meta={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+
+run error
+gc_clear_range k=a end=b ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "a"
+
+run error
+gc_clear_range k=c end=d ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "c"/1.000000000,0
+
+run error
+gc_clear_range k=h end=i ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "h"/5.000000000,0
+
+run error
+gc_clear_range k=f end=g ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data {f-g}/5.000000000,0
+
+run error
+gc_clear_range k=j end=k ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "j"/5.000000000,0
+
+run error
+gc_clear_range k=l end=m ts=4,0
+----
+>> at end:
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/1
+data: "c"/1.000000000,0 -> /BYTES/2
+data: "h"/5.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/3
+data: "j"/5.000000000,0 -> /BYTES/4
+meta: "l"/0,0 -> txn={id=00000000 key="l" pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/5.000000000,0 -> /BYTES/5
+error: (*withstack.withStack:) attempt to clear range with data "l"


### PR DESCRIPTION
This commit adds range_deletion_keys parameters to GC request.
range_deletion_keys is used by GC queue to remove chunks of
consecutive keys where no new data was written above the GC
threshold and storage can optimize deletions with range
tombstones.
To support new types of keys, GCer interface is also updated
to pass provided keys down to request.


When deleting large chunks of keys usually produced by range tombstones
GC will use point deletion for all versions found within replica key
range.
That kind of operations would generate unnecessary load on the storage
because each individual version must be deleted independently.
This patch adds an ability for GC to find ranges of consecutive keys
which are not interleaved with any newer data and create
delete_range_key GC requests to remove them.


Release note: None