### PR TITLE
optbuilder: remove spurious casts in binary ops

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1962,6 +1962,13 @@ func TestTenantLogic_vectorize_agg(
 	runLogicTest(t, "vectorize_agg")
 }
 
+func TestTenantLogic_vectorize_overloads(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vectorize_overloads")
+}
+
 func TestTenantLogic_vectorize_shutdown(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -1,5 +1,3 @@
-# LogicTest: local
-
 statement ok
 CREATE TABLE many_types (
     _bool        BOOL,
@@ -183,7 +181,7 @@ NULL
 [2, "hi", {"b": ["bar", {"c": 4}]}]
 [1, "hello"]
 
-query T
+query T rowsort
 SELECT _bytes || _bytes FROM many_types
 ----
 NULL
@@ -191,7 +189,7 @@ NULL
 456456
 NULL
 
-query T
+query T rowsort
 SELECT _string || _string FROM many_types
 ----
 NULL
@@ -199,7 +197,7 @@ NULL
 456456
 NULL
 
-query T
+query T rowsort
 SELECT _json || _json FROM many_types
 ----
 NULL
@@ -207,7 +205,7 @@ NULL
 [2, "hi", {"b": ["bar", {"c": 4}]}, 2, "hi", {"b": ["bar", {"c": 4}]}]
 [1, "hello", {"a": ["foo", {"b": 3}]}, 1, "hello", {"a": ["foo", {"b": 3}]}]
 
-query T
+query T rowsort
 SELECT _varbit || _varbit FROM many_types
 ----
 NULL
@@ -245,7 +243,7 @@ NULL
 0
 0
 
-query T
+query T rowsort
 SELECT _varbit >> 1 FROM many_types
 ----
 NULL
@@ -253,7 +251,7 @@ NULL
 01
 01101
 
-query T
+query T rowsort
 SELECT _varbit << 1 FROM many_types
 ----
 NULL
@@ -261,7 +259,7 @@ NULL
 10
 10100
 
-query T
+query T rowsort
 SELECT _varbit << 3 FROM many_types
 ----
 NULL
@@ -284,7 +282,7 @@ SELECT _int2^_int2 FROM many_types WHERE _int2 < 10
 statement error integer out of range
 SELECT _int2^_int4 FROM many_types
 
-query T
+query T rowsort
 SELECT _json -> _int2 FROM many_types
 ----
 NULL
@@ -292,7 +290,7 @@ NULL
 NULL
 {"a": ["foo", {"b": 3}]}
 
-query T
+query T rowsort
 SELECT _json -> _int4 FROM many_types
 ----
 NULL
@@ -300,7 +298,7 @@ NULL
 NULL
 {"a": ["foo", {"b": 3}]}
 
-query T
+query T rowsort
 SELECT _json -> _int FROM many_types
 ----
 NULL
@@ -308,7 +306,7 @@ NULL
 NULL
 {"a": ["foo", {"b": 3}]}
 
-query T
+query T rowsort
 SELECT _json -> 2 FROM many_types
 ----
 NULL
@@ -316,7 +314,7 @@ NULL
 {"b": ["bar", {"c": 4}]}
 {"a": ["foo", {"b": 3}]}
 
-query T
+query T rowsort
 SELECT _json -> 2 -> 'a' FROM many_types
 ----
 NULL
@@ -325,22 +323,22 @@ NULL
 ["foo", {"b": 3}]
 
 query TT
-SELECT _json #> _stringarray, _json #> '{2,a}' FROM many_types
+SELECT _json #> _stringarray, _json #> '{2,a}' FROM many_types ORDER BY _int
 ----
 NULL               NULL
+NULL               ["foo", {"b": 3}]
 ["foo", {"b": 3}]  ["foo", {"b": 3}]
 ["bar", {"c": 4}]  NULL
-NULL               ["foo", {"b": 3}]
 
 query TT
-SELECT _json #> _stringarray #> '{1,b}', _json #> '{2,a}' #> '{1,b}' FROM many_types
+SELECT _json #> _stringarray #> '{1,b}', _json #> '{2,a}' #> '{1,b}' FROM many_types ORDER BY _int
 ----
 NULL  NULL
+NULL  3
 3     3
 NULL  NULL
-NULL  3
 
-query T
+query T rowsort
 SELECT _json #> '{}' FROM many_types
 ----
 NULL
@@ -357,14 +355,14 @@ NULL  NULL
 NULL  NULL
 
 query TT
-SELECT _json #>> _stringarray, _json #>> '{2,a}' FROM many_types
+SELECT _json #>> _stringarray, _json #>> '{2,a}' FROM many_types ORDER BY _int
 ----
 NULL               NULL
+NULL               ["foo", {"b": 3}]
 ["foo", {"b": 3}]  ["foo", {"b": 3}]
 ["bar", {"c": 4}]  NULL
-NULL               ["foo", {"b": 3}]
 
-query TT
+query TT rowsort
 SELECT _json #> '{2,a}' #>> _stringarray, _json #> '{2,a}' #>> '{1,b}' FROM many_types
 ----
 NULL  NULL
@@ -372,7 +370,7 @@ NULL  3
 NULL  NULL
 NULL  3
 
-query T
+query T rowsort
 SELECT _json #>> '{}' FROM many_types
 ----
 NULL
@@ -400,7 +398,7 @@ NULL
 NULL
 NULL
 
-query B
+query B rowsort
 SELECT _json -> _int -> 'a' = '["foo", {"b": 3}]' FROM many_types
 ----
 NULL

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1942,6 +1942,13 @@ func TestLogic_vectorize_agg(
 	runLogicTest(t, "vectorize_agg")
 }
 
+func TestLogic_vectorize_overloads(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vectorize_overloads")
+}
+
 func TestLogic_vectorize_shutdown(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1935,6 +1935,13 @@ func TestLogic_vectorize_agg(
 	runLogicTest(t, "vectorize_agg")
 }
 
+func TestLogic_vectorize_overloads(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vectorize_overloads")
+}
+
 func TestLogic_vectorize_shutdown(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1956,6 +1956,13 @@ func TestLogic_vectorize_agg(
 	runLogicTest(t, "vectorize_agg")
 }
 
+func TestLogic_vectorize_overloads(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vectorize_overloads")
+}
+
 func TestLogic_vectorize_shutdown(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1942,6 +1942,13 @@ func TestLogic_vectorize_agg(
 	runLogicTest(t, "vectorize_agg")
 }
 
+func TestLogic_vectorize_overloads(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vectorize_overloads")
+}
+
 func TestLogic_vectorize_shutdown(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -482,7 +482,7 @@ vectorized: true
                 │ estimated row count: 1,000 (missing stats)
                 │ render length: length(k)
                 │ render ?column?: 2
-                │ render column12: k::STRING || v::STRING
+                │ render column12: k || v
                 │
                 └── • scan
                       columns: (k, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/trigram_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/trigram_index
@@ -270,3 +270,31 @@ vectorized: true
           missing stats
           table: a@a_b_idx
           spans: 1 span
+
+# Test that trigram indexes accelerate even when the datatype is non-String.
+statement ok
+CREATE TABLE b (
+  a VARCHAR,
+  INVERTED INDEX(a gin_trgm_ops)
+)
+
+query T
+EXPLAIN SELECT * FROM b WHERE a % 'foob'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: a % 'foob'
+│
+└── • index join
+    │ table: b@b_pkey
+    │
+    └── • inverted filter
+        │ inverted column: a_inverted_key
+        │ num spans: 2
+        │
+        └── • scan
+              missing stats
+              table: b@b_a_idx
+              spans: 2 spans

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -332,15 +332,11 @@ EXPLAIN (VEC) SELECT _int2 * _int2 FROM ints WHERE _int4 + _int4 = _int8 + 2
 ----
 │
 └ Node 1
-  └ *colexecproj.projMultInt64Int64Op
-    └ *colexecbase.castInt2IntOp
-      └ *colexecbase.castInt2IntOp
-        └ *colexecsel.selEQInt64Int64Op
-          └ *colexecprojconst.projPlusInt64Int64ConstOp
-            └ *colexecproj.projPlusInt64Int64Op
-              └ *colexecbase.castInt4IntOp
-                └ *colexecbase.castInt4IntOp
-                  └ *colfetcher.ColBatchScan
+  └ *colexecproj.projMultInt16Int16Op
+    └ *colexecsel.selEQInt64Int64Op
+      └ *colexecprojconst.projPlusInt64Int64ConstOp
+        └ *colexecproj.projPlusInt32Int32Op
+          └ *colfetcher.ColBatchScan
 
 # Check that joinReader core is wrapped into the plan when vectorize is set to
 # `experimental_always` - that core is the only exception to disabling of

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_overloads
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_overloads
@@ -124,28 +124,24 @@ EXPLAIN (VEC) SELECT _inet - _int2 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projMinusDatumInt64Op
-    └ *colexecbase.castInt2IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projMinusDatumInt16Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _int2^_int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projPowInt64Int64Op
-    └ *colexecbase.castInt4IntOp
-      └ *colexecbase.castInt2IntOp
-        └ *colfetcher.ColBatchScan
+  └ *colexecproj.projPowInt16Int32Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _int2^_int FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projPowInt64Int64Op
-    └ *colexecbase.castInt2IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projPowInt16Int64Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _float^_float FROM many_types
@@ -160,9 +156,8 @@ EXPLAIN (VEC) SELECT _decimal^_int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projPowDecimalInt64Op
-    └ *colexecbase.castInt4IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projPowDecimalInt32Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _inet - 1 FROM many_types
@@ -177,9 +172,8 @@ EXPLAIN (VEC) SELECT _int4 + _inet FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projPlusDatumInt64Op
-    └ *colexecbase.castInt4IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projPlusInt32DatumOp
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT 2 + _inet FROM many_types
@@ -266,18 +260,16 @@ EXPLAIN (VEC) SELECT _varbit << _int2 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projLShiftDatumInt64Op
-    └ *colexecbase.castInt2IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projLShiftDatumInt16Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _varbit << _int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projLShiftDatumInt64Op
-    └ *colexecbase.castInt4IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projLShiftDatumInt32Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _varbit << _int FROM many_types
@@ -301,18 +293,16 @@ EXPLAIN (VEC) SELECT _varbit >> _int2 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projRShiftDatumInt64Op
-    └ *colexecbase.castInt2IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projRShiftDatumInt16Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _varbit >> _int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projRShiftDatumInt64Op
-    └ *colexecbase.castInt4IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projRShiftDatumInt32Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _varbit >> _int FROM many_types
@@ -327,18 +317,16 @@ EXPLAIN (VEC) SELECT _json -> _int2 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projJSONFetchValJSONInt64Op
-    └ *colexecbase.castInt2IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projJSONFetchValJSONInt16Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _json -> _int4 FROM many_types
 ----
 │
 └ Node 1
-  └ *colexecproj.projJSONFetchValJSONInt64Op
-    └ *colexecbase.castInt4IntOp
-      └ *colfetcher.ColBatchScan
+  └ *colexecproj.projJSONFetchValJSONInt32Op
+    └ *colfetcher.ColBatchScan
 
 query T
 EXPLAIN (VEC) SELECT _json -> _int FROM many_types
@@ -439,7 +427,6 @@ EXPLAIN (VEC) SELECT _int4 // _int FROM many_types WHERE _int <> 0
 ----
 │
 └ Node 1
-  └ *colexecproj.projFloorDivInt64Int64Op
-    └ *colexecbase.castInt4IntOp
-      └ *colexecsel.selNEInt64Int64ConstOp
-        └ *colfetcher.ColBatchScan
+  └ *colexecproj.projFloorDivInt32Int64Op
+    └ *colexecsel.selNEInt64Int64ConstOp
+      └ *colfetcher.ColBatchScan

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -220,8 +220,14 @@ func (b *Builder) buildScalar(
 		// select the right overload. The solution is to wrap any mismatched
 		// arguments with a CastExpr that preserves the static type.
 
-		left := reType(t.TypedLeft(), t.ResolvedBinOp().LeftType)
-		right := reType(t.TypedRight(), t.ResolvedBinOp().RightType)
+		left := t.TypedLeft()
+		if left.ResolvedType() == types.Unknown {
+			left = reType(left, t.ResolvedBinOp().LeftType)
+		}
+		right := t.TypedRight()
+		if right.ResolvedType() == types.Unknown {
+			right = reType(right, t.ResolvedBinOp().RightType)
+		}
 		out = b.constructBinary(
 			treebin.MakeBinaryOperator(t.Operator.Symbol),
 			b.buildScalar(left, inScope, nil, nil, colRefs),

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1221,7 +1221,7 @@ insert decimals
       │    │    │         └── assignment-cast: DECIMAL(10,1) [as=c_cast:12]
       │    │    │              └── c_default:11
       │    │    └── projections
-      │    │         └── a_cast:9::DECIMAL + c_cast:12::DECIMAL [as=d_comp:13]
+      │    │         └── a_cast:9 + c_cast:12 [as=d_comp:13]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:14]
       │              └── d_comp:13
@@ -1266,7 +1266,7 @@ insert decimals
       │    │    │         └── assignment-cast: DECIMAL(10,1) [as=c_cast:12]
       │    │    │              └── c_default:11
       │    │    └── projections
-      │    │         └── a_cast:9::DECIMAL + c_cast:12::DECIMAL [as=d_comp:13]
+      │    │         └── a_cast:9 + c_cast:12 [as=d_comp:13]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:14]
       │              └── d_comp:13
@@ -1432,7 +1432,7 @@ insert assn_cast_comp
       │    │              └── column4:13
       │    └── projections
       │         ├── column2:11 + 10 [as=i_comp_comp:15]
-      │         └── d_cast:14::DECIMAL + 2.5 [as=d_comp_comp:16]
+      │         └── d_cast:14 + 2.5 [as=d_comp_comp:16]
       └── projections
            ├── assignment-cast: INT2 [as=i_comp_cast:17]
            │    └── i_comp_comp:15

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -879,9 +879,8 @@ concat [type=int[]]
  ├── array: [type=int[]]
  │    ├── const: 1 [type=int]
  │    └── const: 2 [type=int]
- └── cast: INT8 [type=int]
-      └── cast: INT2 [type=int2]
-           └── null [type=unknown]
+ └── cast: INT2 [type=int2]
+      └── null [type=unknown]
 
 build-scalar
 NULL::bigint || ARRAY[1, 2]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -198,7 +198,7 @@ project
  ├── scan kv
  │    └── columns: k:1!null v:2 crdb_internal_mvcc_timestamp:3 tableoid:4
  └── projections
-      └── v:2::STRING || 'foo' [as=r:5]
+      └── v:2 || 'foo' [as=r:5]
 
 build
 SELECT lower(v) FROM kv

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1688,7 +1688,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7::DECIMAL + c:9::DECIMAL
+      │    │    │    │    │              └── a:7 + c:9
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95, NULL, 15::DECIMAL(10,2)] [as=b_new:14]
@@ -1698,7 +1698,7 @@ update decimals
       │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b_cast:16]
       │    │    │              └── b_new:14
       │    │    └── projections
-      │    │         └── a_cast:15::DECIMAL + c:9::DECIMAL [as=d_comp:17]
+      │    │         └── a_cast:15 + c:9 [as=d_comp:17]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:18]
       │              └── d_comp:17
@@ -1733,7 +1733,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7::DECIMAL + c:9::DECIMAL
+      │    │    │    │    │              └── a:7 + c:9
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95,NULL,15.00] [as=b_new:14]
@@ -1743,7 +1743,7 @@ update decimals
       │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b_cast:16]
       │    │    │              └── b_new:14
       │    │    └── projections
-      │    │         └── a_cast:15::DECIMAL + c:9::DECIMAL [as=d_comp:17]
+      │    │         └── a_cast:15 + c:9 [as=d_comp:17]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:18]
       │              └── d_comp:17
@@ -1773,7 +1773,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14::DECIMAL + 10.0
+      │    │    │              └── d:14 + 10.0
       │    │    └── projections
       │    │         ├── ' ' [as=c_new:19]
       │    │         ├── 'foo' [as=qc_new:20]
@@ -1787,7 +1787,7 @@ update assn_cast
       │         └── assignment-cast: STRING [as=s_cast:25]
       │              └── s_new:22
       └── projections
-           └── d:14::DECIMAL + 10.0 [as=d_comp_comp:26]
+           └── d:14 + 10.0 [as=d_comp_comp:26]
 
 # Test standard prepared update with some types that require assignment casts.
 assign-placeholders-build query-args=(' ', 'foo', '1')
@@ -1810,7 +1810,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14::DECIMAL + 10.0
+      │    │    │              └── d:14 + 10.0
       │    │    └── projections
       │    │         ├── ' ' [as=c_new:19]
       │    │         ├── 'foo' [as=qc_new:20]
@@ -1821,7 +1821,7 @@ update assn_cast
       │         └── assignment-cast: "char" [as=qc_cast:23]
       │              └── qc_new:20
       └── projections
-           └── d:14::DECIMAL + 10.0 [as=d_comp_comp:24]
+           └── d:14 + 10.0 [as=d_comp_comp:24]
 
 # Test update to DEFAULT that requires an assignment cast.
 build
@@ -1842,14 +1842,14 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14::DECIMAL + 10.0
+      │    │    │              └── d:14 + 10.0
       │    │    └── projections
       │    │         └── 10::INT2 [as=i_new:19]
       │    └── projections
       │         └── assignment-cast: INT8 [as=i_cast:20]
       │              └── i_new:19
       └── projections
-           └── d:14::DECIMAL + 10.0 [as=d_comp_comp:21]
+           └── d:14 + 10.0 [as=d_comp_comp:21]
 
 # Test update to a column that requires an assignment cast and a computed column
 # that depends on the new value.
@@ -1874,14 +1874,14 @@ update assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d_comp:15
-      │    │    │    │              └── d:14::DECIMAL + 10.0
+      │    │    │    │              └── d:14 + 10.0
       │    │    │    └── projections
       │    │    │         └── 1.45::DECIMAL(10,2) [as=d_new:19]
       │    │    └── projections
       │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:20]
       │    │              └── d_new:19
       │    └── projections
