### PR TITLE
sql: allow NULL in create view definition

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -636,7 +636,11 @@ func addResultColumns(
 	resultColumns colinfo.ResultColumns,
 ) error {
 	for _, colRes := range resultColumns {
-		columnTableDef := tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colRes.Typ}
+		colTyp := colRes.Typ
+		if colTyp.Family() == types.UnknownFamily {
+			colTyp = types.String
+		}
+		columnTableDef := tree.ColumnTableDef{Name: tree.Name(colRes.Name), Type: colTyp}
 		// Nullability constraints do not need to exist on the view, since they are
 		// already enforced on the source data.
 		columnTableDef.Nullable.Nullability = tree.SilentNull

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1313,3 +1313,24 @@ DROP MATERIALIZED VIEW mv1
 
 statement ok
 DROP MATERIALIZED VIEW mv2
+
+statement ok
+CREATE VIEW view_with_null AS SELECT 1 AS a, null AS c
+
+query TTBTTTB
+SHOW COLUMNS FROM view_with_null
+----
+a  INT8    true  NULL  ·  {}  false
+c  STRING  true  NULL  ·  {}  false
+
+
+statement ok
+CREATE MATERIALIZED VIEW materialized_view_with_null AS SELECT a, NULL AS b, b AS c FROM test_view
+
+query TTBTTTB
+SHOW COLUMNS FROM materialized_view_with_null
+----
+a      INT8    true   NULL            ·  {materialized_view_with_null_pkey}  false
+b      STRING  true   NULL            ·  {materialized_view_with_null_pkey}  false
+c      INT8    true   NULL            ·  {materialized_view_with_null_pkey}  false
+rowid  INT8    false  unique_rowid()  ·  {materialized_view_with_null_pkey}  true


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/84000

Release note (sql change): CREATE VIEW statements can now have a
constant NULL column definition. The resulting column is of type TEXT.