### PR TITLE
eval: stop ignoring all ResolveOIDFromOID errors

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -159,15 +159,15 @@ type DummyEvalPlanner struct{}
 // ResolveOIDFromString is part of the Planner interface.
 func (ep *DummyEvalPlanner) ResolveOIDFromString(
 	ctx context.Context, resultType *types.T, toResolve *tree.DString,
-) (*tree.DOid, error) {
-	return nil, errors.WithStack(errEvalPlanner)
+) (*tree.DOid, bool, error) {
+	return nil, false, errors.WithStack(errEvalPlanner)
 }
 
 // ResolveOIDFromOID is part of the Planner interface.
 func (ep *DummyEvalPlanner) ResolveOIDFromOID(
 	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
-) (*tree.DOid, error) {
-	return nil, errors.WithStack(errEvalPlanner)
+) (*tree.DOid, bool, error) {
+	return nil, false, errors.WithStack(errEvalPlanner)
 }
 
 // UnsafeUpsertDescriptor is part of the Planner interface.

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -772,13 +772,13 @@ var pgBuiltins = map[string]builtinDefinition{
 					// The session has not yet created a temporary schema.
 					return tree.NewDOid(0), nil
 				}
-				oid, err := ctx.Planner.ResolveOIDFromString(
+				oid, errSafeToIgnore, err := ctx.Planner.ResolveOIDFromString(
 					ctx.Ctx(), types.RegNamespace, tree.NewDString(schema))
 				if err != nil {
 					// If the OID lookup returns an UndefinedObject error, return 0
 					// instead. We can hit this path if the session created a temporary
 					// schema in one database and then changed databases.
-					if pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+					if errSafeToIgnore && pgerror.GetPGCode(err) == pgcode.UndefinedObject {
 						return tree.NewDOid(0), nil
 					}
 					return nil, err

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -955,8 +955,11 @@ func performIntToOidCast(
 			return tree.WrapAsZeroOid(t), nil
 		}
 
-		dOid, err := res.ResolveOIDFromOID(ctx, t, tree.NewDOid(o))
+		dOid, errSafeToIgnore, err := res.ResolveOIDFromOID(ctx, t, tree.NewDOid(o))
 		if err != nil {
+			if !errSafeToIgnore {
+				return nil, err
+			}
 			dOid = tree.NewDOidWithType(o, t)
 		}
 		return dOid, nil

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -171,7 +171,7 @@ type TypeResolver interface {
 	// query, an error will be returned.
 	ResolveOIDFromString(
 		ctx context.Context, resultType *types.T, toResolve *tree.DString,
-	) (*tree.DOid, error)
+	) (_ *tree.DOid, errSafeToIgnore bool, _ error)
 
 	// ResolveOIDFromOID looks up the populated value of the oid with the
 	// desired resultType which matches the provided oid.
@@ -181,7 +181,7 @@ type TypeResolver interface {
 	// query, an error will be returned.
 	ResolveOIDFromOID(
 		ctx context.Context, resultType *types.T, toResolve *tree.DOid,
-	) (*tree.DOid, error)
+	) (_ *tree.DOid, errSafeToIgnore bool, _ error)
 }
 
 // Planner is a limited planner that can be used from EvalContext.


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/84448

The decision about whether an error is safe to ignore is made at the
place where the error is created/returned. This way, the callers don't
need to be aware of any new error codes that the implementation may
start returning in the future.

Release note (bug fix): Fixed incorrect error handling that could cause
casts to OID types to fail in some cases.