-      │         └── d_cast:20::DECIMAL + 10.0 [as=d_comp_comp:21]
+      │         └── d_cast:20 + 10.0 [as=d_comp_comp:21]
       └── projections
            └── assignment-cast: DECIMAL(10) [as=d_comp_cast:22]
                 └── d_comp_comp:21
@@ -1909,14 +1909,14 @@ update assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d_comp:15
-      │    │    │    │              └── d:14::DECIMAL + 10.0
+      │    │    │    │              └── d:14 + 10.0
       │    │    │    └── projections
       │    │    │         └── 1.45 [as=d_new:19]
       │    │    └── projections
       │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:20]
       │    │              └── d_new:19
       │    └── projections
-      │         └── d_cast:20::DECIMAL + 10.0 [as=d_comp_comp:21]
+      │         └── d_cast:20 + 10.0 [as=d_comp_comp:21]
       └── projections
            └── assignment-cast: DECIMAL(10) [as=d_comp_cast:22]
                 └── d_comp_comp:21
@@ -1947,7 +1947,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7::DECIMAL + c:9::DECIMAL
+      │    │    │    │    │              └── a:7 + c:9
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95, NULL, 15::DECIMAL(10,2)] [as=b_new:14]
@@ -1957,7 +1957,7 @@ update decimals
       │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b_cast:16]
       │    │    │              └── b_new:14
       │    │    └── projections
