### PR TITLE
kvserver,storage: Support range keys in CheckSSTConflicts

### DIFF
--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -444,6 +444,21 @@ func (k MVCCRangeKey) Validate() (err error) {
 	}
 }
 
+// Includes returns if this MVCCRangeKey's bounds include the specified key.
+func (k MVCCRangeKey) Includes(key roachpb.Key) bool {
+	return k.StartKey.Compare(key) <= 0 && k.EndKey.Compare(key) > 0
+}
+
+// Overlaps returns true if this MVCCRangeKey overlaps with the specified one.
+func (k MVCCRangeKey) Overlaps(b MVCCRangeKey) bool {
+	return k.StartKey.Compare(b.EndKey) < 0 && k.EndKey.Compare(b.StartKey) > 0
+}
+
+// Deletes returns whether this MVCCRangeKey deletes the specified MVCC key.
+func (k MVCCRangeKey) Deletes(key MVCCKey) bool {
+	return k.Includes(key.Key) && !k.Timestamp.Less(key.Timestamp)
+}
+
 // MVCCRangeKeyStack represents a stack of range key fragments as returned
 // by SimpleMVCCIterator.RangeKeys(). All fragments have the same key bounds,
 // and are ordered from newest to oldest.


### PR DESCRIPTION
Add support for MVCC range tombstones when checking for
SST conflicts and calculating stats incrementally
in CheckSSTConflicts. This unfortunately blew up
logic in CheckSSTConflicts a lot, but most of that should
be gated behind conditionals that cause a low impact
on performance for non-rangekey sstables.

One part of #83405.

Release note: None.