### PR TITLE
opt: add optbuilder support for multi-statement UDFs

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -101,6 +101,9 @@ type RelExpr interface {
 	setNext(e RelExpr)
 }
 
+// RelListExpr is an ordered list of relational expressions.
+type RelListExpr []RelExpr
+
 // ScalarPropsExpr is implemented by scalar expressions which cache scalar
 // properties, like FiltersExpr and ProjectionsExpr. These expressions are also
 // tagged with the ScalarProps tag.

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -867,6 +867,12 @@ func (f *ExprFmtCtx) formatScalar(scalar opt.ScalarExpr, tp treeprinter.Node) {
 func (f *ExprFmtCtx) formatScalarWithLabel(
 	label string, scalar opt.ScalarExpr, tp treeprinter.Node,
 ) {
+	formatUDFBody := func(udf *UserDefinedFunctionExpr, tp treeprinter.Node) {
+		for i := range udf.Body {
+			f.formatExpr(udf.Body[i], tp)
+		}
+	}
+
 	f.Buffer.Reset()
 	if label != "" {
 		f.Buffer.WriteString(label)
@@ -919,6 +925,13 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 		for i, n := 0, scalar.ChildCount(); i < n; i++ {
 			f.formatExpr(scalar.Child(i), tp)
 		}
+		return
+
+	case opt.UserDefinedFunctionOp:
+		udf := scalar.(*UserDefinedFunctionExpr)
+		fmt.Fprintf(f.Buffer, "udf: %s", udf.Name)
+		tp = tp.Child(f.Buffer.String())
+		formatUDFBody(udf, tp)
 		return
 	}
 
@@ -976,6 +989,13 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 			intercepted = true
 		}
 	}
+	if udf, ok := scalar.(*UserDefinedFunctionExpr); ok {
+		// A UDF function body will be printed after the scalar props, so
+		// pre-emptively set intercepted=true to avoid the default
+		// formatScalarPrivate formatting below.
+		fmt.Fprintf(f.Buffer, "udf: %s", udf.Name)
+		intercepted = true
+	}
 	if !intercepted {
 		fmt.Fprintf(f.Buffer, "%v", scalar.Op())
 		f.formatScalarPrivate(scalar)
@@ -986,6 +1006,11 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 		f.Buffer.WriteByte(']')
 	}
 	tp = tp.Child(f.Buffer.String())
