### PR TITLE
sqlcli,cdc: improve sinkless changefeed display in interactive sql shell

### DIFF
--- a/pkg/cli/clisqlshell/BUILD.bazel
+++ b/pkg/cli/clisqlshell/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "api.go",
         "context.go",
         "doc.go",
+        "parser.go",
         "sql.go",
         "statement_diag.go",
         "statements_value.go",

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -18,7 +18,9 @@ import (
 	"time"
 
 	democlusterapi "github.com/cockroachdb/cockroach/pkg/cli/democluster/api"
+	"github.com/cockroachdb/cockroach/pkg/sql/scanner"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 )
 
 // Context represents the external configuration of the interactive
@@ -84,10 +86,43 @@ type internalContext struct {
 	// current database name, if known. This is maintained on a best-effort basis.
 	dbName string
 
+	// hook to run once, then clear, after running the next batch of statements.
+	afterRun func()
+
+	statementWrappers []statementWrapper
+
 	// state about the current query.
 	mu struct {
 		syncutil.Mutex
 		cancelFn func(ctx context.Context) error
 		doneCh   chan struct{}
 	}
+}
+
+// StatementWrapper allows custom client-side logic to be executed when a statement
+// matches a given pattern.
+// The cli will call Pattern.FindStringSubmatch on every statement before
+// executing it. If it returns non-nil, execution will stop and Wrapper will
+// be called with the statement and match data.
+type statementWrapper struct {
+	Pattern statementType
+	Wrapper func(ctx context.Context, statement string, c *cliState) error
+}
+
+// AddStatementWrapper adds a StatementWrapper to the specified context.
+func (c *internalContext) addStatementWrapper(w statementWrapper) {
+	c.statementWrappers = append(c.statementWrappers, w)
+}
+
+func (c *internalContext) maybeWrapStatement(
+	ctx context.Context, statement string, state *cliState,
+) (err error) {
+	var s scanner.Scanner
+	for _, sw := range c.statementWrappers {
+		s.Init(statement)
+		if sw.Pattern.matches(s) {
+			err = errors.CombineErrors(err, sw.Wrapper(ctx, statement, state))
+		}
+	}
+	return
 }

