### PR TITLE
logictest: remove spec-planning configs

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -538,8 +538,6 @@ type testClusterConfig struct {
 	allowSplitAndScatter bool
 	// if non-empty, overrides the default vectorize mode.
 	overrideVectorize string
-	// if non-empty, overrides the default experimental DistSQL planning mode.
-	overrideExperimentalDistSQLPlanning string
 	// if set, queries using distSQL processors or vectorized operators that can
 	// fall back to disk do so immediately, using only their disk-based
 	// implementation.
@@ -765,12 +763,6 @@ var logicTestConfigs = []testClusterConfig{
 		disableUpgrade:      true,
 	},
 	{
-		name:                                "local-spec-planning",
-		numNodes:                            1,
-		overrideDistSQLMode:                 "off",
-		overrideExperimentalDistSQLPlanning: "on",
-	},
-	{
 		name:                "fakedist",
 		numNodes:            3,
 		useFakeSpanResolver: true,
@@ -792,13 +784,6 @@ var logicTestConfigs = []testClusterConfig{
 		skipShort:           true,
 	},
 	{
-		name:                                "fakedist-spec-planning",
-		numNodes:                            3,
-		useFakeSpanResolver:                 true,
-		overrideDistSQLMode:                 "on",
-		overrideExperimentalDistSQLPlanning: "on",
-	},
-	{
 		name:                "5node",
 		numNodes:            5,
 		overrideDistSQLMode: "on",
@@ -814,12 +799,6 @@ var logicTestConfigs = []testClusterConfig{
 		overrideDistSQLMode: "on",
 		sqlExecUseDisk:      true,
 		skipShort:           true,
-	},
-	{
-		name:                                "5node-spec-planning",
-		numNodes:                            5,
-		overrideDistSQLMode:                 "on",
-		overrideExperimentalDistSQLPlanning: "on",
 	},
 	{
 		// 3node-tenant is a config that runs the test as a SQL tenant. This config
@@ -1008,18 +987,15 @@ var (
 	defaultConfigNames = []string{
 		"local",
 		"local-vec-off",
-		"local-spec-planning",
 		"fakedist",
 		"fakedist-vec-off",
 		"fakedist-disk",
-		"fakedist-spec-planning",
 	}
 	// fiveNodeDefaultConfigName is a special alias for all 5 node configs.
 	fiveNodeDefaultConfigName  = "5node-default-configs"
 	fiveNodeDefaultConfigNames = []string{
 		"5node",
 		"5node-disk",
-		"5node-spec-planning",
 	}
 	// threeNodeTenantDefaultConfigName is a special alias for all 3-node tenant
 	// configs.
@@ -2017,14 +1993,6 @@ func (t *logicTest) newCluster(
 			"SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
 		); err != nil {
 			t.Fatal(err)
-		}
-
-		if cfg.overrideExperimentalDistSQLPlanning != "" {
-			if _, err := conn.Exec(
-				"SET CLUSTER SETTING sql.defaults.experimental_distsql_planning = $1::string", cfg.overrideExperimentalDistSQLPlanning,
-			); err != nil {
-				t.Fatal(err)
-			}
 		}
 
 		// Update the default AS OF time for querying the system.table_statistics

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1,5 +1,3 @@
-# LogicTest: !fakedist-spec-planning
-
 statement ok
 CREATE TABLE foo (a int)
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function_notenant
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function_notenant
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant-default-configs !fakedist-spec-planning
+# LogicTest: !3node-tenant-default-configs
 
 subtest check_consistency
 

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -1,4 +1,4 @@
-# LogicTest: local local-vec-off local-spec-planning
+# LogicTest: local local-vec-off
 
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1,5 +1,3 @@
-# LogicTest: !fakedist-spec-planning
-
 statement ok
 CREATE USER bar; CREATE USER all_user_db; CREATE USER all_user_schema
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/zigzag_join
@@ -1,4 +1,4 @@
-# LogicTest: local local-spec-planning
+# LogicTest: local
 
 # Make sure that the zigzag join is used in the regression tests for #71093.
 statement ok


### PR DESCRIPTION
This commit removes `local-spec-planning`, `fakedist-spec-planning`, and
`5node-spec-planning` logic test configurations since they seem to be
not very useful at the moment. They were introduced to support the new
DistSQL spec factory, but that work has been postponed with no active
development at the moment, so it seems silly to run most of the logic
tests through the configs that are largely duplicate of the other
default ones (because most of the `Construct*` methods are not
implemented in the new factory). Once the active development on the new
factory resumes, it'll be pretty easy to bring them back to life, but at
the moment let's reduce the amount of tests we run without really losing
any test coverage.

Release note: None