### PR TITLE
release-21.2: logging: Expand env vars in logging config

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1489,6 +1489,12 @@ This has the same effect as passing the content of the file via
 the --log flag.`,
 	}
 
+	LogConfigVars = FlagInfo{
+		Name: "log-config-vars",
+		Description: `Environment variables that will be expanded if
+present in the body of the logging configuration.`,
+	}
+
 	DeprecatedStderrThreshold = FlagInfo{
 		Name:        "logtostderr",
 		Description: `Write log messages beyond the specified severity to stderr.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -173,6 +173,9 @@ type cliContext struct {
 
 	// logConfigInput is the YAML input for the logging configuration.
 	logConfigInput settableString
+	// logConfigVars is an array of environment variables used in the logging
+	// configuration that will be expanded by CRDB.
+	logConfigVars []string
 	// logConfig is the resulting logging configuration after the input
 	// configuration has been parsed and validated.
 	logConfig logconfig.Config
@@ -215,6 +218,7 @@ func setCliContextDefaults() {
 	cliCtx.sqlConnDBName = ""
 	cliCtx.allowUnencryptedClientPassword = false
 	cliCtx.logConfigInput = settableString{s: ""}
+	cliCtx.logConfigVars = nil
 	cliCtx.logConfig = logconfig.Config{}
 	cliCtx.ambiguousLogDir = false
 	// TODO(knz): Deprecated in v21.1. Remove this.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -336,6 +336,7 @@ func init() {
 		// Logging configuration.
 		varFlag(pf, &stringValue{settableString: &cliCtx.logConfigInput}, cliflags.Log)
 		varFlag(pf, &fileContentsValue{settableString: &cliCtx.logConfigInput, fileName: "<unset>"}, cliflags.LogConfigFile)
+		stringSliceFlag(pf, &cliCtx.logConfigVars, cliflags.LogConfigVars)
 
 		// Pre-v21.1 overrides. Deprecated.
 		// TODO(knz): Remove this.

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1159,26 +1159,30 @@ Available Commands:
   help              Help about any command
 
 Flags:
-  -h, --help                     help for cockroach
-      --log <string>             
-                                  Logging configuration, expressed using YAML syntax. For example, you can
-                                  change the default logging directory with: --log='file-defaults: {dir: ...}'.
-                                  See the documentation for more options and details.  To preview how the log
-                                  configuration is applied, or preview the default configuration, you can use
-                                  the 'cockroach debug check-log-config' sub-command.
-                                 
-      --log-config-file <file>   
-                                  File name to read the logging configuration from. This has the same effect as
-                                  passing the content of the file via the --log flag.
-                                  (default <unset>)
-      --version                  version for cockroach
+  -h, --help                      help for cockroach
+      --log <string>              
+                                   Logging configuration, expressed using YAML syntax. For example, you can
+                                   change the default logging directory with: --log='file-defaults: {dir: ...}'.
+                                   See the documentation for more options and details.  To preview how the log
+                                   configuration is applied, or preview the default configuration, you can use
+                                   the 'cockroach debug check-log-config' sub-command.
+                                  
+      --log-config-file <file>    
+                                   File name to read the logging configuration from. This has the same effect as
+                                   passing the content of the file via the --log flag.
+                                   (default <unset>)
+      --log-config-vars strings   
+                                   Environment variables that will be expanded if present in the body of the
+                                   logging configuration.
+                                  
+      --version                   version for cockroach
 
 Use "cockroach [command] --help" for more information about a command.
 `
 	helpExpected := fmt.Sprintf("CockroachDB command-line interface and server.\n\n%s",
 		// Due to a bug in spf13/cobra, 'cockroach help' does not include the --version
 		// flag. Strangely, 'cockroach --help' does, as well as usage error messages.
-		strings.ReplaceAll(expUsage, "      --version                  version for cockroach\n", ""))
+		strings.ReplaceAll(expUsage, "      --version                   version for cockroach\n", ""))
 	badFlagExpected := fmt.Sprintf("%s\nError: unknown flag: --foo\n", expUsage)
 
 	testCases := []struct {

--- a/pkg/cli/log_flags_test.go
+++ b/pkg/cli/log_flags_test.go
@@ -15,6 +15,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -23,7 +24,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSetupLogging checks the behavior of logging flags.
@@ -117,6 +121,11 @@ func TestSetupLogging(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	require.NoError(t, os.Setenv("HOST_IP", "1.2.3.4"))
+	defer func() {
+		require.NoError(t, os.Unsetenv("HOST_IP"))
+	}()
+
 	ctx := context.Background()
 
 	datadriven.RunTest(t, "testdata/logflags", func(t *testing.T, td *datadriven.TestData) string {
@@ -188,8 +197,89 @@ func isServerCmd(thisCmd *cobra.Command) bool {
 	return false
 }
 
+func TestValidateLogConfigVars(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	for i, tc := range []struct {
+		vars        []string
+		expectedErr error
+	}{
+		{
+			vars: []string{"HOST_IP"},
+		},
+		{
+			vars:        []string{"COCKROACH_TEST"},
+			expectedErr: errors.Newf(`use of COCKROACH_TEST is not allowed as a logging configuration variable`),
+		},
+	} {
+		err := validateLogConfigVars(tc.vars)
+
+		if !errors.Is(tc.expectedErr, err) {
+			t.Errorf("%d. validateLogConfigVars err expected '%s', but got '%s'.",
+				i, tc.expectedErr, err)
+		}
+	}
+}
+
+func TestExpandEnvironmentVariables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	require.NoError(t, os.Setenv("HOST_IP1", "1.2.3.4"))
+	require.NoError(t, os.Setenv("HOST_IP2", "5.6.7.8"))
+	defer func() {
+		require.NoError(t, os.Unsetenv("HOST_IP1"))
+		require.NoError(t, os.Unsetenv("HOST_IP2"))
+	}()
+	require.NoError(t, os.Unsetenv("EXPAND_ABSENT_VAR1"))
+	require.NoError(t, os.Unsetenv("EXPAND_ABSENT_VAR2"))
+
+	for _, tc := range []struct {
+		in             string
+		vars           []string
+		expectedOut    string
+		expectedErrMsg string
+	}{
+		{
+			in:          "$HOST_IP1",
+			vars:        []string{"HOST_IP1"},
+			expectedOut: "1.2.3.4",
+		},
+		{
+			in:          "${HOST_IP2}",
+			vars:        []string{"HOST_IP2"},
+			expectedOut: "5.6.7.8",
+		},
+		{
+			in:             "$EXPAND_ABSENT_VAR1",
+			vars:           []string{"EXPAND_ABSENT_VAR1"},
+			expectedErrMsg: `variable "EXPAND_ABSENT_VAR1" is not defined in environment`,
+		},
+		{
+			in:             "${EXPAND_ABSENT_VAR2}",
+			vars:           []string{"EXPAND_ABSENT_VAR2"},
+			expectedErrMsg: `variable "EXPAND_ABSENT_VAR2" is not defined in environment`,
+		},
+		{
+			in:             "$HOST_IP3",
+			expectedErrMsg: `unknown variable "HOST_IP3" used in configuration`,
+		},
+		{
+			in:             "${HOST_IP4}",
+			expectedErrMsg: `unknown variable "HOST_IP4" used in configuration`,
+		},
+	} {
+		out, err := expandEnvironmentVariables(tc.in, tc.vars)
+
+		if tc.expectedErrMsg != "" {
+			assert.EqualError(t, err, tc.expectedErrMsg)
+		} else {
+			assert.Nil(t, err)
+		}
+		assert.Equal(t, tc.expectedOut, out)
+	}
+}
+
 // TestLogFlagCombinations checks that --log and --log-config-file properly
-// override each other.
+// override each other and that --log-config-vars stores the appropriate values
+// in the cliContext struct.
 func TestLogFlagCombinations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -219,15 +309,44 @@ func TestLogFlagCombinations(t *testing.T) {
 
 	f := startCmd.Flags()
 	testData := []struct {
-		args           []string
-		expectedLogCfg string
+		args            []string
+		expectedLogCfg  string
+		expectedLogVars []string
 	}{
-		{[]string{"start"}, ""},
-		{[]string{"start", "--log=foo"}, "foo"},
-		{[]string{"start", "--log-config-file=" + tmpfile.Name()}, filecontents},
-		{[]string{"start", "--log=foo", "--log=bar"}, "bar"},
-		{[]string{"start", "--log=foo", "--log-config-file=" + tmpfile.Name()}, filecontents},
-		{[]string{"start", "--log-config-file=" + tmpfile.Name(), "--log=bar"}, "bar"},
+		{
+			args:           []string{"start"},
+			expectedLogCfg: "",
+		},
+		{
+			args:           []string{"start", "--log=foo"},
+			expectedLogCfg: "foo",
+		},
+		{
+			args:           []string{"start", "--log-config-file=" + tmpfile.Name()},
+			expectedLogCfg: filecontents,
+		},
+		{
+			args:           []string{"start", "--log=foo", "--log=bar"},
+			expectedLogCfg: "bar",
+		},
+		{
+			args:           []string{"start", "--log=foo", "--log-config-file=" + tmpfile.Name()},
+			expectedLogCfg: filecontents,
+		},
+		{
+			args:           []string{"start", "--log-config-file=" + tmpfile.Name(), "--log=bar"},
+			expectedLogCfg: "bar",
+		},
+		{
+			args:            []string{"start", "--log-config-file=" + tmpfile.Name(), "--log-config-vars=HOST_IP"},
+			expectedLogCfg:  filecontents,
+			expectedLogVars: []string{"HOST_IP"},
+		},
+		{
+			args:            []string{"start", "--log-config-file=" + tmpfile.Name(), "--log-config-vars=HOST_IP,POD_NAME"},
+			expectedLogCfg:  filecontents,
+			expectedLogVars: []string{"HOST_IP", "POD_NAME"},
+		},
 	}
 
 	for i, td := range testData {
@@ -239,6 +358,11 @@ func TestLogFlagCombinations(t *testing.T) {
 		if td.expectedLogCfg != cliCtx.logConfigInput.s {
 			t.Errorf("%d. cliCtx.logConfigInput.s expected '%s', but got '%s'. td.args was '%#v'.",
 				i, td.expectedLogCfg, cliCtx.logConfigInput.s, td.args)
+		}
+
+		if !reflect.DeepEqual(td.expectedLogVars, cliCtx.logConfigVars) {
+			t.Errorf("%d. cliCtx.logConfigVars expected '%s', but got '%s'. td.args was '%#v'.",
+				i, td.expectedLogCfg, cliCtx.logConfigVars, td.args)
 		}
 	}
 }

--- a/pkg/cli/testdata/logflags
+++ b/pkg/cli/testdata/logflags
@@ -325,6 +325,48 @@ telemetry: <telemetryCfg(<defaultLogDir>)>},
 <stderrCfg(ERROR,true)>},
 <stdCaptureFd2(<defaultLogDir>)>}
 
+# Ensure variable expansion works.
+run
+start
+--log=sinks: {fluent-servers: {health: {channels: [DEV], address: ${HOST_IP}:5170}}}
+--log-config-vars=HOST_IP
+----
+config: {<stdFileDefaults(<defaultLogDir>)>,
+<fluentDefaults>,
+<httpDefaults>,
+sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
+OPS],
+WARNING: [HEALTH,
+STORAGE,
+SESSIONS,
+SQL_SCHEMA,
+USER_ADMIN,
+PRIVILEGES,
+SENSITIVE_ACCESS,
+SQL_EXEC,
+SQL_PERF,
+SQL_INTERNAL_PERF,
+TELEMETRY],<defaultLogDir>,true,crdb-v2)>,
+health: <fileCfg(INFO: [HEALTH],<defaultLogDir>,true,crdb-v2)>,
+pebble: <fileCfg(INFO: [STORAGE],<defaultLogDir>,true,crdb-v2)>,
+security: <fileCfg(INFO: [USER_ADMIN,
+PRIVILEGES],<defaultLogDir>,false,crdb-v2)>,
+sql-audit: <fileCfg(INFO: [SENSITIVE_ACCESS],<defaultLogDir>,false,crdb-v2)>,
+sql-auth: <fileCfg(INFO: [SESSIONS],<defaultLogDir>,false,crdb-v2)>,
+sql-exec: <fileCfg(INFO: [SQL_EXEC],<defaultLogDir>,true,crdb-v2)>,
+sql-schema: <fileCfg(INFO: [SQL_SCHEMA],<defaultLogDir>,true,crdb-v2)>,
+sql-slow: <fileCfg(INFO: [SQL_PERF],<defaultLogDir>,true,crdb-v2)>,
+sql-slow-internal-only: <fileCfg(INFO: [SQL_INTERNAL_PERF],<defaultLogDir>,true,crdb-v2)>,
+telemetry: <telemetryCfg(<defaultLogDir>)>},
+fluent-servers: {health: {channels: {INFO: [DEV]},
+net: tcp,
+address: '1.2.3.4:5170',
+filter: INFO,
+format: json-fluent-compact,
+redactable: true,
+exit-on-error: false}},
+<stderrDisabled>},
+<stdCaptureFd2(<defaultLogDir>)>}
 
 # It's possible to disable the stderr capture.
 run

--- a/pkg/util/envutil/env.go
+++ b/pkg/util/envutil/env.go
@@ -44,10 +44,9 @@ func init() {
 
 func checkVarName(name string) {
 	// Env vars must:
-	//  - start with COCKROACH_
 	//  - be uppercase
 	//  - only contain letters, digits, and _
-	valid := strings.HasPrefix(name, "COCKROACH_")
+	valid := true
 	for i := 0; valid && i < len(name); i++ {
 		c := name[i]
 		valid = ((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_')
@@ -57,15 +56,51 @@ func checkVarName(name string) {
 	}
 }
 
-// getEnv retrieves an environment variable, keeps track of where
+func checkInternalVarName(name string) {
+	// Env vars must:
+	//  - start with COCKROACH_
+	//  - pass basic validity checks in checkVarName
+	if !strings.HasPrefix(name, "COCKROACH_") {
+		panic("invalid env var name " + name)
+	}
+	checkVarName(name)
+}
+
+func checkExternalVarName(name string) {
+	// Env vars must:
+	//  - not start with COCKROACH_
+	//  - pass basic validity checks in checkVarName
+	if strings.HasPrefix(name, "COCKROACH_") {
+		panic("invalid env var name " + name)
+	}
+	checkVarName(name)
+}
+
+// getEnv performs all of the same actions as getAndCacheEnv but also includes
+// a validity check of the variable name.
+func getEnv(varName string, depth int) (string, bool) {
+	checkInternalVarName(varName)
+	return getAndCacheEnv(varName, depth+1)
+}
+
+// getExternalEnv performs all of the same actions as getEnv but also asserts
+// that the variable is not of the form of an internal environment variable,
+// eg. "COCKROACH_".
+func getExternalEnv(varName string, depth int) (string, bool) {
+	checkExternalVarName(varName)
+	return getAndCacheEnv(varName, depth+1)
+}
+
+// getAndCacheEnv retrieves an environment variable, keeps track of where
 // it was accessed, and checks that each environment variable is accessed
 // from at most one place.
 // The bookkeeping enables a report of all influential environment
 // variables with "cockroach debug env". To keep this report useful,
 // all relevant environment variables should be read during start up.
-func getEnv(varName string, depth int) (string, bool) {
+// This function should not be used directly; getEnv or getExternalEnv should
+// be used instead.
+func getAndCacheEnv(varName string, depth int) (string, bool) {
 	_, consumer, _, _ := runtime.Caller(depth + 1)
-	checkVarName(varName)
 
 	envVarRegistry.mu.Lock()
 	defer envVarRegistry.mu.Unlock()
@@ -167,6 +202,7 @@ var valueReportableUnsafeVarRegistry = map[redact.SafeString]struct{}{
 	"DEBUG_HTTP2_GOROUTINES":      {},
 	"GRPC_GO_LOG_SEVERITY_LEVEL":  {},
 	"GRPC_GO_LOG_VERBOSITY_LEVEL": {},
+	"HOST_IP":                     {},
 	"LANG":                        {},
 	"LC_ALL":                      {},
 	"LC_COLLATE":                  {},
@@ -271,6 +307,16 @@ func HomeDir() (string, error) {
 // The returned boolean flag indicates if the variable is set.
 func EnvString(name string, depth int) (string, bool) {
 	return getEnv(name, depth+1)
+}
+
+// ExternalEnvString returns the value set by the specified environment
+// variable. Only non-CRDB environment variables should be accessed via this
+// method. CRDB specific variables should be accessed via EnvString. The depth
+// argument indicates the stack depth of the caller that should be associated
+// with the variable. The returned boolean flag indicates if the variable is
+// set.
+func ExternalEnvString(name string, depth int) (string, bool) {
+	return getExternalEnv(name, depth+1)
 }
 
 // EnvOrDefaultString returns the value set by the specified

--- a/pkg/util/envutil/env_test.go
+++ b/pkg/util/envutil/env_test.go
@@ -30,6 +30,107 @@ func TestEnvOrDefault(t *testing.T) {
 	}
 }
 
+func TestCheckVarName(t *testing.T) {
+	t.Run("checkVarName", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			valid bool
+		}{
+			{
+				name:  "abc123",
+				valid: false,
+			},
+			{
+				name:  "ABC 123",
+				valid: false,
+			},
+			{
+				name:  "@&) 123",
+				valid: false,
+			},
+			{
+				name:  "ABC123",
+				valid: true,
+			},
+			{
+				name:  "ABC_123",
+				valid: true,
+			},
+		} {
+			func() {
+				defer func() {
+					r := recover()
+					if !tc.valid && r == nil {
+						t.Errorf("expected panic for name %q, got none", tc.name)
+					} else if tc.valid && r != nil {
+						t.Errorf("unexpected panic for name %q, got %q", tc.name, r)
+					}
+				}()
+
+				checkVarName(tc.name)
+			}()
+		}
+	})
+
+	t.Run("checkInternalVarName", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			valid bool
+		}{
+			{
+				name:  "ABC_123",
+				valid: false,
+			},
+			{
+				name:  "COCKROACH_X",
+				valid: true,
+			},
+		} {
+			func() {
+				defer func() {
+					r := recover()
+					if !tc.valid && r == nil {
+						t.Errorf("expected panic for name %q, got none", tc.name)
+					} else if tc.valid && r != nil {
+						t.Errorf("unexpected panic for name %q, got %q", tc.name, r)
+					}
+				}()
+
+				checkInternalVarName(tc.name)
+			}()
+		}
+	})
+
+	t.Run("checkExternalVarName", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			valid bool
+		}{
+			{
+				name:  "COCKROACH_X",
+				valid: false,
+			},
+			{
+				name:  "ABC_123",
+				valid: true,
+			},
+		} {
+			func() {
+				defer func() {
+					r := recover()
+					if !tc.valid && r == nil {
+						t.Errorf("expected panic for name %q, got none", tc.name)
+					} else if tc.valid && r != nil {
+						t.Errorf("unexpected panic for name %q, got %q", tc.name, r)
+					}
+				}()
+
+				checkExternalVarName(tc.name)
+			}()
+		}
+	})
+}
+
 func TestTestSetEnvExists(t *testing.T) {
 	key := "COCKROACH_ENVUTIL_TESTSETTING"
 	require.NoError(t, os.Setenv(key, "before"))


### PR DESCRIPTION
Backport 2/2 commits from #82147.

/cc @cockroachdb/release

---

  This commit adds a command line flag `--log-config-vars` that is used
  to specify those environment variables that will be expanded in the
  logging config file contents. This flag enables operators to
  indirectly define an allow list of sorts of trusted environment
  variables.

  A desired use case of this flag is one where `HOST_IP` is pulled from
  the running container environment and used to direct logs to a node
  local instance of FluentBit. In this snipped below, the log.yaml
  configuration file can be defined with a generic `fluent-server` sink
  that specifies `${HOST_IP}:5170` as its address. CRDB will then pull
  the IP from the environment and replace the variable with the IP in
  the logging configuration.

  ```
  containers:
    - name: cockroach
      image: cockroachdb/cockroach
      args:
      - --log-config-file log.yaml
      - --log-config-vars HOST_IP
      env:
        - name: HOST_IP
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
  ```

  Closes #81146.

Release justification: This backport is required to increase the reliability of the CC fleet. Including it will allow the removal of a large swath of brittle deployment code.