### PR TITLE
release-22.1: logging: Expand env vars in logging config

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1576,6 +1576,12 @@ This has the same effect as passing the content of the file via
 the --log flag.`,
 	}
 
+	LogConfigVars = FlagInfo{
+		Name: "log-config-vars",
+		Description: `Environment variables that will be expanded if
+present in the body of the logging configuration.`,
+	}
+
 	DeprecatedStderrThreshold = FlagInfo{
 		Name:        "logtostderr",
 		Description: `Write log messages beyond the specified severity to stderr.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -187,6 +187,9 @@ type cliContext struct {
 
 	// logConfigInput is the YAML input for the logging configuration.
 	logConfigInput settableString
+	// logConfigVars is an array of environment variables used in the logging
+	// configuration that will be expanded by CRDB.
+	logConfigVars []string
 	// logConfig is the resulting logging configuration after the input
 	// configuration has been parsed and validated.
 	logConfig logconfig.Config
@@ -233,6 +236,7 @@ func setCliContextDefaults() {
 	cliCtx.sqlConnDBName = ""
 	cliCtx.allowUnencryptedClientPassword = false
 	cliCtx.logConfigInput = settableString{s: ""}
+	cliCtx.logConfigVars = nil
 	cliCtx.logConfig = logconfig.Config{}
 	cliCtx.logShutdownFn = func() {}
 	cliCtx.ambiguousLogDir = false

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -400,6 +400,7 @@ func init() {
 		// Logging configuration.
 		varFlag(pf, &stringValue{settableString: &cliCtx.logConfigInput}, cliflags.Log)
 		varFlag(pf, &fileContentsValue{settableString: &cliCtx.logConfigInput, fileName: "<unset>"}, cliflags.LogConfigFile)
+		stringSliceFlag(pf, &cliCtx.logConfigVars, cliflags.LogConfigVars)
 
 		// Pre-v21.1 overrides. Deprecated.
 		// TODO(knz): Remove this.

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1274,26 +1274,30 @@ Available Commands:
   help              Help about any command
 
 Flags:
-  -h, --help                     help for cockroach
-      --log <string>             
-                                  Logging configuration, expressed using YAML syntax. For example, you can
-                                  change the default logging directory with: --log='file-defaults: {dir: ...}'.
-                                  See the documentation for more options and details.  To preview how the log
-                                  configuration is applied, or preview the default configuration, you can use
-                                  the 'cockroach debug check-log-config' sub-command.
-                                 
-      --log-config-file <file>   
-                                  File name to read the logging configuration from. This has the same effect as
-                                  passing the content of the file via the --log flag.
-                                  (default <unset>)
-      --version                  version for cockroach
+  -h, --help                      help for cockroach
+      --log <string>              
+                                   Logging configuration, expressed using YAML syntax. For example, you can
+                                   change the default logging directory with: --log='file-defaults: {dir: ...}'.
+                                   See the documentation for more options and details.  To preview how the log
+                                   configuration is applied, or preview the default configuration, you can use
+                                   the 'cockroach debug check-log-config' sub-command.
+                                  
+      --log-config-file <file>    
+                                   File name to read the logging configuration from. This has the same effect as
+                                   passing the content of the file via the --log flag.
+                                   (default <unset>)
+      --log-config-vars strings   
+                                   Environment variables that will be expanded if present in the body of the
+                                   logging configuration.
+                                  
+      --version                   version for cockroach
 
 Use "cockroach [command] --help" for more information about a command.
 `
 	helpExpected := fmt.Sprintf("CockroachDB command-line interface and server.\n\n%s",
 		// Due to a bug in spf13/cobra, 'cockroach help' does not include the --version
 		// flag. Strangely, 'cockroach --help' does, as well as usage error messages.
-		strings.ReplaceAll(expUsage, "      --version                  version for cockroach\n", ""))
+		strings.ReplaceAll(expUsage, "      --version                   version for cockroach\n", ""))
 	badFlagExpected := fmt.Sprintf("%s\nError: unknown flag: --foo\n", expUsage)
 
 	testCases := []struct {

--- a/pkg/cli/log_flags.go
+++ b/pkg/cli/log_flags.go
@@ -17,9 +17,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
@@ -43,6 +45,10 @@ func setupLogging(ctx context.Context, cmd *cobra.Command, isServerCmd, applyCon
 	if cliCtx.deprecatedLogOverrides.anySet() &&
 		cliCtx.logConfigInput.isSet {
 		return errors.Newf("--%s is incompatible with legacy discrete logging flags", cliflags.Log.Name)
+	}
+
+	if err := validateLogConfigVars(cliCtx.logConfigVars); err != nil {
+		return errors.Wrap(err, "invalid logging configuration")
 	}
 
 	// Sanity check to prevent misuse of API.
@@ -118,7 +124,17 @@ func setupLogging(ctx context.Context, cmd *cobra.Command, isServerCmd, applyCon
 
 	// If a configuration was specified via --log, load it.
 	if cliCtx.logConfigInput.isSet {
-		if err := h.Set(cliCtx.logConfigInput.s); err != nil {
+		s := cliCtx.logConfigInput.s
+
+		if len(cliCtx.logConfigVars) > 0 {
+			var err error
+			s, err = expandEnvironmentVariables(s, cliCtx.logConfigVars)
+			if err != nil {
+				return errors.Wrap(err, "unable to expand environment variables")
+			}
+		}
+
+		if err := h.Set(s); err != nil {
 			return err
 		}
 		if h.Config.FileDefaults.Dir != nil {
@@ -458,3 +474,45 @@ sinks:
     max-file-size: 102400
     max-group-size: 1048576
 `
+
+// validateLogConfigVars return an error if any of the passed logging
+// configuration variables are are not permissible. For security, variables
+// that start with COCKROACH_ are explicitly disallowed. See #81146 for more.
+func validateLogConfigVars(vars []string) error {
+	for _, v := range vars {
+		if strings.HasPrefix(strings.ToUpper(v), "COCKROACH_") {
+			return errors.Newf("use of %s is not allowed as a logging configuration variable", v)
+		}
+	}
+	return nil
+}
+
+// expandEnvironmentVariables replaces variables used in string with their
+// values pulled from the environment. If there are variables in the string
+// that are not contained in vars, they will be replaced with the empty string.
+func expandEnvironmentVariables(s string, vars []string) (string, error) {
+	var err error
+
+	m := map[string]string{}
+	// Only pull variable values from the environment if their key is present
+	// in vars to create an allow list.
+	for _, k := range vars {
+		v, ok := envutil.ExternalEnvString(k, 1)
+		if !ok {
+			err = errors.CombineErrors(err, errors.Newf("variable %q is not defined in environment", k))
+			continue
+		}
+		m[k] = v
+	}
+
+	s = os.Expand(s, func(k string) string {
+		v, ok := m[k]
+		if !ok {
+			err = errors.CombineErrors(err, errors.Newf("unknown variable %q used in configuration", k))
+			return ""
+		}
+		return v
+	})
+
+	return s, err
+}

--- a/pkg/cli/testdata/logflags
+++ b/pkg/cli/testdata/logflags
@@ -325,6 +325,49 @@ telemetry: <telemetryCfg(<defaultLogDir>)>},
 <stderrCfg(ERROR,true)>},
 <stdCaptureFd2(<defaultLogDir>)>}
 
