### PR TITLE
backupccl: rewrite IDs in restored system tables

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1767,15 +1767,10 @@ func (r *restoreResumer) publishDescriptors(
 
 	// Go through the descriptors and find any declarative schema change jobs
 	// affecting them.
-	//
-	// If we're restoring all the descriptors, it means we're also restoring the
-	// jobs.
-	if details.DescriptorCoverage != tree.AllDescriptors {
-		if err := scbackup.CreateDeclarativeSchemaChangeJobs(
-			ctx, r.execCfg.JobRegistry, txn, all,
-		); err != nil {
-			return err
-		}
+	if err := scbackup.CreateDeclarativeSchemaChangeJobs(
+		ctx, r.execCfg.JobRegistry, txn, all,
+	); err != nil {
+		return err
 	}
 
 	// Write the new TableDescriptors and flip state over to public so they can be

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -908,11 +908,9 @@ func createImportingDescriptors(
 
 			// Allocate no schedule to the row-level TTL.
 			// This will be re-written when the descriptor is published.
-			if details.DescriptorCoverage != tree.AllDescriptors {
-				for _, table := range mutableTables {
-					if table.HasRowLevelTTL() {
-						table.RowLevelTTL.ScheduleID = 0
-					}
+			for _, table := range mutableTables {
+				if table.HasRowLevelTTL() {
+					table.RowLevelTTL.ScheduleID = 0
 				}
 			}
 
@@ -1810,7 +1808,7 @@ func (r *restoreResumer) publishDescriptors(
 			return err
 		}
 		// Assign a TTL schedule before publishing.
-		if details.DescriptorCoverage != tree.AllDescriptors && mutTable.HasRowLevelTTL() {
+		if mutTable.HasRowLevelTTL() {
 			j, err := sql.CreateRowLevelTTLScheduledJob(
 				ctx,
 				execCfg,

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2479,7 +2479,7 @@ func (r *restoreResumer) restoreSystemTables(
 
 			if err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 				if err := systemTable.config.migrationFunc(ctx, r.execCfg, txn,
-					systemTable.stagingTableName); err != nil {
+					systemTable.stagingTableName, details.DescriptorRewrites); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
Currently the rewrites are all identity but this paves the way for that
to change in a future diff. For now, each table that opts into cluster backup
and restore now has a comment indicating if it contains no descriptor IDs or,
if it does contain a descriptor ID, which column it is in. For those which do
contain a descriptor ID, a migration funciton is now passed which updates that
column to the new ID according to the passed rewrites where it is the old ID.
Again, this will be a noop update for now, but will be critical when that map
starts to assign different IDs during cluster RESTORE. The affected tables, now
that jobs is opted out, are zones, comments, and database_role_settings, each
of which just have a single column containing some sort of desc ID.

For now, one UPDATE is run per remapped ID, however a future optimization could
bundle 10 or 100 mappings into a larger CASE statement to reduce the number of
separate statements a large RESTORE needs to run.

Release note: none.