### PR TITLE
colexec: fix UUID and STRING concat

### DIFF
--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sem/tree/treebin",
         "//pkg/sql/sem/tree/treecmp",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -1993,8 +1994,27 @@ func planProjectionOperators(
 		if err = checkSupportedBinaryExpr(t.TypedLeft(), t.TypedRight(), t.ResolvedType()); err != nil {
 			return op, resultIdx, typs, err
 		}
+		leftExpr, rightExpr := t.TypedLeft(), t.TypedRight()
+		if t.Operator.Symbol == treebin.Concat {
+			// Concat requires special handling.
+			leftType, rightType := leftExpr.ResolvedType(), rightExpr.ResolvedType()
+			if leftType.Family() != rightType.Family() {
+				// When we have two different types, we perform the STRING
+				// concatenation.
+				if leftType.Family() == types.StringFamily {
+					// Need to cast the right expr to the STRING.
+					rightExpr = tree.NewTypedCastExpr(rightExpr, types.String)
+				} else if rightType.Family() == types.StringFamily {
+					// Need to cast the left expr to the STRING.
+					leftExpr = tree.NewTypedCastExpr(leftExpr, types.String)
+				} else {
+					// This is unexpected.
+					return op, resultIdx, typs, errors.New("neither LHS or RHS of Concat operation is a STRING")
+				}
+			}
+		}
 		return planProjectionExpr(
-			ctx, evalCtx, t.Operator, t.ResolvedType(), t.TypedLeft(), t.TypedRight(),
+			ctx, evalCtx, t.Operator, t.ResolvedType(), leftExpr, rightExpr,
 			columnTypes, input, acc, factory, t.Op.EvalOp, nil /* cmpExpr */, releasables, t.Op.NullableArgs,
 		)
 	case *tree.CaseExpr:

--- a/pkg/sql/logictest/testdata/logic_test/uuid
+++ b/pkg/sql/logictest/testdata/logic_test/uuid
@@ -173,3 +173,13 @@ query T
 SELECT uuid_generate_v5(uuid_ns_oid(), 'dog')
 ----
 9a8b57c4-73a4-5dfb-b888-6fff478edf63
+
+# Regression test for incorrect concatenation of a UUID with a STRING in the
+# vectorized engine (#83093).
+statement ok
+CREATE TABLE t83093 (u) AS SELECT 'eb64afe6-ade7-40ce-8352-4bb5eec39075'::UUID
+
+query T
+SELECT u || 'foo' FROM t83093
+----
+eb64afe6-ade7-40ce-8352-4bb5eec39075foo

--- a/pkg/sql/sem/eval/testdata/eval/concat
+++ b/pkg/sql/sem/eval/testdata/eval/concat
@@ -52,6 +52,11 @@ true || 'a' || false
 'trueafalse'
 
 eval
+'eb64afe6-ade7-40ce-8352-4bb5eec39075'::UUID || 'a'
+----
+'eb64afe6-ade7-40ce-8352-4bb5eec39075a'
+
+eval
 (1,2) || 'a' || (3,4)
 ----
 '(1,2)a(3,4)'


### PR DESCRIPTION
e38e172ba911a6dbbb09fd983afd56773a84c1a8 fixed the way we perform Concat
operations when one of the arguments is a string and another is a
non-string, but it forgot to update the vectorized engine accordingly.
We would return an incorrect result there when a UUID was concatenated
with a STRING. I believe only UUID / STRING concatenation is affected
because these two types have the same physical represenation, so the
vectorized `projConcatBytesBytesOp` would get planned. For other
combinations of types the vectorized engine wouldn't get used for the
Concat operation since the corresponding overload isn't defined.

This is now fixed by planning a cast to string whenever needed,
similar to what we do in the row-by-row engine. This also has an effect
of supporting the vectorized evaluation of Concat operation of scalar
types on one side and the STRING on the other.

Fixes: #83093.

Release note (bug fix): Previously concatenating a UUID with a string
would not use the normal string representation of the UUID values. Now
it does, so `'eb64afe6-ade7-40ce-8352-4bb5eec39075'::UUID || 'foo'`
returns `eb64afe6-ade7-40ce-8352-4bb5eec39075foo` rather than the encoded
representation.