-      │    │         └── a_cast:15::DECIMAL + c:9::DECIMAL [as=d_comp:17]
+      │    │         └── a_cast:15 + c:9 [as=d_comp:17]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:18]
       │              └── d_comp:17
@@ -1991,7 +1991,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7::DECIMAL + c:9::DECIMAL
+      │    │    │    │    │              └── a:7 + c:9
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95,NULL,15.00] [as=b_new:14]
@@ -2001,7 +2001,7 @@ update decimals
       │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b_cast:16]
       │    │    │              └── b_new:14
       │    │    └── projections
-      │    │         └── a_cast:15::DECIMAL + c:9::DECIMAL [as=d_comp:17]
+      │    │         └── a_cast:15 + c:9 [as=d_comp:17]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:18]
       │              └── d_comp:17
@@ -2029,7 +2029,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14::DECIMAL + 10.0
+      │    │    │              └── d:14 + 10.0
       │    │    └── projections
       │    │         ├── ' ' [as=c_new:19]
       │    │         └── 10::INT2 [as=i_new:20]
@@ -2039,7 +2039,7 @@ update assn_cast
       │         └── assignment-cast: INT8 [as=i_cast:22]
       │              └── i_new:20
       └── projections
-           └── d:14::DECIMAL + 10.0 [as=d_comp_comp:23]
+           └── d:14 + 10.0 [as=d_comp_comp:23]
 
 # Test tuple-syntax prepared update with DEFAULT that requires assignment casts.
 assign-placeholders-build query-args=(' ')
@@ -2061,7 +2061,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14::DECIMAL + 10.0
+      │    │    │              └── d:14 + 10.0
       │    │    └── projections
       │    │         ├── ' ' [as=c_new:19]
       │    │         └── 10::INT2 [as=i_new:20]
@@ -2071,7 +2071,7 @@ update assn_cast
       │         └── assignment-cast: INT8 [as=i_cast:22]
       │              └── i_new:20
       └── projections
-           └── d:14::DECIMAL + 10.0 [as=d_comp_comp:23]
+           └── d:14 + 10.0 [as=d_comp_comp:23]
 
 # Test update with a subquery that requires an assignment cast.
 build
@@ -2098,7 +2098,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7::DECIMAL + c:9::DECIMAL
+      │    │    │    │    │              └── a:7 + c:9
       │    │    │    │    ├── max1-row
       │    │    │    │    │    ├── columns: n:13!null
       │    │    │    │    │    └── project
@@ -2112,7 +2112,7 @@ update decimals
       │    │    │         └── assignment-cast: DECIMAL(10) [as=a_cast:14]
       │    │    │              └── n:13
       │    │    └── projections
-      │    │         └── a_cast:14::DECIMAL + c:9::DECIMAL [as=d_comp:15]
+      │    │         └── a_cast:14 + c:9 [as=d_comp:15]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:16]
       │              └── d_comp:15
@@ -2146,7 +2146,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7::DECIMAL + c:9::DECIMAL
+      │    │    │    │    │              └── a:7 + c:9
       │    │    │    │    ├── max1-row
       │    │    │    │    │    ├── columns: u:13!null "?column?":18!null
       │    │    │    │    │    └── project
@@ -2166,7 +2166,7 @@ update decimals
       │    │    │         └── assignment-cast: DECIMAL(10,1) [as=c_cast:20]
       │    │    │              └── "?column?":18
       │    │    └── projections
-      │    │         └── a_cast:19::DECIMAL + c_cast:20::DECIMAL [as=d_comp:21]
+      │    │         └── a_cast:19 + c_cast:20 [as=d_comp:21]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:22]
       │              └── d_comp:21
@@ -2197,7 +2197,7 @@ update assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null assn_cast.crdb_internal_mvcc_timestamp:17 assn_cast.tableoid:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d_comp:15
-      │    │    │    │              └── d:14::DECIMAL + 10.0
+      │    │    │    │              └── d:14 + 10.0
       │    │    │    ├── max1-row
       │    │    │    │    ├── columns: "?column?":24!null "?column?":25!null
       │    │    │    │    └── project
@@ -2216,7 +2216,7 @@ update assn_cast
       │         └── assignment-cast: "char" [as=qc_cast:28]
       │              └── "?column?":24
       └── projections
-           └── d:14::DECIMAL + 10.0 [as=d_comp_comp:29]
+           └── d:14 + 10.0 [as=d_comp_comp:29]
 
 # Test ON UPDATE columns that require assignment casts.
 build

--- a/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
+++ b/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
@@ -30,9 +30,9 @@ with &1 (cte)
            │    │    │    │    ├── columns: a:7(int2) b:8(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid)
            │    │    │    │    └── computed column expressions
            │    │    │    │         └── t.c:9
-           │    │    │    │              └── a:7::INT8 + b:8::INT8 [type=int]
+           │    │    │    │              └── a:7 + b:8 [type=int]
            │    │    │    └── projections
-           │    │    │         └── a:7::INT8 + b:8::INT8 [as=t.c:9, type=int]
+           │    │    │         └── a:7 + b:8 [as=t.c:9, type=int]
            │    │    └── projections
            │    │         └── subquery [as=a_new:16, type=int2]
            │    │              └── max1-row
@@ -51,7 +51,7 @@ with &1 (cte)
            │    │                        │         └── t.c:9 [as=c:15, type=int2]
            │    │                        └── 1 [type=int]
            │    └── projections
-           │         └── a_new:16::INT8 + b:8::INT8 [as=c_comp:17, type=int]
+           │         └── a_new:16 + b:8 [as=c_comp:17, type=int]
            └── projections
                 └── assignment-cast: INT2 [as=c_cast:18, type=int2]
                      └── c_comp:17 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1771,7 +1771,7 @@ upsert decimals
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=c_cast:12]
       │    │    │    │    │    │    │              └── c_default:11
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a_cast:9::DECIMAL + c_cast:12::DECIMAL [as=d_comp:13]
+      │    │    │    │    │    │         └── a_cast:9 + c_cast:12 [as=d_comp:13]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:14]
       │    │    │    │    │              └── d_comp:13
@@ -1786,11 +1786,11 @@ upsert decimals
       │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d:18
-      │    │    │    │              └── a:15::DECIMAL + c:17::DECIMAL
+      │    │    │    │              └── a:15 + c:17
       │    │    │    └── filters
       │    │    │         └── a_cast:9 = a:15
       │    │    └── projections
-      │    │         └── a:15::DECIMAL + c:17::DECIMAL [as=d_comp:21]
+      │    │         └── a:15 + c:17 [as=d_comp:21]
       │    └── projections
       │         ├── CASE WHEN a:15 IS NULL THEN a_cast:9 ELSE a:15 END [as=upsert_a:22]
       │         ├── CASE WHEN a:15 IS NULL THEN c_cast:12 ELSE c:17 END [as=upsert_c:23]
@@ -1848,7 +1848,7 @@ upsert decimals
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=c_cast:11]
       │    │    │    │    │    │    │              └── c_default:10
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a_cast:8::DECIMAL + c_cast:11::DECIMAL [as=d_comp:12]
+      │    │    │    │    │    │         └── a_cast:8 + c_cast:11 [as=d_comp:12]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:13]
       │    │    │    │    │              └── d_comp:12
@@ -1863,11 +1863,11 @@ upsert decimals
       │    │    │    │    ├── columns: a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d:17
-      │    │    │    │              └── a:14::DECIMAL + c:16::DECIMAL
+      │    │    │    │              └── a:14 + c:16
       │    │    │    └── filters
       │    │    │         └── a_cast:8 = a:14
       │    │    └── projections
-      │    │         └── a:14::DECIMAL + c:16::DECIMAL [as=d_comp:20]
+      │    │         └── a:14 + c:16 [as=d_comp:20]
       │    └── projections
       │         ├── CASE WHEN a:14 IS NULL THEN a_cast:8 ELSE a:14 END [as=upsert_a:21]
       │         ├── CASE WHEN a:14 IS NULL THEN b_default:9 ELSE b:15 END [as=upsert_b:22]
