### PR TITLE
bazel: remove import of `pkg/roachpb` in `cloudpb`

### DIFF
--- a/pkg/cloud/cloudpb/BUILD.bazel
+++ b/pkg/cloud/cloudpb/BUILD.bazel
@@ -9,7 +9,6 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/roachpb:roachpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
     ],
 )
@@ -21,7 +20,7 @@ go_proto_library(
     proto = ":cloudpb_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/roachpb",
+        "//pkg/roachpb",  # keep
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )

--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -12,7 +12,6 @@ syntax = "proto3";
 package cockroach.cloud.cloudpb;
 option go_package = "cloudpb";
 
-import "roachpb/data.proto";
 import "gogoproto/gogo.proto";
 
 enum ExternalStorageProvider {


### PR DESCRIPTION
Quash this warning:

    cloud/cloudpb/external_storage.proto: warning: Import roachpb/data.proto but not used.

Release note: None