### PR TITLE
release-22.1: sql,catalog: make owner privileges implicit rather than explicit

### DIFF
--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -410,20 +410,35 @@ GRANT UPDATE ON top_secret TO agent_bond;
 		sqlDB.Exec(t, `BACKUP DATABASE mi5 TO $1;`, showPrivs)
 
 		want := [][]string{
-			{`mi5`, `database`, `GRANT ALL ON DATABASE mi5 TO admin; GRANT ALL ON DATABASE mi5 TO agents; GRANT CONNECT ON DATABASE mi5 TO public; GRANT ALL ON DATABASE mi5 TO root; `, `root`},
-			{`public`, `schema`, `GRANT ALL ON SCHEMA public TO admin; GRANT CREATE, USAGE ON SCHEMA public TO public; GRANT ALL ON SCHEMA public TO root; `, `admin`},
-			{`locator`, `schema`, `GRANT ALL ON SCHEMA locator TO admin; GRANT CREATE, GRANT ON SCHEMA locator TO agent_bond; GRANT ALL ON SCHEMA locator TO m; ` +
-				`GRANT ALL ON SCHEMA locator TO root; `, `root`},
-			{`continent`, `type`,
-				`GRANT ALL ON TYPE continent TO admin; GRANT GRANT ON TYPE continent TO agent_bond; GRANT ALL ON TYPE continent TO m; GRANT USAGE ON TYPE continent TO public; GRANT ALL ON TYPE continent TO root; `, `root`},
-			{`_continent`, `type`, `GRANT ALL ON TYPE _continent TO admin; GRANT USAGE ON TYPE _continent TO public; GRANT ALL ON TYPE _continent TO root; `, `root`},
-			{`agent_locations`, `table`, `GRANT ALL ON TABLE agent_locations TO admin; ` +
-				`GRANT SELECT ON TABLE agent_locations TO agent_bond; GRANT UPDATE ON TABLE agent_locations TO agents; ` +
-				`GRANT ALL ON TABLE agent_locations TO m; GRANT ALL ON TABLE agent_locations TO root; `,
-				`root`},
-			{`top_secret`, `table`, `GRANT ALL ON TABLE top_secret TO admin; ` +
-				`GRANT SELECT, UPDATE ON TABLE top_secret TO agent_bond; GRANT INSERT ON TABLE top_secret TO agents; ` +
-				`GRANT ALL ON TABLE top_secret TO m; GRANT ALL ON TABLE top_secret TO root; `, `root`},
+			{`mi5`, `database`, `GRANT ALL ON DATABASE mi5 TO admin WITH GRANT OPTION; ` +
+				`GRANT ALL ON DATABASE mi5 TO agents WITH GRANT OPTION; ` +
+				`GRANT CONNECT ON DATABASE mi5 TO public; ` +
+				`GRANT ALL ON DATABASE mi5 TO root WITH GRANT OPTION; `, `root`},
+			{`public`, `schema`, `GRANT ALL ON SCHEMA public TO admin WITH GRANT OPTION; ` +
+				`GRANT CREATE, USAGE ON SCHEMA public TO public; ` +
+				`GRANT ALL ON SCHEMA public TO root WITH GRANT OPTION; `, `admin`},
+			{`locator`, `schema`, `GRANT ALL ON SCHEMA locator TO admin WITH GRANT OPTION; ` +
+				`GRANT CREATE, GRANT ON SCHEMA locator TO agent_bond WITH GRANT OPTION; ` +
+				`GRANT ALL ON SCHEMA locator TO m WITH GRANT OPTION; ` +
+				`GRANT ALL ON SCHEMA locator TO root WITH GRANT OPTION; `, `root`},
+			{`continent`, `type`, `GRANT ALL ON TYPE continent TO admin WITH GRANT OPTION; ` +
+				`GRANT GRANT ON TYPE continent TO agent_bond WITH GRANT OPTION; ` +
+				`GRANT ALL ON TYPE continent TO m WITH GRANT OPTION; ` +
+				`GRANT USAGE ON TYPE continent TO public; ` +
+				`GRANT ALL ON TYPE continent TO root WITH GRANT OPTION; `, `root`},
+			{`_continent`, `type`, `GRANT ALL ON TYPE _continent TO admin WITH GRANT OPTION; ` +
+				`GRANT USAGE ON TYPE _continent TO public; ` +
+				`GRANT ALL ON TYPE _continent TO root WITH GRANT OPTION; `, `root`},
+			{`agent_locations`, `table`, `GRANT ALL ON TABLE agent_locations TO admin WITH GRANT OPTION; ` +
+				`GRANT SELECT ON TABLE agent_locations TO agent_bond; ` +
+				`GRANT UPDATE ON TABLE agent_locations TO agents; ` +
+				`GRANT ALL ON TABLE agent_locations TO m WITH GRANT OPTION; ` +
+				`GRANT ALL ON TABLE agent_locations TO root WITH GRANT OPTION; `, `root`},
+			{`top_secret`, `table`, `GRANT ALL ON TABLE top_secret TO admin WITH GRANT OPTION; ` +
+				`GRANT SELECT, UPDATE ON TABLE top_secret TO agent_bond; ` +
+				`GRANT INSERT ON TABLE top_secret TO agents; ` +
+				`GRANT ALL ON TABLE top_secret TO m WITH GRANT OPTION; ` +
+				`GRANT ALL ON TABLE top_secret TO root WITH GRANT OPTION; `, `root`},
 		}
 
 		showQuery := fmt.Sprintf(`SELECT object_name, object_type, privileges, owner FROM [SHOW BACKUP '%s' WITH privileges]`, showPrivs)

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -297,6 +297,7 @@ SHOW GRANTS ON TYPE testuser_db.greeting_usage;
 ----
 testuser_db public greeting_usage admin ALL true
 testuser_db public greeting_usage root ALL true