@@ -1926,7 +1926,7 @@ upsert decimals
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=c_cast:11]
       │    │    │    │    │    │    │              └── c_default:10
       │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── a_cast:8::DECIMAL + c_cast:11::DECIMAL [as=d_comp:12]
+      │    │    │    │    │    │         └── a_cast:8 + c_cast:11 [as=d_comp:12]
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:13]
       │    │    │    │    │              └── d_comp:12
@@ -1941,11 +1941,11 @@ upsert decimals
       │    │    │    │    ├── columns: a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d:17
-      │    │    │    │              └── a:14::DECIMAL + c:16::DECIMAL
+      │    │    │    │              └── a:14 + c:16
       │    │    │    └── filters
       │    │    │         └── a_cast:8 = a:14
       │    │    └── projections
-      │    │         └── a:14::DECIMAL + c:16::DECIMAL [as=d_comp:20]
+      │    │         └── a:14 + c:16 [as=d_comp:20]
       │    └── projections
       │         ├── CASE WHEN a:14 IS NULL THEN a_cast:8 ELSE a:14 END [as=upsert_a:21]
       │         ├── CASE WHEN a:14 IS NULL THEN b_default:9 ELSE b:15 END [as=upsert_b:22]
@@ -2013,7 +2013,7 @@ upsert decimals
       │    │    │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=c_cast:12]
       │    │    │    │    │    │    │    │    │              └── c_default:11
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── a_cast:9::DECIMAL + c_cast:12::DECIMAL [as=d_comp:13]
+      │    │    │    │    │    │    │    │         └── a_cast:9 + c_cast:12 [as=d_comp:13]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:14]
       │    │    │    │    │    │    │              └── d_comp:13
@@ -2028,7 +2028,7 @@ upsert decimals
       │    │    │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    │    │    └── computed column expressions
       │    │    │    │    │    │         └── d:18
-      │    │    │    │    │    │              └── a:15::DECIMAL + c:17::DECIMAL
+      │    │    │    │    │    │              └── a:15 + c:17
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a_cast:9 = a:15
       │    │    │    │    └── projections
@@ -2037,7 +2037,7 @@ upsert decimals
       │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b_cast:22]
       │    │    │              └── b_new:21
       │    │    └── projections
-      │    │         └── a:15::DECIMAL + c:17::DECIMAL [as=d_comp:23]
+      │    │         └── a:15 + c:17 [as=d_comp:23]
       │    └── projections
       │         ├── CASE WHEN a:15 IS NULL THEN a_cast:9 ELSE a:15 END [as=upsert_a:24]
       │         ├── CASE WHEN a:15 IS NULL THEN b_cast:10 ELSE b_cast:22 END [as=upsert_b:25]
@@ -2105,7 +2105,7 @@ upsert decimals
       │    │    │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=c_cast:12]
       │    │    │    │    │    │    │    │    │              └── c_default:11
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── a_cast:9::DECIMAL + c_cast:12::DECIMAL [as=d_comp:13]
+      │    │    │    │    │    │    │    │         └── a_cast:9 + c_cast:12 [as=d_comp:13]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1) [as=d_cast:14]
       │    │    │    │    │    │    │              └── d_comp:13
@@ -2120,7 +2120,7 @@ upsert decimals
       │    │    │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    │    │    └── computed column expressions
       │    │    │    │    │    │         └── d:18
-      │    │    │    │    │    │              └── a:15::DECIMAL + c:17::DECIMAL
+      │    │    │    │    │    │              └── a:15 + c:17
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a_cast:9 = a:15
       │    │    │    │    └── projections
@@ -2129,7 +2129,7 @@ upsert decimals
       │    │    │         └── assignment-cast: DECIMAL(5,1)[] [as=b_cast:22]
       │    │    │              └── b_new:21
       │    │    └── projections
-      │    │         └── a:15::DECIMAL + c:17::DECIMAL [as=d_comp:23]
+      │    │         └── a:15 + c:17 [as=d_comp:23]
       │    └── projections
       │         ├── CASE WHEN a:15 IS NULL THEN a_cast:9 ELSE a:15 END [as=upsert_a:24]
       │         ├── CASE WHEN a:15 IS NULL THEN b_cast:10 ELSE b_cast:22 END [as=upsert_b:25]
@@ -2193,7 +2193,7 @@ upsert assn_cast
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         └── NULL::DECIMAL(10) [as=d_default:19]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── d_default:19::DECIMAL + 10.0 [as=d_comp_comp:20]
+      │    │    │    │    │         └── d_default:19 + 10.0 [as=d_comp_comp:20]
       │    │    │    │    └── projections
       │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:21]
       │    │    │    │              └── d_comp_comp:20
@@ -2214,11 +2214,11 @@ upsert assn_cast
       │    │    │    ├── columns: k:22!null c:23 qc:24 i:25 s:26 d:27 d_comp:28 crdb_internal_mvcc_timestamp:29 tableoid:30
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:28
-      │    │    │              └── d:27::DECIMAL + 10.0
+      │    │    │              └── d:27 + 10.0
       │    │    └── filters
       │    │         └── k_cast:15 = k:22
       │    └── projections
-      │         └── d:27::DECIMAL + 10.0 [as=d_comp_comp:31]
+      │         └── d:27 + 10.0 [as=d_comp_comp:31]
       └── projections
            ├── CASE WHEN k:22 IS NULL THEN k_cast:15 ELSE k:22 END [as=upsert_k:32]
            ├── CASE WHEN k:22 IS NULL THEN d_default:19 ELSE d:27 END [as=upsert_d:33]
@@ -2276,7 +2276,7 @@ upsert assn_cast
       │    │    │    │    │    │         ├── NULL::STRING [as=s_default:17]
       │    │    │    │    │    │         └── NULL::DECIMAL(10) [as=d_default:18]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── d_default:18::DECIMAL + 10.0 [as=d_comp_comp:19]
+      │    │    │    │    │         └── d_default:18 + 10.0 [as=d_comp_comp:19]
       │    │    │    │    └── projections
       │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:20]
       │    │    │    │              └── d_comp_comp:19
@@ -2297,11 +2297,11 @@ upsert assn_cast
       │    │    │    ├── columns: k:21!null c:22 qc:23 i:24 s:25 d:26 d_comp:27 crdb_internal_mvcc_timestamp:28 tableoid:29
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:27
-      │    │    │              └── d:26::DECIMAL + 10.0
+      │    │    │              └── d:26 + 10.0
       │    │    └── filters
       │    │         └── k_cast:14 = k:21
       │    └── projections
-      │         └── d:26::DECIMAL + 10.0 [as=d_comp_comp:30]
+      │         └── d:26 + 10.0 [as=d_comp_comp:30]
       └── projections
            ├── CASE WHEN k:21 IS NULL THEN k_cast:14 ELSE k:21 END [as=upsert_k:31]
            ├── CASE WHEN k:21 IS NULL THEN s_default:17 ELSE s:25 END [as=upsert_s:32]
@@ -2351,7 +2351,7 @@ insert assn_cast
       │    │    │    │    └── projections
       │    │    │    │         └── NULL::DECIMAL(10) [as=d_default:19]
       │    │    │    └── projections
-      │    │    │         └── d_default:19::DECIMAL + 10.0 [as=d_comp_comp:20]
+      │    │    │         └── d_default:19 + 10.0 [as=d_comp_comp:20]
       │    │    └── projections
       │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:21]
       │    │              └── d_comp_comp:20
@@ -2359,7 +2359,7 @@ insert assn_cast
       │    │    ├── columns: k:22!null c:23 qc:24 i:25 s:26 d:27 d_comp:28
       │    │    └── computed column expressions
       │    │         └── d_comp:28
-      │    │              └── d:27::DECIMAL + 10.0
+      │    │              └── d:27 + 10.0
       │    └── filters
       │         └── k_cast:15 = k:22
       └── aggregations
@@ -2433,7 +2433,7 @@ upsert assn_cast
       │    │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │    │         └── NULL::DECIMAL(10) [as=d_default:18]
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── d_default:18::DECIMAL + 10.0 [as=d_comp_comp:19]
+      │    │    │    │    │    │    │         └── d_default:18 + 10.0 [as=d_comp_comp:19]
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:20]
       │    │    │    │    │    │              └── d_comp_comp:19
@@ -2454,7 +2454,7 @@ upsert assn_cast
       │    │    │    │    │    ├── columns: k:21!null c:22 qc:23 i:24 s:25 d:26 d_comp:27 crdb_internal_mvcc_timestamp:28 tableoid:29
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d_comp:27
-      │    │    │    │    │              └── d:26::DECIMAL + 10.0
+      │    │    │    │    │              └── d:26 + 10.0
       │    │    │    │    └── filters
       │    │    │    │         └── k_cast:15 = k:21
       │    │    │    └── projections
@@ -2470,7 +2470,7 @@ upsert assn_cast
       │    │         └── assignment-cast: STRING [as=s_cast:36]
       │    │              └── s_new:33
       │    └── projections
-      │         └── d:26::DECIMAL + 10.0 [as=d_comp_comp:37]
+      │         └── d:26 + 10.0 [as=d_comp_comp:37]
       └── projections
            ├── CASE WHEN k:21 IS NULL THEN k_cast:15 ELSE k:21 END [as=upsert_k:38]
            ├── CASE WHEN k:21 IS NULL THEN c_cast:16 ELSE c_cast:34 END [as=upsert_c:39]
