### PR TITLE
release-22.1: sql: fix migrating empty prepared statement

### DIFF
--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -243,8 +243,14 @@ func unaryNegation(e tree.Expr) tree.Expr {
 
 // Parse parses a sql statement string and returns a list of Statements.
 func Parse(sql string) (Statements, error) {
+	return ParseWithInt(sql, defaultNakedIntType)
+}
+
+// ParseWithInt parses a sql statement string and returns a list of
+// Statements. The INT token will result in the specified TInt type.
+func ParseWithInt(sql string, nakedIntType *types.T) (Statements, error) {
 	var p Parser
-	return p.parseWithDepth(1, sql, defaultNakedIntType)
+	return p.parseWithDepth(1, sql, nakedIntType)
 }
 
 // ParseOne parses a sql statement string, ensuring that it contains only a

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -140,13 +140,21 @@ func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, erro
 	}
 
 	for _, prepStmt := range m.PreparedStatements {
-		parserStmt, err := parser.ParseOneWithInt(
-			prepStmt.SQL,
-			parser.NakedIntTypeFromDefaultIntSize(sd.DefaultIntSize),
+		stmts, err := parser.ParseWithInt(
+			prepStmt.SQL, parser.NakedIntTypeFromDefaultIntSize(sd.DefaultIntSize),
 		)
 		if err != nil {
 			return nil, err
 		}
+		if len(stmts) > 1 {
+			// The pgwire protocol only allows at most 1 statement here.
+			return nil, pgerror.WrongNumberOfPreparedStatements(len(stmts))
+		}
+		var parserStmt parser.Statement
+		if len(stmts) == 1 {
+			parserStmt = stmts[0]
+		}
+		// len(stmts) == 0 results in a nil (empty) statement.
 		id := GenerateClusterWideID(evalCtx.ExecCfg.Clock.Now(), evalCtx.ExecCfg.NodeID.SQLInstanceID())
 		stmt := makeStatement(parserStmt, id)
 

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -33,6 +33,13 @@ wire_prepare s4
 INSERT INTO t2 VALUES($1, $2)
 ----
 
+wire_prepare s_empty
+;
+----
+
+wire_exec s_empty
+----
+
 wire_exec s2 1 cat 2022-02-10
 ----
 ERROR: relation "t" does not exist (SQLSTATE 42P01)
@@ -73,6 +80,9 @@ query
 EXECUTE s1
 ----
 1
+
+wire_exec s_empty
+----
 
 # The s2 and s3 statements should experience the same errors that they did
 # before the session migration.


### PR DESCRIPTION
Backport 1/1 commits from #84945.

/cc @cockroachdb/release


Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/84640

Release note (bug fix): The crdb_internal.deserialize_session builtin
function no longer causes an error when handling an empty preprared
statement.
