### PR TITLE
colflow: skip recently introduced test under stress

### DIFF
--- a/pkg/sql/colflow/vectorized_flow_deadlock_test.go
+++ b/pkg/sql/colflow/vectorized_flow_deadlock_test.go
@@ -36,7 +36,7 @@ func TestVectorizedFlowDeadlocksWhenSpilling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressRace(t, "the test is too slow under stressrace")
+	skip.UnderStress(t, "the query might take longer than timeout under stress making the test flaky")
 
 	vecFDsLimit := 8
 	envutil.TestSetEnv(t, "COCKROACH_VEC_MAX_OPEN_FDS", strconv.Itoa(vecFDsLimit))


### PR DESCRIPTION
It seems like the query execution can get slower than the context
timeout when run under stress making the test flaky, so let's skip it
under stress. I'm not worried about losing the test coverage here.

Fixes: #85114.

Release note: None