### PR TITLE
sql: disallow grant option for public role's default privileges

### DIFF
--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -126,7 +126,7 @@ func (n *alterDefaultPrivilegesNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err := params.p.validateRoles(params.ctx, granteeSQLUsernames, true /* isPublicValid */); err != nil {
+	if err := params.p.preChangePrivilegesValidation(params.ctx, granteeSQLUsernames, grantOption, n.n.IsGrant); err != nil {
 		return err
 	}
 

--- a/pkg/sql/catalog/catprivilege/default_privilege.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege.go
@@ -289,18 +289,13 @@ func foldPrivileges(
 ) {
 	if targetObject == privilege.Types &&
 		privileges.CheckPrivilege(username.PublicRoleName(), privilege.USAGE) {
-		publicUser, ok := privileges.FindUser(username.PublicRoleName())
-		if ok {
-			if !privilege.USAGE.IsSetIn(publicUser.WithGrantOption) {
-				setPublicHasUsageOnTypes(defaultPrivilegesForRole, true)
-				privileges.Revoke(
-					username.PublicRoleName(),
-					privilege.List{privilege.USAGE},
-					privilege.Type,
-					false, /* grantOptionFor */
-				)
-			}
-		}
+		setPublicHasUsageOnTypes(defaultPrivilegesForRole, true)
+		privileges.Revoke(
+			username.PublicRoleName(),
+			privilege.List{privilege.USAGE},
+			privilege.Type,
+			false, /* grantOptionFor */
+		)
 	}
 	// ForAllRoles cannot be a grantee, nothing left to do.
 	if role.ForAllRoles {

--- a/pkg/sql/catalog/catprivilege/default_privilege_test.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege_test.go
@@ -786,48 +786,6 @@ func TestModifyDefaultDefaultPrivilegesForPublic(t *testing.T) {
 		t.Errorf("expected public to have USAGE privilege on types")
 	}
 
-	// Test granting when withGrantOption is true.
-	defaultPrivileges.GrantDefaultPrivileges(
-		catpb.DefaultPrivilegesRole{Role: creatorUser},
-		privilege.List{privilege.USAGE},
-		[]username.SQLUsername{username.PublicRoleName()},
-		privilege.Types,
-		true, /* withGrantOption */
-	)
-
-	privDesc := defaultPrivilegesForCreator.DefaultPrivilegesPerObject[privilege.Types]
-	user, found := privDesc.FindUser(username.PublicRoleName())
-	if !found {
-		t.Errorf("public not found on privilege descriptor when expected")
-	}
-	if !privilege.USAGE.IsSetIn(user.WithGrantOption) {
-		t.Errorf("expected public to have USAGE grant options on types")
-	}
-	// This flag should not be true since there is a "modification" - i.e. grant option bits for USAGE are active,
-	// so do not remove that user from the descriptor.
-	if GetPublicHasUsageOnTypes(defaultPrivilegesForCreator) {
-		t.Errorf("expected public to not have USAGE privilege on types")
-	}
-
-	// Test revoking when grantOptionFor is true.
-	defaultPrivileges.RevokeDefaultPrivileges(
-		catpb.DefaultPrivilegesRole{Role: creatorUser},
-		privilege.List{privilege.USAGE},
-		[]username.SQLUsername{username.PublicRoleName()},
-		privilege.Types,
-		true, /* grantOptionFor */
-	)
-
-	privDesc = defaultPrivilegesForCreator.DefaultPrivilegesPerObject[privilege.Types]
-	_, found = privDesc.FindUser(username.PublicRoleName())
-	if found {
-		t.Errorf("public found on privilege descriptor when it was supposed to be removed")
-	}
-	// Public still has usage on types since only the grant option for USAGE was revoked, not the privilege itself.
-	if !GetPublicHasUsageOnTypes(defaultPrivilegesForCreator) {
-		t.Errorf("expected public to have USAGE privilege on types")
-	}
-
 	// Test a complete revoke afterwards.
 	defaultPrivileges.RevokeDefaultPrivileges(
 		catpb.DefaultPrivilegesRole{Role: creatorUser},

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5191,7 +5191,8 @@ CREATE TABLE crdb_internal.default_privileges (
 	for_all_roles   BOOL,
 	object_type     STRING NOT NULL,
 	grantee         STRING NOT NULL,
-	privilege_type  STRING NOT NULL
+	privilege_type  STRING NOT NULL,
+	is_grantable    BOOL
 );`,
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, nil /* all databases */, true, /* requiresPrivileges */
@@ -5217,8 +5218,9 @@ CREATE TABLE crdb_internal.default_privileges (
 									role,                                 // role
 									forAllRoles,                          // for_all_roles
 									tree.NewDString(objectType.String()), // object_type
-									tree.NewDString(userPrivs.User().Normalized()), // grantee
-									tree.NewDString(priv.String()),                 // privilege_type
+									tree.NewDString(userPrivs.User().Normalized()),                      // grantee
+									tree.NewDString(priv.String()),                                      // privilege_type
+									tree.MakeDBool(tree.DBool(priv.IsSetIn(userPrivs.WithGrantOption))), // is_grantable
 								); err != nil {
 									return err
 								}
@@ -5237,6 +5239,8 @@ CREATE TABLE crdb_internal.default_privileges (
 									tree.NewDString(objectType.String()),  // object_type
 									tree.NewDString(defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode().Normalized()), // grantee
 									tree.NewDString(privilege.ALL.String()),                                                     // privilege_type
+									tree.DBoolTrue,
+									// is_grantable
 								); err != nil {
 									return err
 								}
@@ -5251,6 +5255,7 @@ CREATE TABLE crdb_internal.default_privileges (
 								tree.NewDString(privilege.Types.String()),               // object_type
 								tree.NewDString(username.PublicRoleName().Normalized()), // grantee
 								tree.NewDString(privilege.USAGE.String()),               // privilege_type
+								tree.DBoolFalse, // is_grantable
 							); err != nil {
 								return err
 							}

--- a/pkg/sql/delegate/show_default_privileges.go
+++ b/pkg/sql/delegate/show_default_privileges.go
@@ -35,7 +35,8 @@ func (d *delegator) delegateShowDefaultPrivileges(
 	}
 
 	query := fmt.Sprintf(
-		"SELECT role, for_all_roles, object_type, grantee, privilege_type FROM crdb_internal.default_privileges WHERE database_name = %s%s",
+		"SELECT role, for_all_roles, object_type, grantee, privilege_type, is_grantable "+
+			"FROM crdb_internal.default_privileges WHERE database_name = %s%s",
 		lexbase.EscapeSQLString(currentDatabase.Normalize()),
 		schemaClause,
 	)

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -35,7 +35,7 @@ func (n *changeNonDescriptorBackedPrivilegesNode) startExec(params runParams) er
 	if !params.p.ExecCfg().Settings.Version.IsActive(params.ctx, clusterversion.SystemPrivilegesTable) {
 		return errors.Newf("system cluster privileges are not supported until upgrade to version %s is finalized", clusterversion.SystemPrivilegesTable.String())
 	}
-	if err := n.changePrivilegesNode.preChangePrivilegesValidation(params); err != nil {
+	if err := params.p.preChangePrivilegesValidation(params.ctx, n.grantees, n.withGrantOption, n.isGrant); err != nil {
 		return err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
@@ -210,77 +210,77 @@ database_name  schema_name  table_name  grantee  privilege_type  is_grantable
 test           s2           t12         admin    ALL             true
 test           s2           t12         root     ALL             true
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE schema_name IS NOT NULL
 ----
-database_name  schema_name  role  for_all_roles  object_type  grantee    privilege_type
-test           public       NULL  true           tables       testuser2  SELECT
-test           s            NULL  true           tables       testuser2  SELECT
+database_name  schema_name  role  for_all_roles  object_type  grantee    privilege_type  is_grantable
+test           public       NULL  true           tables       testuser2  SELECT          false
+test           s            NULL  true           tables       testuser2  SELECT          false
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA public
 ----
-role  for_all_roles  object_type  grantee  privilege_type
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA s
 ----
-role  for_all_roles  object_type  grantee  privilege_type
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA s2
 ----
-role  for_all_roles  object_type  grantee  privilege_type
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser IN SCHEMA public GRANT ALL ON TABLES TO testuser;
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser IN SCHEMA s GRANT USAGE ON TYPES TO testuser2;
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser IN SCHEMA s2 GRANT SELECT, UPDATE, DROP ON TABLES TO testuser2
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE schema_name IS NOT NULL
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee    privilege_type
-test           public       testuser  false          tables       testuser   ALL
-test           public       NULL      true           tables       testuser2  SELECT
-test           s            testuser  false          types        testuser2  USAGE
-test           s            NULL      true           tables       testuser2  SELECT
-test           s2           testuser  false          tables       testuser2  DROP
-test           s2           testuser  false          tables       testuser2  SELECT
-test           s2           testuser  false          tables       testuser2  UPDATE
+database_name  schema_name  role      for_all_roles  object_type  grantee    privilege_type  is_grantable
+test           public       testuser  false          tables       testuser   ALL             false
+test           public       NULL      true           tables       testuser2  SELECT          false
+test           s            testuser  false          types        testuser2  USAGE           false
+test           s            NULL      true           tables       testuser2  SELECT          false
+test           s2           testuser  false          tables       testuser2  DROP            false
+test           s2           testuser  false          tables       testuser2  SELECT          false
+test           s2           testuser  false          tables       testuser2  UPDATE          false
 
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA public
 ----
-role      for_all_roles  object_type  grantee   privilege_type
-testuser  false          tables       testuser  ALL
+role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+testuser  false          tables       testuser  ALL             false
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA s
 ----
-role      for_all_roles  object_type  grantee    privilege_type
-testuser  false          types        testuser2  USAGE
+role      for_all_roles  object_type  grantee    privilege_type  is_grantable
+testuser  false          types        testuser2  USAGE           false
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA s2
 ----
-role      for_all_roles  object_type  grantee    privilege_type
-testuser  false          tables       testuser2  DROP
-testuser  false          tables       testuser2  SELECT
-testuser  false          tables       testuser2  UPDATE
+role      for_all_roles  object_type  grantee    privilege_type  is_grantable
+testuser  false          tables       testuser2  DROP            false
+testuser  false          tables       testuser2  SELECT          false
+testuser  false          tables       testuser2  UPDATE          false
 
 user root
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES FOR ROLE testuser IN SCHEMA s2
 ----
-role      for_all_roles  object_type  grantee    privilege_type
-testuser  false          tables       testuser2  DROP
-testuser  false          tables       testuser2  SELECT
-testuser  false          tables       testuser2  UPDATE
+role      for_all_roles  object_type  grantee    privilege_type  is_grantable
+testuser  false          tables       testuser2  DROP            false
+testuser  false          tables       testuser2  SELECT          false
+testuser  false          tables       testuser2  UPDATE          false
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA "'; drop database test; SELECT '";
 ----
-role  for_all_roles  object_type  grantee  privilege_type
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -4,77 +4,77 @@ ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         root      false          tables       public    SELECT
-test           NULL         root      false          sequences    public    SELECT
-test           NULL         root      false          schemas      public    USAGE
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         root      false          types        public    USAGE
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         root      false          sequences    public    SELECT          false
+test           NULL         root      false          schemas      public    USAGE           false
+test           NULL         root      false          tables       public    SELECT          false
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         root      false          types        public    USAGE           false
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
 
 statement ok
 CREATE USER foo
@@ -88,50 +88,50 @@ ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE grantee='foo' OR grantee='bar'
 ----
-database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
-defaultdb      NULL         bar   false          tables       bar      ALL
-defaultdb      NULL         bar   false          sequences    bar      ALL
-defaultdb      NULL         bar   false          types        bar      ALL
-defaultdb      NULL         bar   false          schemas      bar      ALL
-defaultdb      NULL         foo   false          tables       foo      ALL
-defaultdb      NULL         foo   false          sequences    foo      ALL
-defaultdb      NULL         foo   false          types        foo      ALL
-defaultdb      NULL         foo   false          schemas      foo      ALL
-postgres       NULL         bar   false          tables       bar      ALL
-postgres       NULL         bar   false          sequences    bar      ALL
-postgres       NULL         bar   false          types        bar      ALL
-postgres       NULL         bar   false          schemas      bar      ALL
-postgres       NULL         foo   false          tables       foo      ALL
-postgres       NULL         foo   false          sequences    foo      ALL
-postgres       NULL         foo   false          types        foo      ALL
-postgres       NULL         foo   false          schemas      foo      ALL
-system         NULL         bar   false          tables       bar      ALL
-system         NULL         bar   false          sequences    bar      ALL
-system         NULL         bar   false          types        bar      ALL
-system         NULL         bar   false          schemas      bar      ALL
-system         NULL         foo   false          tables       foo      ALL
-system         NULL         foo   false          sequences    foo      ALL
-system         NULL         foo   false          types        foo      ALL
-system         NULL         foo   false          schemas      foo      ALL
-test           NULL         bar   false          tables       bar      ALL
-test           NULL         bar   false          sequences    bar      ALL
-test           NULL         bar   false          types        bar      ALL
-test           NULL         bar   false          schemas      bar      ALL
-test           NULL         foo   false          tables       foo      ALL
-test           NULL         foo   false          sequences    foo      ALL
-test           NULL         foo   false          types        foo      ALL
-test           NULL         foo   false          schemas      foo      ALL
-test           NULL         root  false          sequences    bar      ALL
-test           NULL         root  false          sequences    foo      ALL
-test           NULL         root  false          types        bar      ALL
-test           NULL         root  false          types        foo      ALL
-test           NULL         root  false          schemas      bar      ALL
-test           NULL         root  false          schemas      foo      ALL
-test           NULL         root  false          tables       bar      ALL
-test           NULL         root  false          tables       foo      ALL
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type  is_grantable
+defaultdb      NULL         bar   false          tables       bar      ALL             true
+defaultdb      NULL         bar   false          sequences    bar      ALL             true
+defaultdb      NULL         bar   false          types        bar      ALL             true
+defaultdb      NULL         bar   false          schemas      bar      ALL             true
+defaultdb      NULL         foo   false          tables       foo      ALL             true
+defaultdb      NULL         foo   false          sequences    foo      ALL             true
+defaultdb      NULL         foo   false          types        foo      ALL             true
+defaultdb      NULL         foo   false          schemas      foo      ALL             true
+postgres       NULL         bar   false          tables       bar      ALL             true
+postgres       NULL         bar   false          sequences    bar      ALL             true
+postgres       NULL         bar   false          types        bar      ALL             true
+postgres       NULL         bar   false          schemas      bar      ALL             true
+postgres       NULL         foo   false          tables       foo      ALL             true
+postgres       NULL         foo   false          sequences    foo      ALL             true
+postgres       NULL         foo   false          types        foo      ALL             true
+postgres       NULL         foo   false          schemas      foo      ALL             true
+system         NULL         bar   false          tables       bar      ALL             true
+system         NULL         bar   false          sequences    bar      ALL             true
+system         NULL         bar   false          types        bar      ALL             true
+system         NULL         bar   false          schemas      bar      ALL             true
+system         NULL         foo   false          tables       foo      ALL             true
+system         NULL         foo   false          sequences    foo      ALL             true
+system         NULL         foo   false          types        foo      ALL             true
+system         NULL         foo   false          schemas      foo      ALL             true
+test           NULL         bar   false          tables       bar      ALL             true
+test           NULL         bar   false          sequences    bar      ALL             true
+test           NULL         bar   false          types        bar      ALL             true
+test           NULL         bar   false          schemas      bar      ALL             true
+test           NULL         foo   false          tables       foo      ALL             true
+test           NULL         foo   false          sequences    foo      ALL             true
+test           NULL         foo   false          types        foo      ALL             true
+test           NULL         foo   false          schemas      foo      ALL             true
+test           NULL         root  false          sequences    bar      ALL             false
+test           NULL         root  false          sequences    foo      ALL             false
+test           NULL         root  false          types        bar      ALL             false
+test           NULL         root  false          types        foo      ALL             false
+test           NULL         root  false          schemas      bar      ALL             false
+test           NULL         root  false          schemas      foo      ALL             false
+test           NULL         root  false          tables       bar      ALL             false
+test           NULL         root  false          tables       foo      ALL             false
 
 statement ok
 GRANT foo, bar TO root;
@@ -142,58 +142,58 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE role='foo' OR role='bar'
 ----
-database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
-defaultdb      NULL         bar   false          tables       bar      ALL
-defaultdb      NULL         bar   false          sequences    bar      ALL
-defaultdb      NULL         bar   false          types        bar      ALL
-defaultdb      NULL         bar   false          schemas      bar      ALL
-defaultdb      NULL         bar   false          types        public   USAGE
-defaultdb      NULL         foo   false          tables       foo      ALL
-defaultdb      NULL         foo   false          sequences    foo      ALL
-defaultdb      NULL         foo   false          types        foo      ALL
-defaultdb      NULL         foo   false          schemas      foo      ALL
-defaultdb      NULL         foo   false          types        public   USAGE
-postgres       NULL         bar   false          tables       bar      ALL
-postgres       NULL         bar   false          sequences    bar      ALL
-postgres       NULL         bar   false          types        bar      ALL
-postgres       NULL         bar   false          schemas      bar      ALL
-postgres       NULL         bar   false          types        public   USAGE
-postgres       NULL         foo   false          tables       foo      ALL
-postgres       NULL         foo   false          sequences    foo      ALL
-postgres       NULL         foo   false          types        foo      ALL
-postgres       NULL         foo   false          schemas      foo      ALL
-postgres       NULL         foo   false          types        public   USAGE
-system         NULL         bar   false          tables       bar      ALL
-system         NULL         bar   false          sequences    bar      ALL
-system         NULL         bar   false          types        bar      ALL
-system         NULL         bar   false          schemas      bar      ALL
-system         NULL         bar   false          types        public   USAGE
-system         NULL         foo   false          tables       foo      ALL
-system         NULL         foo   false          sequences    foo      ALL
-system         NULL         foo   false          types        foo      ALL
-system         NULL         foo   false          schemas      foo      ALL
-system         NULL         foo   false          types        public   USAGE
-test           NULL         bar   false          tables       bar      ALL
-test           NULL         bar   false          tables       foo      ALL
-test           NULL         bar   false          sequences    bar      ALL
-test           NULL         bar   false          sequences    foo      ALL
-test           NULL         bar   false          types        bar      ALL
-test           NULL         bar   false          types        foo      ALL
-test           NULL         bar   false          schemas      bar      ALL
-test           NULL         bar   false          schemas      foo      ALL
-test           NULL         bar   false          types        public   USAGE
-test           NULL         foo   false          sequences    bar      ALL
-test           NULL         foo   false          sequences    foo      ALL
-test           NULL         foo   false          types        bar      ALL
-test           NULL         foo   false          types        foo      ALL
-test           NULL         foo   false          schemas      bar      ALL
-test           NULL         foo   false          schemas      foo      ALL
-test           NULL         foo   false          tables       bar      ALL
-test           NULL         foo   false          tables       foo      ALL
-test           NULL         foo   false          types        public   USAGE
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type  is_grantable
+defaultdb      NULL         bar   false          tables       bar      ALL             true
+defaultdb      NULL         bar   false          sequences    bar      ALL             true
+defaultdb      NULL         bar   false          types        bar      ALL             true
+defaultdb      NULL         bar   false          schemas      bar      ALL             true
+defaultdb      NULL         bar   false          types        public   USAGE           false
+defaultdb      NULL         foo   false          tables       foo      ALL             true
+defaultdb      NULL         foo   false          sequences    foo      ALL             true
+defaultdb      NULL         foo   false          types        foo      ALL             true
+defaultdb      NULL         foo   false          schemas      foo      ALL             true
+defaultdb      NULL         foo   false          types        public   USAGE           false
+postgres       NULL         bar   false          tables       bar      ALL             true
+postgres       NULL         bar   false          sequences    bar      ALL             true
+postgres       NULL         bar   false          types        bar      ALL             true
+postgres       NULL         bar   false          schemas      bar      ALL             true
+postgres       NULL         bar   false          types        public   USAGE           false
+postgres       NULL         foo   false          tables       foo      ALL             true
+postgres       NULL         foo   false          sequences    foo      ALL             true
+postgres       NULL         foo   false          types        foo      ALL             true
+postgres       NULL         foo   false          schemas      foo      ALL             true
+postgres       NULL         foo   false          types        public   USAGE           false
+system         NULL         bar   false          tables       bar      ALL             true
+system         NULL         bar   false          sequences    bar      ALL             true
+system         NULL         bar   false          types        bar      ALL             true
+system         NULL         bar   false          schemas      bar      ALL             true
+system         NULL         bar   false          types        public   USAGE           false
+system         NULL         foo   false          tables       foo      ALL             true
+system         NULL         foo   false          sequences    foo      ALL             true
+system         NULL         foo   false          types        foo      ALL             true
+system         NULL         foo   false          schemas      foo      ALL             true
+system         NULL         foo   false          types        public   USAGE           false
+test           NULL         bar   false          sequences    foo      ALL             false
+test           NULL         bar   false          types        foo      ALL             false
+test           NULL         bar   false          schemas      foo      ALL             false
+test           NULL         bar   false          tables       foo      ALL             false
+test           NULL         bar   false          tables       bar      ALL             true
+test           NULL         bar   false          sequences    bar      ALL             true
+test           NULL         bar   false          types        bar      ALL             true
+test           NULL         bar   false          schemas      bar      ALL             true
+test           NULL         bar   false          types        public   USAGE           false
+test           NULL         foo   false          sequences    bar      ALL             false
+test           NULL         foo   false          types        bar      ALL             false
+test           NULL         foo   false          schemas      bar      ALL             false
+test           NULL         foo   false          tables       bar      ALL             false
+test           NULL         foo   false          tables       foo      ALL             true
+test           NULL         foo   false          sequences    foo      ALL             true
+test           NULL         foo   false          types        foo      ALL             true
+test           NULL         foo   false          schemas      foo      ALL             true
+test           NULL         foo   false          types        public   USAGE           false
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -201,117 +201,117 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       bar       ALL
-test           NULL         root      false          tables       foo       ALL
-test           NULL         root      false          tables       public    SELECT
-test           NULL         root      false          sequences    bar       ALL
-test           NULL         root      false          sequences    foo       ALL
-test           NULL         root      false          sequences    public    SELECT
-test           NULL         root      false          types        bar       ALL
-test           NULL         root      false          types        foo       ALL
-test           NULL         root      false          schemas      bar       ALL
-test           NULL         root      false          schemas      foo       ALL
-test           NULL         root      false          schemas      public    USAGE
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         root      false          types        public    USAGE
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          schemas      bar       ALL             false
+test           NULL         root      false          schemas      foo       ALL             false
+test           NULL         root      false          schemas      public    USAGE           false
+test           NULL         root      false          tables       bar       ALL             false
+test           NULL         root      false          tables       foo       ALL             false
+test           NULL         root      false          tables       public    SELECT          false
+test           NULL         root      false          sequences    bar       ALL             false
+test           NULL         root      false          sequences    foo       ALL             false
+test           NULL         root      false          sequences    public    SELECT          false
+test           NULL         root      false          types        bar       ALL             false
+test           NULL         root      false          types        foo       ALL             false
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         root      false          types        public    USAGE           false
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
@@ -319,223 +319,223 @@ ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       bar       CREATE
-test           NULL         root      false          tables       bar       DROP
-test           NULL         root      false          tables       bar       INSERT
-test           NULL         root      false          tables       bar       DELETE
-test           NULL         root      false          tables       bar       UPDATE
-test           NULL         root      false          tables       bar       ZONECONFIG
-test           NULL         root      false          tables       foo       CREATE
-test           NULL         root      false          tables       foo       DROP
-test           NULL         root      false          tables       foo       INSERT
-test           NULL         root      false          tables       foo       DELETE
-test           NULL         root      false          tables       foo       UPDATE
-test           NULL         root      false          tables       foo       ZONECONFIG
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          tables       bar       CREATE          false
+test           NULL         root      false          tables       bar       DROP            false
+test           NULL         root      false          tables       bar       INSERT          false
+test           NULL         root      false          tables       bar       DELETE          false
+test           NULL         root      false          tables       bar       UPDATE          false
+test           NULL         root      false          tables       bar       ZONECONFIG      false
+test           NULL         root      false          tables       foo       CREATE          false
+test           NULL         root      false          tables       foo       DROP            false
+test           NULL         root      false          tables       foo       INSERT          false
+test           NULL         root      false          tables       foo       DELETE          false
+test           NULL         root      false          tables       foo       UPDATE          false
+test           NULL         root      false          tables       foo       ZONECONFIG      false
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES GRANT DROP, ZONECONFIG ON TABLES TO foo WITH GRANT OPTION;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       foo       DROP
-test           NULL         root      false          tables       foo       ZONECONFIG
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          tables       foo       DROP            true
+test           NULL         root      false          tables       foo       ZONECONFIG      true
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
 
 # Create a second database.
 statement ok
@@ -545,266 +545,266 @@ use test2;
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT DROP, ZONECONFIG ON TABLES TO foo WITH GRANT OPTION;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       foo       DROP
-test           NULL         root      false          tables       foo       ZONECONFIG
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
-test2          NULL         admin     false          tables       admin     ALL
-test2          NULL         admin     false          sequences    admin     ALL
-test2          NULL         admin     false          types        admin     ALL
-test2          NULL         admin     false          schemas      admin     ALL
-test2          NULL         admin     false          types        public    USAGE
-test2          NULL         bar       false          tables       bar       ALL
-test2          NULL         bar       false          sequences    bar       ALL
-test2          NULL         bar       false          types        bar       ALL
-test2          NULL         bar       false          schemas      bar       ALL
-test2          NULL         bar       false          types        public    USAGE
-test2          NULL         foo       false          tables       foo       ALL
-test2          NULL         foo       false          sequences    foo       ALL
-test2          NULL         foo       false          types        foo       ALL
-test2          NULL         foo       false          schemas      foo       ALL
-test2          NULL         foo       false          types        public    USAGE
-test2          NULL         root      false          tables       foo       DROP
-test2          NULL         root      false          tables       foo       ZONECONFIG
-test2          NULL         root      false          tables       root      ALL
-test2          NULL         root      false          sequences    root      ALL
-test2          NULL         root      false          types        root      ALL
-test2          NULL         root      false          schemas      root      ALL
-test2          NULL         root      false          types        public    USAGE
-test2          NULL         testuser  false          tables       testuser  ALL
-test2          NULL         testuser  false          sequences    testuser  ALL
-test2          NULL         testuser  false          types        testuser  ALL
-test2          NULL         testuser  false          schemas      testuser  ALL
-test2          NULL         testuser  false          types        public    USAGE
-test2          NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          tables       foo       DROP            true
+test           NULL         root      false          tables       foo       ZONECONFIG      true
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
+test2          NULL         admin     false          tables       admin     ALL             true
+test2          NULL         admin     false          sequences    admin     ALL             true
+test2          NULL         admin     false          types        admin     ALL             true
+test2          NULL         admin     false          schemas      admin     ALL             true
+test2          NULL         admin     false          types        public    USAGE           false
+test2          NULL         bar       false          tables       bar       ALL             true
+test2          NULL         bar       false          sequences    bar       ALL             true
+test2          NULL         bar       false          types        bar       ALL             true
+test2          NULL         bar       false          schemas      bar       ALL             true
+test2          NULL         bar       false          types        public    USAGE           false
+test2          NULL         foo       false          tables       foo       ALL             true
+test2          NULL         foo       false          sequences    foo       ALL             true
+test2          NULL         foo       false          types        foo       ALL             true
+test2          NULL         foo       false          schemas      foo       ALL             true
+test2          NULL         foo       false          types        public    USAGE           false
+test2          NULL         root      false          tables       foo       DROP            true
+test2          NULL         root      false          tables       foo       ZONECONFIG      true
+test2          NULL         root      false          tables       root      ALL             true
+test2          NULL         root      false          sequences    root      ALL             true
+test2          NULL         root      false          types        root      ALL             true
+test2          NULL         root      false          schemas      root      ALL             true
+test2          NULL         root      false          types        public    USAGE           false
+test2          NULL         testuser  false          tables       testuser  ALL             true
+test2          NULL         testuser  false          sequences    testuser  ALL             true
+test2          NULL         testuser  false          types        testuser  ALL             true
+test2          NULL         testuser  false          schemas      testuser  ALL             true
+test2          NULL         testuser  false          types        public    USAGE           false
+test2          NULL         NULL      true           types        public    USAGE           false
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO foo;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       foo       DROP
-test           NULL         root      false          tables       foo       ZONECONFIG
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
-test2          NULL         admin     false          tables       admin     ALL
-test2          NULL         admin     false          sequences    admin     ALL
-test2          NULL         admin     false          types        admin     ALL
-test2          NULL         admin     false          schemas      admin     ALL
-test2          NULL         admin     false          types        public    USAGE
-test2          NULL         bar       false          tables       bar       ALL
-test2          NULL         bar       false          sequences    bar       ALL
-test2          NULL         bar       false          types        bar       ALL
-test2          NULL         bar       false          schemas      bar       ALL
-test2          NULL         bar       false          types        public    USAGE
-test2          NULL         foo       false          tables       foo       ALL
-test2          NULL         foo       false          sequences    foo       ALL
-test2          NULL         foo       false          types        foo       ALL
-test2          NULL         foo       false          schemas      foo       ALL
-test2          NULL         foo       false          types        public    USAGE
-test2          NULL         root      false          tables       foo       DROP
-test2          NULL         root      false          tables       foo       ZONECONFIG
-test2          NULL         root      false          tables       root      ALL
-test2          NULL         root      false          sequences    root      ALL
-test2          NULL         root      false          types        root      ALL
-test2          NULL         root      false          schemas      root      ALL
-test2          NULL         root      false          types        public    USAGE
-test2          NULL         testuser  false          tables       testuser  ALL
-test2          NULL         testuser  false          sequences    testuser  ALL
-test2          NULL         testuser  false          types        testuser  ALL
-test2          NULL         testuser  false          schemas      testuser  ALL
-test2          NULL         testuser  false          types        public    USAGE
-test2          NULL         NULL      true           tables       foo       SELECT
-test2          NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          tables       foo       DROP            true
+test           NULL         root      false          tables       foo       ZONECONFIG      true
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
+test2          NULL         admin     false          tables       admin     ALL             true
+test2          NULL         admin     false          sequences    admin     ALL             true
+test2          NULL         admin     false          types        admin     ALL             true
+test2          NULL         admin     false          schemas      admin     ALL             true
+test2          NULL         admin     false          types        public    USAGE           false
+test2          NULL         bar       false          tables       bar       ALL             true
+test2          NULL         bar       false          sequences    bar       ALL             true
+test2          NULL         bar       false          types        bar       ALL             true
+test2          NULL         bar       false          schemas      bar       ALL             true
+test2          NULL         bar       false          types        public    USAGE           false
+test2          NULL         foo       false          tables       foo       ALL             true
+test2          NULL         foo       false          sequences    foo       ALL             true
+test2          NULL         foo       false          types        foo       ALL             true
+test2          NULL         foo       false          schemas      foo       ALL             true
+test2          NULL         foo       false          types        public    USAGE           false
+test2          NULL         root      false          tables       foo       DROP            true
+test2          NULL         root      false          tables       foo       ZONECONFIG      true
+test2          NULL         root      false          tables       root      ALL             true
+test2          NULL         root      false          sequences    root      ALL             true
+test2          NULL         root      false          types        root      ALL             true
+test2          NULL         root      false          schemas      root      ALL             true
+test2          NULL         root      false          types        public    USAGE           false
+test2          NULL         testuser  false          tables       testuser  ALL             true
+test2          NULL         testuser  false          sequences    testuser  ALL             true
+test2          NULL         testuser  false          types        testuser  ALL             true
+test2          NULL         testuser  false          schemas      testuser  ALL             true
+test2          NULL         testuser  false          types        public    USAGE           false
+test2          NULL         NULL      true           tables       foo       SELECT          false
+test2          NULL         NULL      true           types        public    USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -541,7 +541,8 @@ CREATE TABLE crdb_internal.default_privileges (
    for_all_roles BOOL NULL,
    object_type STRING NOT NULL,
    grantee STRING NOT NULL,
-   privilege_type STRING NOT NULL
+   privilege_type STRING NOT NULL,
+   is_grantable BOOL NULL
 )  CREATE TABLE crdb_internal.default_privileges (
    database_name STRING NOT NULL,
    schema_name STRING NULL,
@@ -549,7 +550,8 @@ CREATE TABLE crdb_internal.default_privileges (
    for_all_roles BOOL NULL,
    object_type STRING NOT NULL,
    grantee STRING NOT NULL,
-   privilege_type STRING NOT NULL
+   privilege_type STRING NOT NULL,
+   is_grantable BOOL NULL
 )  {}  {}
 CREATE TABLE crdb_internal.feature_usage (
    feature_name STRING NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog_pg_default_acl_with_grant_option
@@ -1,16 +1,25 @@
+statement error grant options cannot be granted to \"public\" role
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC WITH GRANT OPTION
+
+statement error grant options cannot be granted to \"public\" role
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC WITH GRANT OPTION
+
+statement error grant options cannot be granted to \"public\" role
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC WITH GRANT OPTION
+
 statement ok
-ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC WITH GRANT OPTION;
-ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC WITH GRANT OPTION;
-ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC WITH GRANT OPTION;
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC;
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
 
 # Public should appear as an empty string with privileges.
 query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid        defaclrole  defaclnamespace  defaclobjtype  defaclacl
-456512573  1546506610  0                r              {=r*/}
-456512573  1546506610  0                S              {=r*/}
-456512573  1546506610  0                n              {=U*/}
+456512573  1546506610  0                r              {=r/}
+456512573  1546506610  0                S              {=r/}
+456512573  1546506610  0                n              {=U/}
 
 statement ok
 CREATE USER foo
@@ -28,10 +37,10 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid        defaclrole  defaclnamespace  defaclobjtype  defaclacl
-456512573  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r*/}
-456512573  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r*/}
+456512573  1546506610  0                r              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
+456512573  1546506610  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/,=r/}
 456512573  1546506610  0                T              {bar=U*/,foo=U*/}
-456512573  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U*/}
+456512573  1546506610  0                n              {bar=C*U*/,foo=C*U*/,=U/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR SELECT, DELETE ON TABLES FROM foo, bar;
@@ -43,10 +52,10 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid        defaclrole  defaclnamespace  defaclobjtype  defaclacl
-456512573  1546506610  0                r              {bar=C*a*drw*/,foo=C*a*drw*/,=r*/}
-456512573  1546506610  0                S              {bar=Ca*d*r*w/,foo=Ca*d*r*w/,=r*/}
+456512573  1546506610  0                r              {bar=C*a*drw*/,foo=C*a*drw*/,=r/}
+456512573  1546506610  0                S              {bar=Ca*d*r*w/,foo=Ca*d*r*w/,=r/}
 456512573  1546506610  0                T              {bar=U/,foo=U/}
-456512573  1546506610  0                n              {bar=CU*/,foo=CU*/,=U*/}
+456512573  1546506610  0                n              {bar=CU*/,foo=CU*/,=U/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE GRANT OPTION FOR ALL ON TABLES FROM foo, bar;
@@ -58,10 +67,10 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid        defaclrole  defaclnamespace  defaclobjtype  defaclacl
-456512573  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r*/}
-456512573  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r*/}
+456512573  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+456512573  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
 456512573  1546506610  0                T              {bar=U/,foo=U/}
-456512573  1546506610  0                n              {bar=CU/,foo=CU/,=U*/}
+456512573  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 
 statement ok
 GRANT foo, bar TO root;
@@ -85,10 +94,10 @@ oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1062786855  2026795574  0                S              {bar=C*a*d*r*w*/,foo=C*a*d*r*w*/}
 1062786855  2026795574  0                T              {bar=U*/,foo=U*/,=U/}
 1062786855  2026795574  0                n              {bar=C*U*/,foo=C*U*/}
-456512573   1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r*/}
-456512573   1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r*/}
+456512573   1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+456512573   1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
 456512573   1546506610  0                T              {bar=U/,foo=U/}
-456512573   1546506610  0                n              {bar=CU/,foo=CU/,=U*/}
+456512573   1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -110,10 +119,10 @@ oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1062786855  2026795574  0                S              {}
 1062786855  2026795574  0                T              {=U/}
 1062786855  2026795574  0                n              {}
-456512573   1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r*/}
-456512573   1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r*/}
+456512573   1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+456512573   1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
 456512573   1546506610  0                T              {bar=U/,foo=U/}
-456512573   1546506610  0                n              {bar=CU/,foo=CU/,=U*/}
+456512573   1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT ALL ON TABLES TO foo;
@@ -142,10 +151,10 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid        defaclrole  defaclnamespace  defaclobjtype  defaclacl
-456512573  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r*/}
-456512573  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r*/}
+456512573  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+456512573  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
 456512573  1546506610  0                T              {bar=U/,foo=U/}
-456512573  1546506610  0                n              {bar=CU/,foo=CU/,=U*/}
+456512573  1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo GRANT USAGE ON TYPES TO foo WITH GRANT OPTION
@@ -156,10 +165,10 @@ SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid         defaclrole  defaclnamespace  defaclobjtype  defaclacl
 1062786855  2026795574  0                T              {foo=U*/,=U/}
-456512573   1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r*/}
-456512573   1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r*/}
+456512573   1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+456512573   1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
 456512573   1546506610  0                T              {bar=U/,foo=U/}
-456512573   1546506610  0                n              {bar=CU/,foo=CU/,=U*/}
+456512573   1546506610  0                n              {bar=CU/,foo=CU/,=U/}
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo REVOKE GRANT OPTION FOR USAGE ON TYPES FROM foo
@@ -169,7 +178,7 @@ query OOOTT colnames,rowsort
 SELECT * FROM PG_CATALOG.PG_DEFAULT_ACL
 ----
 oid        defaclrole  defaclnamespace  defaclobjtype  defaclacl
-456512573  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r*/}
-456512573  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r*/}
+456512573  1546506610  0                r              {bar=Cadrw/,foo=Cadrw/,=r/}
+456512573  1546506610  0                S              {bar=Cadrw/,foo=Cadrw/,=r/}
 456512573  1546506610  0                T              {bar=U/,foo=U/}
-456512573  1546506610  0                n              {bar=CU/,foo=CU/,=U*/}
+456512573  1546506610  0                n              {bar=CU/,foo=CU/,=U/}

--- a/pkg/sql/logictest/testdata/logic_test/show_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/show_default_privileges
@@ -1,13 +1,13 @@
 # Default privileges start with an implicit set, the creator role has ALL
 # and Public has usage.
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    root    ALL
-root  false  sequences  root    ALL
-root  false  tables     root    ALL
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    root    ALL    true
+root  false  sequences  root    ALL    true
+root  false  tables     root    ALL    true
+root  false  types      public  USAGE  false
+root  false  types      root    ALL    true
 
 # Ensure revoking "default" default privileges reflects in show default
 # privileges.
@@ -15,12 +15,12 @@ statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM root;
 ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM public;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    root  ALL
-root  false  sequences  root  ALL
-root  false  types      root  ALL
+root  false  schemas    root  ALL  true
+root  false  sequences  root  ALL  true
+root  false  types      root  ALL  true
 
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC;
@@ -28,16 +28,16 @@ ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     public  SELECT
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     public  SELECT  false
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 CREATE USER foo
@@ -45,16 +45,16 @@ CREATE USER foo
 statement ok
 CREATE USER bar
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     public  SELECT
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     public  SELECT  false
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO foo, bar;
@@ -62,34 +62,34 @@ ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ROLE foo, bar, root
 ----
-bar   false  schemas    bar     ALL
-bar   false  sequences  bar     ALL
-bar   false  tables     bar     ALL
-bar   false  types      bar     ALL
-bar   false  types      public  USAGE
-foo   false  schemas    foo     ALL
-foo   false  sequences  foo     ALL
-foo   false  tables     foo     ALL
-foo   false  types      foo     ALL
-foo   false  types      public  USAGE
-root  false  schemas    bar     ALL
-root  false  schemas    foo     ALL
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  bar     ALL
-root  false  sequences  foo     ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     bar     ALL
-root  false  tables     foo     ALL
-root  false  tables     public  SELECT
-root  false  types      bar     ALL
-root  false  types      foo     ALL
-root  false  types      public  USAGE
-root  false  types      root    ALL
+bar   false  schemas    bar     ALL     true
+bar   false  sequences  bar     ALL     true
+bar   false  tables     bar     ALL     true
+bar   false  types      bar     ALL     true
+bar   false  types      public  USAGE   false
+foo   false  schemas    foo     ALL     true
+foo   false  sequences  foo     ALL     true
+foo   false  tables     foo     ALL     true
+foo   false  types      foo     ALL     true
+foo   false  types      public  USAGE   false
+root  false  schemas    bar     ALL     false
+root  false  schemas    foo     ALL     false
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  bar     ALL     false
+root  false  sequences  foo     ALL     false
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     bar     ALL     false
+root  false  tables     foo     ALL     false
+root  false  tables     public  SELECT  false
+root  false  types      bar     ALL     false
+root  false  types      foo     ALL     false
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 GRANT foo, bar TO root;
@@ -100,24 +100,24 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    bar     ALL
-root  false  schemas    foo     ALL
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  bar     ALL
-root  false  sequences  foo     ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     bar     ALL
-root  false  tables     foo     ALL
-root  false  tables     public  SELECT
-root  false  types      bar     ALL
-root  false  types      foo     ALL
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    bar     ALL     false
+root  false  schemas    foo     ALL     false
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  bar     ALL     false
+root  false  sequences  foo     ALL     false
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     bar     ALL     false
+root  false  tables     foo     ALL     false
+root  false  tables     public  SELECT  false
+root  false  types      bar     ALL     false
+root  false  types      foo     ALL     false
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -125,24 +125,24 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    bar     ALL
-root  false  schemas    foo     ALL
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  bar     ALL
-root  false  sequences  foo     ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     bar     ALL
-root  false  tables     foo     ALL
-root  false  tables     public  SELECT
-root  false  types      bar     ALL
-root  false  types      foo     ALL
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    bar     ALL     false
+root  false  schemas    foo     ALL     false
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  bar     ALL     false
+root  false  sequences  foo     ALL     false
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     bar     ALL     false
+root  false  tables     foo     ALL     false
+root  false  tables     public  SELECT  false
+root  false  types      bar     ALL     false
+root  false  types      foo     ALL     false
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
@@ -150,37 +150,37 @@ ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    root  ALL
-root  false  sequences  root  ALL
-root  false  tables     bar   CREATE
-root  false  tables     bar   DELETE
-root  false  tables     bar   DROP
-root  false  tables     bar   INSERT
-root  false  tables     bar   UPDATE
-root  false  tables     bar   ZONECONFIG
-root  false  tables     foo   CREATE
-root  false  tables     foo   DELETE
-root  false  tables     foo   DROP
-root  false  tables     foo   INSERT
-root  false  tables     foo   UPDATE
-root  false  tables     foo   ZONECONFIG
-root  false  types      root  ALL
+root  false  schemas    root  ALL         true
+root  false  sequences  root  ALL         true
+root  false  tables     bar   CREATE      false
+root  false  tables     bar   DELETE      false
+root  false  tables     bar   DROP        false
+root  false  tables     bar   INSERT      false
+root  false  tables     bar   UPDATE      false
+root  false  tables     bar   ZONECONFIG  false
+root  false  tables     foo   CREATE      false
+root  false  tables     foo   DELETE      false
+root  false  tables     foo   DROP        false
+root  false  tables     foo   INSERT      false
+root  false  tables     foo   UPDATE      false
+root  false  tables     foo   ZONECONFIG  false
+root  false  types      root  ALL         true
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES GRANT DROP, ZONECONFIG ON TABLES TO foo WITH GRANT OPTION;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    root  ALL
-root  false  sequences  root  ALL
-root  false  tables     foo   DROP
-root  false  tables     foo   ZONECONFIG
-root  false  types      root  ALL
+root  false  schemas    root  ALL         true
+root  false  sequences  root  ALL         true
+root  false  tables     foo   DROP        true
+root  false  tables     foo   ZONECONFIG  true
+root  false  types      root  ALL         true
 
 # Create a second database.
 statement ok
@@ -192,69 +192,69 @@ statement ok
 GRANT testuser TO root;
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser GRANT DROP, ZONECONFIG ON TABLES TO foo WITH GRANT OPTION;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ROLE testuser
 ----
-testuser  false  schemas    testuser  ALL
-testuser  false  sequences  testuser  ALL
-testuser  false  tables     foo       DROP
-testuser  false  tables     foo       ZONECONFIG
-testuser  false  tables     testuser  ALL
-testuser  false  types      public    USAGE
-testuser  false  types      testuser  ALL
+testuser  false  schemas    testuser  ALL         true
+testuser  false  sequences  testuser  ALL         true
+testuser  false  tables     foo       DROP        true
+testuser  false  tables     foo       ZONECONFIG  true
+testuser  false  tables     testuser  ALL         true
+testuser  false  types      public    USAGE       false
+testuser  false  types      testuser  ALL         true
 
 # SHOW DEFAULT PRIVILEGES should show default privileges for the current role.
 user testuser
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-testuser  false  schemas    testuser  ALL
-testuser  false  sequences  testuser  ALL
-testuser  false  tables     testuser  ALL
-testuser  false  types      public    USAGE
-testuser  false  types      testuser  ALL
+testuser  false  schemas    testuser  ALL    true
+testuser  false  sequences  testuser  ALL    true
+testuser  false  tables     testuser  ALL    true
+testuser  false  types      public    USAGE  false
+testuser  false  types      testuser  ALL    true
 
 user root
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ROLE testuser
 ----
-testuser  false  schemas    testuser  ALL
-testuser  false  sequences  testuser  ALL
-testuser  false  tables     foo       DROP
-testuser  false  tables     foo       ZONECONFIG
-testuser  false  tables     testuser  ALL
-testuser  false  types      public    USAGE
-testuser  false  types      testuser  ALL
+testuser  false  schemas    testuser  ALL         true
+testuser  false  sequences  testuser  ALL         true
+testuser  false  tables     foo       DROP        true
+testuser  false  tables     foo       ZONECONFIG  true
+testuser  false  tables     testuser  ALL         true
+testuser  false  types      public    USAGE       false
+testuser  false  types      testuser  ALL         true
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE root GRANT DROP, ZONECONFIG ON TABLES TO foo WITH GRANT OPTION;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ROLE root, testuser
 ----
-root      false  schemas    root      ALL
-root      false  sequences  root      ALL
-root      false  tables     foo       DROP
-root      false  tables     foo       ZONECONFIG
-root      false  tables     root      ALL
-root      false  types      public    USAGE
-root      false  types      root      ALL
-testuser  false  schemas    testuser  ALL
-testuser  false  sequences  testuser  ALL
-testuser  false  tables     foo       DROP
-testuser  false  tables     foo       ZONECONFIG
-testuser  false  tables     testuser  ALL
-testuser  false  types      public    USAGE
-testuser  false  types      testuser  ALL
+root      false  schemas    root      ALL         true
+root      false  sequences  root      ALL         true
+root      false  tables     foo       DROP        true
+root      false  tables     foo       ZONECONFIG  true
+root      false  tables     root      ALL         true
+root      false  types      public    USAGE       false
+root      false  types      root      ALL         true
+testuser  false  schemas    testuser  ALL         true
+testuser  false  sequences  testuser  ALL         true
+testuser  false  tables     foo       DROP        true
+testuser  false  tables     foo       ZONECONFIG  true
+testuser  false  tables     testuser  ALL         true
+testuser  false  types      public    USAGE       false
+testuser  false  types      testuser  ALL         true
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT DROP, ZONECONFIG ON TABLES TO foo WITH GRANT OPTION;
 
 # ForAllRoles is not a real role and thus is not the grantee for any privileges.
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ALL ROLES
 ----
-NULL  true  tables  foo     DROP
-NULL  true  tables  foo     ZONECONFIG
-NULL  true  types   public  USAGE
+NULL  true  tables  foo     DROP        true
+NULL  true  tables  foo     ZONECONFIG  true
+NULL  true  types   public  USAGE       false


### PR DESCRIPTION
See individual commits.

Release note (bug fix): The public role no longer can be granted default
privileges with the grant option. This was a bug because the public role
already cannot have the grant option on regular privileges.

Release note (sql change): The SHOW DEFAULT PRIVILEGES command now has a
column that says if the default privilege will give the grant option to
the grantee.