### PR TITLE
release-22.1: democluster: ensure `sslrootcert` is populated

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1163,9 +1163,16 @@ func (c *transientCluster) getNetworkURLForServer(
 	if c.demoCtx.Insecure {
 		u.WithInsecure()
 	} else {
+		caCert := security.CACertFilename()
+		if isTenant {
+			caCert = security.TenantCACertFilename()
+		}
 		u.
 			WithAuthn(pgurl.AuthnPassword(true, c.adminPassword)).
-			WithTransport(pgurl.TransportTLS(pgurl.TLSRequire, ""))
+			WithTransport(pgurl.TransportTLS(
+				pgurl.TLSRequire,
+				filepath.Join(c.demoDir, caCert),
+			))
 	}
 	return u, nil
 }

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -115,6 +115,7 @@ eexpect "(sql)"
 eexpect "demo:"
 eexpect ":26258"
 eexpect "sslmode=require"
+eexpect "sslrootcert="
 eexpect "(sql/unix)"
 eexpect "demo:"
 eexpect "=26258"
@@ -123,6 +124,7 @@ eexpect "(sql)"
 eexpect "demo:"
 eexpect ":26257"
 eexpect "sslmode=require"
+eexpect "sslrootcert="
 eexpect "defaultdb>"
 
 send_eof
@@ -142,6 +144,7 @@ eexpect "http://"
 eexpect "(sql)"
 eexpect "demo:"
 eexpect "sslmode=require"
+eexpect "sslrootcert="
 eexpect "(sql/unix)"
 eexpect "demo:"
 eexpect "defaultdb>"
@@ -190,6 +193,7 @@ spawn $argv demo --insecure=false --no-example-database
 # Expect that security related tags are part of the connection URL.
 eexpect "(sql)"
 eexpect "sslmode=require"
+eexpect "sslrootcert="
 eexpect "defaultdb>"
 
 send_eof


### PR DESCRIPTION
Backport 1/1 commits from #82358.
refs https://github.com/cockroachdb/docs/issues/14619

/cc @cockroachdb/release

Release justification: demo-only change

---

The `pgx` driver defaults the root CA cert to ~/.postgresql/root.crt
if not provided in the connection URL. For demo clusters, that can
never work.

This commit changes the generated demo URLs to include `sslrootcert`
explicitly and point it to the demo-generate root CA cert.

Release note: None
