### PR TITLE
flowinfra: disable queueing mechanism of the flow scheduler by default

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3436,6 +3436,7 @@ func TestChangefeedJobRetryOnNoInboundStream(t *testing.T) {
 	// force fast "no inbound stream" error
 	var oldMaxRunningFlows int
 	var oldTimeout string
+	sqlDB.Exec(t, "SET CLUSTER SETTING sql.distsql.flow_scheduler_queueing.enabled = true")
 	sqlDB.QueryRow(t, "SHOW CLUSTER SETTING sql.distsql.max_running_flows").Scan(&oldMaxRunningFlows)
 	sqlDB.QueryRow(t, "SHOW CLUSTER SETTING sql.distsql.flow_stream_timeout").Scan(&oldTimeout)
 	serverutils.SetClusterSetting(t, cluster, "sql.distsql.max_running_flows", 0)

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -566,6 +566,9 @@ func TestDistSQLFlowsVirtualTables(t *testing.T) {
 		),
 	)
 
+	// Enable the queueing mechanism of the flow scheduler.
+	sqlDB.Exec(t, "SET CLUSTER SETTING sql.distsql.flow_scheduler_queueing.enabled = true")
+
 	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
 	tableID := sqlutils.QueryTableID(t, sqlDB.DB, "test", "public", "foo")
 	tableKey.Store(execCfg.Codec.TablePrefix(tableID))

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -586,6 +586,9 @@ func TestDistSQLReceiverCancelsDeadFlows(t *testing.T) {
 		),
 	)
 
+	// Enable the queueing mechanism of the flow scheduler.
+	sqlDB.Exec(t, "SET CLUSTER SETTING sql.distsql.flow_scheduler_queueing.enabled = true")
+
 	// Disable the execution of all remote flows and shorten the timeout.
 	const maxRunningFlows = 0
 	const flowStreamTimeout = 1 // in seconds

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -86,6 +86,10 @@ func TestClusterFlow(t *testing.T) {
 		return span
 	}
 
+	// Enable the queueing mechanism of the flow scheduler.
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	sqlDB.Exec(t, "SET CLUSTER SETTING sql.distsql.flow_scheduler_queueing.enabled = true")
+
 	// successful indicates whether the flow execution is successful.
 	for _, successful := range []bool{true, false} {
 		// Set up table readers on three hosts feeding data into a join reader on
@@ -378,15 +382,9 @@ func TestTenantClusterFlow(t *testing.T) {
 		return span
 	}
 
+	// Enable the queueing mechanism of the flow scheduler.
 	sqlDB := sqlutils.MakeSQLRunner(podConns[0])
-	rows := sqlDB.Query(t, "SELECT num FROM test.t")
-	defer rows.Close()
-	for rows.Next() {
-		var key int
-		if err := rows.Scan(&key); err != nil {
-			t.Fatal(err)
-		}
-	}
+	sqlDB.Exec(t, "SET CLUSTER SETTING sql.distsql.flow_scheduler_queueing.enabled = true")
 
 	// successful indicates whether the flow execution is successful.
 	for _, successful := range []bool{true, false} {

--- a/pkg/sql/flowinfra/flow_scheduler_test.go
+++ b/pkg/sql/flowinfra/flow_scheduler_test.go
@@ -133,6 +133,8 @@ func TestFlowScheduler(t *testing.T) {
 	)
 	defer stopper.Stop(ctx)
 
+	// Enable the queueing mechanism of the flow scheduler.
+	flowSchedulerQueueingEnabled.Override(ctx, &settings.SV, true)
 	scheduler := NewFlowScheduler(log.MakeTestingAmbientCtxWithNewTracer(), stopper, settings)
 	scheduler.Init(&metrics)
 	scheduler.Start()


### PR DESCRIPTION
This commit disables the queueing mechanism of the flow scheduler as
part of the effort to remove that queueing altogether during 23.1
release cycle. To get there though we choose a conservative approach of
introducing a cluster setting that determines whether the queueing is
enabled or not, and if it is disabled, then we effectively a treating
`sql.distsql.max_running_flows` limit as infinite. By default, the
queueing is now disabled since recent experiments have shown that the
admission control does a good job of protecting the nodes from the
influx of remote flows.

Addresses: #34229.

Release note: None