### PR TITLE
bazel: bump size of `scbuild` test

### DIFF
--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -58,7 +58,7 @@ go_library(
 
 go_test(
     name = "scbuild_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "builder_test.go",
         "main_test.go",


### PR DESCRIPTION
This has timed out in CI.

Release note: None