@@ -2528,7 +2528,7 @@ upsert assn_cast
       │    │    │    │    │    │         ├── NULL::STRING [as=s_default:15]
       │    │    │    │    │    │         └── NULL::DECIMAL(10) [as=d_default:16]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── d_default:16::DECIMAL + 10.0 [as=d_comp_comp:17]
+      │    │    │    │    │         └── d_default:16 + 10.0 [as=d_comp_comp:17]
       │    │    │    │    └── projections
       │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:18]
       │    │    │    │              └── d_comp_comp:17
@@ -2549,11 +2549,11 @@ upsert assn_cast
       │    │    │    ├── columns: k:19!null c:20 qc:21 i:22 s:23 d:24 d_comp:25 crdb_internal_mvcc_timestamp:26 tableoid:27
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:25
-      │    │    │              └── d:24::DECIMAL + 10.0
+      │    │    │              └── d:24 + 10.0
       │    │    └── filters
       │    │         └── column1:10 = k:19
       │    └── projections
-      │         └── d:24::DECIMAL + 10.0 [as=d_comp_comp:28]
+      │         └── d:24 + 10.0 [as=d_comp_comp:28]
       └── projections
            ├── CASE WHEN k:19 IS NULL THEN column1:10 ELSE k:19 END [as=upsert_k:29]
            ├── CASE WHEN k:19 IS NULL THEN c_default:13 ELSE c:20 END [as=upsert_c:30]
@@ -2609,7 +2609,7 @@ upsert assn_cast
       │    │    │    │    │    │    │    │         ├── NULL::STRING [as=s_default:14]
       │    │    │    │    │    │    │    │         └── NULL::DECIMAL(10) [as=d_default:15]
       │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │         └── d_default:15::DECIMAL + 10.0 [as=d_comp_comp:16]
+      │    │    │    │    │    │    │         └── d_default:15 + 10.0 [as=d_comp_comp:16]
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:17]
       │    │    │    │    │    │              └── d_comp_comp:16
@@ -2630,7 +2630,7 @@ upsert assn_cast
       │    │    │    │    │    ├── columns: k:18!null c:19 qc:20 i:21 s:22 d:23 d_comp:24 crdb_internal_mvcc_timestamp:25 tableoid:26
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d_comp:24
-      │    │    │    │    │              └── d:23::DECIMAL + 10.0
+      │    │    │    │    │              └── d:23 + 10.0
       │    │    │    │    └── filters
       │    │    │    │         └── column1:10 = k:18
       │    │    │    └── projections
@@ -2639,7 +2639,7 @@ upsert assn_cast
       │    │         └── assignment-cast: INT8 [as=i_cast:28]
       │    │              └── i_new:27
       │    └── projections
-      │         └── d:23::DECIMAL + 10.0 [as=d_comp_comp:29]
+      │         └── d:23 + 10.0 [as=d_comp_comp:29]
       └── projections
            ├── CASE WHEN k:18 IS NULL THEN column1:10 ELSE k:18 END [as=upsert_k:30]
            ├── CASE WHEN k:18 IS NULL THEN c_default:12 ELSE c:19 END [as=upsert_c:31]
@@ -2702,7 +2702,7 @@ upsert assn_cast
       │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
       │    │    │    │    │              └── i_default:15
       │    │    │    │    └── projections
-      │    │    │    │         └── d_cast:12::DECIMAL + 10.0 [as=d_comp_comp:18]
+      │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
       │    │    │    └── projections
       │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
       │    │    │              └── d_comp_comp:18
@@ -2723,7 +2723,7 @@ upsert assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
       │    │    └── computed column expressions
       │    │         └── d_comp:26
-      │    │              └── d:25::DECIMAL + 10.0
+      │    │              └── d:25 + 10.0
       │    └── filters
       │         └── column1:10 = k:20
       └── projections
@@ -2786,7 +2786,7 @@ upsert assn_cast
       │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
       │    │    │    │    │              └── i_default:15
       │    │    │    │    └── projections
-      │    │    │    │         └── d_cast:12::DECIMAL + 10.0 [as=d_comp_comp:18]
+      │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
       │    │    │    └── projections
       │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
       │    │    │              └── d_comp_comp:18
@@ -2807,7 +2807,7 @@ upsert assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
       │    │    └── computed column expressions
       │    │         └── d_comp:26
-      │    │              └── d:25::DECIMAL + 10.0
+      │    │              └── d:25 + 10.0
       │    └── filters
       │         └── column1:10 = k:20
       └── projections
@@ -2863,7 +2863,7 @@ insert assn_cast
       │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
       │    │    │    │              └── i_default:15
       │    │    │    └── projections
-      │    │    │         └── d_cast:12::DECIMAL + 10.0 [as=d_comp_comp:18]
+      │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
       │    │    └── projections
       │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
       │    │              └── d_comp_comp:18
@@ -2871,7 +2871,7 @@ insert assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26
       │    │    └── computed column expressions
       │    │         └── d_comp:26
-      │    │              └── d:25::DECIMAL + 10.0
+      │    │              └── d:25 + 10.0
       │    └── filters
       │         └── column1:10 = k:20
       └── aggregations
@@ -2949,7 +2949,7 @@ upsert assn_cast
       │    │    │    │    │    │    │    │    │         └── assignment-cast: INT8 [as=i_cast:17]
       │    │    │    │    │    │    │    │    │              └── i_default:15
       │    │    │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │    │    │         └── d_cast:12::DECIMAL + 10.0 [as=d_comp_comp:18]
+      │    │    │    │    │    │    │    │         └── d_cast:12 + 10.0 [as=d_comp_comp:18]
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:19]
       │    │    │    │    │    │    │              └── d_comp_comp:18
@@ -2970,7 +2970,7 @@ upsert assn_cast
       │    │    │    │    │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
       │    │    │    │    │    │    └── computed column expressions
       │    │    │    │    │    │         └── d_comp:26
-      │    │    │    │    │    │              └── d:25::DECIMAL + 10.0
+      │    │    │    │    │    │              └── d:25 + 10.0
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:10 = k:20
       │    │    │    │    └── projections
@@ -2979,7 +2979,7 @@ upsert assn_cast
       │    │    │         └── assignment-cast: DECIMAL(10) [as=d_cast:30]
       │    │    │              └── d_new:29
       │    │    └── projections
-      │    │         └── d_cast:30::DECIMAL + 10.0 [as=d_comp_comp:31]
+      │    │         └── d_cast:30 + 10.0 [as=d_comp_comp:31]
       │    └── projections
       │         └── assignment-cast: DECIMAL(10) [as=d_comp_cast:32]
       │              └── d_comp_comp:31

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2028,7 +2028,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:14 = p.productid:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
  │    │    │    └── projections
- │    │    │         └── li.quantity:15::INT8 * cost:20::DECIMAL [as=column24:24, outer=(15,20), immutable]
+ │    │    │         └── li.quantity:15 * cost:20 [as=column24:24, outer=(15,20), immutable]
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
  │    │    │    ├── left ordering: +1,+2
@@ -2205,7 +2205,7 @@ project
  │    │    │    │    │    │    └── filters
  │    │    │    │    │    │         └── li.productid:25 = p.productid:29 [outer=(25,29), constraints=(/25: (/NULL - ]; /29: (/NULL - ]), fd=(25)==(29), (29)==(25)]
  │    │    │    │    │    └── projections
- │    │    │    │    │         └── li.quantity:26::INT8 * p.cost:31::DECIMAL [as=column35:35, outer=(26,31), immutable]
+ │    │    │    │    │         └── li.quantity:26 * p.cost:31 [as=column35:35, outer=(26,31), immutable]
  │    │    │    │    └── filters
  │    │    │    │         ├── li.customerid:23 = orders1_.customerid:6 [outer=(6,23), constraints=(/6: (/NULL - ]; /23: (/NULL - ]), fd=(6)==(23), (23)==(6)]
  │    │    │    │         └── li.ordernumber:24 = orders1_.ordernumber:7 [outer=(7,24), constraints=(/7: (/NULL - ]; /24: (/NULL - ]), fd=(7)==(24), (24)==(7)]
@@ -2323,7 +2323,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:14 = p.productid:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
  │    │    │    └── projections
- │    │    │         └── li.quantity:15::INT8 * cost:20::DECIMAL [as=column24:24, outer=(15,20), immutable]
+ │    │    │         └── li.quantity:15 * cost:20 [as=column24:24, outer=(15,20), immutable]
  │    │    ├── left-join (merge)
  │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
  │    │    │    ├── left ordering: +1,+2
@@ -2421,7 +2421,7 @@ project
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:8 = p.productid:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
  │    │    │    └── projections
- │    │    │         └── quantity:9::INT8 * cost:14::DECIMAL [as=column18:18, outer=(9,14), immutable]
+ │    │    │         └── quantity:9 * cost:14 [as=column18:18, outer=(9,14), immutable]
  │    │    └── filters
  │    │         ├── li.customerid:6 = order0_.customerid:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
  │    │         └── li.ordernumber:7 = order0_.ordernumber:2 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -457,7 +457,7 @@ project
            │    └── fd: ()-->(12-20)
            └── projections
                 └── assignment-cast: DECIMAL(12,2) [as=w_ytd_cast:24, outer=(20), immutable]
