### PR TITLE
sql: add estimated and actual statistics to telemetry logging

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2465,6 +2465,14 @@ contains common SQL event/execution details.
 | `TransactionID` | Transaction ID of the query. | no |
 | `DatabaseID` | Database ID of the query. | no |
 | `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
+| `MaxFullScanRowsEstimate` | Maximum number of rows scanned by a full scan, as estimated by the optimizer. | no |
+| `TotalScanRowsEstimate` | Total number of rows read by all scans in the query, as estimated by the optimizer. | no |
+| `OutputRowsEstimate` | The number of rows output by the query, as estimated by the optimizer. | no |
+| `StatsAvailable` | Whether table statistics were available to the optimizer when planning the query. | no |
+| `NanosSinceStatsCollected` | The maximum number of nanoseconds that have passed since stats were collected on any table scanned by this query. | no |
+| `BytesRead` | The number of bytes read from disk. | no |
+| `RowsRead` | The number of rows read from disk. | no |
+| `RowsWritten` | The number of rows written. | no |
 
 
 #### Common fields

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1068,6 +1068,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	}
 
 	var stmtFingerprintID roachpb.StmtFingerprintID
+	var stats topLevelQueryStats
 	defer func() {
 		planner.maybeLogStatement(
 			ctx,
@@ -1080,6 +1081,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
 			stmtFingerprintID,
+			&stats,
 		)
 	}()
 
@@ -1165,7 +1167,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		distribute = DistributionTypeAlways
 	}
 	ex.sessionTracing.TraceExecStart(ctx, "distributed")
-	stats, err := ex.execWithDistSQLEngine(
+	stats, err = ex.execWithDistSQLEngine(
 		ctx, planner, stmt.AST.StatementReturnType(), res, distribute, progAtomic,
 	)
 	if res.Err() == nil {

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -157,8 +157,9 @@ func (p *planner) maybeLogStatement(
 	hasAdminRoleCache *HasAdminRoleCache,
 	telemetryLoggingMetrics *TelemetryLoggingMetrics,
 	stmtFingerprintID roachpb.StmtFingerprintID,
+	queryStats *topLevelQueryStats,
 ) {
-	p.maybeLogStatementInternal(ctx, execType, numRetries, txnCounter, rows, err, queryReceived, hasAdminRoleCache, telemetryLoggingMetrics, stmtFingerprintID)
+	p.maybeLogStatementInternal(ctx, execType, numRetries, txnCounter, rows, err, queryReceived, hasAdminRoleCache, telemetryLoggingMetrics, stmtFingerprintID, queryStats)
 }
 
 func (p *planner) maybeLogStatementInternal(
@@ -170,6 +171,7 @@ func (p *planner) maybeLogStatementInternal(
 	hasAdminRoleCache *HasAdminRoleCache,
 	telemetryMetrics *TelemetryLoggingMetrics,
 	stmtFingerprintID roachpb.StmtFingerprintID,
+	queryStats *topLevelQueryStats,
 ) {
 	// Note: if you find the code below crashing because p.execCfg == nil,
 	// do not add a test "if p.execCfg == nil { do nothing }" !
@@ -389,16 +391,24 @@ func (p *planner) maybeLogStatementInternal(
 			skippedQueries := telemetryMetrics.resetSkippedQueryCount()
 			databaseName := p.CurrentDatabase()
 			sampledQuery := eventpb.SampledQuery{
-				CommonSQLExecDetails:   execDetails,
-				SkippedQueries:         skippedQueries,
-				CostEstimate:           p.curPlan.instrumentation.costEstimate,
-				Distribution:           p.curPlan.instrumentation.distribution.String(),
-				PlanGist:               p.curPlan.instrumentation.planGist.String(),
-				SessionID:              p.extendedEvalCtx.SessionID.String(),
-				Database:               databaseName,
-				StatementID:            p.stmt.QueryID.String(),
-				TransactionID:          p.txn.ID().String(),
-				StatementFingerprintID: uint64(stmtFingerprintID),
+				CommonSQLExecDetails:     execDetails,
+				SkippedQueries:           skippedQueries,
+				CostEstimate:             p.curPlan.instrumentation.costEstimate,
+				Distribution:             p.curPlan.instrumentation.distribution.String(),
+				PlanGist:                 p.curPlan.instrumentation.planGist.String(),
+				SessionID:                p.extendedEvalCtx.SessionID.String(),
+				Database:                 databaseName,
+				StatementID:              p.stmt.QueryID.String(),
+				TransactionID:            p.txn.ID().String(),
+				StatementFingerprintID:   uint64(stmtFingerprintID),
+				MaxFullScanRowsEstimate:  p.curPlan.instrumentation.maxFullScanRows,
+				TotalScanRowsEstimate:    p.curPlan.instrumentation.totalScanRows,
+				OutputRowsEstimate:       p.curPlan.instrumentation.outputRows,
+				StatsAvailable:           p.curPlan.instrumentation.statsAvailable,
+				NanosSinceStatsCollected: int64(p.curPlan.instrumentation.nanosSinceStatsCollected),
+				BytesRead:                queryStats.bytesRead,
+				RowsRead:                 queryStats.rowsRead,
+				RowsWritten:              queryStats.rowsWritten,
 			}
 			db, _ := p.Descriptors().GetImmutableDatabaseByName(ctx, p.txn, databaseName, tree.DatabaseLookupFlags{Required: true})
 			if db != nil {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -129,6 +130,26 @@ type instrumentationHelper struct {
 	// indexRecommendations is a string slice containing index recommendations for
 	// the planned statement. This is only set for EXPLAIN statements.
 	indexRecommendations []string
+
+	// maxFullScanRows is the maximum number of rows scanned by a full scan, as
+	// estimated by the optimizer.
+	maxFullScanRows float64
+
+	// totalScanRows is the total number of rows read by all scans in the query,
+	// as estimated by the optimizer.
+	totalScanRows float64
+
+	// outputRows is the number of rows output by the query, as estimated by the
+	// optimizer.
+	outputRows float64
+
+	// statsAvailable is true if table statistics were available to the optimizer
+	// when planning the query.
+	statsAvailable bool
+
+	// nanosSinceStatsCollected is the maximum number of nanoseconds that have
+	// passed since stats were collected on any table scanned by this query.
+	nanosSinceStatsCollected time.Duration
 }
 
 // outputMode indicates how the statement output needs to be populated (for

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/timeutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -11,6 +11,8 @@
 package execbuilder
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -128,6 +130,18 @@ type Builder struct {
 
 	// ContainsMutation is set to true if the whole plan contains any mutations.
 	ContainsMutation bool
+
+	// MaxFullScanRows is the maximum number of rows scanned by a full scan, as
+	// estimated by the optimizer.
+	MaxFullScanRows float64
+
+	// TotalScanRows is the total number of rows read by all scans in the query,
+	// as estimated by the optimizer.
+	TotalScanRows float64
+
+	// NanosSinceStatsCollected is the maximum number of nanoseconds that have
+	// passed since stats were collected on any table scanned by this query.
+	NanosSinceStatsCollected time.Duration
 
 	// wrapFunctionOverride overrides default implementation to return resolvable
 	// function reference for function with specified function name.

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -670,8 +671,8 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 
 	// Save if we planned a full table/index scan on the builder so that the
 	// planner can be made aware later. We only do this for non-virtual tables.
+	stats := scan.Relational().Stats
 	if !tab.IsVirtualTable() && isUnfiltered {
-		stats := scan.Relational().Stats
 		large := !stats.Available || stats.RowCount > b.evalCtx.SessionData().LargeFullScanRows
 		if scan.Index == cat.PrimaryIndex {
 			b.ContainsFullTableScan = true
@@ -679,6 +680,22 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		} else {
 			b.ContainsFullIndexScan = true
 			b.ContainsLargeFullIndexScan = b.ContainsLargeFullIndexScan || large
+		}
+		if stats.Available && stats.RowCount > b.MaxFullScanRows {
+			b.MaxFullScanRows = stats.RowCount
+		}
+	}
+
+	// Save the total estimated number of rows scanned and the time since stats
+	// were collected.
+	if stats.Available {
+		b.TotalScanRows += stats.RowCount
+		if tab.StatisticCount() > 0 {
+			// The first stat is the most recent one.
+			nanosSinceStatsCollected := timeutil.Since(tab.Statistic(0).CreatedAt())
+			if nanosSinceStatsCollected > b.NanosSinceStatsCollected {
+				b.NanosSinceStatsCollected = nanosSinceStatsCollected
+			}
 		}
 	}
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -623,6 +623,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 		containsLargeFullTableScan = bld.ContainsLargeFullTableScan
 		containsLargeFullIndexScan = bld.ContainsLargeFullIndexScan
 		containsMutation = bld.ContainsMutation
+		planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
+		planTop.instrumentation.totalScanRows = bld.TotalScanRows
+		planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
 	} else {
 		// Create an explain factory and record the explain.Plan.
 		explainFactory := explain.NewFactory(f)
@@ -641,6 +644,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 		containsLargeFullTableScan = bld.ContainsLargeFullTableScan
 		containsLargeFullIndexScan = bld.ContainsLargeFullIndexScan
 		containsMutation = bld.ContainsMutation
+		planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
+		planTop.instrumentation.totalScanRows = bld.TotalScanRows
+		planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
 
 		planTop.instrumentation.RecordExplainPlan(explainPlan)
 	}
@@ -648,6 +654,11 @@ func (opc *optPlanningCtx) runExecBuilder(
 		planTop.instrumentation.planGist = gf.PlanGist()
 	}
 	planTop.instrumentation.costEstimate = float64(mem.RootExpr().(memo.RelExpr).Cost())
+	available := mem.RootExpr().(memo.RelExpr).Relational().Stats.Available
+	planTop.instrumentation.statsAvailable = available
+	if available {
+		planTop.instrumentation.outputRows = mem.RootExpr().(memo.RelExpr).Relational().Stats.RowCount
+	}
 
 	if stmt.ExpectedTypes != nil {
 		cols := result.main.planColumns()

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3353,6 +3353,77 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = strconv.AppendUint(b, uint64(m.StatementFingerprintID), 10)
 	}
 
+	if m.MaxFullScanRowsEstimate != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MaxFullScanRowsEstimate\":"...)
+		b = strconv.AppendFloat(b, float64(m.MaxFullScanRowsEstimate), 'f', -1, 64)
+	}
+
+	if m.TotalScanRowsEstimate != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TotalScanRowsEstimate\":"...)
+		b = strconv.AppendFloat(b, float64(m.TotalScanRowsEstimate), 'f', -1, 64)
+	}
+
+	if m.OutputRowsEstimate != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"OutputRowsEstimate\":"...)
+		b = strconv.AppendFloat(b, float64(m.OutputRowsEstimate), 'f', -1, 64)
+	}
+
+	if m.StatsAvailable {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatsAvailable\":true"...)
+	}
+
+	if m.NanosSinceStatsCollected != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NanosSinceStatsCollected\":"...)
+		b = strconv.AppendInt(b, int64(m.NanosSinceStatsCollected), 10)
+	}
+
+	if m.BytesRead != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"BytesRead\":"...)
+		b = strconv.AppendInt(b, int64(m.BytesRead), 10)
+	}
+
+	if m.RowsRead != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RowsRead\":"...)
+		b = strconv.AppendInt(b, int64(m.RowsRead), 10)
+	}
+
+	if m.RowsWritten != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RowsWritten\":"...)
+		b = strconv.AppendInt(b, int64(m.RowsWritten), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -64,6 +64,34 @@ message SampledQuery {
 
   // Statement fingerprint ID of the query.
   uint64 statement_fingerprint_id = 13 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty'];
+
+  // Maximum number of rows scanned by a full scan, as estimated by the
+  // optimizer.
+  double max_full_scan_rows_estimate = 14 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Total number of rows read by all scans in the query, as estimated by the
+  // optimizer.
+  double total_scan_rows_estimate = 15 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of rows output by the query, as estimated by the optimizer.
+  double output_rows_estimate = 16 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Whether table statistics were available to the optimizer when planning the
+  // query.
+  bool stats_available = 17 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The maximum number of nanoseconds that have passed since stats were
+  // collected on any table scanned by this query.
+  int64 nanos_since_stats_collected = 18 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of bytes read from disk.
+  int64 bytes_read = 19 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of rows read from disk.
+  int64 rows_read = 20 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of rows written.
+  int64 rows_written = 21 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
This commit adds several new fields to the `SampledQuery` structure used for
telemetry logging.

Closes #71666

Release note (sql change): The structured payloads used for telemetry
logs now include the following new fields:
MaxFullScanRowsEstimate: Maximum number of rows scanned by a full scan,
as estimated by the optimizer.
TotalScanRowsEstimate: Total number of rows read by all scans in the query,
as estimated by the optimizer.
OutputRowsEstimate: The number of rows output by the query, as estimated
by the optimizer.
StatsAvailable: Whether table statistics were available to the optimizer
when planning the query.
NanosSinceStatsCollected: The maximum number of nanoseconds that have
passed since stats were collected on any table scanned by this query.
BytesRead: The number of bytes read from disk.
RowsRead: The number of rows read from disk.
RowsWritten: The number of rows written.