+# Ensure variable expansion works.
+run
+start
+--log=sinks: {fluent-servers: {health: {channels: [DEV], address: ${HOST_IP}:5170}}}
+--log-config-vars=HOST_IP
+----
+config: {<stdFileDefaults(<defaultLogDir>)>,
+<fluentDefaults>,
+<httpDefaults>,
+sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
+OPS],
+WARNING: [HEALTH,
+STORAGE,
+SESSIONS,
+SQL_SCHEMA,
+USER_ADMIN,
+PRIVILEGES,
+SENSITIVE_ACCESS,
+SQL_EXEC,
+SQL_PERF,
+SQL_INTERNAL_PERF,
+TELEMETRY],<defaultLogDir>,true,crdb-v2)>,
+health: <fileCfg(INFO: [HEALTH],<defaultLogDir>,true,crdb-v2)>,
+pebble: <fileCfg(INFO: [STORAGE],<defaultLogDir>,true,crdb-v2)>,
+security: <fileCfg(INFO: [USER_ADMIN,
+PRIVILEGES],<defaultLogDir>,false,crdb-v2)>,
+sql-audit: <fileCfg(INFO: [SENSITIVE_ACCESS],<defaultLogDir>,false,crdb-v2)>,
+sql-auth: <fileCfg(INFO: [SESSIONS],<defaultLogDir>,false,crdb-v2)>,
+sql-exec: <fileCfg(INFO: [SQL_EXEC],<defaultLogDir>,true,crdb-v2)>,
+sql-schema: <fileCfg(INFO: [SQL_SCHEMA],<defaultLogDir>,true,crdb-v2)>,
+sql-slow: <fileCfg(INFO: [SQL_PERF],<defaultLogDir>,true,crdb-v2)>,
+sql-slow-internal-only: <fileCfg(INFO: [SQL_INTERNAL_PERF],<defaultLogDir>,true,crdb-v2)>,
+telemetry: <telemetryCfg(<defaultLogDir>)>},
+fluent-servers: {health: {channels: {INFO: [DEV]},
+net: tcp,
+address: '1.2.3.4:5170',
+filter: INFO,
+format: json-fluent-compact,
+redactable: true,
+exit-on-error: false,
+buffering: NONE}},
+<stderrDisabled>},
+<stdCaptureFd2(<defaultLogDir>)>}
 
 # It's possible to disable the stderr capture.
 run