-                     └── w_ytd:20::DECIMAL + 3860.61
+                     └── w_ytd:20 + 3860.61
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -492,7 +492,7 @@ project
            │    └── fd: ()-->(14-24)
            └── projections
                 └── assignment-cast: DECIMAL(12,2) [as=d_ytd_cast:28, outer=(23), immutable]
-                     └── d_ytd:23::DECIMAL + 3860.61
+                     └── d_ytd:23 + 3860.61
 
 opt format=hide-qual
 SELECT c_id
@@ -585,11 +585,11 @@ project
  │         │    └── fd: ()-->(24-44)
  │         └── projections
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:51, outer=(40), immutable]
- │              │    └── c_balance:40::DECIMAL - 3860.61
+ │              │    └── c_balance:40 - 3860.61
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_ytd_payment_cast:52, outer=(41), immutable]
- │              │    └── c_ytd_payment:41::DECIMAL + 3860.61
+ │              │    └── c_ytd_payment:41 + 3860.61
  │              ├── assignment-cast: VARCHAR(500) [as=c_data_cast:53, outer=(24-26,37,44), immutable]
- │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44::STRING, 500) ELSE c_data:44::STRING END
+ │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500) ELSE c_data:44::STRING END
  │              └── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:54, outer=(14,21), immutable]
@@ -910,7 +910,7 @@ update customer
       │    └── fd: ()-->(26), (24,25)-->(27-44)
       └── projections
            ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:49, outer=(25,40), immutable]
-           │    └── c_balance:40::DECIMAL + CASE c_d_id:25 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END
+           │    └── c_balance:40 + CASE c_d_id:25 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END
            └── c_delivery_cnt:43 + 1 [as=c_delivery_cnt_new:47, outer=(43), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -460,7 +460,7 @@ project
            │    └── fd: ()-->(12-20)
            └── projections
                 └── assignment-cast: DECIMAL(12,2) [as=w_ytd_cast:24, outer=(20), immutable]
-                     └── w_ytd:20::DECIMAL + 3860.61
+                     └── w_ytd:20 + 3860.61
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -495,7 +495,7 @@ project
            │    └── fd: ()-->(14-24)
            └── projections
                 └── assignment-cast: DECIMAL(12,2) [as=d_ytd_cast:28, outer=(23), immutable]
-                     └── d_ytd:23::DECIMAL + 3860.61
+                     └── d_ytd:23 + 3860.61
 
 opt format=hide-qual
 SELECT c_id
@@ -588,11 +588,11 @@ project
  │         │    └── fd: ()-->(24-44)
  │         └── projections
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:51, outer=(40), immutable]
- │              │    └── c_balance:40::DECIMAL - 3860.61
+ │              │    └── c_balance:40 - 3860.61
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_ytd_payment_cast:52, outer=(41), immutable]
- │              │    └── c_ytd_payment:41::DECIMAL + 3860.61
+ │              │    └── c_ytd_payment:41 + 3860.61
  │              ├── assignment-cast: VARCHAR(500) [as=c_data_cast:53, outer=(24-26,37,44), immutable]
- │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44::STRING, 500) ELSE c_data:44::STRING END
+ │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500) ELSE c_data:44::STRING END
  │              └── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:54, outer=(14,21), immutable]
@@ -913,7 +913,7 @@ update customer
       │    └── fd: ()-->(26), (24,25)-->(27-44)
       └── projections
            ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:49, outer=(25,40), immutable]
-           │    └── c_balance:40::DECIMAL + CASE c_d_id:25 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END
+           │    └── c_balance:40 + CASE c_d_id:25 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END
            └── c_delivery_cnt:43 + 1 [as=c_delivery_cnt_new:47, outer=(43), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -454,7 +454,7 @@ project
            │    └── fd: ()-->(12-20)
            └── projections
                 └── assignment-cast: DECIMAL(12,2) [as=w_ytd_cast:24, outer=(20), immutable]
-                     └── w_ytd:20::DECIMAL + 3860.61
+                     └── w_ytd:20 + 3860.61
 
 opt format=hide-qual
 UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
@@ -489,7 +489,7 @@ project
            │    └── fd: ()-->(14-24)
            └── projections
                 └── assignment-cast: DECIMAL(12,2) [as=d_ytd_cast:28, outer=(23), immutable]
-                     └── d_ytd:23::DECIMAL + 3860.61
+                     └── d_ytd:23 + 3860.61
 
 opt format=hide-qual
 SELECT c_id
@@ -582,11 +582,11 @@ project
  │         │    └── fd: ()-->(24-44)
  │         └── projections
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:51, outer=(40), immutable]
- │              │    └── c_balance:40::DECIMAL - 3860.61
+ │              │    └── c_balance:40 - 3860.61
  │              ├── assignment-cast: DECIMAL(12,2) [as=c_ytd_payment_cast:52, outer=(41), immutable]
- │              │    └── c_ytd_payment:41::DECIMAL + 3860.61
+ │              │    └── c_ytd_payment:41 + 3860.61
  │              ├── assignment-cast: VARCHAR(500) [as=c_data_cast:53, outer=(24-26,37,44), immutable]
- │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44::STRING, 500) ELSE c_data:44::STRING END
+ │              │    └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500) ELSE c_data:44::STRING END
  │              └── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
  └── projections
       └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:54, outer=(14,21), immutable]
@@ -912,7 +912,7 @@ update customer
       │    └── fd: ()-->(26), (24,25)-->(27-44)
       └── projections
            ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:49, outer=(25,40), immutable]
-           │    └── c_balance:40::DECIMAL + CASE c_d_id:25 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END
+           │    └── c_balance:40 + CASE c_d_id:25 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END
            └── c_delivery_cnt:43 + 1 [as=c_delivery_cnt_new:47, outer=(43), immutable]
 
 opt format=hide-qual

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -97,7 +97,7 @@ sort
       │    │    │    └── filters
       │    │    │         └── sc_id:1 = in_sc_id:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │    │    └── projections
-      │    │         └── tr_qty:42::INT8 * tr_bid_price:43::DECIMAL [as=column54:54, outer=(42,43), immutable]
+      │    │         └── tr_qty:42 * tr_bid_price:43 [as=column54:54, outer=(42,43), immutable]
       │    └── aggregations
       │         └── sum [as=sum:55, outer=(54)]
       │              └── column54:54
@@ -199,7 +199,7 @@ sort
       │    │    │    └── filters
       │    │    │         └── in_id:49 = co_in_id:37 [outer=(37,49), constraints=(/37: (/NULL - ]; /49: (/NULL - ]), fd=(37)==(49), (49)==(37)]
       │    │    └── projections
-      │    │         └── tr_qty:11::INT8 * tr_bid_price:12::DECIMAL [as=column54:54, outer=(11,12), immutable]
+      │    │         └── tr_qty:11 * tr_bid_price:12 [as=column54:54, outer=(11,12), immutable]
       │    └── aggregations
       │         └── sum [as=sum:55, outer=(54)]
       │              └── column54:54
@@ -361,7 +361,7 @@ top-k
       │    │    │    │    └── filters (true)
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         └── hs_qty:11::INT8 * lt_price:16::DECIMAL [as=column21:21, outer=(11,16), immutable]
+      │    │         └── hs_qty:11 * lt_price:16 [as=column21:21, outer=(11,16), immutable]
       │    └── aggregations
       │         ├── sum [as=sum:22, outer=(21)]
       │         │    └── column21:21
@@ -439,7 +439,7 @@ top-k
       │    │    │    │    └── filters (true)
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         └── hs_qty:11::INT8 * lt_price:16::DECIMAL [as=column21:21, outer=(11,16), immutable]
+      │    │         └── hs_qty:11 * lt_price:16 [as=column21:21, outer=(11,16), immutable]
       │    └── aggregations
       │         ├── sum [as=sum:22, outer=(21)]
       │         │    └── column21:21
@@ -865,8 +865,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:31 * dm_close:12::DECIMAL [as=column43:43, outer=(12,31), immutable]
- │    │         └── s_num_out:31 * lt_price:20::DECIMAL [as=column45:45, outer=(20,31), immutable]
+ │    │         ├── s_num_out:31 * dm_close:12 [as=column43:43, outer=(12,31), immutable]
+ │    │         └── s_num_out:31 * lt_price:20 [as=column45:45, outer=(20,31), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:44, outer=(43)]
  │         │    └── column43:43
@@ -947,8 +947,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:31 * dm_close:12::DECIMAL [as=column43:43, outer=(12,31), immutable]
- │    │         └── s_num_out:31 * lt_price:20::DECIMAL [as=column45:45, outer=(20,31), immutable]
+ │    │         ├── s_num_out:31 * dm_close:12 [as=column43:43, outer=(12,31), immutable]
+ │    │         └── s_num_out:31 * lt_price:20 [as=column45:45, outer=(20,31), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:44, outer=(43)]
  │         │    └── column43:43
