### PR TITLE
release-22.1: revert "sql: add database ID to sampled query log"

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2438,7 +2438,6 @@ contains common SQL event/execution details.
 | `Database` | Name of the database that initiated the query. | no |
 | `StatementID` | Statement ID of the query. | no |
 | `TransactionID` | Transaction ID of the query. | no |
-| `DatabaseID` | Database ID of the query. | no |
 | `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
 
 

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -387,7 +387,6 @@ func (p *planner) maybeLogStatementInternal(
 		}
 		if telemetryMetrics.maybeUpdateLastEmittedTime(telemetryMetrics.timeNow(), requiredTimeElapsed) {
 			skippedQueries := telemetryMetrics.resetSkippedQueryCount()
-			databaseName := p.CurrentDatabase()
 			sampledQuery := eventpb.SampledQuery{
 				CommonSQLExecDetails:   execDetails,
 				SkippedQueries:         skippedQueries,
@@ -395,14 +394,10 @@ func (p *planner) maybeLogStatementInternal(
 				Distribution:           p.curPlan.instrumentation.distribution.String(),
 				PlanGist:               p.curPlan.instrumentation.planGist.String(),
 				SessionID:              p.extendedEvalCtx.SessionID.String(),
-				Database:               databaseName,
+				Database:               p.CurrentDatabase(),
 				StatementID:            p.stmt.QueryID.String(),
 				TransactionID:          p.txn.ID().String(),
 				StatementFingerprintID: uint64(stmtFingerprintID),
-			}
-			db, _ := p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn, databaseName, tree.DatabaseLookupFlags{Required: true})
-			if db != nil {
-				sampledQuery.DatabaseID = uint32(db.GetID())
 			}
 			p.logOperationalEventsOnlyExternally(ctx, eventLogEntry{event: &sampledQuery})
 		} else {

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -12,7 +12,6 @@ package sql
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"math"
 	"regexp"
@@ -97,14 +96,10 @@ func TestTelemetryLogging(t *testing.T) {
 
 	var sessionID string
 	var databaseName string
-	var dbID uint32
 
 	db := sqlutils.MakeSQLRunner(sqlDB)
-	conn := db.DB.(*gosql.DB)
-
 	db.QueryRow(t, `SHOW session_id`).Scan(&sessionID)
 	db.QueryRow(t, `SHOW database`).Scan(&databaseName)
-	dbID = sqlutils.QueryDatabaseID(t, conn, databaseName)
 	db.Exec(t, `SET application_name = 'telemetry-logging-test'`)
 	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
 	db.Exec(t, "CREATE TABLE t();")
@@ -279,9 +274,6 @@ func TestTelemetryLogging(t *testing.T) {
 				}
 				if !strings.Contains(e.Message, "\"Database\":\""+databaseName+"\"") {
 					t.Errorf("expected to find Database: %s", databaseName)
-				}
-				if !strings.Contains(e.Message, "\"DatabaseID\":"+strconv.Itoa(int(dbID))) {
-					t.Errorf("expected to find DatabaseID: %v", dbID)
 				}
 				stmtFingerprintID := roachpb.ConstructStatementFingerprintID(tc.queryNoConstants, false, true, databaseName)
 				if !strings.Contains(e.Message, "\"StatementFingerprintID\":"+strconv.FormatUint(uint64(stmtFingerprintID), 10)) {

--- a/pkg/util/log/eventpb/gen.go
+++ b/pkg/util/log/eventpb/gen.go
@@ -343,6 +343,10 @@ func readInput(
 				return errors.Newf("field definition must not span multiple lines: %q", line)
 			}
 
+			if reservedDefRe.MatchString(line) {
+				continue
+			}
+
 			// A field.
 			if strings.HasPrefix(line, "repeated") {
 				line = "array_of_" + strings.TrimSpace(strings.TrimPrefix(line, "repeated"))
@@ -446,6 +450,8 @@ var fieldDefRe = regexp.MustCompile(`\s*(?P<typ>[a-z._A-Z0-9]+)` +
 	`(.*"redact:\\"(?P<reportingsafe>nonsensitive|mixed)\\"")?` +
 	`(.*"redact:\\"safeif:(?P<safeif>([^\\]|\\[^"])+)\\"")?` +
 	`).*$`)
+
+var reservedDefRe = regexp.MustCompile(`\s*(reserved ([1-9][0-9]*);)`)
 
 func camelToSnake(typeName string) string {
 	var res strings.Builder

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3276,15 +3276,6 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, '"')
 	}
 
-	if m.DatabaseID != 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"DatabaseID\":"...)
-		b = strconv.AppendUint(b, uint64(m.DatabaseID), 10)
-	}
-
 	if m.StatementFingerprintID != 0 {
 		if printComma {
 			b = append(b, ',')

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -59,8 +59,7 @@ message SampledQuery {
   // Transaction ID of the query.
   string transaction_id = 11 [(gogoproto.customname) = "TransactionID", (gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // Database ID of the query.
-  uint32 database_id = 12 [(gogoproto.customname) = "DatabaseID", (gogoproto.jsontag) = ",omitempty"];
+  reserved 12;
 
   // Statement fingerprint ID of the query.
   uint64 statement_fingerprint_id = 13 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty'];


### PR DESCRIPTION
Reverts: #84195, PR that introduces the `DatabaseID` to the `SampledQuery`
telemetry log.

This reverts commit 0b9023d284e59e384a2ada31f1a7192cd260bf46, reversing
changes made to 8265e2a5f2e13738dea81039c53665b952fe6b81.

Removes the `DatabaseID` field from the `SampledQuery` telemetry log due to
the potential of indefinite blocking in the case of a lease acquisition
failure. Protobuf field not reserved as no official build was released
with these changes yet.

Release note (sql change): Removes the DatabaseID field from the
SampledQuery telemetry log due to the potential of indefinite blocking
in the case of a lease acquisition failure.

Release justification: Category 2: Bug fixes and low-risk updates to new functionality