### PR TITLE
Revert "sql: Add database ID to sampled query log"

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2463,7 +2463,6 @@ contains common SQL event/execution details.
 | `Database` | Name of the database that initiated the query. | no |
 | `StatementID` | Statement ID of the query. | no |
 | `TransactionID` | Transaction ID of the query. | no |
-| `DatabaseID` | Database ID of the query. | no |
 | `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
 | `MaxFullScanRowsEstimate` | Maximum number of rows scanned by a full scan, as estimated by the optimizer. | no |
 | `TotalScanRowsEstimate` | Total number of rows read by all scans in the query, as estimated by the optimizer. | no |

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -389,7 +389,6 @@ func (p *planner) maybeLogStatementInternal(
 		}
 		if telemetryMetrics.maybeUpdateLastEmittedTime(telemetryMetrics.timeNow(), requiredTimeElapsed) {
 			skippedQueries := telemetryMetrics.resetSkippedQueryCount()
-			databaseName := p.CurrentDatabase()
 			sampledQuery := eventpb.SampledQuery{
 				CommonSQLExecDetails:     execDetails,
 				SkippedQueries:           skippedQueries,
@@ -397,7 +396,7 @@ func (p *planner) maybeLogStatementInternal(
 				Distribution:             p.curPlan.instrumentation.distribution.String(),
 				PlanGist:                 p.curPlan.instrumentation.planGist.String(),
 				SessionID:                p.extendedEvalCtx.SessionID.String(),
-				Database:                 databaseName,
+				Database:                 p.CurrentDatabase(),
 				StatementID:              p.stmt.QueryID.String(),
 				TransactionID:            p.txn.ID().String(),
 				StatementFingerprintID:   uint64(stmtFingerprintID),
@@ -409,10 +408,6 @@ func (p *planner) maybeLogStatementInternal(
 				BytesRead:                queryStats.bytesRead,
 				RowsRead:                 queryStats.rowsRead,
 				RowsWritten:              queryStats.rowsWritten,
-			}
-			db, _ := p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn, databaseName, tree.DatabaseLookupFlags{Required: true})
-			if db != nil {
-				sampledQuery.DatabaseID = uint32(db.GetID())
 			}
 			p.logOperationalEventsOnlyExternally(ctx, eventLogEntry{event: &sampledQuery})
 		} else {

--- a/pkg/util/log/eventpb/gen.go
+++ b/pkg/util/log/eventpb/gen.go
@@ -343,6 +343,11 @@ func readInput(
 				return errors.Newf("field definition must not span multiple lines: %q", line)
 			}
 
+			// Skip reserved fields.
+			if reservedDefRe.MatchString(line) {
+				continue
+			}
+
 			// A field.
 			if strings.HasPrefix(line, "repeated") {
 				line = "array_of_" + strings.TrimSpace(strings.TrimPrefix(line, "repeated"))
@@ -447,6 +452,8 @@ var fieldDefRe = regexp.MustCompile(`\s*(?P<typ>[a-z._A-Z0-9]+)` +
 	`(.*"redact:\\"(?P<reportingsafe>nonsensitive|mixed)\\"")?` +
 	`(.*"redact:\\"safeif:(?P<safeif>([^\\]|\\[^"])+)\\"")?` +
 	`).*$`)
+
+var reservedDefRe = regexp.MustCompile(`\s*(reserved ([1-9][0-9]*);)`)
 
 func camelToSnake(typeName string) string {
 	var res strings.Builder

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3335,15 +3335,6 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, '"')
 	}
 
-	if m.DatabaseID != 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"DatabaseID\":"...)
-		b = strconv.AppendUint(b, uint64(m.DatabaseID), 10)
-	}
-
 	if m.StatementFingerprintID != 0 {
 		if printComma {
 			b = append(b, ',')

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -59,9 +59,6 @@ message SampledQuery {
   // Transaction ID of the query.
   string transaction_id = 11 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // Database ID of the query.
-  uint32 database_id = 12 [(gogoproto.customname) = "DatabaseID", (gogoproto.jsontag) = ",omitempty"];
-
   // Statement fingerprint ID of the query.
   uint64 statement_fingerprint_id = 13 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty'];
 
@@ -92,6 +89,8 @@ message SampledQuery {
 
   // The number of rows written.
   int64 rows_written = 21 [(gogoproto.jsontag) = ",omitempty"];
+
+  reserved 12;
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
Reverts: #84195
This reverts commit 307817e96ee7ef4c5d6f908aa5fb01adbca5f62d.

Removes the DatabaseID field from the
`SampledQuery` telemetry log due to the potential of indefinite blocking
in the case of a lease acquisition failure. Protobuf field not reserved as 
no official build was released with these changes yet.

Release note (sql change): Removes the DatabaseID field from the
`SampledQuery` telemetry log due to the potential of indefinite blocking
in the case of a lease acquisition failure.