@@ -1049,8 +1049,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:57 * dm_close:38::DECIMAL [as=column69:69, outer=(38,57), immutable]
- │    │         └── s_num_out:57 * lt_price:46::DECIMAL [as=column71:71, outer=(46,57), immutable]
+ │    │         ├── s_num_out:57 * dm_close:38 [as=column69:69, outer=(38,57), immutable]
+ │    │         └── s_num_out:57 * lt_price:46 [as=column71:71, outer=(46,57), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:70, outer=(69)]
  │         │    └── column69:69
@@ -1150,8 +1150,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:57 * dm_close:38::DECIMAL [as=column69:69, outer=(38,57), immutable]
- │    │         └── s_num_out:57 * lt_price:46::DECIMAL [as=column71:71, outer=(46,57), immutable]
+ │    │         ├── s_num_out:57 * dm_close:38 [as=column69:69, outer=(38,57), immutable]
+ │    │         └── s_num_out:57 * lt_price:46 [as=column71:71, outer=(46,57), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:70, outer=(69)]
  │         │    └── column69:69
@@ -1226,8 +1226,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:28 * dm_close:9::DECIMAL [as=column40:40, outer=(9,28), immutable]
- │    │         └── s_num_out:28 * lt_price:17::DECIMAL [as=column42:42, outer=(17,28), immutable]
+ │    │         ├── s_num_out:28 * dm_close:9 [as=column40:40, outer=(9,28), immutable]
+ │    │         └── s_num_out:28 * lt_price:17 [as=column42:42, outer=(17,28), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:41, outer=(40)]
  │         │    └── column40:40
@@ -1304,8 +1304,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:28 * dm_close:9::DECIMAL [as=column40:40, outer=(9,28), immutable]
- │    │         └── s_num_out:28 * lt_price:17::DECIMAL [as=column42:42, outer=(17,28), immutable]
+ │    │         ├── s_num_out:28 * dm_close:9 [as=column40:40, outer=(9,28), immutable]
+ │    │         └── s_num_out:28 * lt_price:17 [as=column42:42, outer=(17,28), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:41, outer=(40)]
  │         │    └── column40:40
@@ -2835,7 +2835,7 @@ project
  └── projections
       └── cast: FLOAT8 [as=float8:24, outer=(6), immutable, subquery]
            └── plus
-                ├── ca_bal:6::DECIMAL
+                ├── ca_bal:6
                 └── subquery
                      └── project
                           ├── columns: ca_assets:23
@@ -2866,7 +2866,7 @@ project
                           │    │    │    │    └── fd: ()-->(9), (10)-->(11)
                           │    │    │    └── filters (true)
                           │    │    └── projections
-                          │    │         └── hs_qty:11::INT8 * lt_price:16::DECIMAL [as=column21:21, outer=(11,16), immutable]
+                          │    │         └── hs_qty:11 * lt_price:16 [as=column21:21, outer=(11,16), immutable]
                           │    └── aggregations
                           │         └── sum [as=sum:22, outer=(21)]
                           │              └── column21:21
@@ -3673,7 +3673,7 @@ update holding_summary
       │    └── fd: ()-->(6-8)
       └── projections
            └── assignment-cast: INT4 [as=hs_qty_cast:12, outer=(8), immutable]
-                └── hs_qty:8::INT8 + 10
+                └── hs_qty:8 + 10
 
 # Q5
 opt
@@ -3804,7 +3804,7 @@ update holding
       │    └── fd: ()-->(9-14)
       └── projections
            └── assignment-cast: INT4 [as=h_qty_cast:18, outer=(14), immutable]
-                └── h_qty:14::INT8 + 10
+                └── h_qty:14 + 10
 
 # Q9
 opt
@@ -4262,7 +4262,7 @@ with &2 (update_trade_commission)
       │    │         │    └── fd: ()-->(60,63,64)
       │    │         └── projections
       │    │              ├── assignment-cast: DECIMAL(12,2) [as=b_comm_total_cast:69, outer=(64), immutable]
-      │    │              │    └── b_comm_total:64::DECIMAL + 5E+1
+      │    │              │    └── b_comm_total:64 + 5E+1
       │    │              └── b_num_trades:63 + 1 [as=b_num_trades_new:68, outer=(63), immutable]
       │    └── projections
       │         └── 1 [as="?column?":70]
@@ -4490,7 +4490,7 @@ with &2 (insert_settlement)
            │         │    └── fd: ()-->(71-76)
            │         └── projections
            │              └── assignment-cast: DECIMAL(12,2) [as=ca_bal_cast:80, outer=(76), immutable]
-           │                   └── customer_account.ca_bal:76::DECIMAL + 1E+2
+           │                   └── customer_account.ca_bal:76 + 1E+2
            └── projections
                 └── customer_account.ca_bal:68::FLOAT8 [as=ca_bal:82, outer=(68), immutable]
 
@@ -5854,7 +5854,7 @@ update exchange
       │    └── fd: (10)-->(11-16)
       └── projections
            └── assignment-cast: VARCHAR(150) [as=ex_desc_cast:20, outer=(15), immutable]
-                └── CASE ex_desc:15 NOT LIKE '%LAST UPDATED%' WHEN true THEN (ex_desc:15::STRING || ' LAST UPDATED ') || '2017-05-10 13:00:00' ELSE substring(ex_desc:15, 1, length(ex_desc:15) - 19) || '2017-05-10 13:00:00' END
+                └── CASE ex_desc:15 NOT LIKE '%LAST UPDATED%' WHEN true THEN (ex_desc:15 || ' LAST UPDATED ') || '2017-05-10 13:00:00' ELSE substring(ex_desc:15, 1, length(ex_desc:15) - 19) || '2017-05-10 13:00:00' END
 
 # Q11
 opt

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -94,7 +94,7 @@ sort
       │    │    │    │         └── s_symb:21 = tr_s_symb:41 [outer=(21,41), constraints=(/21: (/NULL - ]; /41: (/NULL - ]), fd=(21)==(41), (41)==(21)]
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         └── tr_qty:42::INT8 * tr_bid_price:43::DECIMAL [as=column54:54, outer=(42,43), immutable]
+      │    │         └── tr_qty:42 * tr_bid_price:43 [as=column54:54, outer=(42,43), immutable]
       │    └── aggregations
       │         └── sum [as=sum:55, outer=(54)]
       │              └── column54:54
@@ -221,7 +221,7 @@ sort
       │    │    │    └── filters
       │    │    │         └── in_id:49 = co_in_id:37 [outer=(37,49), constraints=(/37: (/NULL - ]; /49: (/NULL - ]), fd=(37)==(49), (49)==(37)]
       │    │    └── projections
-      │    │         └── tr_qty:11::INT8 * tr_bid_price:12::DECIMAL [as=column54:54, outer=(11,12), immutable]
+      │    │         └── tr_qty:11 * tr_bid_price:12 [as=column54:54, outer=(11,12), immutable]
       │    └── aggregations
       │         └── sum [as=sum:55, outer=(54)]
       │              └── column54:54
@@ -383,7 +383,7 @@ top-k
       │    │    │    │    └── filters (true)
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         └── hs_qty:11::INT8 * lt_price:16::DECIMAL [as=column21:21, outer=(11,16), immutable]
+      │    │         └── hs_qty:11 * lt_price:16 [as=column21:21, outer=(11,16), immutable]
       │    └── aggregations
       │         ├── sum [as=sum:22, outer=(21)]
       │         │    └── column21:21
@@ -461,7 +461,7 @@ top-k
       │    │    │    │    └── filters (true)
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         └── hs_qty:11::INT8 * lt_price:16::DECIMAL [as=column21:21, outer=(11,16), immutable]
+      │    │         └── hs_qty:11 * lt_price:16 [as=column21:21, outer=(11,16), immutable]
       │    └── aggregations
       │         ├── sum [as=sum:22, outer=(21)]
       │         │    └── column21:21
@@ -888,8 +888,8 @@ project
  │    │    │    └── filters
  │    │    │         └── symb:9 = dm_s_symb:11 [outer=(9,11), constraints=(/9: (/NULL - ]; /11: (/NULL - ]), fd=(9)==(11), (11)==(9)]
  │    │    └── projections
- │    │         ├── s_num_out:31 * dm_close:12::DECIMAL [as=column43:43, outer=(12,31), immutable]
- │    │         └── s_num_out:31 * lt_price:20::DECIMAL [as=column45:45, outer=(20,31), immutable]
+ │    │         ├── s_num_out:31 * dm_close:12 [as=column43:43, outer=(12,31), immutable]
+ │    │         └── s_num_out:31 * lt_price:20 [as=column45:45, outer=(20,31), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:44, outer=(43)]
  │         │    └── column43:43
@@ -970,8 +970,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:31 * dm_close:12::DECIMAL [as=column43:43, outer=(12,31), immutable]
- │    │         └── s_num_out:31 * lt_price:20::DECIMAL [as=column45:45, outer=(20,31), immutable]
+ │    │         ├── s_num_out:31 * dm_close:12 [as=column43:43, outer=(12,31), immutable]
+ │    │         └── s_num_out:31 * lt_price:20 [as=column45:45, outer=(20,31), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:44, outer=(43)]
  │         │    └── column43:43
@@ -1076,8 +1076,8 @@ project
  │    │    │    └── filters
  │    │    │         └── symb:35 = dm_s_symb:37 [outer=(35,37), constraints=(/35: (/NULL - ]; /37: (/NULL - ]), fd=(35)==(37), (37)==(35)]
  │    │    └── projections
