### PR TITLE
admission,kvserver: improved byte token estimation for writes

### DIFF
--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -467,9 +467,10 @@ func (r *replicaGCer) send(ctx context.Context, req roachpb.GCRequest) error {
 			return err
 		}
 	}
-	_, pErr := r.repl.Send(ctx, ba)
+	_, writeBytes, pErr := r.repl.SendWithWriteBytes(ctx, ba)
+	defer writeBytes.Release()
 	if r.admissionController != nil {
-		r.admissionController.AdmittedKVWorkDone(admissionHandle)
+		r.admissionController.AdmittedKVWorkDone(admissionHandle, writeBytes)
 	}
 	if pErr != nil {
 		log.VErrEventf(ctx, 2, "%v", pErr.String())

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -174,7 +174,7 @@ func (r *Replica) evalAndPropose(
 		writeBytes.WriteBytes = int64(len(proposal.command.WriteBatch.Data))
 	}
 	if proposal.command.ReplicatedEvalResult.AddSSTable != nil {
-		writeBytes.SSTableBytes = int64(len(proposal.command.ReplicatedEvalResult.AddSSTable.Data))
+		writeBytes.IngestedBytes = int64(len(proposal.command.ReplicatedEvalResult.AddSSTable.Data))
 	}
 	// If the request requested that Raft consensus be performed asynchronously,
 	// return a proposal result immediately on the proposal's done channel.

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -101,7 +101,8 @@ var optimisticEvalLimitedScans = settings.RegisterBoolSetting(
 func (r *Replica) Send(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
-	br, _, pErr := r.SendWithWriteBytes(ctx, ba)
+	br, writeBytes, pErr := r.SendWithWriteBytes(ctx, ba)
+	writeBytes.Release()
 	return br, pErr
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -3729,7 +3730,7 @@ type KVAdmissionController interface {
 	) (handle interface{}, err error)
 	// AdmittedKVWorkDone is called after the admitted KV work is done
 	// executing.
-	AdmittedKVWorkDone(handle interface{})
+	AdmittedKVWorkDone(handle interface{}, writeBytes *StoreWriteBytes)
 	// SetTenantWeightProvider is used to set the provider that will be
 	// periodically polled for weights. The stopper should be used to terminate
 	// the periodic polling.
@@ -3763,9 +3764,10 @@ type KVAdmissionControllerImpl struct {
 	kvAdmissionQ     *admission.WorkQueue
 	storeGrantCoords *admission.StoreGrantCoordinators
 	settings         *cluster.Settings
+	every            log.EveryN
 }
 
-var _ KVAdmissionController = KVAdmissionControllerImpl{}
+var _ KVAdmissionController = &KVAdmissionControllerImpl{}
 
 type admissionHandle struct {
 	tenantID                           roachpb.TenantID
@@ -3781,15 +3783,16 @@ func MakeKVAdmissionController(
 	storeGrantCoords *admission.StoreGrantCoordinators,
 	settings *cluster.Settings,
 ) KVAdmissionController {
-	return KVAdmissionControllerImpl{
+	return &KVAdmissionControllerImpl{
 		kvAdmissionQ:     kvAdmissionQ,
 		storeGrantCoords: storeGrantCoords,
 		settings:         settings,
+		every:            log.Every(10 * time.Second),
 	}
 }
 
 // AdmitKVWork implements the KVAdmissionController interface.
-func (n KVAdmissionControllerImpl) AdmitKVWork(
+func (n *KVAdmissionControllerImpl) AdmitKVWork(
 	ctx context.Context, tenantID roachpb.TenantID, ba *roachpb.BatchRequest,
 ) (handle interface{}, err error) {
 	ah := admissionHandle{tenantID: tenantID}
@@ -3828,7 +3831,6 @@ func (n KVAdmissionControllerImpl) AdmitKVWork(
 		}
 		admissionEnabled := true
 		if ah.storeAdmissionQ != nil {
-			// TODO(sumeer): Plumb WriteBytes for ingest requests.
 			ah.storeWorkHandle, err = ah.storeAdmissionQ.Admit(
 				ctx, admission.StoreWriteWorkInfo{WorkInfo: admissionInfo})
 			if err != nil {
@@ -3840,11 +3842,16 @@ func (n KVAdmissionControllerImpl) AdmitKVWork(
 				// kvAdmissionQ.Admit, and so callAdmittedWorkDoneOnKVAdmissionQ will
 				// stay false.
 				ah.storeAdmissionQ = nil
+				admissionEnabled = false
 			}
 		}
 		if admissionEnabled {
 			ah.callAdmittedWorkDoneOnKVAdmissionQ, err = n.kvAdmissionQ.Admit(ctx, admissionInfo)
 			if err != nil {
+				if ah.storeAdmissionQ != nil {
+					// No bytes were written.
+					_ = ah.storeAdmissionQ.AdmittedWorkDone(ah.storeWorkHandle, admission.StoreWorkDoneInfo{})
+				}
 				return admissionHandle{}, err
 			}
 		}
@@ -3853,19 +3860,33 @@ func (n KVAdmissionControllerImpl) AdmitKVWork(
 }
 
 // AdmittedKVWorkDone implements the KVAdmissionController interface.
-func (n KVAdmissionControllerImpl) AdmittedKVWorkDone(handle interface{}) {
+func (n *KVAdmissionControllerImpl) AdmittedKVWorkDone(
+	handle interface{}, writeBytes *StoreWriteBytes,
+) {
 	ah := handle.(admissionHandle)
 	if ah.callAdmittedWorkDoneOnKVAdmissionQ {
 		n.kvAdmissionQ.AdmittedWorkDone(ah.tenantID)
 	}
 	if ah.storeAdmissionQ != nil {
-		// TODO(sumeer): Plumb ingestedIntoL0Bytes and handle error return value.
-		_ = ah.storeAdmissionQ.AdmittedWorkDone(ah.storeWorkHandle, 0)
+		var doneInfo admission.StoreWorkDoneInfo
+		if writeBytes != nil {
+			doneInfo = admission.StoreWorkDoneInfo(*writeBytes)
+		}
+		err := ah.storeAdmissionQ.AdmittedWorkDone(ah.storeWorkHandle, doneInfo)
+		if err != nil {
+			// This shouldn't be happening.
+			if util.RaceEnabled {
+				log.Fatalf(context.Background(), "%s", errors.WithAssertionFailure(err))
+			}
+			if n.every.ShouldLog() {
+				log.Errorf(context.Background(), "%s", err)
+			}
+		}
 	}
 }
 
 // SetTenantWeightProvider implements the KVAdmissionController interface.
-func (n KVAdmissionControllerImpl) SetTenantWeightProvider(
+func (n *KVAdmissionControllerImpl) SetTenantWeightProvider(
 	provider TenantWeightProvider, stopper *stop.Stopper,
 ) {
 	go func() {

--- a/pkg/kv/kvserver/store_send.go
+++ b/pkg/kv/kvserver/store_send.go
@@ -44,7 +44,9 @@ import (
 func (s *Store) Send(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
-	br, _, pErr = s.SendWithWriteBytes(ctx, ba)
+	var writeBytes *StoreWriteBytes
+	br, writeBytes, pErr = s.SendWithWriteBytes(ctx, ba)
+	writeBytes.Release()
 	return br, pErr
 }
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1009,17 +1009,16 @@ func (n *Node) batchInternal(
 
 	tStart := timeutil.Now()
 	handle, err := n.admissionController.AdmitKVWork(ctx, tenID, args)
-	defer n.admissionController.AdmittedKVWorkDone(handle)
 	if err != nil {
 		return nil, err
 	}
-	var pErr *roachpb.Error
-	// TODO(sumeer): plumb *StoreWriteBytes to admission control.
 	var writeBytes *kvserver.StoreWriteBytes
-	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, *args)
-	if writeBytes != nil {
+	defer func() {
+		n.admissionController.AdmittedKVWorkDone(handle, writeBytes)
 		writeBytes.Release()
-	}
+	}()
+	var pErr *roachpb.Error
+	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, *args)
 	if pErr != nil {
 		br = &roachpb.BatchResponse{}
 		log.VErrEventf(ctx, 3, "error from stores.Send: %s", pErr)

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "doc.go",
         "granter.go",
+        "store_token_estimation.go",
         "work_queue.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/admission",
@@ -32,6 +33,7 @@ go_test(
     name = "admission_test",
     srcs = [
         "granter_test.go",
+        "store_token_estimation_test.go",
         "work_queue_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/pkg/util/admission/store_token_estimation.go
+++ b/pkg/util/admission/store_token_estimation.go
@@ -1,0 +1,361 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package admission
+
+import "github.com/cockroachdb/pebble"
+
+// The logic in this file deals with token estimation for a store write in two
+// situations: (a) at admission time, (b) when the admitted work is done. At
+// (a) we have no information provided about the work size (NB: this choice is
+// debatable, since for ingests we could extract some information pre-request
+// evaluation). At (b) we have the information in StoreWorkDoneInfo, which
+// gets aggregated by the StoreWorkQueue into storeAdmissionStats.
+//
+// Both kinds of token estimation are guessing the tokens that a request
+// should rightfully consume, based on models that are "trained" on actual
+// resource consumption observed, and reported work sizes, in the past.
+//
+// The token estimation is complicated by the fact that many writes do not
+// integrate with admission control. Specifically, even if they did not ask to
+// be admitted, it would be beneficial for them to provide the information at
+// (b), so we could subtract tokens for the work they did. The list of
+// significant non-integrated writes is:
+//
+// 1. Range snapshot application (does ingestion).
+//
+// 2. State machine application for regular writes: StoreWorkDoneInfo,
+//    WriteBytes only accounts for the write to the raft log.
+//
+// 3. Follower writes, to the raft log and to the state machine, both regular
+//    and ingests.
+//
+// Over time, we should change the code to perform step (b) for (1) and for
+// the raft log for (3). This will require noticing under raft that a write is
+// at the leaseholder, so that we don't account for the raft log write a
+// second time (since it has already been accounted for at proposal
+// evaluation). The current code here is designed to fit that future world,
+// while also attempting to deal with the limitations of this lack of
+// integration.
+//
+// Specifically, in such a future world, even though we have the raft log
+// writes for regular writes, and ingest bytes for ingestion requests, we have
+// a mix of workloads that are concurrently doing writes. These could be
+// multiple SQL-originating workloads with different size writes, and bulk
+// workloads that are doing index backfills. We desire workload agnostic token
+// estimation so a mix of various workloads can share the same token
+// estimation model.
+//
+// We also have the immediate practical requirement that if there are bytes
+// added to L0 (based on Pebble stats) that are unaccounted for by
+// StoreWorkDoneInfo, we should compensate for that by adjusting our
+// estimates. This may lead to per-work over-estimation, but that is better
+// than an unhealthy LSM. A consequence of this is that we are willing to add
+// tokens based on unaccounted write bytes to work that only did ingestion and
+// willing to add tokens based on unaccounted ingested bytes to work that only
+// did regular writes.
+//
+// We observe:
+// - The lack of integration of state machine application can be mostly
+//   handled by a multiplier on the bytes written to the raft log. Say a
+//   multiplier of ~2.
+//
+// - We expect that most range snapshot applications will ingest into levels
+//   below L0, so if we limit our attention to Pebble stats relating to
+//   ingestion into L0, we may not see the effect of these unaccounted bytes,
+//   which will result in more accurate estimation.
+//
+// - Ingests have some fraction that get ingested into L0, i.e., a multiplier
+//   <= 1.
+//
+// Based on these observations we adopt a linear model for estimating the
+// actual bytes (y), given the accounted bytes (x): y = a.x + b. The
+// estimation of a and b is done by tokensLinearModelFitter. We constrain the
+// interval of a to be [min,max] to prevent wild fluctuations and to account
+// for what we know about the system:
+// - For writes, we expect the multiplier a to be close to 2, due to the
+//   subsequent application to the state machine. So it would be reasonable to
+//   constrain a to [1, 2]. However, in experiments we've seen inconsistencies
+//   between Pebble stats and admission control stats, due to choppiness in
+//   work getting done, which is better modeled by allowing multiplier a to be
+//   less constrained. So we use [0.5, 3].
+//
+// - For ingests, we expect the multiplier a to be <= 1, since some fraction
+//   of the ingest goes into L0. So it would be reasonable to constrain a to
+//   [0, 1]. For the same reason as the previous bullet, we use [0.001, 1.5].
+//   This lower-bound of 0.001 is debatable, since it will cause some token
+//   consumption even if all ingested bytes are going to levels below L0.
+//   TODO(sumeer): consider lowering the lower bound, after experimentation.
+//
+// In both the writes and ingests case, y is the bytes being added to L0.
+//
+// NB: these linear models will be workload agnostic if most of the bytes are
+// modeled via the a.x term, and not via the b term, since workloads are
+// likely (at least for regular writes) to vary significantly in x.
+
+// tokensLinearModel represents a model y = multiplier.x + constant.
+type tokensLinearModel struct {
+	multiplier float64
+	// constant >= 0
+	constant int64
+}
+
+// tokensLinearModelFitter fits y = multiplier.x + constant, based on the
+// current interval and then exponentially smooths the multiplier and
+// constant.
+//
+// This fitter is probably poor and could be improved by taking history into
+// account in a cleverer way, such as looking at many past samples and doing
+// linear regression, under the assumption that the workload is stable.
+// However, the simple approach here should be an improvement on the additive
+// approach we previously used.
+//
+//
+// TODO(sumeer): improve the model based on realistic combinations of
+// workloads (e.g. foreground writes + index backfills).
+type tokensLinearModelFitter struct {
+	// [multiplierMin, multiplierMax] constrains the multiplier.
+	multiplierMin float64
+	multiplierMax float64
+
+	intLinearModel                tokensLinearModel
+	smoothedLinearModel           tokensLinearModel
+	smoothedPerWorkAccountedBytes int64
+
+	// Should be set to true for the ingested bytes model: if all bytes are
+	// ingested below L0, the actual bytes will be zero and the accounted bytes
+	// non-zero. We need to update the model in this case.
+	updateWithZeroActualNonZeroAccountedForIngestedModel bool
+}
+
+func makeTokensLinearModelFitter(
+	multMin float64, multMax float64, updateWithZeroActualNonZeroAccountedForIngestedModel bool,
+) tokensLinearModelFitter {
+	return tokensLinearModelFitter{
+		multiplierMin: multMin,
+		multiplierMax: multMax,
+		smoothedLinearModel: tokensLinearModel{
+			multiplier: (multMin + multMax) / 2,
+			constant:   1,
+		},
+		smoothedPerWorkAccountedBytes:                        1,
+		updateWithZeroActualNonZeroAccountedForIngestedModel: updateWithZeroActualNonZeroAccountedForIngestedModel,
+	}
+}
+
+// updateModelUsingIntervalStats updates the model, based on various stats
+// over the last interval: the number of work items admitted (workCount), the
+// bytes claimed by these work items (accountedBytes), and the actual bytes
+// observed in the LSM for that interval (actualBytes).
+//
+
+// As mentioned earlier, the current fitting algorithm is probably poor, though an
+// improvement on what we had previously. The approach taken is:
+//
+// - Fit the best model we can for the interval,
+//   multiplier*accountedBytes + workCount*constant = actualBytes, while
+//   minimizing the constant. We prefer the model to use the multiplier for
+//   most of what it needs to account for actualBytes.
+//   This exact model ignores inaccuracies due to integer arithmetic -- we
+//   don't care about rounding errors since an error of 2 bytes per request is
+//   inconsequential.
+//
+// - The multiplier has to conform to the [min,max] configured for this model,
+//   and constant has to conform to a value >= 1. The constant is constrained
+//   to be >=1 on the intuition that we want a request to consume at least 1
+//   token -- it isn't clear that this intuition is meaningful in any way.
+//
+// - Exponentially smooth this exact model's multiplier and constant based on
+//   history.
+func (f *tokensLinearModelFitter) updateModelUsingIntervalStats(
+	accountedBytes int64, actualBytes int64, workCount int64,
+) {
+	if workCount <= 1 || (actualBytes <= 0 &&
+		(!f.updateWithZeroActualNonZeroAccountedForIngestedModel || accountedBytes <= 0)) {
+		// Don't want to update the model if workCount is very low or actual bytes
+		// is zero (except for the exceptions in the if-condition above).
+		//
+		// Not updating the model at all does have the risk that a large constant
+		// will keep penalizing in the future. For example, if there are only
+		// ingests, and the regular writes model had a large constant, it will
+		// keep penalizing ingests. So we scale down the constant as if the new
+		// model had a 0 value for the constant and the exponential smoothing
+		// alpha was 0.5, i.e., halve the constant.
+		f.intLinearModel = tokensLinearModel{}
+		f.smoothedLinearModel.constant = max(1, f.smoothedLinearModel.constant/2)
+		return
+	}
+	if actualBytes < 0 {
+		actualBytes = 0
+	}
+	const alpha = 0.5
+	if accountedBytes <= 0 {
+		if actualBytes > 0 {
+			// Anomaly. Assume that we will see smoothedPerWorkAccountedBytes in the
+			// future. This prevents us from blowing up the constant in the model due
+			// to this anomaly.
+			accountedBytes = workCount * max(1, f.smoothedPerWorkAccountedBytes)
+		} else {
+			// actualBytes is also 0.
+			accountedBytes = 1
+		}
+	} else {
+		perWorkAccountedBytes := accountedBytes / workCount
+		f.smoothedPerWorkAccountedBytes = int64(
+			alpha*float64(perWorkAccountedBytes) + (1-alpha)*float64(f.smoothedPerWorkAccountedBytes))
+	}
+	// INVARIANT: workCount > 0, accountedBytes > 0, actualBytes >= 0.
+
+	// Start with the lower bound of 1 on constant, since we want most of bytes
+	// to be fitted using the multiplier. So workCount tokens go into that.
+	constant := int64(1)
+	// Then compute the multiplier.
+	multiplier := float64(max(0, actualBytes-workCount*constant)) / float64(accountedBytes)
+	// The multiplier may be too high or too low, so make it conform to
+	// [min,max].
+	if multiplier > f.multiplierMax {
+		multiplier = f.multiplierMax
+	} else if multiplier < f.multiplierMin {
+		multiplier = f.multiplierMin
+	}
+	// This is the model with the multiplier as small or large as possible,
+	// while minimizing constant (which is 1).
+	modelBytes := int64(multiplier*float64(accountedBytes)) + (constant * workCount)
+	// If the model is not accounting for all of actualBytes, we are forced to
+	// increase the constant to cover the difference.
+	if modelBytes < actualBytes {
+		constantAdjust := (actualBytes - modelBytes) / workCount
+		// Avoid overflow in case of bad stats.
+		if constantAdjust+constant > 0 {
+			constant += constantAdjust
+		}
+	}
+	// The best model we can come up for the interval.
+	f.intLinearModel = tokensLinearModel{
+		multiplier: multiplier,
+		constant:   constant,
+	}
+	// Smooth the multiplier and constant factors.
+	f.smoothedLinearModel.multiplier = alpha*multiplier + (1-alpha)*f.smoothedLinearModel.multiplier
+	f.smoothedLinearModel.constant = int64(
+		alpha*float64(constant) + (1-alpha)*float64(f.smoothedLinearModel.constant))
+}
+
+type storePerWorkTokenEstimator struct {
+	atAdmissionWorkTokens         int64
+	atDoneWriteTokensLinearModel  tokensLinearModelFitter
+	atDoneIngestTokensLinearModel tokensLinearModelFitter
+
+	cumStoreAdmissionStats storeAdmissionStats
+	cumL0WriteBytes        uint64
+	cumL0IngestedBytes     uint64
+
+	// Tracked for logging and copied out of here.
+	aux perWorkTokensAux
+}
+
+// perWorkTokensAux encapsulates auxiliary (informative) numerical state that
+// helps in understanding the behavior of storePerWorkTokenEstimator.
+type perWorkTokensAux struct {
+	intWorkCount                int64
+	intL0WriteBytes             int64
+	intL0IngestedBytes          int64
+	intL0WriteAccountedBytes    int64
+	intL0IngestedAccountedBytes int64
+	intWriteLinearModel         tokensLinearModel
+	intIngestedLinearModel      tokensLinearModel
+}
+
+func makeStorePerWorkTokenEstimator() storePerWorkTokenEstimator {
+	return storePerWorkTokenEstimator{
+		atAdmissionWorkTokens:         1,
+		atDoneWriteTokensLinearModel:  makeTokensLinearModelFitter(0.5, 3, false),
+		atDoneIngestTokensLinearModel: makeTokensLinearModelFitter(0.001, 1.5, true),
+	}
+}
+
+// NB: first call to updateEstimates only initializes the cumulative values.
+func (e *storePerWorkTokenEstimator) updateEstimates(
+	l0Metrics pebble.LevelMetrics, admissionStats storeAdmissionStats,
+) {
+	if e.cumL0WriteBytes == 0 {
+		e.cumStoreAdmissionStats = admissionStats
+		e.cumL0WriteBytes = l0Metrics.BytesFlushed
+		e.cumL0IngestedBytes = l0Metrics.BytesIngested
+		return
+	}
+	intL0WriteBytes := int64(l0Metrics.BytesFlushed) - int64(e.cumL0WriteBytes)
+	intL0IngestedBytes := int64(l0Metrics.BytesIngested) - int64(e.cumL0IngestedBytes)
+	intWorkCount := int64(admissionStats.admittedCount) -
+		int64(e.cumStoreAdmissionStats.admittedCount)
+	intL0WriteAccountedBytes :=
+		int64(admissionStats.writeAccountedBytes) - int64(e.cumStoreAdmissionStats.writeAccountedBytes)
+	// Note that these are not really L0 ingested bytes, since we don't know how
+	// many did go to L0.
+	intL0IngestedAccountedBytes := int64(admissionStats.ingestedAccountedBytes) -
+		int64(e.cumStoreAdmissionStats.ingestedAccountedBytes)
+	e.atDoneWriteTokensLinearModel.updateModelUsingIntervalStats(
+		intL0WriteAccountedBytes, intL0WriteBytes, intWorkCount)
+	e.atDoneIngestTokensLinearModel.updateModelUsingIntervalStats(
+		intL0IngestedAccountedBytes, intL0IngestedBytes, intWorkCount)
+
+	intL0TotalBytes := intL0WriteBytes + intL0IngestedBytes
+	if intWorkCount > 1 && intL0TotalBytes > 0 {
+		// Update the atAdmissionWorkTokens
+		intAtAdmissionWorkTokens := intL0TotalBytes / intWorkCount
+		const alpha = 0.5
+		e.atAdmissionWorkTokens = int64(alpha*float64(intAtAdmissionWorkTokens) +
+			(1-alpha)*float64(e.atAdmissionWorkTokens))
+		e.atAdmissionWorkTokens = max(1, e.atAdmissionWorkTokens)
+	}
+	e.cumStoreAdmissionStats = admissionStats
+	e.cumL0WriteBytes = l0Metrics.BytesFlushed
+	e.cumL0IngestedBytes = l0Metrics.BytesIngested
+	e.aux = perWorkTokensAux{
+		intWorkCount:                intWorkCount,
+		intL0WriteBytes:             intL0WriteBytes,
+		intL0IngestedBytes:          intL0IngestedBytes,
+		intL0WriteAccountedBytes:    intL0WriteAccountedBytes,
+		intL0IngestedAccountedBytes: intL0IngestedAccountedBytes,
+		intWriteLinearModel:         e.atDoneWriteTokensLinearModel.intLinearModel,
+		intIngestedLinearModel:      e.atDoneIngestTokensLinearModel.intLinearModel,
+	}
+}
+
+func (e *storePerWorkTokenEstimator) getStoreRequestEstimatesAtAdmission() storeRequestEstimates {
+	return storeRequestEstimates{writeTokens: e.atAdmissionWorkTokens}
+}
+
+func (e *storePerWorkTokenEstimator) getModelsAtAdmittedDone() (
+	writeLM tokensLinearModel,
+	ingestedLM tokensLinearModel,
+) {
+	return e.atDoneWriteTokensLinearModel.smoothedLinearModel,
+		e.atDoneIngestTokensLinearModel.smoothedLinearModel
+}
+
+// TODO(sumeer):
+// - Make followers tell admission control about the size of their write and
+//   sstable bytes, without asking for permission. We will include these in
+//   the admitted count and fit them to the same model, so that it is more
+//   accurate. Additionally, we will scale down the bytes for
+//   at-admission-tokens by the fraction
+//   bytes-that-sought-permission/(bytes-that-sought-permission +
+//   bytes-that-did-not-seek-permission)
+//   Additionally, this work that did not seek permission will consume tokens.
+//
+// - Integrate snapshot ingests: these are likely to usually land in L6, so
+//   may not fit the existing ingest model well. Additionally, we do not want
+//   large range snapshots to consume a huge number of tokens. We do know how
+//   many bytes were ingested into L0 for such snapshots. We can use those
+//   bytes to hide the L0 increase caused by these snapshots so that they do
+//   not affect the model. And not have them consume any tokens (this is a
+//   simpler version of https://github.com/cockroachdb/cockroach/pull/80914,
+//   and not the final solution).

--- a/pkg/util/admission/store_token_estimation_test.go
+++ b/pkg/util/admission/store_token_estimation_test.go
@@ -1,0 +1,135 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package admission
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/pebble"
+	"github.com/stretchr/testify/require"
+)
+
+func scanFloat(t *testing.T, d *datadriven.TestData, key string) float64 {
+	var vstring string
+	d.ScanArgs(t, key, &vstring)
+	v, err := strconv.ParseFloat(vstring, 64)
+	require.NoError(t, err)
+	return v
+}
+
+func printLinearModel(b *strings.Builder, m tokensLinearModel) {
+	fmt.Fprintf(b, "%.2fx+%d", m.multiplier, m.constant)
+}
+
+func printLinearModelFitter(b *strings.Builder, fitter tokensLinearModelFitter) {
+	fmt.Fprintf(b, "int: ")
+	printLinearModel(b, fitter.intLinearModel)
+	fmt.Fprintf(b, " smoothed: ")
+	printLinearModel(b, fitter.smoothedLinearModel)
+	fmt.Fprintf(b, " per-work-accounted: %d\n", fitter.smoothedPerWorkAccountedBytes)
+}
+
+func TestTokensLinearModelFitter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var fitter tokensLinearModelFitter
+	fitterToString := func() string {
+		var b strings.Builder
+		printLinearModelFitter(&b, fitter)
+		return b.String()
+	}
+	datadriven.RunTest(t, testutils.TestDataPath(t, "tokens_linear_model_fitter"),
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "init":
+				multMin := scanFloat(t, d, "mult-min")
+				multMax := scanFloat(t, d, "mult-max")
+				updateWithZeroActualNonZeroAccounted := false
+				if d.HasArg("ingested-model") {
+					d.ScanArgs(t, "ingested-model", &updateWithZeroActualNonZeroAccounted)
+				}
+				fitter = makeTokensLinearModelFitter(multMin, multMax, updateWithZeroActualNonZeroAccounted)
+				return fitterToString()
+
+			case "update":
+				var accountedBytes, actualBytes, workCount int
+				d.ScanArgs(t, "accounted-bytes", &accountedBytes)
+				d.ScanArgs(t, "actual-bytes", &actualBytes)
+				d.ScanArgs(t, "work-count", &workCount)
+				fitter.updateModelUsingIntervalStats(
+					int64(accountedBytes), int64(actualBytes), int64(workCount))
+				return fitterToString()
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+}
+
+func TestStorePerWorkTokenEstimator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var estimator storePerWorkTokenEstimator
+	var l0Metrics pebble.LevelMetrics
+	var admissionStats storeAdmissionStats
+
+	datadriven.RunTest(t, testutils.TestDataPath(t, "store_per_work_token_estimator"),
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "init":
+				estimator = makeStorePerWorkTokenEstimator()
+				l0Metrics = pebble.LevelMetrics{}
+				admissionStats = storeAdmissionStats{}
+				return ""
+
+			case "update":
+				// The parameters are over the interval.
+				var intFlushed, intIngested uint64
+				d.ScanArgs(t, "flushed", &intFlushed)
+				d.ScanArgs(t, "ingested", &intIngested)
+				l0Metrics.BytesFlushed += intFlushed
+				l0Metrics.BytesIngested += intIngested
+				var admitted, writeAccounted, ingestedAccounted uint64
+				d.ScanArgs(t, "admitted", &admitted)
+				d.ScanArgs(t, "write-accounted", &writeAccounted)
+				d.ScanArgs(t, "ingested-accounted", &ingestedAccounted)
+				admissionStats.admittedCount += admitted
+				admissionStats.writeAccountedBytes += writeAccounted
+				admissionStats.ingestedAccountedBytes += ingestedAccounted
+				estimator.updateEstimates(l0Metrics, admissionStats)
+				wlm, ilm := estimator.getModelsAtAdmittedDone()
+				require.Equal(t, wlm, estimator.atDoneWriteTokensLinearModel.smoothedLinearModel)
+				require.Equal(t, ilm, estimator.atDoneIngestTokensLinearModel.smoothedLinearModel)
+				var b strings.Builder
+				fmt.Fprintf(&b, "interval state: %+v\n", estimator.aux)
+				fmt.Fprintf(&b, "at-admission-tokens: %d\n",
+					estimator.getStoreRequestEstimatesAtAdmission().writeTokens)
+				fmt.Fprintf(&b, "write-tokens: ")
+				printLinearModelFitter(&b, estimator.atDoneWriteTokensLinearModel)
+				fmt.Fprintf(&b, "ingest-tokens: ")
+				printLinearModelFitter(&b, estimator.atDoneIngestTokensLinearModel)
+				return b.String()
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+
+}

--- a/pkg/util/admission/testdata/format_adjust_tokens_stats.txt
+++ b/pkg/util/admission/testdata/format_adjust_tokens_stats.txt
@@ -1,6 +1,6 @@
 echo
 ----
 zero:
-compaction score 0.000 (0 ssts, 0 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
+compaction score 0.000 (0 ssts, 0 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 0.00x+0 B) + ingested-model 0.00x+0 B (smoothed 0.00x+0 B) + at-admission-tokens 0 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
 real-numbers:
-compaction score 2.700[L0-overload] (195 ssts, 27 sub-levels), L0 growth 577 MiB: 178 MiB acc-write + 73 MiB acc-ingest + 326 MiB unacc [≈270 KiB/req, n=621], compacted 77 MiB [≈62 MiB], flushed 0 B [≈0 B]; admitting 116 MiB (rate 7.7 MiB/s) due to L0 growth (used 0 B) with L0 penalty: +270 KiB/req, *0.34/ingest
+compaction score 2.700[L0-overload] (195 ssts, 27 sub-levels), L0 growth 577 MiB (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 0.00x+0 B) + ingested-model 0.00x+0 B (smoothed 0.00x+0 B) + at-admission-tokens 0 B, compacted 77 MiB [≈62 MiB], flushed 0 B [≈0 B]; admitting 116 MiB (rate 7.7 MiB/s) due to L0 growth (used 0 B)

--- a/pkg/util/admission/testdata/io_load_listener
+++ b/pkg/util/admission/testdata/io_load_listener
@@ -6,13 +6,13 @@ init
 
 prep-admission-stats admitted=0
 ----
-{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0}
 
-# Even though above the threshold, the first 15 ticks don't limit the tokens.
-set-state l0-bytes=10000 l0-added=1000 l0-files=21 l0-sublevels=21
+# Even though above the threshold, the first 60 ticks don't limit the tokens.
+set-state l0-bytes=10000 l0-added-write=1000 l0-files=21 l0-sublevels=21
 ----
-compaction score 0.000 (21 ssts, 21 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
+compaction score 0.000 (21 ssts, 21 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
+{ioLoadListenerState:{cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
 tick: 0, setAvailableIOTokens: unlimited
 tick: 1, setAvailableIOTokens: unlimited
 tick: 2, setAvailableIOTokens: unlimited
@@ -74,20 +74,21 @@ tick: 57, setAvailableIOTokens: unlimited
 tick: 58, setAvailableIOTokens: unlimited
 tick: 59, setAvailableIOTokens: unlimited
 
-prep-admission-stats admitted=10000
+prep-admission-stats admitted=10000 write-bytes=40000
 ----
-{admittedCount:10000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:10000 writeAccountedBytes:40000 ingestedAccountedBytes:0}
 
 # Delta added is 100,000. The l0-bytes are the same, so compactions removed
 # 100,000 bytes. Smoothed removed by compactions is 50,000. Each admitted is
 # expected to add 10 bytes. We want to add only 25,000 (half the smoothed
 # removed), but smoothing it drops the tokens to 12,500.
-set-state l0-bytes=10000 l0-added=101000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=10000 l0-added-write=101000 l0-files=21 l0-sublevels=21
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 98 KiB: 0 B acc-write + 0 B acc-ingest + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈49 KiB], flushed 0 B [≈0 B]; admitting 12 KiB (rate 833 B/s) due to L0 growth (used 0 B) with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:10000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:101000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:50000 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:12500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:12500 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:100000 intPerWorkUnaccountedL0Bytes:10 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 209
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 98 KiB (write 98 KiB ingest 0 B): requests 10000 with 39 KiB acc-write + 0 B acc-ingest + write-model 2.25x+1 B (smoothed 2.00x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 5 B, compacted 98 KiB [≈49 KiB], flushed 0 B [≈0 B]; admitting 12 KiB (rate 833 B/s) due to L0 growth (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:101000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:50000 smoothedCompactionByteTokens:12500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:12500 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:5} writeLM:{multiplier:2 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10000 intL0WriteBytes:100000 intL0IngestedBytes:0 intL0WriteAccountedBytes:40000 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:2.25 constant:1} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 5
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 2.00x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 209
 tick: 1, setAvailableIOTokens: 209
 tick: 2, setAvailableIOTokens: 209
 tick: 3, setAvailableIOTokens: 209
@@ -148,17 +149,18 @@ tick: 57, setAvailableIOTokens: 209
 tick: 58, setAvailableIOTokens: 209
 tick: 59, setAvailableIOTokens: 169
 
-prep-admission-stats admitted=20000
+prep-admission-stats admitted=20000 write-bytes=80000
 ----
-{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:20000 writeAccountedBytes:80000 ingestedAccountedBytes:0}
 
 # Same delta as previous but smoothing bumps up the tokens to 25,000.
-set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21
+set-state l0-bytes=10000 l0-added-write=201000 l0-files=21 l0-sublevels=21
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 98 KiB: 0 B acc-write + 0 B acc-ingest + 98 KiB unacc [≈10 B/req, n=10000], compacted 98 KiB [≈73 KiB], flushed 0 B [≈0 B]; admitting 24 KiB (rate 1.6 KiB/s) due to L0 growth (used 0 B) with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:75000 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:100000 intPerWorkUnaccountedL0Bytes:10 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 417
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 98 KiB (write 98 KiB ingest 0 B): requests 10000 with 39 KiB acc-write + 0 B acc-ingest + write-model 2.25x+1 B (smoothed 2.12x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 7 B, compacted 98 KiB [≈73 KiB], flushed 0 B [≈0 B]; admitting 24 KiB (rate 1.6 KiB/s) due to L0 growth (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:75000 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:7} writeLM:{multiplier:2.125 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:100000 intL0CompactedBytes:100000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10000 intL0WriteBytes:100000 intL0IngestedBytes:0 intL0WriteAccountedBytes:40000 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:2.25 constant:1} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 7
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 2.12x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 417
 tick: 1, setAvailableIOTokens: 417
 tick: 2, setAvailableIOTokens: 417
 tick: 3, setAvailableIOTokens: 417
@@ -220,25 +222,27 @@ tick: 58, setAvailableIOTokens: 417
 tick: 59, setAvailableIOTokens: 397
 
 # No delta. This used to trigger an overflow bug.
-set-state l0-bytes=10000 l0-added=201000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=201000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈10 B/req, n=1], compacted 0 B [≈37 KiB], flushed 0 B [≈0 B]; admitting 21 KiB (rate 1.4 KiB/s) due to L0 growth (used 0 B) with L0 penalty: +10 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:37500 smoothedIntPerWorkUnaccountedL0Bytes:10 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:21875 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:21875 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:10} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 10
-tick: 0, setAvailableIOTokens: 365
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 2.12x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 7 B, compacted 0 B [≈37 KiB], flushed 0 B [≈0 B]; admitting 21 KiB (rate 1.4 KiB/s) due to L0 growth (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:201000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:37500 smoothedCompactionByteTokens:21875 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:21875 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:7} writeLM:{multiplier:2.125 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 7
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 2.12x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 365
 
-prep-admission-stats admitted=30000
+prep-admission-stats admitted=30000 write-bytes=120000
 ----
-{admittedCount:30000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:30000 writeAccountedBytes:120000 ingestedAccountedBytes:0}
 
 # l0-sublevels drops below threshold. We calculate the smoothed values, but
 # don't limit the tokens.
-set-state l0-bytes=10000 l0-added=501000 l0-files=21 l0-sublevels=20 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=501000 l0-files=21 l0-sublevels=20 print-only-first-tick=true
 ----
-compaction score 1.000 (21 ssts, 20 sub-levels), L0 growth 293 KiB: 0 B acc-write + 0 B acc-ingest + 293 KiB unacc [≈20 B/req, n=10000], compacted 293 KiB [≈165 KiB], flushed 0 B [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:30000 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:501000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:168750 smoothedIntPerWorkUnaccountedL0Bytes:20 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:160937.5 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:20} aux:{intL0AddedBytes:300000 intL0CompactedBytes:300000 intAdmittedCount:10000 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:300000 intPerWorkUnaccountedL0Bytes:30 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 20
-tick: 0, setAvailableIOTokens: unlimited
+compaction score 1.000 (21 ssts, 20 sub-levels), L0 growth 293 KiB (write 293 KiB ingest 0 B): requests 10000 with 39 KiB acc-write + 0 B acc-ingest + write-model 3.00x+18 B (smoothed 2.56x+9 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 18 B, compacted 293 KiB [≈165 KiB], flushed 0 B [≈0 B]; admitting all
+{ioLoadListenerState:{cumL0AddedBytes:501000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:168750 smoothedCompactionByteTokens:160937.5 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:18} writeLM:{multiplier:2.5625 constant:9} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:300000 intL0CompactedBytes:300000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10000 intL0WriteBytes:300000 intL0IngestedBytes:0 intL0WriteAccountedBytes:40000 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:3 constant:18} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 18
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 2.56x+9 ingested-lm: 0.75x+1
+setAvailableIOTokens: unlimited
 
 # Test cases with more information in storeAdmissionStats.
 init
@@ -246,52 +250,58 @@ init
 
 prep-admission-stats admitted=0
 ----
-{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0}
 
-set-state l0-bytes=1000 l0-added=1000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
+set-state l0-bytes=1000 l0-added-write=1000 l0-added-ingested=0 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-compaction score 0.000 (21 ssts, 21 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
+compaction score 0.000 (21 ssts, 21 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
+{ioLoadListenerState:{cumL0AddedBytes:1000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
 tick: 0, setAvailableIOTokens: unlimited
 
-# L0 will see an addition of 200,000 bytes. 180,000 bytes were mentioned by
-# the admitted requests, but 30,000 went into levels below L0. So 150,000 are
-# accounted for.
-prep-admission-stats admitted=10 admitted-bytes=180000 ingested-bytes=50000 ingested-into-l0=20000
+# L0 will see an addition of 200,000 bytes. 150,000 bytes were mentioned by
+# the admitted requests.
+prep-admission-stats admitted=10 write-bytes=130000 ingested-bytes=20000
 ----
-{admittedCount:10 admittedWithBytesCount:0 admittedAccountedBytes:180000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
+{admittedCount:10 writeAccountedBytes:130000 ingestedAccountedBytes:20000}
 
-set-state l0-bytes=1000 l0-added=201000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
+set-state l0-bytes=1000 l0-added-write=171000 l0-added-ingested=30000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 195 KiB: 127 KiB acc-write + 20 KiB acc-ingest + 49 KiB unacc [≈4.9 KiB/req, n=10], compacted 195 KiB [≈98 KiB], flushed 0 B [≈0 B]; admitting 24 KiB (rate 1.6 KiB/s) due to L0 growth (used 0 B) with L0 penalty: +4.9 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:10 admittedWithBytesCount:0 admittedAccountedBytes:180000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:201000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:100000 smoothedIntPerWorkUnaccountedL0Bytes:5000 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:5000} aux:{intL0AddedBytes:200000 intL0CompactedBytes:200000 intAdmittedCount:10 intAdmittedBytes:180000 intIngestedBytes:50000 intIngestedAccountedL0Bytes:20000 intAccountedL0Bytes:150000 intUnaccountedL0Bytes:50000 intPerWorkUnaccountedL0Bytes:5000 l0BytesIngestFraction:0.4 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 5000
-tick: 0, setAvailableIOTokens: 417
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 195 KiB (write 166 KiB ingest 29 KiB): requests 10 with 127 KiB acc-write + 20 KiB acc-ingest + write-model 1.31x+1 B (smoothed 1.53x+1 B) + ingested-model 1.50x+1 B (smoothed 1.12x+1 B) + at-admission-tokens 9.8 KiB, compacted 195 KiB [≈98 KiB], flushed 0 B [≈0 B]; admitting 24 KiB (rate 1.6 KiB/s) due to L0 growth (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:201000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:100000 smoothedCompactionByteTokens:25000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:25000 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:10000} writeLM:{multiplier:1.5288076923076923 constant:1} ingestedLM:{multiplier:1.125 constant:1} aux:{intL0AddedBytes:200000 intL0CompactedBytes:200000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:170000 intL0IngestedBytes:30000 intL0WriteAccountedBytes:130000 intL0IngestedAccountedBytes:20000 intWriteLinearModel:{multiplier:1.3076153846153846 constant:1} intIngestedLinearModel:{multiplier:1.4995 constant:1}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 10000
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.53x+1 ingested-lm: 1.12x+1
+setAvailableIOTokens: 417
 
 # L0 will see an addition of 20,000 bytes, all of which are accounted for.
-prep-admission-stats admitted=20 admitted-bytes=200000 ingested-bytes=50000 ingested-into-l0=20000
+# Since the ingested bytes in this interval are 0, the constant for the
+# ingested model is decayed by a factor of 2.
+prep-admission-stats admitted=20 write-bytes=150000 ingested-bytes=20000
 ----
-{admittedCount:20 admittedWithBytesCount:0 admittedAccountedBytes:200000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
+{admittedCount:20 writeAccountedBytes:150000 ingestedAccountedBytes:20000}
 
-set-state l0-bytes=1000 l0-added=221000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
+set-state l0-bytes=1000 l0-added-write=191000 l0-added-ingested=30000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB: 20 KiB acc-write + 0 B acc-ingest + 0 B unacc [≈2.4 KiB/req, n=10], compacted 20 KiB [≈59 KiB], flushed 0 B [≈0 B]; admitting 27 KiB (rate 1.8 KiB/s) due to L0 growth (used 0 B) with L0 penalty: +2.4 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:20 admittedWithBytesCount:0 admittedAccountedBytes:200000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:221000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:60000 smoothedIntPerWorkUnaccountedL0Bytes:2500 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:27500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:27500 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:2500} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAdmittedBytes:20000 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:20000 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 2500
-tick: 0, setAvailableIOTokens: 459
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB (write 20 KiB ingest 0 B): requests 10 with 20 KiB acc-write + 0 B acc-ingest + write-model 1.00x+1 B (smoothed 1.26x+1 B) + ingested-model 0.00x+0 B (smoothed 1.12x+1 B) + at-admission-tokens 5.9 KiB, compacted 20 KiB [≈59 KiB], flushed 0 B [≈0 B]; admitting 27 KiB (rate 1.8 KiB/s) due to L0 growth (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:221000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:60000 smoothedCompactionByteTokens:27500 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:27500 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:6000} writeLM:{multiplier:1.2641538461538462 constant:1} ingestedLM:{multiplier:1.125 constant:1} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:20000 intL0IngestedBytes:0 intL0WriteAccountedBytes:20000 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0.9995 constant:1} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 6000
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.26x+1 ingested-lm: 1.12x+1
+setAvailableIOTokens: 459
 
 # L0 will see an addition of 20,000 bytes, but we think we have added 100,000
 # bytes to L0. We don't let unaccounted bytes become negative.
-prep-admission-stats admitted=30 admitted-bytes=300000 ingested-bytes=50000 ingested-into-l0=20000
+# Since the ingested bytes in this interval are 0, the constant for the
+# ingested model is decayed by a factor of 2.
+prep-admission-stats admitted=30 write-bytes=250000 ingested-bytes=20000 ingested-into-l0=20000
 ----
-{admittedCount:30 admittedWithBytesCount:0 admittedAccountedBytes:300000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000}
+{admittedCount:30 writeAccountedBytes:250000 ingestedAccountedBytes:20000}
 
-set-state l0-bytes=1000 l0-added=241000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
+set-state l0-bytes=1000 l0-added-write=211000 l0-added-ingested=30000 l0-files=21 l0-sublevels=21 print-only-first-tick=true
 ----
-compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB: 98 KiB acc-write + 0 B acc-ingest + 0 B unacc [≈1.2 KiB/req, n=10], compacted 20 KiB [≈39 KiB], flushed 0 B [≈0 B]; admitting 23 KiB (rate 1.5 KiB/s) due to L0 growth (used 0 B) with L0 penalty: +1.2 KiB/req, *0.45/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:30 admittedWithBytesCount:0 admittedAccountedBytes:300000 ingestedAccountedBytes:50000 ingestedAccountedL0Bytes:20000} cumL0AddedBytes:241000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:40000 smoothedIntPerWorkUnaccountedL0Bytes:1250 smoothedIntIngestedAccountedL0BytesFraction:0.45 smoothedCompactionByteTokens:23750 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:23750 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.45 workByteAddition:1250} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intAdmittedCount:10 intAdmittedBytes:100000 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:100000 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.45, workByteAddition: 1250
-tick: 0, setAvailableIOTokens: 396
+compaction score 1.050[L0-overload] (21 ssts, 21 sub-levels), L0 growth 20 KiB (write 20 KiB ingest 0 B): requests 10 with 98 KiB acc-write + 0 B acc-ingest + write-model 0.50x+1 B (smoothed 0.88x+1 B) + ingested-model 0.00x+0 B (smoothed 1.12x+1 B) + at-admission-tokens 3.9 KiB, compacted 20 KiB [≈39 KiB], flushed 0 B [≈0 B]; admitting 23 KiB (rate 1.5 KiB/s) due to L0 growth (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:241000 curL0Bytes:1000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:40000 smoothedCompactionByteTokens:23750 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:23750 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:4000} writeLM:{multiplier:0.8820769230769231 constant:1} ingestedLM:{multiplier:1.125 constant:1} aux:{intL0AddedBytes:20000 intL0CompactedBytes:20000 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:10 intL0WriteBytes:20000 intL0IngestedBytes:0 intL0WriteAccountedBytes:100000 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0.5 constant:1} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 4000
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 0.88x+1 ingested-lm: 1.12x+1
+setAvailableIOTokens: 396
 
 # Test case with flush tokens.
 init
@@ -299,67 +309,73 @@ init
 
 prep-admission-stats admitted=0
 ----
-{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
+{admittedCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0}
 
-set-state l0-bytes=10000 l0-added=1000 l0-files=1 l0-sublevels=1 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=1000 l0-files=1 l0-sublevels=1 print-only-first-tick=true
 ----
-compaction score 0.000 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=0], compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0 workByteAddition:0} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:0 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
+compaction score 0.000 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 0 B [≈0 B]; admitting all
+{ioLoadListenerState:{cumL0AddedBytes:1000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0 smoothedNumFlushTokens:0 flushUtilTargetFraction:0 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:0 intFlushUtilization:0 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
 tick: 0, setAvailableIOTokens: unlimited
 
 # Flush loop utilization is too low for the interval flush tokens to
 # contribute to the smoothed value, or for tokens to become limited.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=100 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=100 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 9.8 KiB: 0 B acc-write + 0 B acc-ingest + 9.8 KiB unacc [≈0 B/req, n=1], compacted 9.8 KiB [≈4.9 KiB], flushed 7.3 KiB [≈0 B]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:5000 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:5000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:10000 intL0CompactedBytes:10000 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:10000 intPerWorkUnaccountedL0Bytes:10000 l0BytesIngestFraction:0 intFlushTokens:7500 intFlushUtilization:0.0196078431372549 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: unlimited
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 9.8 KiB (write 9.8 KiB ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 9.8 KiB [≈4.9 KiB], flushed 7.3 KiB [≈0 B]; admitting all
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:5000 smoothedCompactionByteTokens:5000 smoothedNumFlushTokens:0 flushUtilTargetFraction:1.5 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:10000 intL0CompactedBytes:10000 intFlushTokens:7500 intFlushUtilization:0.0196078431372549 intWriteStalls:0 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:10000 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: unlimited
 
 # Flush loop utilization is high enough, so we compute flush tokens for limiting admission.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=10 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=1000 flush-work-sec=2 flush-idle-sec=10 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈2.4 KiB], flushed 7.3 KiB [≈7.3 KiB]; admitting 11 KiB (rate 750 B/s) due to memtable flush (multiplier 1.500) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:2500 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:2500 smoothedNumFlushTokens:7500 flushUtilTargetFraction:1.5 totalNumByteTokens:11250 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:7500 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 188
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈2.4 KiB], flushed 7.3 KiB [≈7.3 KiB]; admitting 11 KiB (rate 750 B/s) due to memtable flush (multiplier 1.500) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:0 smoothedIntL0CompactedBytes:2500 smoothedCompactionByteTokens:2500 smoothedNumFlushTokens:7500 flushUtilTargetFraction:1.5 totalNumByteTokens:11250 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:7500 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 188
 
 # Write stalls are happening, so decrease the flush utilization target
 # fraction from 1.5 to 1.475. But the peak flush rate has also increased since
 # now we flushed 10x the bytes, so the overall tokens increase.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=1 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=1 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈1.2 KiB], flushed 73 KiB [≈40 KiB]; admitting 59 KiB (rate 4.0 KiB/s) due to memtable flush (multiplier 1.475) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:1 smoothedIntL0CompactedBytes:1250 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:1250 smoothedNumFlushTokens:41250 flushUtilTargetFraction:1.475 totalNumByteTokens:60843 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 doLogFlush:true} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1015
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈1.2 KiB], flushed 73 KiB [≈40 KiB]; admitting 59 KiB (rate 4.0 KiB/s) due to memtable flush (multiplier 1.475) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:1 smoothedIntL0CompactedBytes:1250 smoothedCompactionByteTokens:1250 smoothedNumFlushTokens:41250 flushUtilTargetFraction:1.475 totalNumByteTokens:60843 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:true} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1015
 
 # Two write stalls happened, so decrease the flush utilization target fraction
 # by a bigger step, from 1.475 to 1.425. Since the smoothed peak flush rate is
 # increasing, the overall flush tokens continue to increase.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=3 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=3 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈625 B], flushed 73 KiB [≈57 KiB]; admitting 81 KiB (rate 5.4 KiB/s) due to memtable flush (multiplier 1.425) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:3 smoothedIntL0CompactedBytes:625 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:625 smoothedNumFlushTokens:58125 flushUtilTargetFraction:1.4250000000000003 totalNumByteTokens:82828 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:2 prevTokensUsed:0 tokenKind:1 doLogFlush:true} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1381
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈625 B], flushed 73 KiB [≈57 KiB]; admitting 81 KiB (rate 5.4 KiB/s) due to memtable flush (multiplier 1.425) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:3 smoothedIntL0CompactedBytes:625 smoothedCompactionByteTokens:625 smoothedNumFlushTokens:58125 flushUtilTargetFraction:1.4250000000000003 totalNumByteTokens:82828 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:2 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:true} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1381
 
 # Five more write stalls, so the the flush utilization target fraction is
 # decreased to 1.35. The smoothed peak flush rate continues to increase.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=8 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=8 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈312 B], flushed 73 KiB [≈65 KiB]; admitting 88 KiB (rate 5.8 KiB/s) due to memtable flush (multiplier 1.350) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:8 smoothedIntL0CompactedBytes:312 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:312.5 smoothedNumFlushTokens:66562.5 flushUtilTargetFraction:1.3500000000000005 totalNumByteTokens:89859 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:5 prevTokensUsed:0 tokenKind:1 doLogFlush:true} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1498
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈312 B], flushed 73 KiB [≈65 KiB]; admitting 88 KiB (rate 5.8 KiB/s) due to memtable flush (multiplier 1.350) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:8 smoothedIntL0CompactedBytes:312 smoothedCompactionByteTokens:312.5 smoothedNumFlushTokens:66562.5 flushUtilTargetFraction:1.3500000000000005 totalNumByteTokens:89859 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:5 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:true} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1498
 
 # Another write stall, and the flush utilization target fraction drops to 1.325.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=9 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=9 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈156 B], flushed 73 KiB [≈69 KiB]; admitting 92 KiB (rate 6.1 KiB/s) due to memtable flush (multiplier 1.325) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:9 smoothedIntL0CompactedBytes:156 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:156.25 smoothedNumFlushTokens:70781.25 flushUtilTargetFraction:1.3250000000000006 totalNumByteTokens:93785 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 doLogFlush:true} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1564
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈156 B], flushed 73 KiB [≈69 KiB]; admitting 92 KiB (rate 6.1 KiB/s) due to memtable flush (multiplier 1.325) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:9 smoothedIntL0CompactedBytes:156 smoothedCompactionByteTokens:156.25 smoothedNumFlushTokens:70781.25 flushUtilTargetFraction:1.3250000000000006 totalNumByteTokens:93785 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:true} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1564
 
 # Set a lower bound of 1.3 on the flush utilization target fraction.
 set-min-flush-util percent=130
@@ -367,21 +383,23 @@ set-min-flush-util percent=130
 
 # Another write stall causes the flush utilization target fraction to decrease
 # to 1.3, which is also the lower bound.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=10 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=10 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈78 B], flushed 73 KiB [≈71 KiB]; admitting 92 KiB (rate 6.2 KiB/s) due to memtable flush (multiplier 1.300) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:10 smoothedIntL0CompactedBytes:78 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:78.125 smoothedNumFlushTokens:72890.625 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:94757 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 doLogFlush:true} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1580
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈78 B], flushed 73 KiB [≈71 KiB]; admitting 92 KiB (rate 6.2 KiB/s) due to memtable flush (multiplier 1.300) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:10 smoothedIntL0CompactedBytes:78 smoothedCompactionByteTokens:78.125 smoothedNumFlushTokens:72890.625 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:94757 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:true} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1580
 
 # Despite another write stall, the flush utilization target fraction does not
 # decrease since it is already at the lower bound.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=11 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=11 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈39 B], flushed 73 KiB [≈72 KiB]; admitting 94 KiB (rate 6.3 KiB/s) due to memtable flush (multiplier 1.300) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:11 smoothedIntL0CompactedBytes:39 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:39.0625 smoothedNumFlushTokens:73945.3125 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:96128 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1603
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈39 B], flushed 73 KiB [≈72 KiB]; admitting 94 KiB (rate 6.3 KiB/s) due to memtable flush (multiplier 1.300) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:11 smoothedIntL0CompactedBytes:39 smoothedCompactionByteTokens:39.0625 smoothedNumFlushTokens:73945.3125 flushUtilTargetFraction:1.3000000000000007 totalNumByteTokens:96128 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1603
 
 # Bump up the lower bound to 1.35, which is greater than the current flush
 # utilization target fraction.
@@ -390,61 +408,68 @@ set-min-flush-util percent=135
 
 # Despite another write stall, the flush utilization target fraction
 # increases to the new lower bound.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=12 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=12 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈19 B], flushed 73 KiB [≈73 KiB]; admitting 98 KiB (rate 6.5 KiB/s) due to memtable flush (multiplier 1.350) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:12 smoothedIntL0CompactedBytes:19 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:19.53125 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:100538 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1676
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈19 B], flushed 73 KiB [≈73 KiB]; admitting 98 KiB (rate 6.5 KiB/s) due to memtable flush (multiplier 1.350) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:12 smoothedIntL0CompactedBytes:19 smoothedCompactionByteTokens:19.53125 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:100538 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1676
 
 # The flush utilization is too low, so there is no limit on flush tokens.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=100 write-stall-count=13 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=100 write-stall-count=13 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈9 B], flushed 73 KiB [≈73 KiB]; admitting all
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:9 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:9.765625 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.0196078431372549 intWriteStalls:1 prevTokensUsed:0 tokenKind:0 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: unlimited
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈9 B], flushed 73 KiB [≈73 KiB]; admitting all
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:9 smoothedCompactionByteTokens:9.765625 smoothedNumFlushTokens:74472.65625 flushUtilTargetFraction:1.35 totalNumByteTokens:9223372036854775807 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.0196078431372549 intWriteStalls:1 prevTokensUsed:0 tokenKind:0 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: unlimited
 
 # Flush utilization is high enough, so flush tokens are again limited.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈4 B], flushed 73 KiB [≈73 KiB]; admitting 98 KiB (rate 6.6 KiB/s) due to memtable flush (multiplier 1.350) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:4 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:4.8828125 smoothedNumFlushTokens:74736.328125 flushUtilTargetFraction:1.35 totalNumByteTokens:100894 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1682
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈4 B], flushed 73 KiB [≈73 KiB]; admitting 98 KiB (rate 6.6 KiB/s) due to memtable flush (multiplier 1.350) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:4 smoothedCompactionByteTokens:4.8828125 smoothedNumFlushTokens:74736.328125 flushUtilTargetFraction:1.35 totalNumByteTokens:100894 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1682
 
 # No write stalls, and token utilization is high, which will have an effect
 # in the next pebbleMetricsTick.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈2 B], flushed 73 KiB [≈73 KiB]; admitting 99 KiB (rate 6.6 KiB/s) due to memtable flush (multiplier 1.350) (used 0 B) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:2 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:2.44140625 smoothedNumFlushTokens:74868.1640625 flushUtilTargetFraction:1.35 totalNumByteTokens:101072 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 doLogFlush:false} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1685
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈2 B], flushed 73 KiB [≈73 KiB]; admitting 99 KiB (rate 6.6 KiB/s) due to memtable flush (multiplier 1.350) (used 0 B)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:2 smoothedCompactionByteTokens:2.44140625 smoothedNumFlushTokens:74868.1640625 flushUtilTargetFraction:1.35 totalNumByteTokens:101072 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:0 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:false} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1685
 
 # No write stalls, and token utilization was high, so flush utilization
 # target fraction is increased to 1.375.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈1 B], flushed 73 KiB [≈73 KiB]; admitting 101 KiB (rate 6.7 KiB/s) due to memtable flush (multiplier 1.375) (used 197 KiB) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:1 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:1.220703125 smoothedNumFlushTokens:74934.08203125 flushUtilTargetFraction:1.375 totalNumByteTokens:103034 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:202144 tokenKind:1 doLogFlush:true} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1718
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈1 B], flushed 73 KiB [≈73 KiB]; admitting 101 KiB (rate 6.7 KiB/s) due to memtable flush (multiplier 1.375) (used 197 KiB)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:1 smoothedCompactionByteTokens:1.220703125 smoothedNumFlushTokens:74934.08203125 flushUtilTargetFraction:1.375 totalNumByteTokens:103034 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:202144 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:true} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1718
 
 # No write stalls, and token utilization was high, so flush utilization
 # target fraction is increased to 1.4.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=13 all-tokens-used=true print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flushed 73 KiB [≈73 KiB]; admitting 102 KiB (rate 6.8 KiB/s) due to memtable flush (multiplier 1.400) (used 201 KiB) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0.6103515625 smoothedNumFlushTokens:74967.041015625 flushUtilTargetFraction:1.4 totalNumByteTokens:104953 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:206068 tokenKind:1 doLogFlush:true} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1750
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 73 KiB [≈73 KiB]; admitting 102 KiB (rate 6.8 KiB/s) due to memtable flush (multiplier 1.400) (used 201 KiB)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:13 smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0.6103515625 smoothedNumFlushTokens:74967.041015625 flushUtilTargetFraction:1.4 totalNumByteTokens:104953 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:0 prevTokensUsed:206068 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:true} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1750
 
 # There is a write stall, so even though token utilization is high, we
 # decrease flush utilization target fraction to 1.375.
-set-state l0-bytes=10000 l0-added=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=14 all-tokens-used=true print-only-first-tick=true
+set-state l0-bytes=10000 l0-added-write=11000 l0-files=1 l0-sublevels=1 flush-bytes=10000 flush-work-sec=2 flush-idle-sec=10 write-stall-count=14 all-tokens-used=true print-only-first-tick=true
 ----
-compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B: 0 B acc-write + 0 B acc-ingest + 0 B unacc [≈0 B/req, n=1], compacted 0 B [≈0 B], flushed 73 KiB [≈73 KiB]; admitting 101 KiB (rate 6.7 KiB/s) due to memtable flush (multiplier 1.375) (used 205 KiB) with L0 penalty: +1 B/req, *0.50/ingest
-{ioLoadListenerState:{cumAdmissionStats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0} cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:14 smoothedIntL0CompactedBytes:0 smoothedIntPerWorkUnaccountedL0Bytes:0 smoothedIntIngestedAccountedL0BytesFraction:0.5 smoothedCompactionByteTokens:0.30517578125 smoothedNumFlushTokens:74983.5205078125 flushUtilTargetFraction:1.375 totalNumByteTokens:103102 tokensAllocated:0 tokensUsed:0} requestEstimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intAdmittedCount:1 intAdmittedBytes:0 intIngestedBytes:0 intIngestedAccountedL0Bytes:0 intAccountedL0Bytes:0 intUnaccountedL0Bytes:0 intPerWorkUnaccountedL0Bytes:0 l0BytesIngestFraction:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:209906 tokenKind:1 doLogFlush:true} ioThreshold:<nil>}
-store-request-estimates: fractionOfIngestIntoL0: 0.50, workByteAddition: 1
-tick: 0, setAvailableIOTokens: 1719
+compaction score 0.050 (1 ssts, 1 sub-levels), L0 growth 0 B (write 0 B ingest 0 B): requests 0 with 0 B acc-write + 0 B acc-ingest + write-model 0.00x+0 B (smoothed 1.75x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 1 B, compacted 0 B [≈0 B], flushed 73 KiB [≈73 KiB]; admitting 101 KiB (rate 6.7 KiB/s) due to memtable flush (multiplier 1.375) (used 205 KiB)
+{ioLoadListenerState:{cumL0AddedBytes:11000 curL0Bytes:10000 cumWriteStallCount:14 smoothedIntL0CompactedBytes:0 smoothedCompactionByteTokens:0.30517578125 smoothedNumFlushTokens:74983.5205078125 flushUtilTargetFraction:1.375 totalNumByteTokens:103102 tokensAllocated:0 tokensUsed:0} requestEstimates:{writeTokens:1} writeLM:{multiplier:1.75 constant:1} ingestedLM:{multiplier:0.7505 constant:1} aux:{intL0AddedBytes:0 intL0CompactedBytes:0 intFlushTokens:75000 intFlushUtilization:0.16666666666666666 intWriteStalls:1 prevTokensUsed:209906 tokenKind:1 perWorkTokensAux:{intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}} doLogFlush:true} ioThreshold:<nil>}
+store-request-estimates: writeTokens: 1
+tick: 0, setAdmittedDoneModelsLocked: write-lm: 1.75x+1 ingested-lm: 0.75x+1
+setAvailableIOTokens: 1719

--- a/pkg/util/admission/testdata/store_per_work_token_estimator
+++ b/pkg/util/admission/testdata/store_per_work_token_estimator
@@ -1,0 +1,57 @@
+init
+----
+
+# First call initializes.
+update flushed=1000 ingested=0 admitted=10 write-accounted=500 ingested-accounted=0
+----
+interval state: {intWorkCount:0 intL0WriteBytes:0 intL0IngestedBytes:0 intL0WriteAccountedBytes:0 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:0 constant:0} intIngestedLinearModel:{multiplier:0 constant:0}}
+at-admission-tokens: 1
+write-tokens: int: 0.00x+0 smoothed: 1.75x+1 per-work-accounted: 1
+ingest-tokens: int: 0.00x+0 smoothed: 0.75x+1 per-work-accounted: 1
+
+# Writes account for ~1/2 of what is written, reflecting what can happen with
+# application to the state machine. No ingests.
+update flushed=1000 ingested=0 admitted=10 write-accounted=500 ingested-accounted=0
+----
+interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:0 intL0WriteAccountedBytes:500 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:1.98 constant:1} intIngestedLinearModel:{multiplier:0 constant:0}}
+at-admission-tokens: 50
+write-tokens: int: 1.98x+1 smoothed: 1.86x+1 per-work-accounted: 25
+ingest-tokens: int: 0.00x+0 smoothed: 0.75x+1 per-work-accounted: 1
+
+# Same as previous.
+update flushed=1000 ingested=0 admitted=10 write-accounted=500 ingested-accounted=0
+----
+interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:0 intL0WriteAccountedBytes:500 intL0IngestedAccountedBytes:0 intWriteLinearModel:{multiplier:1.98 constant:1} intIngestedLinearModel:{multiplier:0 constant:0}}
+at-admission-tokens: 75
+write-tokens: int: 1.98x+1 smoothed: 1.92x+1 per-work-accounted: 37
+ingest-tokens: int: 0.00x+0 smoothed: 0.75x+1 per-work-accounted: 1
+
+# Ingestion also happens. Bumps up the at-admission-tokens since at that time
+# we can't differentiate between writes and ingests. The constants in the
+# linear models stays 1, since we can fit effectively using the multipliers.
+# This means a mix of regular writes and sstable ingests (say index
+# backfills), will not effect the cost attributed to regular writes.
+update flushed=1000 ingested=1000 admitted=10 write-accounted=500 ingested-accounted=4000
+----
+interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:1000 intL0WriteAccountedBytes:500 intL0IngestedAccountedBytes:4000 intWriteLinearModel:{multiplier:1.98 constant:1} intIngestedLinearModel:{multiplier:0.2475 constant:1}}
+at-admission-tokens: 137
+write-tokens: int: 1.98x+1 smoothed: 1.95x+1 per-work-accounted: 43
+ingest-tokens: int: 0.25x+1 smoothed: 0.50x+1 per-work-accounted: 200
+
+# No ingestion observed by LSM, though ingested-accounted is non-zero -- this
+# updates the model since all these ingested bytes could have gone to levels
+# lower than L0.
+update flushed=1000 ingested=0 admitted=10 write-accounted=450 ingested-accounted=500
+----
+interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:0 intL0WriteAccountedBytes:450 intL0IngestedAccountedBytes:500 intWriteLinearModel:{multiplier:2.2 constant:1} intIngestedLinearModel:{multiplier:0.001 constant:1}}
+at-admission-tokens: 118
+write-tokens: int: 2.20x+1 smoothed: 2.08x+1 per-work-accounted: 44
+ingest-tokens: int: 0.00x+1 smoothed: 0.25x+1 per-work-accounted: 125
+
+# Large amount of ingestion. Bumps up at-admission-tokens.
+update flushed=1000 ingested=1000000 admitted=10 write-accounted=450 ingested-accounted=2000000
+----
+interval state: {intWorkCount:10 intL0WriteBytes:1000 intL0IngestedBytes:1000000 intL0WriteAccountedBytes:450 intL0IngestedAccountedBytes:2000000 intWriteLinearModel:{multiplier:2.2 constant:1} intIngestedLinearModel:{multiplier:0.499995 constant:1}}
+at-admission-tokens: 50109
+write-tokens: int: 2.20x+1 smoothed: 2.14x+1 per-work-accounted: 44
+ingest-tokens: int: 0.50x+1 smoothed: 0.37x+1 per-work-accounted: 100062

