### PR TITLE
release-21.2: eval: stop ignoring all ResolveOIDFromOID errors

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -180,15 +180,15 @@ type DummyEvalPlanner struct{}
 // ResolveOIDFromString is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) ResolveOIDFromString(
 	ctx context.Context, resultType *types.T, toResolve *tree.DString,
-) (*tree.DOid, error) {
-	return nil, errors.WithStack(errEvalPlanner)
+) (*tree.DOid, bool, error) {
+	return nil, false, errors.WithStack(errEvalPlanner)
 }
 
 // ResolveOIDFromOID is part of the EvalPlanner interface.
 func (ep *DummyEvalPlanner) ResolveOIDFromOID(
 	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
-) (*tree.DOid, error) {
-	return nil, errors.WithStack(errEvalPlanner)
+) (*tree.DOid, bool, error) {
+	return nil, false, errors.WithStack(errEvalPlanner)
 }
 
 // UnsafeUpsertDescriptor is part of the EvalPlanner interface.

--- a/pkg/sql/sem/tree/casts.go
+++ b/pkg/sql/sem/tree/casts.go
@@ -1473,8 +1473,11 @@ func performIntToOidCast(ctx *EvalContext, t *types.T, v DInt) (Datum, error) {
 		return ret, nil
 
 	default:
-		oid, err := ctx.Planner.ResolveOIDFromOID(ctx.Ctx(), t, NewDOid(v))
+		oid, errSafeToIgnore, err := ctx.Planner.ResolveOIDFromOID(ctx.Ctx(), t, NewDOid(v))
 		if err != nil {
+			if !errSafeToIgnore {
+				return nil, err
+			}
 			oid = NewDOid(v)
 			oid.semanticType = t
 		}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3136,7 +3136,7 @@ type TypeResolver interface {
 	// query, an error will be returned.
 	ResolveOIDFromString(
 		ctx context.Context, resultType *types.T, toResolve *DString,
-	) (*DOid, error)
+	) (_ *DOid, errSafeToIgnore bool, _ error)
 
 	// ResolveOIDFromOID looks up the populated value of the oid with the
 	// desired resultType which matches the provided oid.
@@ -3146,7 +3146,7 @@ type TypeResolver interface {
 	// query, an error will be returned.
 	ResolveOIDFromOID(
 		ctx context.Context, resultType *types.T, toResolve *DOid,
-	) (*DOid, error)
+	) (_ *DOid, errSafeToIgnore bool, _ error)
 }
 
 // EvalPlanner is a limited planner that can be used from EvalContext.


### PR DESCRIPTION
Backport 1/1 commits from #85086.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/84448

The decision about whether an error is safe to ignore is made at the
place where the error is created/returned. This way, the callers don't
need to be aware of any new error codes that the implementation may
start returning in the future.

Release note (bug fix): Fixed incorrect error handling that could cause
casts to OID types to fail in some cases.