+
+	if udf, ok := scalar.(*UserDefinedFunctionExpr); ok {
+		// Always print UDF function body.
+		formatUDFBody(udf, tp)
+	}
 
 	if !intercepted {
 		for i, n := 0, scalar.ChildCount(); i < n; i++ {
@@ -1510,9 +1535,6 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		fmt.Fprintf(f.Buffer, " %s,%s,%s", t.JoinType, t.LeftEq, t.RightEq)
 
 	case *FunctionPrivate:
-		fmt.Fprintf(f.Buffer, " %s", t.Name)
-
-	case *UserDefinedFunctionPrivate:
 		fmt.Fprintf(f.Buffer, " %s", t.Name)
 
 	case *WindowsItemPrivate:

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -867,7 +867,7 @@ func (f *ExprFmtCtx) formatScalar(scalar opt.ScalarExpr, tp treeprinter.Node) {
 func (f *ExprFmtCtx) formatScalarWithLabel(
 	label string, scalar opt.ScalarExpr, tp treeprinter.Node,
 ) {
-	formatUDFBody := func(udf *UserDefinedFunctionExpr, tp treeprinter.Node) {
+	formatUDFBody := func(udf *UDFExpr, tp treeprinter.Node) {
 		for i := range udf.Body {
 			f.formatExpr(udf.Body[i], tp)
 		}
@@ -927,8 +927,8 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 		}
 		return
 
-	case opt.UserDefinedFunctionOp:
-		udf := scalar.(*UserDefinedFunctionExpr)
+	case opt.UDFOp:
+		udf := scalar.(*UDFExpr)
 		fmt.Fprintf(f.Buffer, "udf: %s", udf.Name)
 		tp = tp.Child(f.Buffer.String())
 		formatUDFBody(udf, tp)
@@ -989,7 +989,7 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 			intercepted = true
 		}
 	}
-	if udf, ok := scalar.(*UserDefinedFunctionExpr); ok {
+	if udf, ok := scalar.(*UDFExpr); ok {
 		// A UDF function body will be printed after the scalar props, so
 		// pre-emptively set intercepted=true to avoid the default
 		// formatScalarPrivate formatting below.
@@ -1007,7 +1007,7 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 	}
 	tp = tp.Child(f.Buffer.String())
 
-	if udf, ok := scalar.(*UserDefinedFunctionExpr); ok {
+	if udf, ok := scalar.(*UDFExpr); ok {
 		// Always print UDF function body.
 		formatUDFBody(udf, tp)
 	}

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -652,6 +652,12 @@ func (h *hasher) HashRelExpr(val RelExpr) {
 	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
 }
 
+func (h *hasher) HashRelListExpr(val []RelExpr) {
+	for i := range val {
+		h.HashRelExpr(val[i])
+	}
+}
+
 func (h *hasher) HashScalarExpr(val opt.ScalarExpr) {
 	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
 }
@@ -1051,6 +1057,18 @@ func (h *hasher) IsPointerEqual(l, r unsafe.Pointer) bool {
 
 func (h *hasher) IsRelExprEqual(l, r RelExpr) bool {
 	return l == r
+}
+
+func (h *hasher) IsRelListExprEqual(l, r []RelExpr) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if l[i] != r[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *hasher) IsScalarExprEqual(l, r opt.ScalarExpr) bool {

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -63,7 +63,7 @@ func (c *CustomFuncs) deriveHasHoistableSubquery(scalar opt.ScalarExpr) bool {
 		// only occurs when the Any is nested, in a projection, etc.
 		return !t.Input.Relational().OuterCols.Empty()
 
-	case *memo.UserDefinedFunctionExpr:
+	case *memo.UDFExpr:
 		// Do not attempt to hoist UDFs.
 		return false
 	}

--- a/pkg/sql/opt/norm/testdata/rules/udf
+++ b/pkg/sql/opt/norm/testdata/rules/udf
@@ -12,7 +12,7 @@ values
  ├── key: ()
  ├── fd: ()-->(2)
  └── tuple
-      └── user-defined-function: one
+      └── udf: one
            └── values
                 ├── columns: "?column?":1!null
                 ├── cardinality: [1 - 1]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1214,16 +1214,15 @@ define NthValue {
     Nth ScalarExpr
 }
 
-# UserDefinedFunction invokes a user-defined function. The
-# UserDefinedFunctionPrivate field contains the name of the function and a
-# pointer to its type.
+# UDF invokes a user-defined function. The UDFPrivate field contains the name of
+# the function, the statements in the function body, and a pointer to its type.
 [Scalar]
-define UserDefinedFunction {
-    _ UserDefinedFunctionPrivate
+define UDF {
+    _ UDFPrivate
 }
 
 [Private]
-define UserDefinedFunctionPrivate {
+define UDFPrivate {
     Name string
     Body RelListExpr
     Typ Type

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1219,13 +1219,13 @@ define NthValue {
 # pointer to its type.
 [Scalar]
 define UserDefinedFunction {
-    Body RelExpr
     _ UserDefinedFunctionPrivate
 }
 
 [Private]
 define UserDefinedFunctionPrivate {
     Name string
+    Body RelListExpr
     Typ Type
 }
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -610,8 +610,8 @@ func (b *Builder) buildUDF(
 		rels[i] = bodyScope.expr
 	}
 
-	out = b.factory.ConstructUserDefinedFunction(
-		&memo.UserDefinedFunctionPrivate{
+	out = b.factory.ConstructUDF(
+		&memo.UDFPrivate{
 			Name: def.Name,
 			Body: rels,
 			Typ:  f.ResolvedType(),

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -590,27 +590,30 @@ func (b *Builder) buildFunction(
 
 // buildUDF builds a set of memo groups that represents a user-defined function
 // invocation.
-// TODO(mgartner): Support multi-statement UDFs.
 // TODO(mgartner): Support UDFs with arguments.
 func (b *Builder) buildUDF(
 	f *tree.FuncExpr, def *tree.FunctionDefinition, inScope, outScope *scope, outCol *scopeColumn,
 ) (out opt.ScalarExpr) {
-	stmt, err := parser.ParseOne(f.ResolvedOverload().Body)
+	stmts, err := parser.Parse(f.ResolvedOverload().Body)
 	if err != nil {
 		panic(err)
 	}
 
-	// A statement inside a UDF body cannot refer to anything from the outer
-	// expression calling the function, so we use an empty scope.
-	// TODO(mgartner): We may need to set bodyScope.atRoot=true to prevent CTEs
-	// that mutate and are not at the top-level.
-	bodyScope := b.allocScope()
-	bodyScope = b.buildStmt(stmt.AST, nil /* desiredTypes */, bodyScope)
+	rels := make(memo.RelListExpr, len(stmts))
+	for i := range stmts {
+		// A statement inside a UDF body cannot refer to anything from the outer
+		// expression calling the function, so we use an empty scope.
+		// TODO(mgartner): We may need to set bodyScope.atRoot=true to prevent
+		// CTEs that mutate and are not at the top-level.
+		bodyScope := b.allocScope()
+		bodyScope = b.buildStmt(stmts[i].AST, nil /* desiredTypes */, bodyScope)
+		rels[i] = bodyScope.expr
+	}
 
 	out = b.factory.ConstructUserDefinedFunction(
-		bodyScope.expr,
 		&memo.UserDefinedFunctionPrivate{
 			Name: def.Name,
+			Body: rels,
 			Typ:  f.ResolvedType(),
 		},
 	)

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -15,6 +15,13 @@ exec-ddl
 CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS 'SELECT 1';
 ----
 
+exec-ddl
+CREATE FUNCTION two() RETURNS INT LANGUAGE SQL AS $$
+  SELECT 1;
+  SELECT 2;
+$$
+----
+
 build
 SELECT one()
 ----
@@ -23,7 +30,7 @@ project
  ├── values
  │    └── ()
  └── projections
-      └── user-defined-function: one [as=one:2]
+      └── udf: one [as=one:2]
            └── project
                 ├── columns: "?column?":1!null
                 ├── values
@@ -39,7 +46,7 @@ project
  ├── scan abc
  │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
  └── projections
-      └── user-defined-function: one [as=one:7]
+      └── udf: one [as=one:7]
            └── project
                 ├── columns: "?column?":6!null
                 ├── values
@@ -58,7 +65,7 @@ project
       │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
       └── filters
            └── eq
-                ├── user-defined-function: one
+                ├── udf: one
                 │    └── project
                 │         ├── columns: "?column?":6!null
                 │         ├── values
@@ -66,3 +73,54 @@ project
                 │         └── projections
                 │              └── 1 [as="?column?":6]
                 └── c:3
+
+build
+SELECT a + one(), b + two() FROM abc WHERE c = two()
+----
+project
+ ├── columns: "?column?":9 "?column?":12
+ ├── select
+ │    ├── columns: a:1!null b:2 c:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    ├── scan abc
+ │    │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    └── filters
+ │         └── eq
+ │              ├── c:3
+ │              └── udf: two
+ │                   ├── project
+ │                   │    ├── columns: "?column?":6!null
+ │                   │    ├── values
+ │                   │    │    └── ()
+ │                   │    └── projections
+ │                   │         └── 1 [as="?column?":6]
+ │                   └── project
+ │                        ├── columns: "?column?":7!null
+ │                        ├── values
+ │                        │    └── ()
+ │                        └── projections
+ │                             └── 2 [as="?column?":7]
+ └── projections
+      ├── plus [as="?column?":9]
+      │    ├── a:1
+      │    └── udf: one
+      │         └── project
+      │              ├── columns: "?column?":8!null
+      │              ├── values
+      │              │    └── ()
+      │              └── projections
+      │                   └── 1 [as="?column?":8]
+      └── plus [as="?column?":12]
+           ├── b:2
+           └── udf: two
+                ├── project
+                │    ├── columns: "?column?":10!null
+                │    ├── values
+                │    │    └── ()
+                │    └── projections
+                │         └── 1 [as="?column?":10]
+                └── project
+                     ├── columns: "?column?":11!null
+                     ├── values
+                     │    └── ()
+                     └── projections
+                          └── 2 [as="?column?":11]

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -232,7 +232,7 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 	if define.Tags.Contains("Scalar") {
 		fmt.Fprintf(g.w, "var _ opt.ScalarExpr = &%s{}\n\n", opTyp.name)
 
-		// Generate the ID method.
+		// Generate the Rank method.
 		fmt.Fprintf(g.w, "func (e *%s) Rank() opt.ScalarRank {\n", opTyp.name)
 		if define.Tags.Contains("ListItem") {
 			fmt.Fprintf(g.w, "  panic(errors.AssertionFailedf(\"list items have no rank\"))")
@@ -518,7 +518,7 @@ func (g *exprsGen) genListExprFuncs(define *lang.DefineExpr) {
 	opTyp := g.md.typeOf(define)
 	fmt.Fprintf(g.w, "var _ opt.ScalarExpr = &%s{}\n\n", opTyp.name)
 
-	// Generate the ID method.
+	// Generate the Rank method.
 	fmt.Fprintf(g.w, "func (e *%s) Rank() opt.ScalarRank {\n", opTyp.name)
 	fmt.Fprintf(g.w, "  panic(errors.AssertionFailedf(\"lists have no rank\"))")
 	fmt.Fprintf(g.w, "}\n\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -188,6 +188,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"RelExpr":             {fullName: "memo.RelExpr", isExpr: true, isInterface: true},
 		"Expr":                {fullName: "opt.Expr", isExpr: true, isInterface: true},
 		"ScalarExpr":          {fullName: "opt.ScalarExpr", isExpr: true, isInterface: true},
+		"RelListExpr":         {fullName: "memo.RelListExpr"},
 		"Operator":            {fullName: "opt.Operator", passByVal: true},
 		"ColumnID":            {fullName: "opt.ColumnID", passByVal: true},
 		"ColSet":              {fullName: "opt.ColSet", passByVal: true},


### PR DESCRIPTION
#### opt: fix typos in optgen comments

Release note: None

#### opt: add optbuilder support for multi-statement UDFs

User-defined functions with multiple statements in the function body can
now be built by optbuilder.

Release note: None

#### opt: rename UserDefinedFunctionExpr to UDFExpr

The name of UDF optimizer expressions has been shortened. I originally
avoided the short form because it was formatted as "u-d-f" in optimizer
expressions, which I found unsightly. Now that UDF expression formatting
is custom, the name can be shortened without affecting how it is
formatted.

Release note: None
