### PR TITLE
build: fix dev ui watch

### DIFF
--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -9,12 +9,8 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
-rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
-cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
-rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
-cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
@@ -28,12 +24,8 @@ bazel info bazel-bin --color=no
 bazel info workspace --color=no
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
-rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
-cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
-rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
-cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=oss --env.target=http://localhost:8080 --port 3000
@@ -49,12 +41,8 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
-rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
-cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
-rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
-cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000 --https
@@ -70,12 +58,8 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
-rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
-cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
-rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
-cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://example.crdb.io:4848 --port 3000
@@ -91,12 +75,8 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
-rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
-cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
-rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
-cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui build:watch
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 12345
@@ -131,12 +111,8 @@ cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/wo
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.js
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
 cp sandbox/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/ccl/src/js/protos.d.ts
-rm -rf crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
-cp -r sandbox/pkg/ui/workspaces/eslint-plugin-crdb/dist crdb-checkout/pkg/ui/workspaces/eslint-plugin-crdb/dist
 rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
 cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
-rm -rf crdb-checkout/pkg/ui/workspaces/db-console/dist
-cp -r sandbox/pkg/ui/workspaces/db-console/dist crdb-checkout/pkg/ui/workspaces/db-console/dist
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/db-console
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/cluster-ui jest --watch


### PR DESCRIPTION
A previous commit [1] added a few extra cp commands to an internal
helper of the ./dev ui subcommands, but its use in dev ui watch resulted
in an attempt to package output before it was created. Revert
the unnecessary parts of dc5fb3e958, restoring dev ui watch.

[1] dc5fb3e958 (dev: add ./dev generate js subcommand, 2022-07-20)

Release note: None