### PR TITLE
sqlproxy: delete proxyConn wrapper

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -289,7 +289,7 @@ func newProxyHandler(
 
 // handle is called by the proxy server to handle a single incoming client
 // connection.
-func (handler *proxyHandler) handle(ctx context.Context, incomingConn *proxyConn) error {
+func (handler *proxyHandler) handle(ctx context.Context, incomingConn net.Conn) error {
 	connRecievedTime := timeutil.Now()
 
 	fe := FrontendAdmit(incomingConn, handler.incomingTLSConfig())

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -426,10 +426,9 @@ func TestProxyTLSClose(t *testing.T) {
 	require.NoError(t, runTestQuery(ctx, conn))
 
 	// Cut the connection.
-	incomingConn, ok := proxyIncomingConn.Load().(*proxyConn)
+	incomingConn, ok := proxyIncomingConn.Load().(net.Conn)
 	require.True(t, ok)
 	require.NoError(t, incomingConn.Close())
-	<-incomingConn.done() // should immediately proceed
 	_ = conn.Close(ctx)
 
 	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())


### PR DESCRIPTION
The proxyConn wrapper is applied to the client connection, but it is not
used for anything. proxyConn was introduced by https://github.com/cockroachdb/cockroach/pull/57037. It refers to a
Cockroach Cloud internal usage that is no longer relevant.

Release note: None