### PR TITLE
requestbatcher: nil unused slice entries in batchQueue heap

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -639,7 +639,6 @@ func (q *batchQueue) get(id roachpb.RangeID) (*batch, bool) {
 }
 
 func (q *batchQueue) remove(ba *batch) {
-	delete(q.byRange, ba.rangeID())
 	heap.Remove(q, ba.idx)
 }
 
@@ -678,6 +677,7 @@ func (q *batchQueue) Push(v interface{}) {
 
 func (q *batchQueue) Pop() interface{} {
 	ba := q.batches[len(q.batches)-1]
+	q.batches[len(q.batches)-1] = nil // for GC
 	q.batches = q.batches[:len(q.batches)-1]
 	delete(q.byRange, ba.rangeID())
 	ba.idx = -1


### PR DESCRIPTION
This change nils out unused entries in the `batchQueue`'s slice when the slice is truncated to avoid retaining references to batches of requests and preventing them from being GCed.

The change also removes a redundant update of the batchQueue's byRange map. The `delete` was redundant because `heap.Remove` already calls `Pop`.

I found this while looking at https://github.com/cockroachlabs/support/issues/1707, but I don't think this is actually the cause of the perceived memory leak.