### PR TITLE
sql: reduce noise of logging the DistSQL diagram

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -840,7 +840,6 @@ func (p *PlanningCtx) flowSpecsToDiagram(
 	flows map[base.SQLInstanceID]*execinfrapb.FlowSpec,
 	diagramFlags execinfrapb.DiagramFlags,
 ) (execinfrapb.FlowDiagram, error) {
-	log.VEvent(ctx, 1, "creating plan diagram")
 	var stmtStr string
 	if p.planner != nil && p.planner.stmt.AST != nil {
 		stmtStr = p.planner.stmt.String()

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -506,16 +506,16 @@ func (dsp *DistSQLPlanner) Run(
 		}
 	}
 
-	if sp := tracing.SpanFromContext(ctx); sp != nil {
+	if log.ExpensiveLogEnabled(ctx, 2) {
 		var stmtStr string
 		if planCtx.planner != nil && planCtx.planner.stmt.AST != nil {
 			stmtStr = planCtx.planner.stmt.String()
 		}
 		_, url, err := execinfrapb.GeneratePlanDiagramURL(stmtStr, flows, execinfrapb.DiagramFlags{})
 		if err != nil {
-			log.Infof(ctx, "error generating diagram: %s", err)
+			log.VEventf(ctx, 2, "error generating diagram: %s", err)
 		} else {
-			log.Infof(ctx, "plan diagram URL:\n%s", url.String())
+			log.VEventf(ctx, 2, "plan diagram URL:\n%s", url.String())
 		}
 	}
 


### PR DESCRIPTION
In a recent commit we made it so that we now log the DistSQL diagram
into the trace. However, the condition for when to log was too "wide"
(checking whether the tracing span is present in the context which is
essentially `true` all the time) and caused too much noise in the logs
even when the diagram wasn't intended to be logged. This commit fixes
that and also switches to using `VEvent` so that the logs don't get
the diagram at all as well as removes another somewhat redundant event
message.

Release note: None