--- a/pkg/util/admission/testdata/store_work_queue
+++ b/pkg/util/admission/testdata/store_work_queue
@@ -4,8 +4,8 @@ init
 print
 ----
 closed epoch: 0 tenantHeap len: 0
-stats:{admittedCount:0 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
-estimates:{fractionOfIngestIntoL0:0.5 workByteAddition:1}
+stats:{admittedCount:0 writeAccountedBytes:0 ingestedAccountedBytes:0}
+estimates:{writeTokens:1}
 
 set-try-get-return-value v=true
 ----
@@ -13,91 +13,103 @@ set-try-get-return-value v=true
 admit id=1 tenant=53 priority=0 create-time-millis=1 bypass=false
 ----
 tryGet: returning true
-id 1: admit succeeded with handle {tenantID:{InternalValue:53} writeBytes:0 writeTokens:1 workByteAdditionTokens:1 ingestRequest:false admissionEnabled:true}
+id 1: admit succeeded with handle {tenantID:{InternalValue:53} writeTokens:1 admissionEnabled:true}
 
 work-done id=1
 ----
+storeWriteDone: originalTokens 1, doneBytes(write 0,ingested 0) returning 0
 
-set-store-request-estimates percent-ingested-into-l0=20 work-bytes-addition=100
+set-store-request-estimates write-tokens=100
 ----
 closed epoch: 0 tenantHeap len: 0
  tenant-id: 53 used: 1, w: 1, fifo: -128
-stats:{admittedCount:1 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
-estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+stats:{admittedCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0}
+estimates:{writeTokens:100}
 
 admit id=2 tenant=55 priority=0 create-time-millis=1 bypass=false
 ----
 tryGet: returning true
-id 2: admit succeeded with handle {tenantID:{InternalValue:55} writeBytes:0 writeTokens:100 workByteAdditionTokens:100 ingestRequest:false admissionEnabled:true}
+id 2: admit succeeded with handle {tenantID:{InternalValue:55} writeTokens:100 admissionEnabled:true}
 
-admit id=3 tenant=53 priority=0 create-time-millis=1 bypass=false write-bytes=1000000 ingest-request=true
+admit id=3 tenant=53 priority=0 create-time-millis=1 bypass=false
 ----
 tryGet: returning true
-id 3: admit succeeded with handle {tenantID:{InternalValue:53} writeBytes:1000000 writeTokens:200100 workByteAdditionTokens:100 ingestRequest:true admissionEnabled:true}
+id 3: admit succeeded with handle {tenantID:{InternalValue:53} writeTokens:100 admissionEnabled:true}
 
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 200101, w: 1, fifo: -128
+ tenant-id: 53 used: 101, w: 1, fifo: -128
  tenant-id: 55 used: 100, w: 1, fifo: -128
-stats:{admittedCount:1 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
-estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+stats:{admittedCount:1 writeAccountedBytes:0 ingestedAccountedBytes:0}
+estimates:{writeTokens:100}
 
 set-try-get-return-value v=false
 ----
 
-admit id=4 tenant=57 priority=0 create-time-millis=1 bypass=false write-bytes=2000 ingest-request=false
+admit id=4 tenant=57 priority=0 create-time-millis=1 bypass=false
 ----
 tryGet: returning false
 
-work-done id=2
+work-done id=2 additional-tokens=500
 ----
+storeWriteDone: originalTokens 100, doneBytes(write 0,ingested 0) returning 500
 
 print
 ----
 closed epoch: 0 tenantHeap len: 1 top tenant: 57
- tenant-id: 53 used: 200101, w: 1, fifo: -128
- tenant-id: 55 used: 100, w: 1, fifo: -128
+ tenant-id: 53 used: 101, w: 1, fifo: -128
+ tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 0, w: 1, fifo: -128 waiting work heap: [0: pri: 0, ct: 1, epoch: 0, qt: 0]
-stats:{admittedCount:2 admittedWithBytesCount:0 admittedAccountedBytes:0 ingestedAccountedBytes:0 ingestedAccountedL0Bytes:0}
-estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+stats:{admittedCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0}
+estimates:{writeTokens:100}
 
 granted
 ----
 continueGrantChain 0
-id 4: admit succeeded with handle {tenantID:{InternalValue:57} writeBytes:2000 writeTokens:2100 workByteAdditionTokens:100 ingestRequest:false admissionEnabled:true}
-granted: returned 2100
-
-work-done id=3 ingested-into-l0=20000
-----
-returnGrant 180000
+id 4: admit succeeded with handle {tenantID:{InternalValue:57} writeTokens:100 admissionEnabled:true}
+granted: returned 100
 
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 20101, w: 1, fifo: -128
- tenant-id: 55 used: 100, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-stats:{admittedCount:3 admittedWithBytesCount:1 admittedAccountedBytes:1000000 ingestedAccountedBytes:1000000 ingestedAccountedL0Bytes:20000}
-estimates:{fractionOfIngestIntoL0:0.2 workByteAddition:100}
+ tenant-id: 53 used: 101, w: 1, fifo: -128
+ tenant-id: 55 used: 600, w: 1, fifo: -128
+ tenant-id: 57 used: 100, w: 1, fifo: -128
+stats:{admittedCount:2 writeAccountedBytes:0 ingestedAccountedBytes:0}
+estimates:{writeTokens:100}
 
-set-store-request-estimates percent-ingested-into-l0=10 work-bytes-addition=10000
+work-done id=3 ingested-bytes=1000000 additional-tokens=50000
 ----
-closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 20101, w: 1, fifo: -128
- tenant-id: 55 used: 100, w: 1, fifo: -128
- tenant-id: 57 used: 2100, w: 1, fifo: -128
-stats:{admittedCount:3 admittedWithBytesCount:1 admittedAccountedBytes:1000000 ingestedAccountedBytes:1000000 ingestedAccountedL0Bytes:20000}
-estimates:{fractionOfIngestIntoL0:0.1 workByteAddition:10000}
-
-work-done id=4
-----
+storeWriteDone: originalTokens 100, doneBytes(write 0,ingested 1000000) returning 50000
 
 print
 ----
 closed epoch: 0 tenantHeap len: 0
- tenant-id: 53 used: 20101, w: 1, fifo: -128
- tenant-id: 55 used: 100, w: 1, fifo: -128
+ tenant-id: 53 used: 50101, w: 1, fifo: -128
+ tenant-id: 55 used: 600, w: 1, fifo: -128
+ tenant-id: 57 used: 100, w: 1, fifo: -128
+stats:{admittedCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000}
+estimates:{writeTokens:100}
+
+set-store-request-estimates write-tokens=10000
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 50101, w: 1, fifo: -128
+ tenant-id: 55 used: 600, w: 1, fifo: -128
+ tenant-id: 57 used: 100, w: 1, fifo: -128
+stats:{admittedCount:3 writeAccountedBytes:0 ingestedAccountedBytes:1000000}
+estimates:{writeTokens:10000}
+
+work-done id=4 write-bytes=2000 ingested-bytes=1000 additional-tokens=2000
+----
+storeWriteDone: originalTokens 100, doneBytes(write 2000,ingested 1000) returning 2000
+
+print
+----
+closed epoch: 0 tenantHeap len: 0
+ tenant-id: 53 used: 50101, w: 1, fifo: -128
+ tenant-id: 55 used: 600, w: 1, fifo: -128
  tenant-id: 57 used: 2100, w: 1, fifo: -128
-stats:{admittedCount:4 admittedWithBytesCount:2 admittedAccountedBytes:1002000 ingestedAccountedBytes:1000000 ingestedAccountedL0Bytes:20000}
-estimates:{fractionOfIngestIntoL0:0.1 workByteAddition:10000}
+stats:{admittedCount:4 writeAccountedBytes:2000 ingestedAccountedBytes:1001000}
+estimates:{writeTokens:10000}

--- a/pkg/util/admission/testdata/tokens_linear_model_fitter
+++ b/pkg/util/admission/testdata/tokens_linear_model_fitter
@@ -1,0 +1,104 @@
+# TODO(sumeer): it would be easier to confirm that the new model was a better
+# fit for the latest stats if we printed the error for the existing model and
+# the new model (see the comment at
+# https://github.com/cockroachdb/cockroach/pull/85059#pullrequestreview-1065876690).
+# One small problem with that is that tokensLinearModelFitter has heuristics
+# that it uses to ignore accounted-bytes when 0. Such problems are
+# surmountable.
+
+# Model with multiplier interval [1,2], like the model for regular writes.
+init mult-min=1 mult-max=2
+----
+int: 0.00x+0 smoothed: 1.50x+1 per-work-accounted: 1
+
+# The per-work-accounted will not change, since accounted-bytes=0, so we use
+# a*1+b*2=100, and minimize b, which results in a=2, b=48.
+update accounted-bytes=0 actual-bytes=100 work-count=2
+----
+int: 2.00x+48 smoothed: 1.75x+24 per-work-accounted: 1
+
+# Same update, so same interval model. The smoothed model is trending higher
+# due to exponential smoothing.
+update accounted-bytes=0 actual-bytes=100 work-count=2
+----
+int: 2.00x+48 smoothed: 1.88x+36 per-work-accounted: 1
+
+# Can't compute an interval model, so scale down the constant in the smoothed
+# model.
+update accounted-bytes=10 actual-bytes=0 work-count=4
+----
+int: 0.00x+0 smoothed: 1.88x+18 per-work-accounted: 1
+
+# Can't compute an interval model, so scale down the constant in the smoothed
+# model.
+update accounted-bytes=10 actual-bytes=10 work-count=1
+----
+int: 0.00x+0 smoothed: 1.88x+9 per-work-accounted: 1
+
+# Minimal constant is 1, so 4 bytes accounted by the additive term, and the
+# remaining 176 bytes are accounted by using a multiplier against 100.
+update accounted-bytes=100 actual-bytes=180 work-count=4
+----
+int: 1.76x+1 smoothed: 1.82x+5 per-work-accounted: 13
+
+update accounted-bytes=50 actual-bytes=10 work-count=2
+----
+int: 1.00x+1 smoothed: 1.41x+3 per-work-accounted: 19
+
+# Accounted bytes is zero, even though there were multiple units of work. Use
+# the smoothed per-work accounted bytes for the interval model.
+update accounted-bytes=0 actual-bytes=100 work-count=4
+----
+int: 1.26x+1 smoothed: 1.34x+2 per-work-accounted: 19
+
+# Model with multiplier [0.01,1], like the model for ingested bytes.
+init mult-min=0.01 mult-max=1 ingested-model=true
+----
+int: 0.00x+0 smoothed: 0.51x+1 per-work-accounted: 1
+
+update accounted-bytes=0 actual-bytes=100 work-count=2
+----
+int: 1.00x+49 smoothed: 0.75x+25 per-work-accounted: 1
+
+update accounted-bytes=100 actual-bytes=110 work-count=10
+----
+int: 1.00x+1 smoothed: 0.88x+13 per-work-accounted: 5
+
+update accounted-bytes=10000 actual-bytes=11000 work-count=100
+----
+int: 1.00x+10 smoothed: 0.94x+11 per-work-accounted: 52
+
+# Accounted bytes is zero, even though there were multiple units of work. Use
+# the smoothed per-work accounted bytes for the interval model.
+update accounted-bytes=0 actual-bytes=10000 work-count=100
+----
+int: 1.00x+48 smoothed: 0.97x+29 per-work-accounted: 52
+
+update accounted-bytes=20000 actual-bytes=10000 work-count=100
+----
+int: 0.49x+1 smoothed: 0.73x+15 per-work-accounted: 126
+
+update accounted-bytes=20000 actual-bytes=10000 work-count=100
+----
+int: 0.49x+1 smoothed: 0.61x+8 per-work-accounted: 163
+
+# Model is not updated because work-count is 1, except constant is halved.
+update accounted-bytes=1000 actual-bytes=500 work-count=1
+----
+int: 0.00x+0 smoothed: 0.61x+4 per-work-accounted: 163
+
+# Model is not updated because both bytes are zero, except constant is halved.
+update accounted-bytes=0 actual-bytes=0 work-count=5
+----
+int: 0.00x+0 smoothed: 0.61x+2 per-work-accounted: 163
+
+# Model is updated even though actual-bytes is 0, since accounted-bytes is >
+# 0. This can happen when all ingested bytes go into levels below L0.
+update accounted-bytes=1000 actual-bytes=0 work-count=2
+----
+int: 0.01x+1 smoothed: 0.31x+1 per-work-accounted: 331
+
+# Repeat of the previous.
+update accounted-bytes=1000 actual-bytes=0 work-count=2
+----
+int: 0.01x+1 smoothed: 0.16x+1 per-work-accounted: 415


### PR DESCRIPTION
The existing scheme for byte token estimation simply looked
at the total bytes added to L0 and divided it among the number
of requests. This was because (a) the parameters to provide
better size information for the request were not populated by
kvserver, (b) the basic estimation approach was flawed since
it assumed that regular writes would be roughly equal sized,
and assumed that ingests would tell what fraction went into L0.

The kvserver-side plumbing for improving (a) were done in a
preceding PR (#83937). This one completes that plumbing to pass on
admission.StoreWorkDoneInfo to the admission control package.
In this scheme the {WriteBytes,IngestedBytes} are provided
post-proposal evaluation, and the IngestedBytes is for the
whole LSM. This PR makes changes to the plumbing in the
admission package: specifically, the post-work-done token
adjustments are performed via the granterWithStoreWriteDone
interface and the addition to granterWithIOTokens. The former
also returns the token adjustments to StoreWorkQueue so
that the per-tenant fairness accounting in WorkQueue can be
updated.

The main changes in this PR are in the byte token
estimation logic in the admission package, where the
estimation now uses a linear model y=a.x + b, where
x is the bytes provided in admission.StoreWorkDoneInfo,
and y is the bytes added to L0 via write or ingestion.
If we consider regular writes, one can expect that even
with many different sized workloads concurrently being
active on a node, we should be able to fit a model where
a is roughly 2 and b is tiny -- this is because x is the
bytes written to the raft log and does not include the
subsequent state machine application. Similarly, one can
expect the a term being in the interval [0,1] for ingested
work. The linear model is meant to fix flaw (b) mentioned
earlier. The current linear model fitting in
store_token_estimation.go is very simple and can be
independently improved in the future -- there are code
comments outlining this. Additionally, all the byte token
estimation logic in granter.go has been removed, which
is better from a code readability perspective.

This change was evaluated with a single node that first
saw a kv0 workload that writes 64KB blocks, then
additionally a kv0 workload that writes 4KB blocks, and
finally a third workload that starts doing an index
backfill due to creating an index on the v column in
the kv table.

Here are snippets from a sequence of log statements when
only the first workload (64KB writes) was running:
```
write-model 1.46x+1 B (smoothed 1.50x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 78 KiB
write-model 1.37x+1 B (smoothed 1.36x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 80 KiB
write-model 1.50x+1 B (smoothed 1.43x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 79 KiB
write-model 1.39x+1 B (smoothed 1.30x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 77 KiB
```
Note that the parameter a, in a.x does fluctuate. The
additive value b stays at the minimum of 1 bytes, which
is desirable. There is no change to the starting ingest
model since there are no ingestions.

After both the 4KB and 64KB writes are active the log
statements look like:
```
write-model 1.85x+1 B (smoothed 1.78x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 59 KiB
write-model 1.23x+1 B (smoothed 1.51x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 47 KiB
write-model 1.21x+1 B (smoothed 1.36x+1 B) + ingested-model 0.00x+0 B (smoothed 0.75x+1 B) + at-admission-tokens 40 KiB
```
Note that the b value stays at 1 byte. The tokens consumed
at admission time are evenly divided among requests, so
the value has dropped.

When the index backfill is also running, the sstables are
ingested into L5 and L6, so the x value in the ingested
model is high, but what is ingested into L0 is low, which
means a becomes very small for the ingested-model -- see
the smoothed 0.00x+1 B below. There is choppiness in this
experiment wrt the write model and the at-admission-tokens,
which is caused by a high number of write stalls. This
was not planned for, and is a side-effect of huge Pebble
manifests caused by 64KB keys. So ignore those values in
the following log statements.
```
write-model 1.93x+1 B (smoothed 1.56x+2 B) + ingested-model 0.00x+1 B (smoothed 0.00x+1 B) + at-admission-tokens 120 KiB
write-model 2.34x+1 B (smoothed 1.95x+1 B) + ingested-model 0.00x+1 B (smoothed 0.00x+1 B) + at-admission-tokens 157 KiB
```

Fixes #79092
Informs #82536

Release note: None