+testuser_db public greeting_usage testuser ALL true
 
 query-sql
 SHOW GRANTS ON testuser_db.testtable_greeting_usage;
@@ -515,54 +516,63 @@ SHOW GRANTS ON DATABASE testdb
 testdb admin ALL true
 testdb public CONNECT false
 testdb root ALL true
+testdb testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.testtable_simple
 ----
 testdb public testtable_simple admin ALL true
 testdb public testtable_simple root ALL true
+testdb public testtable_simple testuser ALL true
 
 query-sql
 SHOW GRANTS ON SCHEMA testdb.sc
 ----
 testdb sc admin ALL true
 testdb sc root ALL true
+testdb sc testuser ALL true
 
 query-sql
 SHOW GRANTS ON SCHEMA testdb.public
 ----
 testdb public admin ALL true
 testdb public root ALL true
+testdb public testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.sc.othertable
 ----
 testdb sc othertable admin ALL true
 testdb sc othertable root ALL true
+testdb sc othertable testuser ALL true
 
 query-sql
 SHOW GRANTS ON TYPE greeting_usage;
 ----
 testdb public greeting_usage admin ALL true
 testdb public greeting_usage root ALL true
+testdb public greeting_usage testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.testtable_greeting_usage;
 ----
 testdb public testtable_greeting_usage admin ALL true
 testdb public testtable_greeting_usage root ALL true
+testdb public testtable_greeting_usage testuser ALL true
 
 query-sql
 SHOW GRANTS ON TYPE greeting_owner;
 ----
 testdb public greeting_owner admin ALL true
 testdb public greeting_owner root ALL true
+testdb public greeting_owner testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.testtable_greeting_owner;
 ----
 testdb public testtable_greeting_owner admin ALL true
 testdb public testtable_greeting_owner root ALL true
+testdb public testtable_greeting_owner testuser ALL true
 
 # Ensure that testuser is the owner of the restored database/schemas.
 query-sql

--- a/pkg/migration/migrations/remove_invalid_database_privileges_external_test.go
+++ b/pkg/migration/migrations/remove_invalid_database_privileges_external_test.go
@@ -121,6 +121,7 @@ func TestConvertIncompatibleDatabasePrivilegesToDefaultPrivileges(t *testing.T) 
 
 	tdb.CheckQueryResults(t, "SHOW GRANTS ON DATABASE test", [][]string{
 		{"test", "admin", "ALL", "true"},
+		{"test", "demo", "ALL", "true"},
 		{"test", "root", "ALL", "true"},
 		{"test", "testuser2", "CREATE", "false"},
 	})

