### PR TITLE
sql: add columns to node_execution_insights

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -895,14 +895,42 @@ CREATE TABLE crdb_internal.node_distsql_flows (
 )  {}  {}
 CREATE TABLE crdb_internal.node_execution_insights (
    session_id STRING NOT NULL,
-   transaction_id UUID NOT NULL,
-   statement_id STRING NOT NULL,
-   statement_fingerprint_id BYTES NOT NULL
+   txn_id UUID NOT NULL,
+   txn_fingerprint_id BYTES NOT NULL,
+   stmt_id STRING NOT NULL,
+   stmt_fingerprint_id BYTES NOT NULL,
+   query STRING NOT NULL,
+   status STRING NOT NULL,
+   start_time TIMESTAMP NOT NULL,
+   end_time TIMESTAMP NOT NULL,
+   full_scan BOOL NOT NULL,
+   user_name STRING NOT NULL,
+   app_name STRING NOT NULL,
+   database_name STRING NOT NULL,
+   plan_gist STRING NOT NULL,
+   rows_read INT8 NOT NULL,
+   rows_written INT8 NOT NULL,
+   priority FLOAT8 NOT NULL,
+   retries INT8 NOT NULL
 )  CREATE TABLE crdb_internal.node_execution_insights (
    session_id STRING NOT NULL,
-   transaction_id UUID NOT NULL,
-   statement_id STRING NOT NULL,
-   statement_fingerprint_id BYTES NOT NULL
+   txn_id UUID NOT NULL,
+   txn_fingerprint_id BYTES NOT NULL,
+   stmt_id STRING NOT NULL,
+   stmt_fingerprint_id BYTES NOT NULL,
+   query STRING NOT NULL,
+   status STRING NOT NULL,
+   start_time TIMESTAMP NOT NULL,
+   end_time TIMESTAMP NOT NULL,
+   full_scan BOOL NOT NULL,
+   user_name STRING NOT NULL,
+   app_name STRING NOT NULL,
+   database_name STRING NOT NULL,
+   plan_gist STRING NOT NULL,
+   rows_read INT8 NOT NULL,
+   rows_written INT8 NOT NULL,
+   priority FLOAT8 NOT NULL,
+   retries INT8 NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_inflight_trace_spans (
    trace_id INT8 NOT NULL,
@@ -1450,7 +1478,7 @@ CREATE VIEW crdb_internal.statement_statistics (
         FROM
           system.statement_statistics
     )
-  LEFT JOIN LATERAL unnest(index_recommendations) AS index_rec ON true
+    LEFT JOIN LATERAL unnest(index_recommendations) AS index_rec ON true
   GROUP BY
     aggregated_ts,
     fingerprint_id,
@@ -1509,7 +1537,7 @@ CREATE VIEW crdb_internal.statement_statistics (
         FROM
           system.statement_statistics
     )
-  LEFT JOIN LATERAL unnest(index_recommendations) AS index_rec ON true
+    LEFT JOIN LATERAL unnest(index_recommendations) AS index_rec ON true
   GROUP BY
     aggregated_ts,
     fingerprint_id,

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql/clusterunique",
         "//pkg/sql/execstats",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats/insights",
         "//pkg/util/stop",

--- a/pkg/sql/sqlstats/insights/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/BUILD.bazel
@@ -48,7 +48,10 @@ proto_library(
     srcs = ["insights.proto"],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
+    deps = [
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
 )
 
 go_proto_library(

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -13,6 +13,7 @@ package cockroach.sql.insights;
 option go_package = "insights";
 
 import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
 
 message Session {
   bytes id = 1 [(gogoproto.customname) = "ID",
@@ -24,6 +25,11 @@ message Transaction {
   bytes id = 1 [(gogoproto.customname) = "ID",
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
     (gogoproto.nullable) = false];
+  uint64 fingerprint_id = 2
+  [(gogoproto.customname) = "FingerprintID",
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/roachpb.TransactionFingerprintID",
+    (gogoproto.nullable) = false];
+  double user_priority = 3;
 }
 
 message Statement {
@@ -33,6 +39,18 @@ message Statement {
   uint64 fingerprint_id = 2 [(gogoproto.customname) = "FingerprintID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StmtFingerprintID"];
   double latency_in_seconds = 3;
+  string query = 4;
+  string status = 5;
+  google.protobuf.Timestamp start_time = 6 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  google.protobuf.Timestamp end_time = 7 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  bool full_scan = 8;
+  string user = 9;
+  string application_name = 10;
+  string database = 11;
+  string plan_gist = 12;
+  int64 rows_read = 13;
+  int64 rows_written = 14;
+  int64 retries = 15;
 }
 
 message Insight {

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/insights",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
@@ -475,7 +476,15 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 					Query:       fingerprint,
 					ImplicitTxn: testCase.implicit,
 				},
-				sqlstats.RecordedStmtStats{},
+				sqlstats.RecordedStmtStats{
+					SessionData: &sessiondata.SessionData{
+						SessionData: sessiondatapb.SessionData{
+							UserProto:       username.RootUserName().EncodeProto(),
+							Database:        "defaultdb",
+							ApplicationName: "appname_findme",
+						},
+					},
+				},
 			)
 			require.NoError(t, err)
 			txnFingerprintIDHash.Add(uint64(stmtFingerprintID))
@@ -576,7 +585,15 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 				stmtFingerprintID, err := statsCollector.RecordStatement(
 					ctx,
 					roachpb.StatementStatisticsKey{Query: fingerprint},
-					sqlstats.RecordedStmtStats{},
+					sqlstats.RecordedStmtStats{
+						SessionData: &sessiondata.SessionData{
+							SessionData: sessiondatapb.SessionData{
+								UserProto:       username.RootUserName().EncodeProto(),
+								Database:        "defaultdb",
+								ApplicationName: "appname_findme",
+							},
+						},
+					},
 				)
 				require.NoError(t, err)
 				txnFingerprintIDHash.Add(uint64(stmtFingerprintID))

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -42,6 +42,14 @@ var timestampSize = int64(unsafe.Sizeof(time.Time{}))
 
 var _ sqlstats.Writer = &Container{}
 
+func getStatusString(statementError error) string {
+	if statementError == nil {
+		return "completed"
+	}
+
+	return "failed"
+}
+
 // RecordStatement implements sqlstats.Writer interface.
 // RecordStatement saves per-statement statistics.
 //
@@ -166,6 +174,18 @@ func (s *Container) RecordStatement(
 		ID:               value.StatementID,
 		FingerprintID:    stmtFingerprintID,
 		LatencyInSeconds: value.ServiceLatency,
+		Query:            value.Query,
+		Status:           getStatusString(value.StatementError),
+		StartTime:        value.StartTime,
+		EndTime:          value.EndTime,
+		FullScan:         value.FullScan,
+		User:             value.SessionData.User().SQLIdentifier(),
+		ApplicationName:  value.SessionData.ApplicationName,
+		Database:         value.SessionData.Database,
+		PlanGist:         value.PlanGist,
+		Retries:          int64(value.AutoRetryCount),
+		RowsRead:         value.RowsRead,
+		RowsWritten:      value.RowsWritten,
 	})
 
 	return stats.ID, nil
@@ -276,7 +296,9 @@ func (s *Container) RecordTransaction(
 		stats.mu.data.ExecStats.MaxDiskUsage.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MaxDiskUsage))
 	}
 
-	s.outliersRegistry.ObserveTransaction(value.SessionID, &insights.Transaction{ID: value.TransactionID})
+	s.outliersRegistry.ObserveTransaction(value.SessionID, &insights.Transaction{
+		ID:            value.TransactionID,
+		FingerprintID: key})
 
 	return nil
 }

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -193,6 +194,7 @@ type Provider interface {
 type RecordedStmtStats struct {
 	SessionID            clusterunique.ID
 	StatementID          clusterunique.ID
+	TransactionID        uuid.UUID
 	AutoRetryCount       int
 	RowsAffected         int
 	ParseLatency         float64
@@ -209,6 +211,11 @@ type RecordedStmtStats struct {
 	PlanGist             string
 	StatementError       error
 	IndexRecommendations []string
+	Query                string
+	StartTime            time.Time
+	EndTime              time.Time
+	FullScan             bool
+	SessionData          *sessiondata.SessionData
 }
 
 // RecordedTxnStats stores the statistics of a transaction to be recorded.


### PR DESCRIPTION
This commit adds the following new columns
to crdb_internal.node_execution_insights table.

```
txn_id                     UUID NOT NULL,
txn_fingerprint_id         BYTES NOT NULL,
query                      STRING NOT NULL,
status                     STRING NOT NULL,
start_time                 TIMESTAMP NOT NULL,
end_time                   TIMESTAMP NOT NULL,
full_scan                  BOOL NOT NULL,
user_name                  STRING NOT NULL,
application_name           STRING NOT NULL,
database_name              STRING NOT NULL,
plan_gist                  STRING NOT NULL,
rows_read                  INT8 NOT NULL,
rows_written               INT8 NOT NULL,
priority                   FLOAT NOT NULL,
retries                    INT8 NOT NULL
```

Part of #81024

Release note (sql change): Adding txn_id,
  txn_fingerprint_id, query, status, start_time,
  end_time, full_scan, user_name, application_name,
  database_name, plan_gist, rows_read, rows_written,
  priority, and retries columns to
  crdb_internal.node_execution_insights