--- a/pkg/cli/clisqlshell/parser.go
+++ b/pkg/cli/clisqlshell/parser.go
@@ -1,0 +1,133 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package clisqlshell
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/scanner"
+)
+
+// We don't depend on tree in this package, but we do
+// have access to the real tokenizer, so this file uses it
+// to do some quick client-side parsing of SQL statements.
+// Currently it's just testing whether the query about to be
+// executed starts with the creation of a sinkless changefeed,
+// which is mildly non-trivial to detect because changefeeds
+// can contain arbitrary SQL expressions.
+
+// token is the type of constants like lexbase.CREATE.
+type token = int32
+
+// statementType defines a specific tree walk that
+// constitutes a pattern match. We match when we
+// call Scan, it sees no more tokens, and we're
+// at a node where matchEOF = true.
+// We short-circuit and return false early if
+// we get to a node with abortMatch=true or
+// an undefined transition: the token is not in
+// transitions and defaultTransition is unset.
+type statementType struct{ parseNode }
+
+// parseNode is a state we can enter while parsing
+// a string to check for a specific match.
+type parseNode struct {
+	matchEOF          bool
+	abortMatch        bool
+	transitions       map[token]*parseNode
+	defaultTransition *parseNode
+}
+
+func (t *parseNode) matches(stmts scanner.Scanner) bool {
+	if t.abortMatch {
+		return false
+	}
+
+	// Scan the next token. If there is none, we know
+	// whether or not we've matched. Otherwise,
+	// perform the state transition corresponding to the
+	// token.
+	var lval fakeSym
+	stmts.Scan(&lval)
+	if lval.id == 0 {
+		return t.matchEOF
+	}
+	next, ok := t.transitions[lval.id]
+	if ok {
+		return next.matches(stmts)
+	}
+	// If no state transition is defined for this token,
+	// do the default state transition if there is one,
+	// otherwise this is a failed match.
+	if t.defaultTransition != nil {
+		return t.defaultTransition.matches(stmts)
+	}
+	return false
+}
+
+// CREATE CHANGEFEED with no INTO clause, or EXPERIMENTAL CHANGEFEED.
+var createSinklessChangefeed statementType = statementType{
+	parseNode{transitions: map[token]*parseNode{
+		lexbase.CREATE:       &sinklessChangefeed,
+		lexbase.EXPERIMENTAL: &sinklessChangefeed,
+	}},
+}
+
+var noMatch parseNode = parseNode{abortMatch: true}
+
+var sinklessChangefeedAnyArg = parseNode{
+	matchEOF: true,
+}
+
+func init() {
+	// Transitions that create a loop are added in init() to avoid a variable dependency cycle.
+	sinklessChangefeedAnyArg.defaultTransition = &sinklessChangefeedArgs
+}
+
+// Return false on any INTO keyword not preceded by an AS.
+// AS INTO is a result column alias, while any other use of
+// INTO in a changefeed expression creates a sink.
+var sinklessChangefeedArgs parseNode = parseNode{
+	matchEOF: true,
+	transitions: map[token]*parseNode{
+		lexbase.INTO: &noMatch,
+		lexbase.AS:   &sinklessChangefeedAnyArg,
+	},
+}
+
+var sinklessChangefeed parseNode = parseNode{
+	transitions: map[token]*parseNode{lexbase.CHANGEFEED: sinklessChangefeedArgs.repeated()},
+}
+
+// repeated causes a node to keep consuming tokens until it hits one it recognizes.
+func (t *parseNode) repeated() *parseNode {
+	t.defaultTransition = t
+	return t
+}
+
+// fakeSym is a dummy implementation of the
+// scanner.ScanSymType interface so that
+// we can get token ids out of scanner.Scan().
+type fakeSym struct {
+	id  int32
+	pos int32
+	s   string
+}
+
+var _ scanner.ScanSymType = (*fakeSym)(nil)
+
+func (s fakeSym) ID() int32                 { return s.id }
+func (s *fakeSym) SetID(id int32)           { s.id = id }
+func (s fakeSym) Pos() int32                { return s.pos }
+func (s *fakeSym) SetPos(p int32)           { s.pos = p }
+func (s fakeSym) Str() string               { return s.s }
+func (s *fakeSym) SetStr(v string)          { s.s = v }
+func (s fakeSym) UnionVal() interface{}     { return nil }
+func (s fakeSym) SetUnionVal(v interface{}) {}

--- a/pkg/cli/interactive_tests/test_changefeed.tcl
+++ b/pkg/cli/interactive_tests/test_changefeed.tcl
@@ -1,0 +1,46 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+start_test "Check that changefeed flushes readable output to the terminal."
+send "$argv sql\r"
+eexpect root@
+send "create table target(i int primary key);insert into target values (0);\r"
+eexpect "CREATE"
+eexpect "INSERT"
+eexpect root@
+send "create changefeed for target with diff;\r"
+eexpect "ERROR: rangefeeds require the kv.rangefeed.enabled setting"
+eexpect root@
+send "SET CLUSTER SETTING kv.rangefeed.enabled=true;\r"
+eexpect "SET"
+eexpect root@
+send "create changefeed for target with diff;\r"
+eexpect "target"
+eexpect "before"
+interrupt
+eexpect root@
+end_test
+
+start_test "Check that display changes for the changefeed are reset afterwards."
+send "select 'A'::bytea;\r"
+eexpect "\\x41"
+eexpect root@
+end_test
+
+start_test "Check that non-default formats are honored."
+send "\\set display_format=csv;\r"
+eexpect root@
+send "create changefeed for target;\r"
+eexpect "table,key,value"
+eexpect "target,"
+interrupt
+end_test
+
+stop_server $argv


### PR DESCRIPTION
This commit improves the experience of someone
trying out CREATE CHANGEFEED or EXPERIMENTAL
CHANGEFEED in a cockroach sql terminal by
automatically turning off the table display
format (which prevents flushing) and setting
bytea_output=escape, as core changefeeds output
JSON as bytes datums, for the duration of the
changefeed query.

Changefeeds with sinks specified are not affected,
nor are cockroach sql invocations that don't
detectably output to a terminal.

Release note (cli change): Improved the output of sinkless changefeeds in the cockroach sql terminal.

Release justification: Prevents UX degradation in 22.2 as a side effect of fixing the bytea_output bug.