--- a/pkg/sql/catalog/catpb/privilege.go
+++ b/pkg/sql/catalog/catpb/privilege.go
@@ -214,6 +214,9 @@ func NewPublicSchemaPrivilegeDescriptor() *PrivilegeDescriptor {
 func (p *PrivilegeDescriptor) CheckGrantOptions(
 	user security.SQLUsername, privList privilege.List,
 ) bool {
+	if p.Owner() == user {
+		return true
+	}
 	userPriv, exists := p.FindUser(user)
 	if !exists {
 		return false
@@ -483,10 +486,26 @@ type UserPrivilege struct {
 
 // Show returns the list of {username, privileges} sorted by username.
 // 'privileges' is a string of comma-separated sorted privilege names.
-func (p PrivilegeDescriptor) Show(objectType privilege.ObjectType) []UserPrivilege {
+// The owner always implicitly receives ALL privileges with the GRANT OPTION. If
+// showImplicitOwnerPrivs is true, then that implicit privilege is shown here.
+// Otherwise, only the privileges that were explicitly granted to the owner are
+// shown.
+func (p PrivilegeDescriptor) Show(
+	objectType privilege.ObjectType, showImplicitOwnerPrivs bool,
+) []UserPrivilege {
 	ret := make([]UserPrivilege, 0, len(p.Users))
+	sawOwner := false
 	for _, userPriv := range p.Users {
-		privileges := privilege.PrivilegesFromBitFields(userPriv.Privileges, userPriv.WithGrantOption, objectType)
+		privBits := userPriv.Privileges
+		grantOptionBits := userPriv.WithGrantOption
+		if userPriv.User() == p.Owner() {
+			sawOwner = true
+			if showImplicitOwnerPrivs {
+				privBits = privilege.ALL.Mask()
+				grantOptionBits = privilege.ALL.Mask()
+			}
+		}
+		privileges := privilege.PrivilegesFromBitFields(privBits, grantOptionBits, objectType)
 		sort.Slice(privileges, func(i, j int) bool {
 			return strings.Compare(privileges[i].Kind.String(), privileges[j].Kind.String()) < 0
 		})
@@ -495,11 +514,22 @@ func (p PrivilegeDescriptor) Show(objectType privilege.ObjectType) []UserPrivile
 			Privileges: privileges,
 		})
 	}
+	// The node user owns system tables, but since it's just an internal reserved
+	// name, we don't show node's privileges here.
+	if showImplicitOwnerPrivs && !sawOwner && !p.Owner().IsNodeUser() {
+		ret = append(ret, UserPrivilege{
+			User:       p.Owner(),
+			Privileges: []privilege.Privilege{{Kind: privilege.ALL, GrantOption: true}},
+		})
+	}
 	return ret
 }
 
 // CheckPrivilege returns true if 'user' has 'privilege' on this descriptor.
 func (p PrivilegeDescriptor) CheckPrivilege(user security.SQLUsername, priv privilege.Kind) bool {
+	if p.Owner() == user {
+		return true
+	}
 	userPriv, ok := p.FindUser(user)
 	if !ok {
 		// User "node" has all privileges.

--- a/pkg/sql/catalog/catpb/privilege_test.go
+++ b/pkg/sql/catalog/catpb/privilege_test.go
@@ -162,7 +162,7 @@ func TestPrivilege(t *testing.T) {
 				descriptor.Revoke(tc.grantee, tc.revoke, tc.objectType, false)
 			}
 		}
-		show := descriptor.Show(tc.objectType)
+		show := descriptor.Show(tc.objectType, true /* showImplicitOwnerPrivs */)
 		if len(show) != len(tc.show) {
 			t.Fatalf("#%d: show output for descriptor %+v differs, got: %+v, expected %+v",
 				tcNum, descriptor, show, tc.show)

--- a/pkg/sql/catalog/catprivilege/default_privilege.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege.go
@@ -315,6 +315,9 @@ func foldPrivileges(
 		return
 	}
 	if privileges.HasAllPrivileges(role.Role, targetObject.ToPrivilegeObjectType()) {
+		// Even though the owner's ALL privileges are implicit, we still need this
+		// because it's possible to modify the default privileges to be more
+		// fine-grained than ALL.
 		user := privileges.FindOrCreateUser(role.Role)
 		if user.WithGrantOption == 0 {
 			setRoleHasAllOnTargetObject(defaultPrivilegesForRole, true, targetObject)
@@ -343,6 +346,9 @@ func expandPrivileges(
 		return
 	}
 	if GetRoleHasAllPrivilegesOnTargetObject(defaultPrivilegesForRole, targetObject) {
+		// Even though the owner's ALL privileges are implicit, we still need this
+		// because it's possible to modify the default privileges to be more
+		// fine-grained than ALL.
 		privileges.Grant(defaultPrivilegesForRole.GetExplicitRole().UserProto.Decode(), privilege.List{privilege.ALL}, false /* withGrantOption */)
 		setRoleHasAllOnTargetObject(defaultPrivilegesForRole, false, targetObject)
 	}
@@ -361,19 +367,6 @@ func GetUserPrivilegesForObject(
 		userPrivileges = append(userPrivileges, catpb.UserPrivileges{
 			UserProto:  security.PublicRoleName().EncodeProto(),
 			Privileges: privilege.USAGE.Mask(),
-		})
-	}
-	// If ForAllRoles is specified, we can return early.
-	// ForAllRoles is not a real role and does not have implicit default privileges
-	// for itself.
-	if !p.IsExplicitRole() {
-		return userPrivileges
-	}
-	userProto := p.GetExplicitRole().UserProto
-	if GetRoleHasAllPrivilegesOnTargetObject(&p, targetObject) {
-		return append(userPrivileges, catpb.UserPrivileges{
-			UserProto:  userProto,
-			Privileges: privilege.ALL.Mask(),
 		})
 	}
 	return userPrivileges

--- a/pkg/sql/catalog/catprivilege/default_privilege_test.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege_test.go
@@ -380,10 +380,9 @@ func TestPresetDefaultPrivilegesInSchema(t *testing.T) {
 			nonSystemDatabaseID, creatorUser, targetObject, &catpb.PrivilegeDescriptor{},
 		)
 
-		// There are no preset privileges on a default privilege descriptor defined
-		// for a schema.
-		if newPrivileges.CheckPrivilege(creatorUser, privilege.ALL) {
-			t.Errorf("creator should not have ALL privileges on %s", targetObject)
+		// The owner always has ALL privileges.
+		if !newPrivileges.CheckPrivilege(creatorUser, privilege.ALL) {
+			t.Errorf("expected creator to have ALL privileges on %s", targetObject)
 		}
 
 		if targetObject == tree.Types {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4858,7 +4858,7 @@ CREATE TABLE crdb_internal.cluster_database_privileges (
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
-				privs := db.GetPrivileges().Show(privilege.Database)
+				privs := db.GetPrivileges().Show(privilege.Database, true /* showImplicitOwnerPrivs */)
 				dbNameStr := tree.NewDString(db.GetName())
 				// TODO(knz): This should filter for the current user, see
 				// https://github.com/cockroachdb/cockroach/issues/35572

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1018,7 +1018,7 @@ var informationSchemaTypePrivilegesTable = virtualSchemaTable{
 					typeNameStr := tree.NewDString(typeDesc.GetName())
 					// TODO(knz): This should filter for the current user, see
 					// https://github.com/cockroachdb/cockroach/issues/35572
-					privs := typeDesc.GetPrivileges().Show(privilege.Type)
+					privs := typeDesc.GetPrivileges().Show(privilege.Type, true /* showImplicitOwnerPrivs */)
 					for _, u := range privs {
 						userNameStr := tree.NewDString(u.User.Normalized())
 						for _, priv := range u.Privileges {
@@ -1060,7 +1060,7 @@ var informationSchemaSchemataTablePrivileges = virtualSchemaTable{
 		return forEachDatabaseDesc(ctx, p, dbContext, true, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
 				return forEachSchema(ctx, p, db, func(sc catalog.SchemaDescriptor) error {
-					privs := sc.GetPrivileges().Show(privilege.Schema)
+					privs := sc.GetPrivileges().Show(privilege.Schema, true /* showImplicitOwnerPrivs */)
 					dbNameStr := tree.NewDString(db.GetName())
 					scNameStr := tree.NewDString(sc.GetName())
 					// TODO(knz): This should filter for the current user, see
@@ -1372,7 +1372,7 @@ func populateTablePrivileges(
 			// TODO(knz): This should filter for the current user, see
 			// https://github.com/cockroachdb/cockroach/issues/35572
 			populateGrantOption := p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.ValidateGrantOption)
-			for _, u := range table.GetPrivileges().Show(privilege.Table) {
+			for _, u := range table.GetPrivileges().Show(privilege.Table, true /* showImplicitOwnerPrivs */) {
 				granteeNameStr := tree.NewDString(u.User.Normalized())
 				for _, priv := range u.Privileges {
 					var isGrantable tree.Datum

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
@@ -43,9 +43,10 @@ CREATE SCHEMA testuser_s2;
 query TTTTB colnames
 SHOW GRANTS ON SCHEMA testuser_s2
 ----
-database_name  schema_name  grantee  privilege_type  is_grantable
-d              testuser_s2  admin    ALL             true
-d              testuser_s2  root     ALL             true
+database_name  schema_name  grantee   privilege_type  is_grantable
+d              testuser_s2  admin     ALL             true
+d              testuser_s2  root      ALL             true
+d              testuser_s2  testuser  ALL             true
 
 user root
 
@@ -117,9 +118,10 @@ CREATE SCHEMA s4
 query TTTTB colnames
 SHOW GRANTS ON SCHEMA s4
 ----
-database_name  schema_name  grantee  privilege_type  is_grantable
-d              s4           admin    ALL             true
-d              s4           root     ALL             true
+database_name  schema_name  grantee   privilege_type  is_grantable
+d              s4           admin     ALL             true
+d              s4           root      ALL             true
+d              s4           testuser  ALL             true
 
 user root
 statement ok
@@ -143,9 +145,10 @@ CREATE SCHEMA s5
 query TTTTB colnames
 SHOW GRANTS ON SCHEMA s5
 ----
-database_name  schema_name  grantee  privilege_type  is_grantable
-d              s5           admin    ALL             true
-d              s5           root     ALL             true
+database_name  schema_name  grantee   privilege_type  is_grantable
+d              s5           admin     ALL             true
+d              s5           root      ALL             true
+d              s5           testuser  ALL             true
 
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO testuser, testuser2

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_sequence
@@ -32,9 +32,10 @@ CREATE SEQUENCE testuser_s2;
 query TTTTTB colnames
 SHOW GRANTS ON testuser_s2
 ----
-database_name  schema_name  table_name   grantee  privilege_type  is_grantable
-d              public       testuser_s2  admin    ALL             true
-d              public       testuser_s2  root     ALL             true
+database_name  schema_name  table_name   grantee   privilege_type  is_grantable
+d              public       testuser_s2  admin     ALL             true
+d              public       testuser_s2  root      ALL             true
+d              public       testuser_s2  testuser  ALL             true
 
 user root
 
@@ -128,9 +129,10 @@ CREATE SEQUENCE s4
 query TTTTTB colnames
 SHOW GRANTS ON s4
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-d              public       s4          admin    ALL             true
-d              public       s4          root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+d              public       s4          admin     ALL             true
+d              public       s4          root      ALL             true
+d              public       s4          testuser  ALL             true
 
 user root
 statement ok
@@ -153,6 +155,7 @@ CREATE SEQUENCE s5
 query TTTTTB colnames
 SHOW GRANTS ON s5
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-d              public       s5          admin    ALL             true
-d              public       s5          root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+d              public       s5          admin     ALL             true
+d              public       s5          root      ALL             true
+d              public       s5          testuser  ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
@@ -47,9 +47,10 @@ CREATE TABLE testuser_t2();
 query TTTTTB colnames
 SHOW GRANTS ON testuser_t2
 ----
-database_name  schema_name  table_name   grantee  privilege_type  is_grantable
-d              public       testuser_t2  admin    ALL             true
-d              public       testuser_t2  root     ALL             true
+database_name  schema_name  table_name   grantee   privilege_type  is_grantable
+d              public       testuser_t2  admin     ALL             true
+d              public       testuser_t2  root      ALL             true
+d              public       testuser_t2  testuser  ALL             true
 
 user root
 
@@ -196,7 +197,7 @@ SHOW GRANTS ON t5
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 d              public       t5          admin      ALL             true
 d              public       t5          root       ALL             true
-d              public       t5          testuser   SELECT          true
+d              public       t5          testuser   ALL             true
 d              public       t5          testuser2  SELECT          false
 
 user root
@@ -218,9 +219,10 @@ CREATE TABLE t6()
 query TTTTTB colnames
 SHOW GRANTS ON t6
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-d              public       t6          admin    ALL             true
-d              public       t6          root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+d              public       t6          admin     ALL             true
+d              public       t6          root      ALL             true
+d              public       t6          testuser  ALL             true
 
 user root
 
@@ -310,6 +312,7 @@ SHOW GRANTS ON t10
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 d              public       t10         admin      ALL             true
 d              public       t10         root       ALL             true
+d              public       t10         testuser   ALL             true
 d              public       t10         testuser2  SELECT          false
 d              public       t10         testuser3  SELECT          false
 
@@ -336,9 +339,10 @@ CREATE TABLE t12()
 query TTTTTB colnames
 SHOW GRANTS ON t12
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-d              public       t12         admin    ALL             true
-d              public       t12         root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+d              public       t12         admin     ALL             true
+d              public       t12         root      ALL             true
+d              public       t12         testuser  ALL             true
 
 # Cannot specify PUBLIC as the target role.
 statement error pq: user or role public does not exist

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_type
@@ -33,9 +33,10 @@ CREATE TYPE testuser_t2 AS ENUM();
 query TTTTTB colnames
 SHOW GRANTS ON TYPE testuser_t2
 ----
-database_name  schema_name  type_name    grantee  privilege_type  is_grantable
-d              public       testuser_t2  admin    ALL             true
-d              public       testuser_t2  root     ALL             true
+database_name  schema_name  type_name    grantee   privilege_type  is_grantable
+d              public       testuser_t2  admin     ALL             true
+d              public       testuser_t2  root      ALL             true
+d              public       testuser_t2  testuser  ALL             true
 
 user root
 
@@ -107,9 +108,10 @@ CREATE TYPE t4 AS ENUM()
 query TTTTTB colnames
 SHOW GRANTS ON TYPE t4
 ----
-database_name  schema_name  type_name  grantee  privilege_type  is_grantable
-d              public       t4         admin    ALL             true
-d              public       t4         root     ALL             true
+database_name  schema_name  type_name  grantee   privilege_type  is_grantable
+d              public       t4         admin     ALL             true
+d              public       t4         root      ALL             true
+d              public       t4         testuser  ALL             true
 
 user root
 statement ok
@@ -131,6 +133,7 @@ CREATE TYPE t5 AS ENUM()
 query TTTTTB colnames
 SHOW GRANTS ON TYPE t5
 ----
-database_name  schema_name  type_name  grantee  privilege_type  is_grantable
-d              public       t5         admin    ALL             true
-d              public       t5         root     ALL             true
+database_name  schema_name  type_name  grantee   privilege_type  is_grantable
+d              public       t5         admin     ALL             true
+d              public       t5         root      ALL             true
+d              public       t5         testuser  ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
@@ -187,6 +187,7 @@ SHOW GRANTS ON t11
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t11         admin      ALL             true
 test           public       t11         root       ALL             true
+test           public       t11         testuser   ALL             true
 test           public       t11         testuser2  SELECT          false
 
 # Default privileges for schemas have no defaults - no privileges are defined
@@ -206,9 +207,10 @@ CREATE TABLE s2.t12()
 query TTTTTB colnames
 SHOW GRANTS ON s2.t12
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-test           s2           t12         admin    ALL             true
-test           s2           t12         root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+test           s2           t12         admin     ALL             true
+test           s2           t12         root      ALL             true
+test           s2           t12         testuser  ALL             true
 
 query TTTBTTT colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE schema_name IS NOT NULL

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
@@ -269,9 +269,10 @@ CREATE TABLE t9()
 query TTTTTB colnames
 SHOW GRANTS ON TABLE t9;
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-test           public       t9          admin    ALL             true
-test           public       t9          root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+test           public       t9          admin     ALL             true
+test           public       t9          root      ALL             true
+test           public       t9          testuser  ALL             true
 
 statement ok
 GRANT DELETE ON TABLE t9 TO testuser
@@ -326,6 +327,7 @@ SHOW GRANTS ON TABLE t11;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t11         admin      ALL             true
 test           public       t11         root       ALL             true
+test           public       t11         testuser   ALL             true
 test           public       t11         testuser2  SELECT          false
 
 user testuser2
@@ -350,6 +352,7 @@ SHOW GRANTS ON TABLE t12;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t12         admin      ALL             true
 test           public       t12         root       ALL             true
+test           public       t12         testuser   ALL             true
 test           public       t12         testuser2  INSERT          true
 test           public       t12         testuser2  SELECT          true
 
@@ -375,6 +378,7 @@ SHOW GRANTS ON TABLE t13;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t13         admin      ALL             true
 test           public       t13         root       ALL             true
+test           public       t13         testuser   ALL             true
 test           public       t13         testuser2  ALL             true
 
 user testuser2
@@ -399,7 +403,14 @@ SHOW GRANTS ON TABLE t14;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t14         admin      ALL             true
 test           public       t14         root       ALL             true
+test           public       t14         testuser   ALL             true
 test           public       t14         testuser2  ALL             false
+
+statement ok
+GRANT INSERT, DELETE ON TABLE t12 TO target WITH GRANT OPTION
+
+statement ok
+ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO testuser WITH GRANT OPTION
 
 user testuser2
 
@@ -417,9 +428,10 @@ CREATE TABLE t15()
 query TTTTTB colnames
 SHOW GRANTS ON TABLE t15;
 ----
-database_name  schema_name  table_name  grantee  privilege_type  is_grantable
-test           public       t15         admin    ALL             true
-test           public       t15         root     ALL             true
+database_name  schema_name  table_name  grantee   privilege_type  is_grantable
+test           public       t15         admin     ALL             true
+test           public       t15         root      ALL             true
+test           public       t15         testuser  ALL             true
 
 #
 # Test schemas

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -180,3 +180,24 @@ owner_grant_option  admin                     ALL             true
 owner_grant_option  owner_grant_option_child  CONNECT         true
 owner_grant_option  public                    CONNECT         false
 owner_grant_option  root                      ALL             true
+owner_grant_option  testuser                  ALL             true
+
+# Verify that is_grantable moves to the new owner.
+
+user root
+
+statement ok
+CREATE ROLE other_owner
+
+statement ok
+ALTER DATABASE owner_grant_option OWNER TO other_owner
+
+query TTTB colnames
+SHOW GRANTS ON DATABASE owner_grant_option
+----
+database_name       grantee                   privilege_type  is_grantable
+owner_grant_option  admin                     ALL             true
+owner_grant_option  other_owner               ALL             true
+owner_grant_option  owner_grant_option_child  CONNECT         false
+owner_grant_option  public                    CONNECT         false
+owner_grant_option  root                      ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_option_mixed_version
+++ b/pkg/sql/logictest/testdata/logic_test/grant_option_mixed_version
@@ -87,21 +87,22 @@ SELECT
   privilege_type,
   is_grantable
 FROM information_schema.schema_privileges
+ORDER BY 1, 2, 3, 4
 ----
 grantee    table_catalog  table_schema        privilege_type  is_grantable
+admin      test           pg_temp             ALL             NULL
+admin      test           public              ALL             NULL
+admin      test           s                   ALL             NULL
 public     test           crdb_internal       USAGE           NULL
 public     test           information_schema  USAGE           NULL
 public     test           pg_catalog          USAGE           NULL
 public     test           pg_extension        USAGE           NULL
-admin      test           pg_temp             ALL             NULL
 public     test           pg_temp             CREATE          NULL
 public     test           pg_temp             USAGE           NULL
-root       test           pg_temp             ALL             NULL
-admin      test           public              ALL             NULL
 public     test           public              CREATE          NULL
 public     test           public              USAGE           NULL
+root       test           pg_temp             ALL             NULL
 root       test           public              ALL             NULL
-admin      test           s                   ALL             NULL
 root       test           s                   ALL             NULL
 testuser   test           s                   ALL             NULL
 testuser2  test           s                   CREATE          NULL

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -637,6 +637,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t1          admin      ALL             true
 test           public       t1          root       ALL             true
+test           public       t1          testuser   ALL             true
 test           public       t1          testuser2  SELECT          false
 
 # even though testuser doesn't have privileges on table t1, it can still grant
@@ -653,6 +654,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t1          admin      ALL             true
 test           public       t1          root       ALL             true
+test           public       t1          testuser   ALL             true
 test           public       t1          testuser2  ALL             true
 
 query TTTTTB colnames
@@ -661,6 +663,7 @@ SHOW GRANTS ON TABLE t1;
 database_name  schema_name  table_name  grantee    privilege_type  is_grantable
 test           public       t1          admin      ALL             true
 test           public       t1          root       ALL             true
+test           public       t1          testuser   ALL             true
 test           public       t1          testuser2  ALL             true
 
 # owner can give privileges back to themself
@@ -754,3 +757,22 @@ test           public       owner_grant_option  admin                     ALL   
 test           public       owner_grant_option  owner_grant_option_child  SELECT          true
 test           public       owner_grant_option  root                      ALL             true
 test           public       owner_grant_option  testuser                  ALL             true
+
+# Verify that is_grantable moves to the new owner.
+
+user root
+
+statement ok
+CREATE ROLE other_owner
+
+statement ok
+ALTER TABLE owner_grant_option OWNER TO other_owner
+
+query TTTTTB colnames
+SHOW GRANTS ON TABLE owner_grant_option
+----
+database_name  schema_name  table_name          grantee                   privilege_type  is_grantable
+test           public       owner_grant_option  admin                     ALL             true
+test           public       owner_grant_option  other_owner               ALL             true
+test           public       owner_grant_option  owner_grant_option_child  SELECT          false
+test           public       owner_grant_option  root                      ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -88,8 +88,8 @@ public     test           public              USAGE           NO
 root       test           public              ALL             YES
 admin      test           s                   ALL             YES
 root       test           s                   ALL             YES
-testuser   test           s                   ALL             YES
 testuser2  test           s                   CREATE          NO
+testuser   test           s                   ALL             YES
 
 # Check grants for testuser2, which should inherit from the public role.
 query TBB colnames rowsort
@@ -136,3 +136,22 @@ test           owner_grant_option  admin                     ALL             tru
 test           owner_grant_option  owner_grant_option_child  USAGE           true
 test           owner_grant_option  root                      ALL             true
 test           owner_grant_option  testuser                  ALL             true
+
+# Verify that is_grantable moves to the new owner.
+
+user root
+
+statement ok
+CREATE ROLE other_owner
+
+statement ok
+ALTER SCHEMA owner_grant_option OWNER TO other_owner
+
+query TTTTB colnames
+SHOW GRANTS ON SCHEMA owner_grant_option
+----
+database_name  schema_name         grantee                   privilege_type  is_grantable
+test           owner_grant_option  admin                     ALL             true
+test           owner_grant_option  other_owner               ALL             true
+test           owner_grant_option  owner_grant_option_child  USAGE           false
+test           owner_grant_option  root                      ALL             true

--- a/pkg/sql/logictest/testdata/logic_test/grant_type
+++ b/pkg/sql/logictest/testdata/logic_test/grant_type
@@ -106,3 +106,23 @@ test           public       owner_grant_option  owner_grant_option_child  USAGE 
 test           public       owner_grant_option  public                    USAGE           false
 test           public       owner_grant_option  root                      ALL             true
 test           public       owner_grant_option  testuser                  ALL             true
+
+# Verify that is_grantable moves to the new owner.
+
+user root
+
+statement ok
+CREATE ROLE other_owner
+
+statement ok
+ALTER TYPE owner_grant_option OWNER TO other_owner
+
+query TTTTTB colnames
+SHOW GRANTS ON TYPE owner_grant_option
+----
+database_name  schema_name  type_name           grantee                   privilege_type  is_grantable
+test           public       owner_grant_option  admin                     ALL             true
+test           public       owner_grant_option  other_owner               ALL             true
+test           public       owner_grant_option  owner_grant_option_child  USAGE           false
+test           public       owner_grant_option  public                    USAGE           false
+test           public       owner_grant_option  root                      ALL             true

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2642,7 +2642,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html`,
 		if err = forEachTableDesc(ctx, p, dbContext, virtualMany,
 			func(db catalog.DatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
 				owner := table.GetPrivileges().Owner()
-				for _, u := range table.GetPrivileges().Show(privilege.Table) {
+				for _, u := range table.GetPrivileges().Show(privilege.Table, true /* showImplicitOwnerPrivs */) {
 					if err := addSharedDependency(
 						dbOid(db.GetID()),       // dbid
 						pgClassOid,              // classid
@@ -2664,7 +2664,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html`,
 		if err = forEachDatabaseDesc(ctx, p, nil /*all databases*/, false, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
 				owner := db.GetPrivileges().Owner()
-				for _, u := range db.GetPrivileges().Show(privilege.Database) {
+				for _, u := range db.GetPrivileges().Show(privilege.Database, true /* showImplicitOwnerPrivs */) {
 					if err := addSharedDependency(
 						tree.NewDOid(0),   // dbid
 						pgDatabaseOid,     // classid


### PR DESCRIPTION
Backport 1/1 commits from #84879.

/cc @cockroachdb/release

Release justification: bug fix

---

Previously, the privileges for an object owner would be explicitly
granted at the time of object creation. However, this is a bug, since if
the owner is changed, the original owner no longer should have
priveleges, and the new owner should have them instead. It's fixed by
relying on the CheckPrivilege functions checking for ownership, and the
privileges.Show function returning the implicit owner privs at
introspection time.

Release note (bug fix): Fixed a bug where the priveleges for an object
owner would not be correctly transferred when the owner is changed.
