### PR TITLE
sql: better tracing of apply joins

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -51,7 +51,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
@@ -155,10 +154,6 @@ const (
 // a replica for a given range. It is exported so that it may be overwritten
 // during initialization by CCL code to enable follower reads.
 var ReplicaOraclePolicy = replicaoracle.BinPackingChoice
-
-// If true, the plan diagram (in JSON) is logged for each plan (used for
-// debugging).
-var logPlanDiagram = envutil.EnvOrDefaultBool("COCKROACH_DISTSQL_LOG_PLAN", false)
 
 // NewDistSQLPlanner initializes a DistSQLPlanner.
 //

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -506,8 +506,7 @@ func (dsp *DistSQLPlanner) Run(
 		}
 	}
 
-	if logPlanDiagram {
-		log.VEvent(ctx, 3, "creating plan diagram for logging")
+	if sp := tracing.SpanFromContext(ctx); sp != nil {
 		var stmtStr string
 		if planCtx.planner != nil && planCtx.planner.stmt.AST != nil {
 			stmtStr = planCtx.planner.stmt.String()


### PR DESCRIPTION
**sql: add tracing spans for each iteration of apply join**

This commit creates a separate tracing span for each iteration of apply
join and recursive CTE execution to make the traces easier to digest.

Release note: None

**sql: log DistSQL diagrams when tracing is enabled**

This commit makes it so that we always include all DistSQL diagrams into
the trace. This could be especially helpful when executing apply join
iterations to understand the plan that each iteration gets. This commit
also removes an environment variable that used to control this logging
previously since I don't think anyone has used it in years now that we
have better tools for debugging (like a stmt bundle).

Informs: #https://github.com/cockroachlabs/support/issues/1681.

Release note: None