- │    │         ├── s_num_out:57 * dm_close:38::DECIMAL [as=column69:69, outer=(38,57), immutable]
- │    │         └── s_num_out:57 * lt_price:46::DECIMAL [as=column71:71, outer=(46,57), immutable]
+ │    │         ├── s_num_out:57 * dm_close:38 [as=column69:69, outer=(38,57), immutable]
+ │    │         └── s_num_out:57 * lt_price:46 [as=column71:71, outer=(46,57), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:70, outer=(69)]
  │         │    └── column69:69
@@ -1177,8 +1177,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:57 * dm_close:38::DECIMAL [as=column69:69, outer=(38,57), immutable]
- │    │         └── s_num_out:57 * lt_price:46::DECIMAL [as=column71:71, outer=(46,57), immutable]
+ │    │         ├── s_num_out:57 * dm_close:38 [as=column69:69, outer=(38,57), immutable]
+ │    │         └── s_num_out:57 * lt_price:46 [as=column71:71, outer=(46,57), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:70, outer=(69)]
  │         │    └── column69:69
@@ -1261,8 +1261,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:28 * dm_close:9::DECIMAL [as=column40:40, outer=(9,28), immutable]
- │    │         └── s_num_out:28 * lt_price:17::DECIMAL [as=column42:42, outer=(17,28), immutable]
+ │    │         ├── s_num_out:28 * dm_close:9 [as=column40:40, outer=(9,28), immutable]
+ │    │         └── s_num_out:28 * lt_price:17 [as=column42:42, outer=(17,28), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:41, outer=(40)]
  │         │    └── column40:40
@@ -1339,8 +1339,8 @@ project
  │    │    │    │    └── filters (true)
  │    │    │    └── filters (true)
  │    │    └── projections
- │    │         ├── s_num_out:28 * dm_close:9::DECIMAL [as=column40:40, outer=(9,28), immutable]
- │    │         └── s_num_out:28 * lt_price:17::DECIMAL [as=column42:42, outer=(17,28), immutable]
+ │    │         ├── s_num_out:28 * dm_close:9 [as=column40:40, outer=(9,28), immutable]
+ │    │         └── s_num_out:28 * lt_price:17 [as=column42:42, outer=(17,28), immutable]
  │    └── aggregations
  │         ├── sum [as=sum:41, outer=(40)]
  │         │    └── column40:40
@@ -2866,7 +2866,7 @@ project
  └── projections
       └── cast: FLOAT8 [as=float8:24, outer=(6), immutable, subquery]
            └── plus
-                ├── ca_bal:6::DECIMAL
+                ├── ca_bal:6
                 └── subquery
                      └── project
                           ├── columns: ca_assets:23
@@ -2897,7 +2897,7 @@ project
                           │    │    │    │    └── fd: ()-->(9), (10)-->(11)
                           │    │    │    └── filters (true)
                           │    │    └── projections
-                          │    │         └── hs_qty:11::INT8 * lt_price:16::DECIMAL [as=column21:21, outer=(11,16), immutable]
+                          │    │         └── hs_qty:11 * lt_price:16 [as=column21:21, outer=(11,16), immutable]
                           │    └── aggregations
                           │         └── sum [as=sum:22, outer=(21)]
                           │              └── column21:21
@@ -3704,7 +3704,7 @@ update holding_summary
       │    └── fd: ()-->(6-8)
       └── projections
            └── assignment-cast: INT4 [as=hs_qty_cast:12, outer=(8), immutable]
-                └── hs_qty:8::INT8 + 10
+                └── hs_qty:8 + 10
 
 # Q5
 opt
@@ -3835,7 +3835,7 @@ update holding
       │    └── fd: ()-->(9-14)
       └── projections
            └── assignment-cast: INT4 [as=h_qty_cast:18, outer=(14), immutable]
-                └── h_qty:14::INT8 + 10
+                └── h_qty:14 + 10
 
 # Q9
 opt
@@ -4287,7 +4287,7 @@ with &2 (update_trade_commission)
       │    │         │    └── fd: ()-->(60,63,64)
       │    │         └── projections
       │    │              ├── assignment-cast: DECIMAL(12,2) [as=b_comm_total_cast:69, outer=(64), immutable]
-      │    │              │    └── b_comm_total:64::DECIMAL + 5E+1
+      │    │              │    └── b_comm_total:64 + 5E+1
       │    │              └── b_num_trades:63 + 1 [as=b_num_trades_new:68, outer=(63), immutable]
       │    └── projections
       │         └── 1 [as="?column?":70]
@@ -4515,7 +4515,7 @@ with &2 (insert_settlement)
            │         │    └── fd: ()-->(71-76)
            │         └── projections
            │              └── assignment-cast: DECIMAL(12,2) [as=ca_bal_cast:80, outer=(76), immutable]
-           │                   └── customer_account.ca_bal:76::DECIMAL + 1E+2
+           │                   └── customer_account.ca_bal:76 + 1E+2
            └── projections
                 └── customer_account.ca_bal:68::FLOAT8 [as=ca_bal:82, outer=(68), immutable]
 
@@ -5866,7 +5866,7 @@ update exchange
       │    └── fd: (10)-->(11-16)
       └── projections
            └── assignment-cast: VARCHAR(150) [as=ex_desc_cast:20, outer=(15), immutable]
-                └── CASE ex_desc:15 NOT LIKE '%LAST UPDATED%' WHEN true THEN (ex_desc:15::STRING || ' LAST UPDATED ') || '2017-05-10 13:00:00' ELSE substring(ex_desc:15, 1, length(ex_desc:15) - 19) || '2017-05-10 13:00:00' END
+                └── CASE ex_desc:15 NOT LIKE '%LAST UPDATED%' WHEN true THEN (ex_desc:15 || ' LAST UPDATED ') || '2017-05-10 13:00:00' ELSE substring(ex_desc:15, 1, length(ex_desc:15) - 19) || '2017-05-10 13:00:00' END
 
 # Q11
 opt

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1018,9 +1018,9 @@ sort
       │    │    └── filters
       │    │         └── id:20 = transactiondetails.cardid:4 [outer=(4,20), constraints=(/4: (/NULL - ]; /20: (/NULL - ]), fd=(4)==(20), (20)==(4)]
       │    └── projections
-      │         ├── quantity:5 * transactiondetails.sellprice:6::DECIMAL [as=column39:39, outer=(5,6), immutable]
-      │         ├── quantity:5 * transactiondetails.buyprice:7::DECIMAL [as=column41:41, outer=(5,7), immutable]
-      │         ├── quantity:5 * (transactiondetails.sellprice:6::DECIMAL - transactiondetails.buyprice:7::DECIMAL) [as=column43:43, outer=(5-7), immutable]
+      │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column39:39, outer=(5,6), immutable]
+      │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column41:41, outer=(5,7), immutable]
+      │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column43:43, outer=(5-7), immutable]
       │         └── extract('day', transactiondate:3) [as=column45:45, outer=(3), stable]
       └── aggregations
            ├── sum [as=sum:40, outer=(39)]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1022,9 +1022,9 @@ sort
       │    │    └── filters
       │    │         └── id:24 = transactiondetails.cardid:4 [outer=(4,24), constraints=(/4: (/NULL - ]; /24: (/NULL - ]), fd=(4)==(24), (24)==(4)]
       │    └── projections
-      │         ├── quantity:5 * transactiondetails.sellprice:6::DECIMAL [as=column47:47, outer=(5,6), immutable]
-      │         ├── quantity:5 * transactiondetails.buyprice:7::DECIMAL [as=column49:49, outer=(5,7), immutable]
-      │         ├── quantity:5 * (transactiondetails.sellprice:6::DECIMAL - transactiondetails.buyprice:7::DECIMAL) [as=column51:51, outer=(5-7), immutable]
+      │         ├── transactiondetails.sellprice:6 * quantity:5 [as=column47:47, outer=(5,6), immutable]
+      │         ├── transactiondetails.buyprice:7 * quantity:5 [as=column49:49, outer=(5,7), immutable]
+      │         ├── quantity:5 * (transactiondetails.sellprice:6 - transactiondetails.buyprice:7) [as=column51:51, outer=(5-7), immutable]
       │         └── extract('day', transactiondate:3) [as=column53:53, outer=(3), stable]
       └── aggregations
            ├── sum [as=sum:48, outer=(47)]
@@ -1572,7 +1572,7 @@ update cardsinfo [as=ci]
       │              └── q:37
       └── projections
            ├── assignment-cast: DECIMAL(10,4) [as=discountbuyprice_cast:53, outer=(23,25), immutable]
-           │    └── buyprice:23::DECIMAL - discount:25::DECIMAL
+           │    └── buyprice:23 - discount:25
            ├── CAST(NULL AS STRING) [as=notes_default:50]
            ├── 0 [as=oldinventory_default:51]
            └── COALESCE(sum_int:47, 0) [as=actualinventory_new:49, outer=(47)]


### PR DESCRIPTION
Fixes #85106 

Previously, the optbuilder would insert spurious casts in binary
operators while building a plan to avoid a tricky type checking case.
This got in the way of checking for inverted filter support for
trigrams. Now, the code only inserts the cast if necessary (if the input
expression is NULL).

Release note: None