### PR TITLE
release-22.1: eval: stop ignoring all ResolveOIDFromOID errors

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -159,15 +159,15 @@ type DummyEvalPlanner struct{}
 // ResolveOIDFromString is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) ResolveOIDFromString(
 	ctx context.Context, resultType *types.T, toResolve *tree.DString,
-) (*tree.DOid, error) {
-	return nil, errors.WithStack(errEvalPlanner)
+) (*tree.DOid, bool, error) {
+	return nil, false, errors.WithStack(errEvalPlanner)
 }
 
 // ResolveOIDFromOID is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) ResolveOIDFromOID(
 	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
-) (*tree.DOid, error) {
-	return nil, errors.WithStack(errEvalPlanner)
+) (*tree.DOid, bool, error) {
+	return nil, false, errors.WithStack(errEvalPlanner)
 }
 
 // UnsafeUpsertDescriptor is part of the EvalPlanner interface.

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -28,7 +28,7 @@ import (
 // ResolveOIDFromString is part of tree.TypeResolver.
 func (p *planner) ResolveOIDFromString(
 	ctx context.Context, resultType *types.T, toResolve *tree.DString,
-) (*tree.DOid, error) {
+) (_ *tree.DOid, errSafeToIgnore bool, _ error) {
 	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
 	return resolveOID(
 		ctx, p.Txn(),
@@ -40,7 +40,7 @@ func (p *planner) ResolveOIDFromString(
 // ResolveOIDFromOID is part of tree.TypeResolver.
 func (p *planner) ResolveOIDFromOID(
 	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
-) (*tree.DOid, error) {
+) (_ *tree.DOid, errSafeToIgnore bool, _ error) {
 	ie := p.ExecCfg().InternalExecutorFactory(ctx, p.SessionData())
 	return resolveOID(
 		ctx, p.Txn(),
@@ -55,10 +55,10 @@ func resolveOID(
 	ie sqlutil.InternalExecutor,
 	resultType *types.T,
 	toResolve tree.Datum,
-) (*tree.DOid, error) {
+) (_ *tree.DOid, errSafeToIgnore bool, _ error) {
 	info, ok := regTypeInfos[resultType.Oid()]
 	if !ok {
-		return nil, pgerror.Newf(
+		return nil, true, pgerror.Newf(
 			pgcode.InvalidTextRepresentation,
 			"invalid input syntax for type %s: %q",
 			resultType,
@@ -78,20 +78,20 @@ func resolveOID(
 		sessiondata.NoSessionDataOverride, q, toResolve)
 	if err != nil {
 		if errors.HasType(err, (*tree.MultipleResultsError)(nil)) {
-			return nil, pgerror.Newf(pgcode.AmbiguousAlias,
+			return nil, false, pgerror.Newf(pgcode.AmbiguousAlias,
 				"more than one %s named %s", info.objName, toResolve)
 		}
-		return nil, err
+		return nil, false, err
 	}
 	if results.Len() == 0 {
-		return nil, pgerror.Newf(info.errType,
+		return nil, true, pgerror.Newf(info.errType,
 			"%s %s does not exist", info.objName, toResolve)
 	}
 	return tree.NewDOidWithName(
 		results[0].(*tree.DOid).DInt,
 		resultType,
 		tree.AsStringWithFlags(results[1], tree.FmtBareStrings),
-	), nil
+	), true, nil
 }
 
 // regTypeInfo contains details on a pg_catalog table that has a reg* type.

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -762,13 +762,13 @@ var pgBuiltins = map[string]builtinDefinition{
 					// The session has not yet created a temporary schema.
 					return tree.NewDOid(0), nil
 				}
-				oid, err := ctx.Planner.ResolveOIDFromString(
+				oid, errSafeToIgnore, err := ctx.Planner.ResolveOIDFromString(
 					ctx.Ctx(), types.RegNamespace, tree.NewDString(schema))
 				if err != nil {
 					// If the OID lookup returns an UndefinedObject error, return 0
 					// instead. We can hit this path if the session created a temporary
 					// schema in one database and then changed databases.
-					if pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+					if errSafeToIgnore && pgerror.GetPGCode(err) == pgcode.UndefinedObject {
 						return tree.NewDOid(0), nil
 					}
 					return nil, err

--- a/pkg/sql/sem/tree/cast.go
+++ b/pkg/sql/sem/tree/cast.go
@@ -2561,8 +2561,11 @@ func performIntToOidCast(ctx *EvalContext, t *types.T, v DInt) (Datum, error) {
 			return wrapAsZeroOid(t), nil
 		}
 
-		dOid, err := ctx.Planner.ResolveOIDFromOID(ctx.Ctx(), t, NewDOid(v))
+		dOid, errSafeToIgnore, err := ctx.Planner.ResolveOIDFromOID(ctx.Ctx(), t, NewDOid(v))
 		if err != nil {
+			if !errSafeToIgnore {
+				return nil, err
+			}
 			dOid = NewDOid(v)
 			dOid.semanticType = t
 		}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4799,8 +4799,11 @@ func ParseDOid(ctx *EvalContext, s string, t *types.T) (*DOid, error) {
 	// If it is an integer in string form, convert it as an int.
 	if val, err := ParseDInt(strings.TrimSpace(s)); err == nil {
 		tmpOid := NewDOid(*val)
-		oid, err := ctx.Planner.ResolveOIDFromOID(ctx.Ctx(), t, tmpOid)
+		oid, errSafeToIgnore, err := ctx.Planner.ResolveOIDFromOID(ctx.Ctx(), t, tmpOid)
 		if err != nil {
+			if !errSafeToIgnore {
+				return nil, err
+			}
 			oid = tmpOid
 			oid.semanticType = t
 		}
@@ -4870,9 +4873,11 @@ func ParseDOid(ctx *EvalContext, s string, t *types.T) (*DOid, error) {
 		// Trim type modifiers, e.g. `numeric(10,3)` becomes `numeric`.
 		s = pgSignatureRegexp.ReplaceAllString(s, "$1")
 
-		dOid, missingTypeErr := ctx.Planner.ResolveOIDFromString(ctx.Ctx(), t, NewDString(Name(s).Normalize()))
+		dOid, errSafeToIgnore, missingTypeErr := ctx.Planner.ResolveOIDFromString(ctx.Ctx(), t, NewDString(Name(s).Normalize()))
 		if missingTypeErr == nil {
-			return dOid, missingTypeErr
+			return dOid, nil
+		} else if !errSafeToIgnore {
+			return nil, missingTypeErr
 		}
 		// Fall back to some special cases that we support for compatibility
 		// only. Client use syntax like 'sometype'::regtype to produce the oid
@@ -4909,7 +4914,8 @@ func ParseDOid(ctx *EvalContext, s string, t *types.T) (*DOid, error) {
 			name:         tn.ObjectName.String(),
 		}, nil
 	default:
-		return ctx.Planner.ResolveOIDFromString(ctx.Ctx(), t, NewDString(s))
+		d, _ /* errSafeToIgnore */, err := ctx.Planner.ResolveOIDFromString(ctx.Ctx(), t, NewDString(s))
+		return d, err
 	}
 }
 

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3179,7 +3179,7 @@ type TypeResolver interface {
 	// query, an error will be returned.
 	ResolveOIDFromString(
 		ctx context.Context, resultType *types.T, toResolve *DString,
-	) (*DOid, error)
+	) (_ *DOid, errSafeToIgnore bool, _ error)
 
 	// ResolveOIDFromOID looks up the populated value of the oid with the
 	// desired resultType which matches the provided oid.
@@ -3189,7 +3189,7 @@ type TypeResolver interface {
 	// query, an error will be returned.
 	ResolveOIDFromOID(
 		ctx context.Context, resultType *types.T, toResolve *DOid,
-	) (*DOid, error)
+	) (_ *DOid, errSafeToIgnore bool, _ error)
 }
 
 // EvalPlanner is a limited planner that can be used from EvalContext.


### PR DESCRIPTION
Backport 1/1 commits from #85086.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/84448

The decision about whether an error is safe to ignore is made at the
place where the error is created/returned. This way, the callers don't
need to be aware of any new error codes that the implementation may
start returning in the future.

Release note (bug fix): Fixed incorrect error handling that could cause
casts to OID types to fail in some cases.
