### PR TITLE
gss: only skip libpq subtest instead of the whole test

### DIFF
--- a/pkg/acceptance/compose/gss/psql/gss_test.go
+++ b/pkg/acceptance/compose/gss/psql/gss_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
@@ -148,6 +149,7 @@ func TestGSS(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Run("libpq", func(t *testing.T) {
+				skip.WithIssue(t, 84978)
 				userConnector, err := pq.NewConnector(fmt.Sprintf("user=%s sslmode=require krbspn=postgres/gss_cockroach_1.gss_default", tc.user))
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -21,13 +21,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 const composeDir = "compose"
 
 func TestComposeGSS(t *testing.T) {
-	skip.WithIssue(t, 84978)
 	testCompose(t, filepath.Join("gss", "docker-compose.yml"), "psql")
 }
 


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/84981
Following up from https://github.com/cockroachdb/cockroach/pull/84978#issuecomment-1194606028

I don't know how to fix  the libpq test, but it looks like the other
ones are working, so we can still get signal out of them.

Release note: None