### PR TITLE
release-22.1: acceptance: skip `TestComposeGSS`

### DIFF
--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -22,11 +22,13 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 const composeDir = "compose"
 
 func TestComposeGSS(t *testing.T) {
+	skip.WithIssue(t, 84978)
 	testCompose(t, filepath.Join("gss", "docker-compose.yml"), "psql")
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #84982.

/cc @cockroachdb/release

Release justification: fixes CI.

---

Touches #84981.

Release note: None
