### PR TITLE
kvcoord: remove an artifact of unsetting WriteTooOld flag

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -345,11 +345,6 @@ func newLeafTxnCoordSender(
 	tcf *TxnCoordSenderFactory, tis *roachpb.LeafTxnInputState,
 ) kv.TxnSender {
 	txn := &tis.Txn
-	// 19.2 roots might have this flag set. In 20.1, the flag is only set by the
-	// server and terminated by the client in the span refresher interceptor. If
-	// the root is a 19.2 node, we reset the flag because it only confuses
-	// that interceptor and provides no benefit.
-	txn.WriteTooOld = false
 	txn.AssertInitialized(context.TODO())
 
 	if txn.Status != roachpb.PENDING {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -220,13 +220,6 @@ func (sr *txnSpanRefresher) sendLockedWithRefreshAttempts(
 	}
 	br, pErr := sr.wrapped.SendLocked(ctx, ba)
 
-	// 19.2 servers might give us an error with the WriteTooOld flag set. This
-	// interceptor wants to always terminate that flag. In the case of an error,
-	// we can just ignore it.
-	if pErr != nil && pErr.GetTxn() != nil {
-		pErr.GetTxn().WriteTooOld = false
-	}
-
 	if pErr == nil && br.Txn.WriteTooOld {
 		// If we got a response with the WriteTooOld flag set, then we pretend that
 		// we got a WriteTooOldError, which will cause us to attempt to refresh and


### PR DESCRIPTION
It seems like during 20.1 release cycle we had a change so that the
errors don't carry `WriteTooOld` flag set to `true` and now only the
BatchResponse can have that. We kept the ability of unsetting that flag
so that in a mixed-version scenario we wouldn't run into any issues, but
now that unsetting behavior is no longer needed and is removed in this
commit.

My particular interest in removing this is because it is the only
modification of the `SetupFlowRequest` proto (which carries the `Txn`
proto inside) that occurs during the distributed query setup, and I want
to have more parallelization there.

Release note: None