### PR TITLE
server: fix filter clause in stmtdetails API

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -416,8 +416,9 @@ func getStatementDetailsQueryClausesAndArgs(
 	if err != nil {
 		return "", nil, err
 	}
-	args = append(args, strconv.FormatUint(fingerprintID, 16))
-	buffer.WriteString(fmt.Sprintf(" WHERE encode(fingerprint_id, 'hex') = $%d", len(args)))
+
+	args = append(args, sqlstatsutil.EncodeUint64ToBytes(fingerprintID))
+	buffer.WriteString(fmt.Sprintf(" WHERE fingerprint_id = $%d", len(args)))
 
 	// Filter out internal statements by app name.
 	buffer.WriteString(fmt.Sprintf(" AND app_name NOT LIKE '%s%%'", catconstants.InternalAppNamePrefix))

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -2080,6 +2080,7 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 			fullScanCount:     0,
 			databases:         []string{"roachblog"},
 		})
+
 	// Execute same fingerprint id statement on a different application
 	statements = []string{
 		`set application_name = 'second-app'`,
@@ -2209,6 +2210,35 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 	for _, test := range testData {
 		testPath(test.path, test.expectedResult)
 	}
+
+	// Test fix for #83608. The stmt being below requested has a fingerprint id
+	// that is 15 chars in hexadecimal. We should be able to find this stmt now
+	// that we construct the filter using a bytes comparison instead of string.
+
+	statements = []string{
+		`set application_name = 'fix_83608'`,
+		`set database = defaultdb`,
+		`SELECT 1, 2, 3, 4`,
+	}
+	for _, stmt := range statements {
+		thirdServerSQL.Exec(t, stmt)
+	}
+
+	selectQuery := "SELECT _, _, _, _"
+	fingerprintID = roachpb.ConstructStatementFingerprintID(selectQuery, false,
+		true, "defaultdb")
+
+	testPath(
+		fmt.Sprintf(`stmtdetails/%v`, fingerprintID),
+		resultValues{
+			query:             selectQuery,
+			totalCount:        1,
+			aggregatedTsCount: 1,
+			planHashCount:     1,
+			appNames:          []string{"fix_83608"},
+			fullScanCount:     0,
+			databases:         []string{"defaultdb"},
+		})
 }
 
 func TestListSessionsSecurity(t *testing.T) {


### PR DESCRIPTION
Fixes #83608
Fixes #81697

Previously, when retrieving stmt details via a query to
the `crdb_internal.statement_statistics` table in the
`StatementDetails` method, we construct a string equality
check to find the stmt. This string filter was incorrectly
constructed as the two strings being used could differ in
length, with one value being exactly 16 chars long and the
other value possibly less (leading 0s truncated).

This commit constructs the clause using  a byte array
comparison, avoiding the unnecessary string conversion
for the row datum and the need to consider inconsistent
string lengths.

Release note (bug fix): stmt details page now renders properly
for statements where the hex representation of the fingerprint_id
is less than 16 digits.