### PR TITLE
sql/schemachanger: `CREATE INDEX USING HASH` creates virtual shard col

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -361,6 +361,7 @@ func maybeCreateAndAddShardCol(
 			ColumnID:    shardColID,
 			TypeT:       scpb.TypeT{Type: types.Int4},
 			ComputeExpr: b.WrapExpression(tbl.TableID, parsedExpr),
+			IsVirtual:   true,
 		},
 	}
 	addColumn(b, spec, n)

--- a/pkg/sql/schemachanger/scbuild/testdata/create_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_index
@@ -80,59 +80,27 @@ build
 CREATE INDEX id4
 	ON defaultdb.t1 (id, name) USING HASH STORING (money) WITH (bucket_count=8)
 ----
-- [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC]
-  {columnId: 1, indexId: 1, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC]
-  {columnId: 2, indexId: 1, kind: STORED, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC]
-  {columnId: 3, indexId: 1, kind: STORED, ordinalInKind: 1, tableId: 104}
-- [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC]
-  {constraintId: 1, indexId: 1, isUnique: true, tableId: 104}
-- [[IndexName:{DescID: 104, Name: t1_pkey, IndexID: 1}, ABSENT], PUBLIC]
-  {indexId: 1, name: t1_pkey, tableId: 104}
 - [[Column:{DescID: 104, ColumnID: 4}, PUBLIC], ABSENT]
   {columnId: 4, isHidden: true, pgAttributeNum: 4, tableId: 104}
 - [[ColumnName:{DescID: 104, Name: crdb_internal_id_name_shard_8, ColumnID: 4}, PUBLIC], ABSENT]
   {columnId: 4, name: crdb_internal_id_name_shard_8, tableId: 104}
 - [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}, PUBLIC], ABSENT]
-  {columnId: 4, computeExpr: {expr: 'mod(fnv32(crdb_internal.datums_to_bytes(id, name)), 8:::INT8)'}, tableId: 104, type: {family: IntFamily, oid: 23, width: 32}}
+  {columnId: 4, computeExpr: {expr: 'mod(fnv32(crdb_internal.datums_to_bytes(id, name)), 8:::INT8)'}, isVirtual: true, tableId: 104, type: {family: IntFamily, oid: 23, width: 32}}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 2, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT]
-  {columnId: 2, indexId: 2, kind: STORED, tableId: 104}
+  {columnId: 2, indexId: 2, ordinalInKind: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC], ABSENT]
-  {columnId: 3, indexId: 2, kind: STORED, ordinalInKind: 1, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}, PUBLIC], ABSENT]
-  {columnId: 4, indexId: 2, kind: STORED, ordinalInKind: 2, tableId: 104}
-- [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT]
-  {constraintId: 1, indexId: 2, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
-- [[IndexName:{DescID: 104, Name: t1_pkey, IndexID: 2}, PUBLIC], ABSENT]
-  {indexId: 2, name: t1_pkey, tableId: 104}
+  {columnId: 3, indexId: 2, kind: STORED, tableId: 104}
+- [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT]
+  {indexId: 2, sharding: {columnNames: [id, name], isSharded: true, name: crdb_internal_id_name_shard_8, shardBuckets: 8}, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
+- [[IndexName:{DescID: 104, Name: id4, IndexID: 2}, PUBLIC], ABSENT]
+  {indexId: 2, name: id4, tableId: 104}
 - [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
-  {constraintId: 1, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 104}
+  {indexId: 3, isUsingSecondaryEncoding: true, sharding: {columnNames: [id, name], isSharded: true, name: crdb_internal_id_name_shard_8, shardBuckets: 8}, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT]
-  {columnId: 2, indexId: 3, kind: STORED, tableId: 104}
+  {columnId: 2, indexId: 3, ordinalInKind: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC], ABSENT]
-  {columnId: 3, indexId: 3, kind: STORED, ordinalInKind: 1, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 3}, PUBLIC], ABSENT]
-  {columnId: 4, indexId: 3, kind: STORED, ordinalInKind: 2, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT]
-  {columnId: 1, indexId: 4, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT]
-  {columnId: 2, indexId: 4, ordinalInKind: 1, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, PUBLIC], ABSENT]
-  {columnId: 3, indexId: 4, kind: STORED, tableId: 104}
-- [[SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT]
-  {indexId: 4, sharding: {columnNames: [id, name], isSharded: true, name: crdb_internal_id_name_shard_8, shardBuckets: 8}, sourceIndexId: 1, tableId: 104, temporaryIndexId: 5}
-- [[IndexName:{DescID: 104, Name: id4, IndexID: 4}, PUBLIC], ABSENT]
-  {indexId: 4, name: id4, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
-  {indexId: 5, isUsingSecondaryEncoding: true, sharding: {columnNames: [id, name], isSharded: true, name: crdb_internal_id_name_shard_8, shardBuckets: 8}, sourceIndexId: 1, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT]
-  {columnId: 1, indexId: 5, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, PUBLIC], ABSENT]
-  {columnId: 2, indexId: 5, ordinalInKind: 1, tableId: 104}
-- [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}, PUBLIC], ABSENT]
-  {columnId: 3, indexId: 5, kind: STORED, tableId: 104}
+  {columnId: 3, indexId: 3, kind: STORED, tableId: 104}


### PR DESCRIPTION
Previously, `CREATE INDEX USING HASH` in the declarative schema changer
ends up creating a STORED shard column. That was inadequate because the
lagacy schema changer's behavior, since v22.1 and later, is that it
creates a *virtual* shard column. This PR fixes it and added a logic
test on this.

Fix: #84625

Release note: None