### PR TITLE
kvserver: ignore leaseholder replica type in DistSender

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2146,7 +2146,7 @@ func (ds *DistSender) sendToReplicas(
 			// account that the local node can't be down) it won't take long until we
 			// talk to a replica that tells us who the leaseholder is.
 			if ctx.Err() == nil {
-				if lh := routing.Leaseholder(); lh != nil && *lh == curReplica {
+				if lh := routing.Leaseholder(); lh != nil && lh.IsSame(curReplica) {
 					routing.EvictLease(ctx)
 				}
 			}
@@ -2228,7 +2228,7 @@ func (ds *DistSender) sendToReplicas(
 						// (possibly because it hasn't applied its lease yet). Perhaps that
 						// lease expires and someone else gets a new one, so by moving on we
 						// get out of possibly infinite loops.
-						if *lh != curReplica || sameReplicaRetries < sameReplicaRetryLimit {
+						if !lh.IsSame(curReplica) || sameReplicaRetries < sameReplicaRetryLimit {
 							transport.MoveToFront(*lh)
 						}
 					}

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -256,7 +256,7 @@ func (gt *grpcTransport) SkipReplica() {
 
 func (gt *grpcTransport) MoveToFront(replica roachpb.ReplicaDescriptor) {
 	for i := range gt.replicas {
-		if gt.replicas[i] == replica {
+		if gt.replicas[i].IsSame(replica) {
 			// If we've already processed the replica, decrement the current
 			// index before we swap.
 			if i < gt.nextReplicaIdx {

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -416,6 +416,12 @@ func (r ReplicaDescriptor) String() string {
 	return redact.StringWithoutMarkers(r)
 }
 
+// IsSame returns true if the two replica descriptors refer to the same replica,
+// ignoring the replica type.
+func (r ReplicaDescriptor) IsSame(o ReplicaDescriptor) bool {
+	return r.NodeID == o.NodeID && r.StoreID == o.StoreID && r.ReplicaID == o.ReplicaID
+}
+
 // SafeFormat implements the redact.SafeFormatter interface.
 func (r ReplicaDescriptor) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("(n%d,s%d):", r.NodeID, r.StoreID)


### PR DESCRIPTION
The DistSender could fail to prioritize a newly discovered leaseholder
from a `NotLeaseHolderError` if the leaseholder had a non-`VOTER`
replica type. Instead, it would continue to try replicas in order until
possibly exhausting the transport and backing off, leading to increased
tail latencies. This applies in particular to 22.1, where we allowed
`VOTER_INCOMING` replicas to acquire the lease (see 22b4fb51).

The primary reason is that `grpcTransport.MoveToFront()` would fail to
compare the new leaseholder replica descriptor with the one in its range
descriptor. There are two reasons why this can happen:

1. `ReplicaDescriptor.ReplicaType` is a pointer, where the zero-value
   `nil` is equivalent to `VOTER`. The equality comparison used in
   `MoveToFront()` is `==`, but pointer equality compares the memory
   address rather than the value.

2. The transport will keep using the initial range descriptor when it
   was created, and not updating it as we receive updated range
   descriptors. This means that the transport may e.g. have a `nil`
   replica type while the leaseholder has an `VOTER_INCOMING` replica
   type.

This patch fixes both issues by adding `ReplicaDescriptor.IsSame()`
which compares replica identities while ignoring the type.

Resolves #85060.
Touches #74546.

Release note (bug fix): Fixed a bug where new leaseholders (with a
`VOTER_INCOMING` type) would not always be detected properly during
query execution, leading to occasional increased tail latencies due
to unnecessary internal retries.