--- a/pkg/util/envutil/env_test.go
+++ b/pkg/util/envutil/env_test.go
@@ -30,6 +30,107 @@ func TestEnvOrDefault(t *testing.T) {
 	}
 }
 
+func TestCheckVarName(t *testing.T) {
+	t.Run("checkVarName", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			valid bool
+		}{
+			{
+				name:  "abc123",
+				valid: false,
+			},
+			{
+				name:  "ABC 123",
+				valid: false,
+			},
+			{
+				name:  "@&) 123",
+				valid: false,
+			},
+			{
+				name:  "ABC123",
+				valid: true,
+			},
+			{
+				name:  "ABC_123",
+				valid: true,
+			},
+		} {
+			func() {
+				defer func() {
+					r := recover()
+					if !tc.valid && r == nil {
+						t.Errorf("expected panic for name %q, got none", tc.name)
+					} else if tc.valid && r != nil {
+						t.Errorf("unexpected panic for name %q, got %q", tc.name, r)
+					}
+				}()
+
+				checkVarName(tc.name)
+			}()
+		}
+	})
+
+	t.Run("checkInternalVarName", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			valid bool
+		}{
+			{
+				name:  "ABC_123",
+				valid: false,
+			},
+			{
+				name:  "COCKROACH_X",
+				valid: true,
+			},
+		} {
+			func() {
+				defer func() {
+					r := recover()
+					if !tc.valid && r == nil {
+						t.Errorf("expected panic for name %q, got none", tc.name)
+					} else if tc.valid && r != nil {
+						t.Errorf("unexpected panic for name %q, got %q", tc.name, r)
+					}
+				}()
+
+				checkInternalVarName(tc.name)
+			}()
+		}
+	})
+
+	t.Run("checkExternalVarName", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			valid bool
+		}{
+			{
+				name:  "COCKROACH_X",
+				valid: false,
+			},
+			{
+				name:  "ABC_123",
+				valid: true,
+			},
+		} {
+			func() {
+				defer func() {
+					r := recover()
+					if !tc.valid && r == nil {
+						t.Errorf("expected panic for name %q, got none", tc.name)
+					} else if tc.valid && r != nil {
+						t.Errorf("unexpected panic for name %q, got %q", tc.name, r)
+					}
+				}()
+
+				checkExternalVarName(tc.name)
+			}()
+		}
+	})
+}
+
 func TestTestSetEnvExists(t *testing.T) {
 	key := "COCKROACH_ENVUTIL_TESTSETTING"
 	require.NoError(t, os.Setenv(key, "before"))


### PR DESCRIPTION
Backport 2/2 commits from #82147.

/cc @cockroachdb/release

---

  This commit adds a command line flag `--log-config-vars` that is used
  to specify those environment variables that will be expanded in the
  logging config file contents. This flag enables operators to
  indirectly define an allow list of sorts of trusted environment
  variables.

  A desired use case of this flag is one where `HOST_IP` is pulled from
  the running container environment and used to direct logs to a node
  local instance of FluentBit. In this snipped below, the log.yaml
  configuration file can be defined with a generic `fluent-server` sink
  that specifies `${HOST_IP}:5170` as its address. CRDB will then pull
  the IP from the environment and replace the variable with the IP in
  the logging configuration.

  ```
  containers:
    - name: cockroach
      image: cockroachdb/cockroach
      args:
      - --log-config-file log.yaml
      - --log-config-vars HOST_IP
      env:
        - name: HOST_IP
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
  ```

  Closes #81146.

Release justification: This backport is required to increase the reliability of the CC fleet. Including it will allow the removal of a large swath of brittle deployment code.
