### PR TITLE
changefeedccl: reduce allocations in kvevent blocking buffer 

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -255,14 +255,14 @@ func createBenchmarkChangefeed(
 	if err != nil {
 		return nil, nil, err
 	}
-	tickFn := func(ctx context.Context) (*jobspb.ResolvedSpan, error) {
+	tickFn := func(ctx context.Context) (jobspb.ResolvedSpan, error) {
 		event, err := buf.Get(ctx)
 		if err != nil {
-			return nil, err
+			return jobspb.ResolvedSpan{}, err
 		}
 		if event.Type() == kvevent.TypeKV {
 			if err := eventConsumer.ConsumeEvent(ctx, event); err != nil {
-				return nil, err
+				return jobspb.ResolvedSpan{}, err
 			}
 		}
 		return event.Resolved(), nil

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -542,7 +542,7 @@ func (ca *changeAggregator) tick() error {
 		a := event.DetachAlloc()
 		a.Release(ca.Ctx)
 		resolved := event.Resolved()
-		if ca.knobs.ShouldSkipResolved == nil || !ca.knobs.ShouldSkipResolved(resolved) {
+		if ca.knobs.FilterSpanWithMutation == nil || !ca.knobs.FilterSpanWithMutation(&resolved) {
 			return ca.noteResolvedSpan(resolved)
 		}
 	case kvevent.TypeFlush:
@@ -555,8 +555,8 @@ func (ca *changeAggregator) tick() error {
 // noteResolvedSpan periodically flushes Frontier progress from the current
 // changeAggregator node to the changeFrontier node to allow the changeFrontier
 // to persist the overall changefeed's progress
-func (ca *changeAggregator) noteResolvedSpan(resolved *jobspb.ResolvedSpan) error {
-	advanced, err := ca.frontier.ForwardResolvedSpan(*resolved)
+func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) error {
+	advanced, err := ca.frontier.ForwardResolvedSpan(resolved)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1636,14 +1636,14 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 			s.SystemServer.DB(), s.Codec, "d", "foo")
 		tableSpan := fooDesc.PrimaryIndexSpan(s.Codec)
 
-		// ShouldSkipResolved should ensure that once the backfill begins, the following resolved events
+		// FilterSpanWithMutation should ensure that once the backfill begins, the following resolved events
 		// that are for that backfill (are of the timestamp right after the backfill timestamp) resolve some
 		// but not all of the time, which results in a checkpoint eventually being created
 		haveGaps := false
 		var backfillTimestamp hlc.Timestamp
 		var initialCheckpoint roachpb.SpanGroup
 		var foundCheckpoint int32
-		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+		knobs.FilterSpanWithMutation = func(r *jobspb.ResolvedSpan) bool {
 			// Stop resolving anything after checkpoint set to avoid eventually resolving the full span
 			if initialCheckpoint.Len() > 0 {
 				return true
@@ -1706,7 +1706,7 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 		var secondCheckpoint roachpb.SpanGroup
 		foundCheckpoint = 0
 		haveGaps = false
-		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+		knobs.FilterSpanWithMutation = func(r *jobspb.ResolvedSpan) bool {
 			// Stop resolving anything after second checkpoint set to avoid backfill completion
 			if secondCheckpoint.Len() > 0 {
 				return true
@@ -1756,7 +1756,7 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 
 		// Collect spans we attempt to resolve after when we resume.
 		var resolved []roachpb.Span
-		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+		knobs.FilterSpanWithMutation = func(r *jobspb.ResolvedSpan) bool {
 			resolved = append(resolved, r.Span)
 			return false
 		}
@@ -5659,7 +5659,7 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 		// Emit resolved events for majority of spans.  Be extra paranoid and ensure that
 		// we have at least 1 span for which we don't emit resolved timestamp (to force checkpointing).
 		haveGaps := false
-		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+		knobs.FilterSpanWithMutation = func(r *jobspb.ResolvedSpan) bool {
 			if r.Span.Equal(tableSpan) {
 				// Do not emit resolved events for the entire table span.
 				// We "simulate" large table by splitting single table span into many parts, so
@@ -5742,7 +5742,7 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 
 		// Collect spans we attempt to resolve after when we resume.
 		var resolved []roachpb.Span
-		knobs.ShouldSkipResolved = func(r *jobspb.ResolvedSpan) bool {
+		knobs.FilterSpanWithMutation = func(r *jobspb.ResolvedSpan) bool {
 			if !r.Span.Equal(tableSpan) {
 				resolved = append(resolved, r.Span)
 			}
@@ -6865,7 +6865,7 @@ func TestChangefeedFlushesSinkToReleaseMemory(t *testing.T) {
 	// an effect of never advancing the frontier, and thus never flushing
 	// the sink due to frontier advancement.  The only time we flush the sink
 	// is if the memory pressure causes flush request to be delivered.
-	knobs.ShouldSkipResolved = func(_ *jobspb.ResolvedSpan) bool {
+	knobs.FilterSpanWithMutation = func(_ *jobspb.ResolvedSpan) bool {
 		return true
 	}
 

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -36,15 +36,18 @@ go_test(
     name = "kvevent_test",
     srcs = [
         "alloc_test.go",
+        "bench_test.go",
         "blocking_buffer_test.go",
     ],
     embed = [":kvevent"],
     deps = [
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc/keyside",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/ccl/changefeedccl/kvevent/bench_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/bench_test.go
@@ -1,0 +1,121 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkMemBuffer(b *testing.B) {
+	rand, _ := randutil.NewTestRand()
+
+	run := func() {
+		ba, release := getBoundAccountWithBudget(4096)
+		defer release()
+
+		metrics := kvevent.MakeMetrics(time.Minute)
+
+		// Arrange for mem buffer to notify us when it waits for resources.
+		waitCh := make(chan struct{}, 1)
+		notifyWait := func(ctx context.Context, poolName string, r quotapool.Request) {
+			select {
+			case waitCh <- struct{}{}:
+			default:
+			}
+		}
+
+		st := cluster.MakeTestingClusterSettings()
+		buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics, quotapool.OnWaitStart(notifyWait))
+		defer func() {
+			require.NoError(b, buf.CloseWithReason(context.Background(), nil))
+		}()
+
+		producerCtx, stopProducers := context.WithCancel(context.Background())
+		wg := ctxgroup.WithContext(producerCtx)
+		defer func() {
+			_ = wg.Wait() // Ignore error -- this group returns context cancellation.
+		}()
+
+		numRows := 0
+		wg.GoCtx(func(ctx context.Context) error {
+			for {
+				err := buf.Add(ctx, kvevent.MakeResolvedEvent(generateSpan(b, rand), hlc.Timestamp{}, jobspb.ResolvedSpan_NONE))
+				if err != nil {
+					return err
+				}
+				numRows++
+			}
+		})
+
+		<-waitCh
+		writtenRows := numRows
+
+		for i := 0; i < writtenRows; i++ {
+			e, err := buf.Get(context.Background())
+			if err != nil {
+				b.Fatal("could not read from buffer")
+			}
+			a := e.DetachAlloc()
+			a.Release(context.Background())
+		}
+		stopProducers()
+	}
+
+	for i := 0; i < b.N; i++ {
+		run()
+	}
+}
+
+func generateSpan(b *testing.B, rng *rand.Rand) roachpb.Span {
+	start := rng.Intn(2 << 20)
+	end := start + rng.Intn(2<<20)
+	startDatum := tree.NewDInt(tree.DInt(start))
+	endDatum := tree.NewDInt(tree.DInt(end))
+	const tableID = 42
+
+	startKey, err := keyside.Encode(
+		keys.SystemSQLCodec.TablePrefix(tableID),
+		startDatum,
+		encoding.Ascending,
+	)
+	if err != nil {
+		b.Fatal("could not generate key")
+	}
+
+	endKey, err := keyside.Encode(
+		keys.SystemSQLCodec.TablePrefix(tableID),
+		endDatum,
+		encoding.Ascending,
+	)
+	if err != nil {
+		b.Fatal("could not generate key")
+	}
+
+	return roachpb.Span{
+		Key:    startKey,
+		EndKey: endKey,
+	}
+}

--- a/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner_test.go
@@ -33,7 +33,7 @@ type recordResolvedWriter struct {
 
 func (r *recordResolvedWriter) Add(ctx context.Context, e kvevent.Event) error {
 	if e.Type() == kvevent.TypeResolved {
-		r.resolved = append(r.resolved, *e.Resolved())
+		r.resolved = append(r.resolved, e.Resolved())
 	}
 	return nil
 }

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -31,9 +31,9 @@ type TestingKnobs struct {
 	// It allows the tests to muck with the Sink, and even return altogether different
 	// implementation.
 	WrapSink func(s Sink, jobID jobspb.JobID) Sink
-	// ShouldSkipResolved is a filter returning true if the resolved span event should
-	// be skipped.
-	ShouldSkipResolved func(resolved *jobspb.ResolvedSpan) bool
+	// FilterSpanWithMutation is a filter returning true if the resolved span event should
+	// be skipped. This method takes a pointer in case resolved spans need to be mutated.
+	FilterSpanWithMutation func(resolved *jobspb.ResolvedSpan) bool
 	// FeedKnobs are kvfeed testing knobs.
 	FeedKnobs kvfeed.TestingKnobs
 	// NullSinkIsExternalIOAccounted controls whether we record


### PR DESCRIPTION
This change removes a pointer from the kvevent.Event struct, reducing overall allocations. The hope is that this reduces the amount of work Go gc has to do, which will reduce SQL latency at the end of the day. When doing backfills, the allocations in kv events add up pretty fast, so reducing even one pointer is significant.

See https://github.com/cockroachdb/cockroach/issues/84709 for more info. I'm not closing the issue with this PR since we may decide to reduce more pointers in future PRs using some of the ideas in the issue comments.

Here are the benchmark results 
```
name          old time/op    new time/op    delta
MemBuffer-10    98.1µs ± 0%    95.8µs ± 1%   -2.35%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
MemBuffer-10    76.9kB ± 0%    64.4kB ± 0%  -16.17%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
MemBuffer-10       859 ± 0%       675 ± 0%  -21.42%  (p=0.008 n=5+5)

```

