### PR TITLE
opt: fix optsteps panic when path to normalized expr is not found

### DIFF
--- a/pkg/sql/opt/testutils/opttester/explore_trace.go
+++ b/pkg/sql/opt/testutils/opttester/explore_trace.go
@@ -75,12 +75,12 @@ func (et *exploreTracer) Next() error {
 	}
 
 	// Compute the lowest cost tree for the source expression.
-	et.srcExpr = et.restrictToExpr(fo.LookupPath(fo.lastAppliedSource))
+	et.srcExpr = et.restrictToExpr(fo.MustLookupPath(fo.lastAppliedSource))
 
 	// Compute the lowest code tree for any target expressions.
 	et.newExprs = et.newExprs[:0]
 	if fo.lastAppliedTarget != nil {
-		et.newExprs = append(et.newExprs, et.restrictToExpr(fo.LookupPath(fo.lastAppliedTarget)))
+		et.newExprs = append(et.newExprs, et.restrictToExpr(fo.MustLookupPath(fo.lastAppliedTarget)))
 
 		if rel, ok := fo.lastAppliedTarget.(memo.RelExpr); ok {
 			for {
@@ -88,7 +88,7 @@ func (et *exploreTracer) Next() error {
 				if rel == nil {
 					break
 				}
-				et.newExprs = append(et.newExprs, et.restrictToExpr(fo.LookupPath(rel)))
+				et.newExprs = append(et.newExprs, et.restrictToExpr(fo.MustLookupPath(rel)))
 			}
 		}
 	}

--- a/pkg/sql/opt/testutils/opttester/forcing_opt.go
+++ b/pkg/sql/opt/testutils/opttester/forcing_opt.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/errors"
 )
 
 // forcingOptimizer is a wrapper around an Optimizer which adds low-level
@@ -122,9 +123,20 @@ func (fo *forcingOptimizer) Optimize() opt.Expr {
 	return expr
 }
 
-// LookupPath returns the path of the given node.
+// LookupPath returns the path of the given node. If a path is not found, it
+// returns nil.
 func (fo *forcingOptimizer) LookupPath(target opt.Expr) []memoLoc {
 	return fo.groups.FindPath(fo.o.Memo().RootExpr(), target)
+}
+
+// MustLookupPath returns the path of the given node. If a path is not found, it
+// panics.
+func (fo *forcingOptimizer) MustLookupPath(target opt.Expr) []memoLoc {
+	path := fo.LookupPath(target)
+	if path == nil {
+		panic(errors.AssertionFailedf("could not find path to expr (%s)", target.Op()))
+	}
+	return path
 }
 
 // RestrictToExpr sets up the optimizer to restrict the result to only those

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1712,7 +1712,11 @@ func (ot *OptTester) optStepsDisplay(before string, after string, os *optSteps) 
 	}
 
 	if before == after {
-		altHeader("%s (no changes)\n", os.LastRuleName())
+		msg := "no changes"
+		if os.LastRuleName().IsNormalize() {
+			msg = "normalization of expression outside of memo"
+		}
+		altHeader("%s (%s)\n", os.LastRuleName(), msg)
 		return
 	}
 

--- a/pkg/sql/opt/testutils/opttester/testdata/opt-steps
+++ b/pkg/sql/opt/testutils/opttester/testdata/opt-steps
@@ -1167,3 +1167,70 @@ Final best expression
    ├── fd: ()-->(1)
    └── tuple [type=tuple{int}]
         └── const: 1 [type=int]
+
+exec-ddl
+CREATE TABLE chk (
+	id INT PRIMARY KEY,
+	a INT,
+	CHECK (a > 1+1)
+)
+----
+
+# Verify that we don't crash when a normalization rule runs on a constraint
+# expression that is never attached to the TableMeta.
+# In this example, the rule is FoldBinary and the check constraint is not
+# attached to the TableMeta because it may evaluate to NULL, which is considered
+# a passing CHECK constraint and therefore the expression is not a universal
+# truth about the contents of the table.
+optsteps
+SELECT id FROM chk
+----
+================================================================================
+Initial expression
+  Cost: 1094.64
+================================================================================
+  project
+   ├── columns: id:1(int!null)
+   ├── key: (1)
+   └── scan chk
+        ├── columns: id:1(int!null) a:2(int) crdb_internal_mvcc_timestamp:3(decimal) tableoid:4(oid)
+        ├── key: (1)
+        └── fd: (1)-->(2-4)
+--------------------------------------------------------------------------------
+FoldBinary (normalization of expression outside of memo)
+--------------------------------------------------------------------------------
+================================================================================
+PruneScanCols
+  Cost: 1064.34
+================================================================================
+   project
+    ├── columns: id:1(int!null)
+    ├── key: (1)
+    └── scan chk
+  -      ├── columns: id:1(int!null) a:2(int) crdb_internal_mvcc_timestamp:3(decimal) tableoid:4(oid)
+  -      ├── key: (1)
+  -      └── fd: (1)-->(2-4)
+  +      ├── columns: id:1(int!null)
+  +      └── key: (1)
+================================================================================
+EliminateProject
+  Cost: 1054.32
+================================================================================
+  -project
+  +scan chk
+    ├── columns: id:1(int!null)
+  - ├── key: (1)
+  - └── scan chk
+  -      ├── columns: id:1(int!null)
+  -      └── key: (1)
+  + └── key: (1)
+--------------------------------------------------------------------------------
+GenerateIndexScans (no changes)
+--------------------------------------------------------------------------------
+================================================================================
+Final best expression
+  Cost: 1054.32
+================================================================================
+  scan chk
+   ├── columns: id:1(int!null)
+   └── key: (1)


### PR DESCRIPTION
Optsteps uses the forcing optimizer to repeatedly optimize a query. At
each iteration, it applies one more rule than the previous iteration and
displays a diff of the memos from successive iterations.

There are two general cases it encounters when generating the diff:

1. If the formatted strings of the best plans in the two memos are
   different, it can simply output a diff of those strings.
2. If the best plans are the same, then the rule must have applied to an
   expression that is not part of the best plan. Optsteps must search
   for the altered expression in the memo and TableMeta to generate the
   diff.

In some cases, the search for the altered expression in (2) may yield no
results because the expression does not exist in the memo or TableMeta.
For example, a CHECK constraint may not be added to TableMeta, as it
usually is, when it can evaluate to NULL (it is not a universal truth
about the contents of the table because a NULL result is considered as
passing the constraint). If a normalization rule is applied to such a
CHECK constraint, then the search in (2) will not find it.

Prior to this commit, optsteps would panic when it could not find an
altered expression in the memo or TableMeta. Now, optsteps will no
longer panic. It's still unable to print a diff of the applied rule, but
a helpful message is shown in the optsteps output explaining why the
diff is omitted.

Also, the search in (2) no longer looks for expressions in TableMeta.
This was never necessary. First, all expressions in TableMeta are
formatted in canonical scan expressions. Second, any rules applied to
those expressions would be normalization rules that always result in a
new best plan, never exploration rules. Therefore, the application of
any rules to TableMeta expressions always results in a formatted string
that differs from the formatted string of the previous iteration. So the
diff would always be generated via (1) and never (2), making the
TableMeta search in (2) unnecessary.

Release note: None