### PR TITLE
roachtest: fix tests to not use `go get`

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -147,7 +147,7 @@ func registerGopg(r registry.Registry) {
 			// We pipe the test output into go-junit-report tool which will output
 			// it in XML format.
 			fmt.Sprintf(`cd %s &&
-							GOPATH=%s go get -u github.com/jstemmer/go-junit-report &&
+							GOPATH=%s go install github.com/jstemmer/go-junit-report@latest &&
 							cat %s | %s/bin/go-junit-report`,
 				destPath, goPath, resultsFilePath, goPath),
 		)

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -72,7 +72,7 @@ func registerGORM(r registry.Registry) {
 		// Install go-junit-report to convert test results to .xml format we know
 		// how to work with.
 		if err := repeatRunE(
-			ctx, t, c, node, "install go-junit-report", fmt.Sprintf("GOPATH=%s go get -u github.com/jstemmer/go-junit-report", goPath),
+			ctx, t, c, node, "install go-junit-report", fmt.Sprintf("GOPATH=%s go install github.com/jstemmer/go-junit-report@latest", goPath),
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -70,7 +70,7 @@ func registerLibPQ(r registry.Registry) {
 		// Install go-junit-report to convert test results to .xml format we know
 		// how to work with.
 		err = repeatRunE(ctx, t, c, node, "install go-junit-report",
-			fmt.Sprintf("GOPATH=%s go get -u github.com/jstemmer/go-junit-report", goPath),
+			fmt.Sprintf("GOPATH=%s go install github.com/jstemmer/go-junit-report@latest", goPath),
 		)
 		require.NoError(t, err)
 

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -76,7 +76,7 @@ func registerPgx(r registry.Registry) {
 
 		t.Status("installing go-junit-report")
 		if err := repeatRunE(
-			ctx, t, c, node, "install go-junit-report", "go get -u github.com/jstemmer/go-junit-report",
+			ctx, t, c, node, "install go-junit-report", "go install github.com/jstemmer/go-junit-report@latest",
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/85058
fixes https://github.com/cockroachdb/cockroach/issues/85047
fixes https://github.com/cockroachdb/cockroach/issues/85045
fixes https://github.com/cockroachdb/cockroach/issues/85044

`go get` no longer works the same in go1.18.

Release note: None