### PR TITLE
sql: add DisableNotVisibleIndex to ScanFlags

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -244,9 +244,9 @@ func (b *stmtBundleBuilder) addOptPlans() {
 
 	b.z.AddFile("opt.txt", formatOptPlan(memo.ExprFmtHideAll))
 	b.z.AddFile("opt-v.txt", formatOptPlan(
-		memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
+		memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes|memo.ExprFmtHideNotVisibleIndexInfo,
 	))
-	b.z.AddFile("opt-vv.txt", formatOptPlan(memo.ExprFmtHideQualifications))
+	b.z.AddFile("opt-vv.txt", formatOptPlan(memo.ExprFmtHideQualifications|memo.ExprFmtHideNotVisibleIndexInfo))
 }
 
 // addExecPlan adds the EXPLAIN (VERBOSE) plan as file plan.txt.

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1006,7 +1006,8 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 			if errors.IsAssertionFailure(err) {
 				// Enhance the error with the EXPLAIN (OPT, VERBOSE) of the inner
 				// expression.
-				fmtFlags := memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes
+				fmtFlags := memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes |
+					memo.ExprFmtHideNotVisibleIndexInfo
 				explainOpt := o.FormatExpr(newRightSide, fmtFlags)
 				err = errors.WithDetailf(err, "newRightSide:\n%s", explainOpt)
 			}

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -91,10 +91,10 @@ func (b *Builder) buildExplainOpt(explain *memo.ExplainExpr) (execPlan, error) {
 	switch {
 	case explain.Options.Flags[tree.ExplainFlagVerbose]:
 		fmtFlags = memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars |
-			memo.ExprFmtHideTypes | memo.ExprFmtHideNotNull
+			memo.ExprFmtHideTypes | memo.ExprFmtHideNotNull | memo.ExprFmtHideNotVisibleIndexInfo
 
 	case explain.Options.Flags[tree.ExplainFlagTypes]:
-		fmtFlags = memo.ExprFmtHideQualifications
+		fmtFlags = memo.ExprFmtHideQualifications | memo.ExprFmtHideNotVisibleIndexInfo
 	}
 
 	// Format the plan here and pass it through to the exec factory.

--- a/pkg/sql/opt/indexrec/indexrec_test.go
+++ b/pkg/sql/opt/indexrec/indexrec_test.go
@@ -29,7 +29,8 @@ func TestIndexRec(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const fmtFlags = memo.ExprFmtHideStats | memo.ExprFmtHideRuleProps |
-		memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes
+		memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes |
+		memo.ExprFmtHideNotVisibleIndexInfo
 	datadriven.Walk(t, testutils.TestDataPath(t), func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -379,7 +379,7 @@ func TestInterner(t *testing.T) {
 		{hashFn: in.hasher.HashScanFlags, eqFn: in.hasher.IsScanFlagsEqual, variations: []testVariation{
 			// Use unnamed fields so that compilation fails if a new field is
 			// added to ScanFlags.
-			{val1: ScanFlags{false, false, false, false, false, 0, 0, util.FastIntSet{}}, val2: ScanFlags{}, equal: true},
+			{val1: ScanFlags{false, false, false, false, false, 0, 0, false, util.FastIntSet{}}, val2: ScanFlags{}, equal: true},
 			{val1: ScanFlags{}, val2: ScanFlags{}, equal: true},
 			{val1: ScanFlags{NoIndexJoin: false}, val2: ScanFlags{NoIndexJoin: true}, equal: false},
 			{val1: ScanFlags{NoIndexJoin: true}, val2: ScanFlags{NoIndexJoin: true}, equal: true},

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestMemo(t *testing.T) {
 	flags := memo.ExprFmtHideCost | memo.ExprFmtHideRuleProps | memo.ExprFmtHideQualifications |
-		memo.ExprFmtHideStats
+		memo.ExprFmtHideStats | memo.ExprFmtHideNotVisibleIndexInfo
 	runDataDrivenTest(t, testutils.TestDataPath(t, "memo"), flags)
 }
 
@@ -43,19 +43,20 @@ func TestFormat(t *testing.T) {
 }
 
 func TestLogicalProps(t *testing.T) {
-	flags := memo.ExprFmtHideCost | memo.ExprFmtHideQualifications | memo.ExprFmtHideStats
+	flags := memo.ExprFmtHideCost | memo.ExprFmtHideQualifications | memo.ExprFmtHideStats |
+		memo.ExprFmtHideNotVisibleIndexInfo
 	runDataDrivenTest(t, testutils.TestDataPath(t, "logprops"), flags)
 }
 
 func TestStats(t *testing.T) {
 	flags := memo.ExprFmtHideCost | memo.ExprFmtHideRuleProps | memo.ExprFmtHideQualifications |
-		memo.ExprFmtHideScalars
+		memo.ExprFmtHideScalars | memo.ExprFmtHideNotVisibleIndexInfo
 	runDataDrivenTest(t, testutils.TestDataPath(t, "stats"), flags)
 }
 
 func TestStatsQuality(t *testing.T) {
 	flags := memo.ExprFmtHideCost | memo.ExprFmtHideRuleProps | memo.ExprFmtHideQualifications |
-		memo.ExprFmtHideScalars
+		memo.ExprFmtHideScalars | memo.ExprFmtHideNotVisibleIndexInfo
 	runDataDrivenTest(t, testutils.TestDataPath(t, "stats_quality"), flags)
 }
 

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -128,7 +128,7 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized, ~23KB, required=[presentation: y:2,x:5,c:10] [ordering: +2])
+memo (optimized, ~24KB, required=[presentation: y:2,x:5,c:10] [ordering: +2])
  ├── G1: (project G2 G3 y x)
  │    ├── [presentation: y:2,x:5,c:10] [ordering: +2]
  │    │    ├── best: (project G2="[ordering: +2]" G3 y x)

--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -31,7 +31,8 @@ func TestTyping(t *testing.T) {
 			memo.ExprFmtHideStats|
 			memo.ExprFmtHideCost|
 			memo.ExprFmtHideQualifications|
-			memo.ExprFmtHideScalars,
+			memo.ExprFmtHideScalars|
+			memo.ExprFmtHideNotVisibleIndexInfo,
 	)
 }
 

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -42,7 +42,8 @@ func TestNormRules(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const fmtFlags = memo.ExprFmtHideStats | memo.ExprFmtHideCost | memo.ExprFmtHideRuleProps |
-		memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes
+		memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes |
+		memo.ExprFmtHideNotVisibleIndexInfo
 	datadriven.Walk(t, testutils.TestDataPath(t, "rules"), func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
@@ -61,7 +62,8 @@ func TestNormRuleProps(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const fmtFlags = memo.ExprFmtHideStats | memo.ExprFmtHideCost |
-		memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes
+		memo.ExprFmtHideQualifications | memo.ExprFmtHideScalars | memo.ExprFmtHideTypes |
+		memo.ExprFmtHideNotVisibleIndexInfo
 	datadriven.Walk(t, testutils.TestDataPath(t, "ruleprops"), func(t *testing.T, path string) {
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -601,6 +601,7 @@ with &2 (cte)
  │                   │         └── &1: count=1 used-columns=(6)
  │                   ├── scan t.public.parent
  │                   │    ├── columns: t.public.parent.p:8(int!null)
+ │                   │    ├── flags: disabled not visible index feature
  │                   │    ├── stats: [rows=1000, distinct(8)=1000, null(8)=0, avgsize(8)=4]
  │                   │    ├── cost: 1044.22
  │                   │    ├── key: (8)

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -299,6 +299,7 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 			nil, /* indexFlags */
 			noRowLocking,
 			b.allocScope(),
+			true, /* disableNotVisibleIndex */
 		)
 		mb.outScope = mb.fetchScope
 
@@ -520,6 +521,7 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 		nil, /* indexFlags */
 		noRowLocking,
 		b.allocScope(),
+		true, /* disableNotVisibleIndex */
 	)
 
 	numFKCols := fk.ColumnCount()
@@ -756,6 +758,7 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 		nil, /* indexFlags */
 		noRowLocking,
 		b.allocScope(),
+		true, /* disableNotVisibleIndex */
 	)
 
 	numFKCols := fk.ColumnCount()

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -295,6 +295,7 @@ func (mb *mutationBuilder) buildInputForUpdate(
 		indexFlags,
 		noRowLocking,
 		inScope,
+		false, /* disableNotVisibleIndex */
 	)
 
 	// Set list of columns that will be fetched by the input expression.
@@ -410,6 +411,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 		indexFlags,
 		noRowLocking,
 		inScope,
+		false, /* disableNotVisibleIndex */
 	)
 	mb.outScope = mb.fetchScope
 

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -294,6 +294,7 @@ func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
 		nil, /* indexFlags */
 		noRowLocking,
 		inScope,
+		true, /* disableNotVisibleIndex */
 	)
 
 	// If the index is a unique partial index, then rows that are not in the
@@ -379,6 +380,7 @@ func (mb *mutationBuilder) buildLeftJoinForUpsertArbiter(
 		nil, /* indexFlags */
 		noRowLocking,
 		inScope,
+		true, /* disableNotVisibleIndex */
 	)
 	// Set fetchColIDs to reference the columns created for the fetch values.
 	mb.setFetchColIDs(mb.fetchScope.cols)
@@ -586,6 +588,7 @@ func (h *arbiterPredicateHelper) tableScope() *scope {
 			nil, /* indexFlags */
 			noRowLocking,
 			h.mb.b.allocScope(),
+			false, /* disableNotVisibleIndex */
 		)
 	}
 	return h.tableScopeLazy

--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -620,6 +620,7 @@ func (h *fkCheckHelper) buildOtherTableScan() (outScope *scope, tabMeta *opt.Tab
 		&tree.IndexFlags{IgnoreForeignKeys: true},
 		noRowLocking,
 		h.mb.b.allocScope(),
+		true, /* disableNotVisibleIndex */
 	), otherTabMeta
 }
 

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -410,6 +410,7 @@ func (h *uniqueCheckHelper) buildTableScan() (outScope *scope, ordinals []int) {
 		&tree.IndexFlags{IgnoreUniqueWithoutIndexKeys: true},
 		noRowLocking,
 		h.mb.b.allocScope(),
+		true, /* disableNotVisibleIndex */
 	), ordinals
 }
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -121,6 +121,7 @@ func (b *Builder) buildDataSource(
 					includeInverted:  false,
 				}),
 				indexFlags, locking, inScope,
+				false, /* disableNotVisibleIndex */
 			)
 
 		case cat.Sequence:
@@ -407,7 +408,8 @@ func (b *Builder) buildScanFromTableRef(
 
 	tn := tree.MakeUnqualifiedTableName(tab.Name())
 	tabMeta := b.addTable(tab, &tn)
-	return b.buildScan(tabMeta, ordinals, indexFlags, locking, inScope)
+
+	return b.buildScan(tabMeta, ordinals, indexFlags, locking, inScope, false /* disableNotVisibleIndex */)
 }
 
 // addTable adds a table to the metadata and returns the TableMeta. The table
@@ -447,6 +449,7 @@ func (b *Builder) buildScan(
 	indexFlags *tree.IndexFlags,
 	locking lockingSpec,
 	inScope *scope,
+	disableNotVisibleIndex bool,
 ) (outScope *scope) {
 	if ordinals == nil {
 		panic(errors.AssertionFailedf("no ordinals"))
@@ -594,6 +597,7 @@ func (b *Builder) buildScan(
 		private.Flags.NoIndexJoin = true
 		private.Flags.NoZigzagJoin = true
 	}
+	private.Flags.DisableNotVisibleIndex = disableNotVisibleIndex
 
 	b.addCheckConstraintsForTable(tabMeta)
 	b.addComputedColsForTable(tabMeta)

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
@@ -41,7 +41,8 @@ delete parent
                 │    └── mapping:
                 │         └──  parent.p:7 => p:11
                 ├── scan child
-                │    └── columns: child.p:13!null
+                │    ├── columns: child.p:13!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:11 = child.p:13
 
@@ -71,7 +72,8 @@ delete parent
       │         │    └── mapping:
       │         │         └──  parent.p:7 => p:11
       │         ├── scan child
-      │         │    └── columns: child.p:13!null
+      │         │    ├── columns: child.p:13!null
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── p:11 = child.p:13
       └── f-k-checks-item: child2(p) -> parent(other)
@@ -82,7 +84,8 @@ delete parent
                 │    └── mapping:
                 │         └──  parent.other:8 => other:16
                 ├── scan child2
-                │    └── columns: child2.p:18!null
+                │    ├── columns: child2.p:18!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── other:16 = child2.p:18
 
@@ -117,7 +120,8 @@ delete doubleparent
                 │         ├──  doubleparent.p1:6 => p1:11
                 │         └──  doubleparent.p2:7 => p2:12
                 ├── scan doublechild
-                │    └── columns: doublechild.p1:14 doublechild.p2:15
+                │    ├── columns: doublechild.p1:14 doublechild.p2:15
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p1:11 = doublechild.p1:14
                      └── p2:12 = doublechild.p2:15
@@ -159,7 +163,8 @@ delete parent
       │         │    └── mapping:
       │         │         └──  parent.p:7 => p:11
       │         ├── scan child
-      │         │    └── columns: child.p:13!null
+      │         │    ├── columns: child.p:13!null
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── p:11 = child.p:13
       └── f-k-checks-item: child2(p) -> parent(other)
@@ -171,6 +176,7 @@ delete parent
                 │    └── mapping:
                 │         └──  parent.other:8 => other:16
                 ├── scan child2
-                │    └── columns: child2.p:18!null
+                │    ├── columns: child2.p:18!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── other:16 = child2.p:18

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -28,7 +28,8 @@ insert child
                 │    └── mapping:
                 │         └──  column2:6 => p:7
                 ├── scan parent
-                │    └── columns: parent.p:8!null
+                │    ├── columns: parent.p:8!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -52,7 +53,8 @@ insert child
  │    │    │    ├── (100, 1)
  │    │    │    └── (200, 1)
  │    │    ├── scan child
- │    │    │    └── columns: c:7!null child.p:8!null
+ │    │    │    ├── columns: c:7!null child.p:8!null
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:5 = c:7
  │    └── aggregations
@@ -67,7 +69,8 @@ insert child
                 │    └── mapping:
                 │         └──  column2:6 => p:11
                 ├── scan parent
-                │    └── columns: parent.p:12!null
+                │    ├── columns: parent.p:12!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:11 = parent.p:12
 
@@ -98,7 +101,8 @@ insert child
                 │    └── mapping:
                 │         └──  y:6 => p:10
                 ├── scan parent
-                │    └── columns: parent.p:11!null
+                │    ├── columns: parent.p:11!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:11
 
@@ -134,7 +138,8 @@ insert child_nullable
                 │    └── filters
                 │         └── p:7 IS NOT NULL
                 ├── scan parent
-                │    └── columns: parent.p:8!null
+                │    ├── columns: parent.p:8!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -162,7 +167,8 @@ insert child_nullable
                 │    └── mapping:
                 │         └──  column2:6 => p:7
                 ├── scan parent
-                │    └── columns: parent.p:8!null
+                │    ├── columns: parent.p:8!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -233,7 +239,8 @@ insert child_nullable_full
                 │    └── filters
                 │         └── p:7 IS NOT NULL
                 ├── scan parent
-                │    └── columns: parent.p:8!null
+                │    ├── columns: parent.p:8!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -301,7 +308,8 @@ insert multi_col_child
                 │         ├── q:12 IS NOT NULL
                 │         └── r:13 IS NOT NULL
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -339,7 +347,8 @@ insert multi_col_child
                 │         ├── p:11 IS NOT NULL
                 │         └── q:12 IS NOT NULL
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -371,7 +380,8 @@ insert multi_col_child
                 │         ├──  column3:9 => q:12
                 │         └──  column4:10 => r:13
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -433,7 +443,8 @@ insert multi_col_child_full
                 │    └── filters
                 │         └── ((p:11 IS NOT NULL) OR (q:12 IS NOT NULL)) OR (r:13 IS NOT NULL)
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -466,7 +477,8 @@ insert multi_col_child_full
                 │         ├──  column3:9 => q:12
                 │         └──  column4:10 => r:13
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -498,7 +510,8 @@ insert multi_col_child_full
                 │         ├──  column3:9 => q:12
                 │         └──  column4:10 => r:13
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -548,7 +561,8 @@ insert multi_col_child_full
                 │         ├──  column3:9 => q:12
                 │         └──  column4:10 => r:13
                 ├── scan multi_col_parent
-                │    └── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -602,7 +616,8 @@ insert multi_ref_child
       │         │    └── filters
       │         │         └── a:11 IS NOT NULL
       │         ├── scan multi_ref_parent_a
-      │         │    └── columns: multi_ref_parent_a.a:12!null
+      │         │    ├── columns: multi_ref_parent_a.a:12!null
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── a:11 = multi_ref_parent_a.a:12
       └── f-k-checks-item: multi_ref_child(b,c) -> multi_ref_parent_bc(b,c)
@@ -619,7 +634,8 @@ insert multi_ref_child
                 │         ├── b:16 IS NOT NULL
                 │         └── c:17 IS NOT NULL
                 ├── scan multi_ref_parent_bc
-                │    └── columns: multi_ref_parent_bc.b:18!null multi_ref_parent_bc.c:19!null
+                │    ├── columns: multi_ref_parent_bc.b:18!null multi_ref_parent_bc.c:19!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── b:16 = multi_ref_parent_bc.b:18
                      └── c:17 = multi_ref_parent_bc.c:19
@@ -664,6 +680,7 @@ insert child
                 │    └── mapping:
                 │         └──  column2:6 => p:7
                 ├── scan parent
-                │    └── columns: parent.p:8!null
+                │    ├── columns: parent.p:8!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -30,7 +30,8 @@ update child
                 │    └── mapping:
                 │         └──  p_new:9 => p:10
                 ├── scan parent
-                │    └── columns: parent.p:12!null
+                │    ├── columns: parent.p:12!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12
 
@@ -66,7 +67,8 @@ update parent
                 │         └── mapping:
                 │              └──  p_new:11 => p:13
                 ├── scan child
-                │    └── columns: child.p:15!null
+                │    ├── columns: child.p:15!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:12 = child.p:15
 
@@ -106,7 +108,8 @@ update child
                 │         └── mapping:
                 │              └──  c_new:9 => c:11
                 ├── scan grandchild
-                │    └── columns: grandchild.c:13!null
+                │    ├── columns: grandchild.c:13!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── c:10 = grandchild.c:13
 
@@ -135,7 +138,8 @@ update child
                 │    └── mapping:
                 │         └──  p_new:9 => p:10
                 ├── scan parent
-                │    └── columns: parent.p:12!null
+                │    ├── columns: parent.p:12!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12
 
@@ -159,7 +163,8 @@ update child
                 │    └── mapping:
                 │         └──  child.p:6 => p:9
                 ├── scan parent
-                │    └── columns: parent.p:11!null
+                │    ├── columns: parent.p:11!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:9 = parent.p:11
 
@@ -189,7 +194,8 @@ update child
       │         │    └── mapping:
       │         │         └──  p_new:9 => p:11
       │         ├── scan parent
-      │         │    └── columns: parent.p:13!null
+      │         │    ├── columns: parent.p:13!null
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── p:11 = parent.p:13
       └── f-k-checks-item: grandchild(c) -> child(c)
@@ -208,7 +214,8 @@ update child
                 │         └── mapping:
                 │              └──  c_new:10 => c:18
                 ├── scan grandchild
-                │    └── columns: grandchild.c:20!null
+                │    ├── columns: grandchild.c:20!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── c:17 = grandchild.c:20
 
@@ -262,7 +269,8 @@ update child
                 │    └── mapping:
                 │         └──  p_new:9 => p:10
                 ├── scan parent
-                │    └── columns: parent.p:12!null
+                │    ├── columns: parent.p:12!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12
 
@@ -294,7 +302,8 @@ update self
                 │    └── mapping:
                 │         └──  y_new:9 => y:10
                 ├── scan self
-                │    └── columns: x:11!null
+                │    ├── columns: x:11!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── y:10 = x:11
 
@@ -330,7 +339,8 @@ update self
                 │         └── mapping:
                 │              └──  x_new:9 => x:11
                 ├── scan self
-                │    └── columns: y:13!null
+                │    ├── columns: y:13!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── x:10 = y:13
 
@@ -411,7 +421,8 @@ update child_multicol_full
                 │         ├──  b_new:14 => b:16
                 │         └──  a_new:13 => c:17
                 ├── scan parent_multicol
-                │    └── columns: parent_multicol.a:18!null parent_multicol.b:19!null parent_multicol.c:20!null
+                │    ├── columns: parent_multicol.a:18!null parent_multicol.b:19!null parent_multicol.c:20!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── a:15 = parent_multicol.a:18
                      ├── b:16 = parent_multicol.b:19
@@ -488,7 +499,8 @@ update fam
                 │    └── filters
                 │         └── d:19 IS NOT NULL
                 ├── scan two
-                │    └── columns: two.a:20!null two.b:21!null
+                │    ├── columns: two.a:20!null two.b:21!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── c:18 = two.a:20
                      └── d:19 = two.b:21
@@ -522,7 +534,8 @@ update fam
                 │    └── filters
                 │         └── c:18 IS NOT NULL
                 ├── scan two
-                │    └── columns: two.a:20!null two.b:21!null
+                │    ├── columns: two.a:20!null two.b:21!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── c:18 = two.a:20
                      └── d:19 = two.b:21
@@ -553,6 +566,7 @@ update child
                 │    └── mapping:
                 │         └──  p_new:9 => p:10
                 ├── scan parent
-                │    └── columns: parent.p:12!null
+                │    ├── columns: parent.p:12!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -57,7 +57,8 @@ upsert c1
                 │    └── mapping:
                 │         └──  column2:7 => p:9
                 ├── scan p
-                │    └── columns: p.p:10!null
+                │    ├── columns: p.p:10!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:9 = p.p:10
 
@@ -96,7 +97,8 @@ upsert c1
  │    │    │         └── first-agg [as=i_default:8]
  │    │    │              └── i_default:8
  │    │    ├── scan c1
- │    │    │    └── columns: c:9!null c1.p:10!null i:11 c1.crdb_internal_mvcc_timestamp:12 c1.tableoid:13
+ │    │    │    ├── columns: c:9!null c1.p:10!null i:11 c1.crdb_internal_mvcc_timestamp:12 c1.tableoid:13
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:6 = c:9
  │    └── projections
@@ -112,7 +114,8 @@ upsert c1
                 │    └── mapping:
                 │         └──  upsert_p:15 => p:17
                 ├── scan p
-                │    └── columns: p.p:18!null
+                │    ├── columns: p.p:18!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:17 = p.p:18
 
@@ -144,7 +147,8 @@ upsert c1
                 │    └── mapping:
                 │         └──  y:7 => p:14
                 ├── scan p
-                │    └── columns: p.p:15!null
+                │    ├── columns: p.p:15!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:14 = p.p:15
 
@@ -186,7 +190,8 @@ upsert c1
  │    │    │    │         └── first-agg [as=i_default:8]
  │    │    │    │              └── i_default:8
  │    │    │    ├── scan c1
- │    │    │    │    └── columns: c:9!null c1.p:10!null i:11 c1.crdb_internal_mvcc_timestamp:12 c1.tableoid:13
+ │    │    │    │    ├── columns: c:9!null c1.p:10!null i:11 c1.crdb_internal_mvcc_timestamp:12 c1.tableoid:13
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:6 = c:9
  │    │    └── projections
@@ -204,7 +209,8 @@ upsert c1
                 │    └── mapping:
                 │         └──  upsert_p:16 => p:18
                 ├── scan p
-                │    └── columns: p.p:19!null
+                │    ├── columns: p.p:19!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:18 = p.p:19
 
@@ -246,7 +252,8 @@ upsert c1
  │    │    │    │         └── first-agg [as=i_default:11]
  │    │    │    │              └── i_default:11
  │    │    │    ├── scan c1
- │    │    │    │    └── columns: c:12!null c1.p:13!null i:14 c1.crdb_internal_mvcc_timestamp:15 c1.tableoid:16
+ │    │    │    │    ├── columns: c:12!null c1.p:13!null i:14 c1.crdb_internal_mvcc_timestamp:15 c1.tableoid:16
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── u:6 = c:12
  │    │    └── projections
@@ -264,7 +271,8 @@ upsert c1
                 │    └── mapping:
                 │         └──  upsert_p:19 => p:21
                 ├── scan p
-                │    └── columns: p.p:22!null
+                │    ├── columns: p.p:22!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:21 = p.p:22
 
@@ -299,7 +307,8 @@ upsert c2
  │    │    │    │         ├── (1,)
  │    │    │    │         └── (2,)
  │    │    │    ├── scan c2
- │    │    │    │    └── columns: c2.c:5!null c2.crdb_internal_mvcc_timestamp:6 c2.tableoid:7
+ │    │    │    │    ├── columns: c2.c:5!null c2.crdb_internal_mvcc_timestamp:6 c2.tableoid:7
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:4 = c2.c:5
  │    │    └── projections
@@ -315,7 +324,8 @@ upsert c2
                 │    └── mapping:
                 │         └──  upsert_c:9 => c:10
                 ├── scan p
-                │    └── columns: p:11!null
+                │    ├── columns: p:11!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── c:10 = p:11
 
@@ -351,7 +361,8 @@ upsert c3
                 │    └── filters
                 │         └── p:7 IS NOT NULL
                 ├── scan p
-                │    └── columns: p.p:8!null
+                │    ├── columns: p.p:8!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:7 = p.p:8
 
@@ -386,7 +397,8 @@ upsert c3
  │    │    │         └── first-agg [as=p_default:6]
  │    │    │              └── p_default:6
  │    │    ├── scan c3
- │    │    │    └── columns: c:7!null c3.p:8 c3.crdb_internal_mvcc_timestamp:9 c3.tableoid:10
+ │    │    │    ├── columns: c:7!null c3.p:8 c3.crdb_internal_mvcc_timestamp:9 c3.tableoid:10
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:5 = c:7
  │    └── projections
@@ -405,7 +417,8 @@ upsert c3
                 │    └── filters
                 │         └── p:13 IS NOT NULL
                 ├── scan p
-                │    └── columns: p.p:14!null
+                │    ├── columns: p.p:14!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:13 = p.p:14
 
@@ -447,7 +460,8 @@ upsert c4
  │    │    │    │         └── first-agg [as=z:8]
  │    │    │    │              └── z:8
  │    │    │    ├── scan c4
- │    │    │    │    └── columns: c:13!null c4.a:14 c4.other:15 c4.crdb_internal_mvcc_timestamp:16 c4.tableoid:17
+ │    │    │    │    ├── columns: c:13!null c4.a:14 c4.other:15 c4.crdb_internal_mvcc_timestamp:16 c4.tableoid:17
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── y:7 = c4.a:14
  │    │    └── projections
@@ -469,7 +483,8 @@ upsert c4
                 │    └── filters
                 │         └── a:22 IS NOT NULL
                 ├── scan p
-                │    └── columns: p:23!null
+                │    ├── columns: p:23!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── a:22 = p:23
 
@@ -507,7 +522,8 @@ upsert c4
  │    │    │    │         └── first-agg [as=z:8]
  │    │    │    │              └── z:8
  │    │    │    ├── scan c4
- │    │    │    │    └── columns: c:13!null c4.a:14 c4.other:15 c4.crdb_internal_mvcc_timestamp:16 c4.tableoid:17
+ │    │    │    │    ├── columns: c:13!null c4.a:14 c4.other:15 c4.crdb_internal_mvcc_timestamp:16 c4.tableoid:17
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── y:7 = c4.a:14
  │    │    └── projections
@@ -529,7 +545,8 @@ upsert c4
                 │    └── filters
                 │         └── a:22 IS NOT NULL
                 ├── scan p
-                │    └── columns: p:23!null
+                │    ├── columns: p:23!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── a:22 = p:23
 
@@ -584,7 +601,8 @@ upsert cpq
                 │         ├──  column2:8 => p:11
                 │         └──  column3:9 => q:12
                 ├── scan pq
-                │    └── columns: pq.p:14 pq.q:15
+                │    ├── columns: pq.p:14 pq.q:15
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:11 = pq.p:14
                      └── q:12 = pq.q:15
@@ -620,7 +638,8 @@ upsert cpq
                 │         ├── p:14 IS NOT NULL
                 │         └── q:15 IS NOT NULL
                 ├── scan pq
-                │    └── columns: pq.p:17 pq.q:18
+                │    ├── columns: pq.p:17 pq.q:18
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:14 = pq.p:17
                      └── q:15 = pq.q:18
@@ -665,7 +684,8 @@ upsert cpq
  │    │    │         └── first-agg [as=other_default:15]
  │    │    │              └── other_default:15
  │    │    ├── scan cpq
- │    │    │    └── columns: c:16!null cpq.p:17 cpq.q:18 cpq.other:19 cpq.crdb_internal_mvcc_timestamp:20 cpq.tableoid:21
+ │    │    │    ├── columns: c:16!null cpq.p:17 cpq.q:18 cpq.other:19 cpq.crdb_internal_mvcc_timestamp:20 cpq.tableoid:21
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── x:7 = c:16
  │    └── projections
@@ -687,7 +707,8 @@ upsert cpq
                 │         ├── p:25 IS NOT NULL
                 │         └── q:26 IS NOT NULL
                 ├── scan pq
-                │    └── columns: pq.p:28 pq.q:29
+                │    ├── columns: pq.p:28 pq.q:29
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:25 = pq.p:28
                      └── q:26 = pq.q:29
@@ -731,7 +752,8 @@ upsert cpq
  │    │    │         └── first-agg [as=other_default:16]
  │    │    │              └── other_default:16
  │    │    ├── scan cpq
- │    │    │    └── columns: c:17!null cpq.p:18 cpq.q:19 cpq.other:20 cpq.crdb_internal_mvcc_timestamp:21 cpq.tableoid:22
+ │    │    │    ├── columns: c:17!null cpq.p:18 cpq.q:19 cpq.other:20 cpq.crdb_internal_mvcc_timestamp:21 cpq.tableoid:22
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── x:7 = c:17
  │    └── projections
@@ -754,7 +776,8 @@ upsert cpq
                 │         ├── p:27 IS NOT NULL
                 │         └── q:28 IS NOT NULL
                 ├── scan pq
-                │    └── columns: pq.p:30 pq.q:31
+                │    ├── columns: pq.p:30 pq.q:31
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:27 = pq.p:30
                      └── q:28 = pq.q:31
@@ -792,7 +815,8 @@ upsert cpq
                 │         ├──  p_default:14 => p:17
                 │         └──  q_default:15 => q:18
                 ├── scan pq
-                │    └── columns: pq.p:20 pq.q:21
+                │    ├── columns: pq.p:20 pq.q:21
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:17 = pq.p:20
                      └── q:18 = pq.q:21
@@ -840,7 +864,8 @@ upsert cpq
  │    │    │    │         └── first-agg [as=other_default:10]
  │    │    │    │              └── other_default:10
  │    │    │    ├── scan cpq
- │    │    │    │    └── columns: c:11!null cpq.p:12 cpq.q:13 cpq.other:14 cpq.crdb_internal_mvcc_timestamp:15 cpq.tableoid:16
+ │    │    │    │    ├── columns: c:11!null cpq.p:12 cpq.q:13 cpq.other:14 cpq.crdb_internal_mvcc_timestamp:15 cpq.tableoid:16
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:7 = c:11
  │    │    └── projections
@@ -864,7 +889,8 @@ upsert cpq
                 │    └── filters
                 │         └── q:23 IS NOT NULL
                 ├── scan pq
-                │    └── columns: pq.p:25 pq.q:26
+                │    ├── columns: pq.p:25 pq.q:26
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:22 = pq.p:25
                      └── q:23 = pq.q:26
@@ -909,7 +935,8 @@ upsert cmulti
       │         │    └── mapping:
       │         │         └──  x:7 => a:14
       │         ├── scan p
-      │         │    └── columns: p.p:15!null
+      │         │    ├── columns: p.p:15!null
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── a:14 = p.p:15
       └── f-k-checks-item: cmulti(b,c) -> pq(p,q)
@@ -921,7 +948,8 @@ upsert cmulti
                 │         ├──  y:8 => b:19
                 │         └──  z:9 => c:20
                 ├── scan pq
-                │    └── columns: pq.p:22 q:23
+                │    ├── columns: pq.p:22 q:23
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── b:19 = pq.p:22
                      └── c:20 = q:23
@@ -963,7 +991,8 @@ upsert cmulti
  │    │    │         └── first-agg [as=d_default:14]
  │    │    │              └── d_default:14
  │    │    ├── scan cmulti
- │    │    │    └── columns: cmulti.a:15!null cmulti.b:16!null cmulti.c:17 d:18 cmulti.crdb_internal_mvcc_timestamp:19 cmulti.tableoid:20
+ │    │    │    ├── columns: cmulti.a:15!null cmulti.b:16!null cmulti.c:17 d:18 cmulti.crdb_internal_mvcc_timestamp:19 cmulti.tableoid:20
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         ├── x:7 = cmulti.a:15
  │    │         └── y:8 = cmulti.b:16
@@ -980,7 +1009,8 @@ upsert cmulti
       │         │    └── mapping:
       │         │         └──  upsert_a:21 => a:24
       │         ├── scan p
-      │         │    └── columns: p.p:25!null
+      │         │    ├── columns: p.p:25!null
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── a:24 = p.p:25
       └── f-k-checks-item: cmulti(b,c) -> pq(p,q)
@@ -992,7 +1022,8 @@ upsert cmulti
                 │         ├──  upsert_b:22 => b:29
                 │         └──  z:9 => c:30
                 ├── scan pq
-                │    └── columns: pq.p:32 q:33
+                │    ├── columns: pq.p:32 q:33
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── b:29 = pq.p:32
                      └── c:30 = q:33
@@ -1052,7 +1083,8 @@ upsert p1
       │    │         └── first-agg [as=column2:6]
       │    │              └── column2:6
       │    ├── scan p1
-      │    │    └── columns: p:7!null other:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    ├── columns: p:7!null other:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:5 = p:7
       └── projections
@@ -1091,7 +1123,8 @@ upsert p1
  │    │    │    │         └── first-agg [as=column2:6]
  │    │    │    │              └── column2:6
  │    │    │    ├── scan p1
- │    │    │    │    └── columns: p1.p:7!null other:8 p1.crdb_internal_mvcc_timestamp:9 p1.tableoid:10
+ │    │    │    │    ├── columns: p1.p:7!null other:8 p1.crdb_internal_mvcc_timestamp:9 p1.tableoid:10
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:5 = p1.p:7
  │    │    └── projections
@@ -1116,7 +1149,8 @@ upsert p1
                 │         └── mapping:
                 │              └──  upsert_p:12 => p:15
                 ├── scan p1c
-                │    └── columns: p1c.p:17!null
+                │    ├── columns: p1c.p:17!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── p:14 = p1c.p:17
 
@@ -1151,7 +1185,8 @@ upsert p1
       │    │    │         └── first-agg [as=column2:6]
       │    │    │              └── column2:6
       │    │    ├── scan p1
-      │    │    │    └── columns: p:7!null other:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    ├── columns: p:7!null other:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:5 = p:7
       │    └── projections
@@ -1198,7 +1233,8 @@ upsert p2
  │    │    │         └── first-agg [as=column2:6]
  │    │    │              └── column2:6
  │    │    ├── scan p2
- │    │    │    └── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
+ │    │    │    ├── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:5 = p:7
  │    └── projections
@@ -1220,7 +1256,8 @@ upsert p2
                 │         └── mapping:
                 │              └──  column2:6 => fk:13
                 ├── scan p2c
-                │    └── columns: p2c.fk:15
+                │    ├── columns: p2c.fk:15
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── fk:12 = p2c.fk:15
 
@@ -1256,7 +1293,8 @@ upsert p2
       │    │    │         └── first-agg [as=column2:6]
       │    │    │              └── column2:6
       │    │    ├── scan p2
-      │    │    │    └── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    ├── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:5 = p:7
       │    └── projections
@@ -1298,7 +1336,8 @@ upsert p2
  │    │    │    │         └── first-agg [as=column2:6]
  │    │    │    │              └── column2:6
  │    │    │    ├── scan p2
- │    │    │    │    └── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
+ │    │    │    │    ├── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:5 = p:7
  │    │    └── projections
@@ -1323,7 +1362,8 @@ upsert p2
                 │         └── mapping:
                 │              └──  upsert_fk:13 => fk:15
                 ├── scan p2c
-                │    └── columns: p2c.fk:17
+                │    ├── columns: p2c.fk:17
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── fk:14 = p2c.fk:17
 
@@ -1359,7 +1399,8 @@ upsert p2
       │    │    │         └── first-agg [as=column1:5]
       │    │    │              └── column1:5
       │    │    ├── scan p2
-      │    │    │    └── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    ├── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column2:6 = fk:8
       │    └── projections
@@ -1399,7 +1440,8 @@ upsert p2
  │    │    │    │         └── first-agg [as=column1:5]
  │    │    │    │              └── column1:5
  │    │    │    ├── scan p2
- │    │    │    │    └── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
+ │    │    │    │    ├── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column2:6 = p2.fk:8
  │    │    └── projections
@@ -1424,7 +1466,8 @@ upsert p2
                 │         └── mapping:
                 │              └──  upsert_fk:13 => fk:15
                 ├── scan p2c
-                │    └── columns: p2c.fk:17
+                │    ├── columns: p2c.fk:17
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── fk:14 = p2c.fk:17
 
@@ -1460,7 +1503,8 @@ upsert p2
       │    │         └── first-agg [as=fk_default:6]
       │    │              └── fk_default:6
       │    ├── scan p2
-      │    │    └── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    ├── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:5 = p:7
       └── projections
@@ -1508,7 +1552,8 @@ upsert pq
  │    │    │         └── first-agg [as=column4:10]
  │    │    │              └── column4:10
  │    │    ├── scan pq
- │    │    │    └── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
+ │    │    │    ├── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:7 = k:11
  │    └── projections
@@ -1532,7 +1577,8 @@ upsert pq
       │         │              ├──  column2:8 => p:20
       │         │              └──  column3:9 => q:21
       │         ├── scan cpq
-      │         │    └── columns: cpq.p:23 cpq.q:24
+      │         │    ├── columns: cpq.p:23 cpq.q:24
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              ├── p:18 = cpq.p:23
       │              └── q:19 = cpq.q:24
@@ -1554,7 +1600,8 @@ upsert pq
                 │              ├──  column2:8 => p:30
                 │              └──  column3:9 => q:31
                 ├── scan cmulti
-                │    └── columns: b:33!null cmulti.c:34
+                │    ├── columns: b:33!null cmulti.c:34
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:28 = b:33
                      └── q:29 = cmulti.c:34
@@ -1592,7 +1639,8 @@ upsert pq
       │    │         └── first-agg [as=p_default:8]
       │    │              └── p_default:8
       │    ├── scan pq
-      │    │    └── columns: k:9!null p:10 q:11 other:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── columns: k:9!null p:10 q:11 other:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:7 = k:9
       └── projections
@@ -1638,7 +1686,8 @@ upsert pq
  │    │    │         └── first-agg [as=p_default:9]
  │    │    │              └── p_default:9
  │    │    ├── scan pq
- │    │    │    └── columns: k:10!null pq.p:11 pq.q:12 pq.other:13 pq.crdb_internal_mvcc_timestamp:14 pq.tableoid:15
+ │    │    │    ├── columns: k:10!null pq.p:11 pq.q:12 pq.other:13 pq.crdb_internal_mvcc_timestamp:14 pq.tableoid:15
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:7 = k:10
  │    └── projections
@@ -1664,7 +1713,8 @@ upsert pq
       │         │              ├──  upsert_p:17 => p:21
       │         │              └──  column2:8 => q:22
       │         ├── scan cpq
-      │         │    └── columns: cpq.p:24 cpq.q:25
+      │         │    ├── columns: cpq.p:24 cpq.q:25
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              ├── p:19 = cpq.p:24
       │              └── q:20 = cpq.q:25
@@ -1686,7 +1736,8 @@ upsert pq
                 │              ├──  upsert_p:17 => p:31
                 │              └──  column2:8 => q:32
                 ├── scan cmulti
-                │    └── columns: b:34!null cmulti.c:35
+                │    ├── columns: b:34!null cmulti.c:35
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:29 = b:34
                      └── q:30 = cmulti.c:35
@@ -1726,7 +1777,8 @@ upsert pq
       │    │    │         └── first-agg [as=column4:10]
       │    │    │              └── column4:10
       │    │    ├── scan pq
-      │    │    │    └── columns: k:11!null p:12 q:13 other:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    ├── columns: k:11!null p:12 q:13 other:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         ├── column2:8 = p:12
       │    │         └── column3:9 = q:13
@@ -1773,7 +1825,8 @@ upsert pq
  │    │    │    │         └── first-agg [as=column4:10]
  │    │    │    │              └── column4:10
  │    │    │    ├── scan pq
- │    │    │    │    └── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
+ │    │    │    │    ├── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         ├── column2:8 = pq.p:12
  │    │    │         └── column3:9 = pq.q:13
@@ -1803,7 +1856,8 @@ upsert pq
       │         │              ├──  upsert_p:19 => p:24
       │         │              └──  upsert_q:20 => q:25
       │         ├── scan cpq
-      │         │    └── columns: cpq.p:27 cpq.q:28
+      │         │    ├── columns: cpq.p:27 cpq.q:28
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              ├── p:22 = cpq.p:27
       │              └── q:23 = cpq.q:28
@@ -1825,7 +1879,8 @@ upsert pq
                 │              ├──  upsert_p:19 => p:34
                 │              └──  upsert_q:20 => q:35
                 ├── scan cmulti
-                │    └── columns: b:37!null cmulti.c:38
+                │    ├── columns: b:37!null cmulti.c:38
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:32 = b:37
                      └── q:33 = cmulti.c:38
@@ -1867,7 +1922,8 @@ upsert pq
       │    │    │         └── first-agg [as=column4:10]
       │    │    │              └── column4:10
       │    │    ├── scan pq
-      │    │    │    └── columns: k:11!null p:12 q:13 other:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    ├── columns: k:11!null p:12 q:13 other:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = k:11
       │    └── projections
@@ -1915,7 +1971,8 @@ upsert pq
  │    │    │    │         └── first-agg [as=column4:10]
  │    │    │    │              └── column4:10
  │    │    │    ├── scan pq
- │    │    │    │    └── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
+ │    │    │    │    ├── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:7 = k:11
  │    │    └── projections
@@ -1944,7 +2001,8 @@ upsert pq
       │         │              ├──  upsert_p:19 => p:24
       │         │              └──  upsert_q:20 => q:25
       │         ├── scan cpq
-      │         │    └── columns: cpq.p:27 cpq.q:28
+      │         │    ├── columns: cpq.p:27 cpq.q:28
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              ├── p:22 = cpq.p:27
       │              └── q:23 = cpq.q:28
@@ -1966,7 +2024,8 @@ upsert pq
                 │              ├──  upsert_p:19 => p:34
                 │              └──  upsert_q:20 => q:35
                 ├── scan cmulti
-                │    └── columns: b:37!null cmulti.c:38
+                │    ├── columns: b:37!null cmulti.c:38
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── p:32 = b:37
                      └── q:33 = cmulti.c:38
@@ -2030,7 +2089,8 @@ upsert tab2
  │    │    │         └── first-agg [as=column3:8]
  │    │    │              └── column3:8
  │    │    ├── scan tab2
- │    │    │    └── columns: c:9!null tab2.d:10 tab2.e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
+ │    │    │    ├── columns: c:9!null tab2.d:10 tab2.e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:6 = c:9
  │    └── projections
@@ -2048,7 +2108,8 @@ upsert tab2
       │         │    └── filters
       │         │         └── d:15 IS NOT NULL
       │         ├── scan tab1
-      │         │    └── columns: b:17
+      │         │    ├── columns: b:17
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── d:15 = b:17
       └── f-k-checks-item: tab3(g) -> tab2(e)
@@ -2067,7 +2128,8 @@ upsert tab2
                 │         └── mapping:
                 │              └──  column3:8 => e:21
                 ├── scan tab3
-                │    └── columns: g:23
+                │    ├── columns: g:23
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── e:20 = g:23
 
@@ -2104,7 +2166,8 @@ upsert tab2
  │    │    │    │         └── first-agg [as=column3:8]
  │    │    │    │              └── column3:8
  │    │    │    ├── scan tab2
- │    │    │    │    └── columns: c:9!null tab2.d:10 tab2.e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
+ │    │    │    │    ├── columns: c:9!null tab2.d:10 tab2.e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:6 = c:9
  │    │    └── projections
@@ -2126,7 +2189,8 @@ upsert tab2
       │         │    └── filters
       │         │         └── d:18 IS NOT NULL
       │         ├── scan tab1
-      │         │    └── columns: b:20
+      │         │    ├── columns: b:20
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── d:18 = b:20
       └── f-k-checks-item: tab3(g) -> tab2(e)
@@ -2145,7 +2209,8 @@ upsert tab2
                 │         └── mapping:
                 │              └──  upsert_e:17 => e:24
                 ├── scan tab3
-                │    └── columns: g:26
+                │    ├── columns: g:26
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── e:23 = g:26
 
@@ -2183,7 +2248,8 @@ upsert tab2
  │    │    │    │         └── first-agg [as=column2:7]
  │    │    │    │              └── column2:7
  │    │    │    ├── scan tab2
- │    │    │    │    └── columns: c:9!null tab2.d:10 e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
+ │    │    │    │    ├── columns: c:9!null tab2.d:10 e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column3:8 = e:11
  │    │    └── projections
@@ -2205,7 +2271,8 @@ upsert tab2
                 │    └── filters
                 │         └── d:18 IS NOT NULL
                 ├── scan tab1
-                │    └── columns: b:20
+                │    ├── columns: b:20
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── d:18 = b:20
 
@@ -2257,7 +2324,8 @@ upsert self
  │    │    │         └── first-agg [as=w:10]
  │    │    │              └── w:10
  │    │    ├── scan self
- │    │    │    └── columns: self.a:14!null self.b:15!null self.c:16 self.d:17 self.crdb_internal_mvcc_timestamp:18 self.tableoid:19
+ │    │    │    ├── columns: self.a:14!null self.b:15!null self.c:16 self.d:17 self.crdb_internal_mvcc_timestamp:18 self.tableoid:19
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         ├── x:7 = self.a:14
  │    │         └── y:8 = self.b:15
@@ -2274,7 +2342,8 @@ upsert self
       │         │         ├──  upsert_a:20 => a:22
       │         │         └──  upsert_b:21 => b:23
       │         ├── scan self
-      │         │    └── columns: self.b:25!null self.d:27
+      │         │    ├── columns: self.b:25!null self.d:27
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              ├── a:22 = self.b:25
       │              └── b:23 = self.d:27
@@ -2290,7 +2359,8 @@ upsert self
       │         │    └── filters
       │         │         └── d:30 IS NOT NULL
       │         ├── scan self
-      │         │    └── columns: self.c:33
+      │         │    ├── columns: self.c:33
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── d:30 = self.c:33
       ├── f-k-checks-item: self(a,b) -> self(b,d)
@@ -2311,7 +2381,8 @@ upsert self
       │         │              ├──  upsert_b:21 => b:39
       │         │              └──  w:10 => d:40
       │         ├── scan self
-      │         │    └── columns: self.a:41!null self.b:42!null
+      │         │    ├── columns: self.a:41!null self.b:42!null
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              ├── b:37 = self.a:41
       │              └── d:38 = self.b:42
@@ -2331,6 +2402,7 @@ upsert self
                 │         └── mapping:
                 │              └──  z:9 => c:48
                 ├── scan self
-                │    └── columns: self.d:52
+                │    ├── columns: self.d:52
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── c:47 = self.d:52

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -29,7 +29,8 @@ root
            └── select
                 ├── columns: c:11!null child.p:12!null
                 ├── scan child
-                │    └── columns: c:11!null child.p:12!null
+                │    ├── columns: c:11!null child.p:12!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── child.p:12 > 1
 
@@ -57,7 +58,8 @@ root
            └── semi-join (hash)
                 ├── columns: c:11!null child.p:12!null
                 ├── scan child
-                │    └── columns: c:11!null child.p:12!null
+                │    ├── columns: c:11!null child.p:12!null
+                │    └── flags: disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: p:15!null
                 │    └── mapping:
@@ -93,7 +95,8 @@ root
            └── semi-join (hash)
                 ├── columns: c:14!null child.p:15!null
                 ├── scan child
-                │    └── columns: c:14!null child.p:15!null
+                │    ├── columns: c:14!null child.p:15!null
+                │    └── flags: disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: p:18!null
                 │    └── mapping:
@@ -118,7 +121,8 @@ root
            ├── columns: <none>
            ├── fetch columns: c:11 child.p:12
            └── scan child
-                └── columns: c:11!null child.p:12!null
+                ├── columns: c:11!null child.p:12!null
+                └── flags: disabled not visible index feature
 
 exec-ddl
 CREATE TABLE grandchild (g INT PRIMARY KEY, c INT REFERENCES child(c) ON DELETE CASCADE)
@@ -150,7 +154,8 @@ root
       │    └── select
       │         ├── columns: c:11!null child.p:12!null
       │         ├── scan child
-      │         │    └── columns: c:11!null child.p:12!null
+      │         │    ├── columns: c:11!null child.p:12!null
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── child.p:12 > 1
       └── cascade
@@ -160,7 +165,8 @@ root
                 └── semi-join (hash)
                      ├── columns: g:19!null grandchild.c:20
                      ├── scan grandchild
-                     │    └── columns: g:19!null grandchild.c:20
+                     │    ├── columns: g:19!null grandchild.c:20
+                     │    └── flags: disabled not visible index feature
                      ├── with-scan &1
                      │    ├── columns: c:23!null
                      │    └── mapping:
@@ -195,7 +201,8 @@ root
       │    └── semi-join (hash)
       │         ├── columns: c:11!null child.p:12!null
       │         ├── scan child
-      │         │    └── columns: c:11!null child.p:12!null
+      │         │    ├── columns: c:11!null child.p:12!null
+      │         │    └── flags: disabled not visible index feature
       │         ├── with-scan &1
       │         │    ├── columns: p:15!null
       │         │    └── mapping:
@@ -209,7 +216,8 @@ root
                 └── semi-join (hash)
                      ├── columns: g:20!null grandchild.c:21
                      ├── scan grandchild
-                     │    └── columns: g:20!null grandchild.c:21
+                     │    ├── columns: g:20!null grandchild.c:21
+                     │    └── flags: disabled not visible index feature
                      ├── with-scan &2
                      │    ├── columns: c:24!null
                      │    └── mapping:
@@ -236,7 +244,8 @@ root
       │    ├── cascades
       │    │    └── grandchild_c_fkey
       │    └── scan child
-      │         └── columns: c:11!null child.p:12!null
+      │         ├── columns: c:11!null child.p:12!null
+      │         └── flags: disabled not visible index feature
       └── cascade
            └── delete grandchild
                 ├── columns: <none>
@@ -244,7 +253,8 @@ root
                 └── select
                      ├── columns: g:19!null grandchild.c:20!null
                      ├── scan grandchild
-                     │    └── columns: g:19!null grandchild.c:20
+                     │    ├── columns: g:19!null grandchild.c:20
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           └── grandchild.c:20 IS DISTINCT FROM CAST(NULL AS INT8)
 
@@ -280,7 +290,8 @@ root
            ├── select
            │    ├── columns: child.c:11!null child.p:12!null
            │    ├── scan child
-           │    │    └── columns: child.c:11!null child.p:12!null
+           │    │    ├── columns: child.c:11!null child.p:12!null
+           │    │    └── flags: disabled not visible index feature
            │    └── filters
            │         └── child.p:12 > 1
            └── f-k-checks
@@ -292,7 +303,8 @@ root
                           │    └── mapping:
                           │         └──  child.c:11 => c:15
                           ├── scan grandchild
-                          │    └── columns: grandchild.c:17
+                          │    ├── columns: grandchild.c:17
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── c:15 = grandchild.c:17
 
@@ -320,7 +332,8 @@ root
            ├── semi-join (hash)
            │    ├── columns: child.c:11!null child.p:12!null
            │    ├── scan child
-           │    │    └── columns: child.c:11!null child.p:12!null
+           │    │    ├── columns: child.c:11!null child.p:12!null
+           │    │    └── flags: disabled not visible index feature
            │    ├── with-scan &1
            │    │    ├── columns: p:15!null
            │    │    └── mapping:
@@ -336,7 +349,8 @@ root
                           │    └── mapping:
                           │         └──  child.c:11 => c:16
                           ├── scan grandchild
-                          │    └── columns: grandchild.c:18
+                          │    ├── columns: grandchild.c:18
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── c:16 = grandchild.c:18
 
@@ -371,7 +385,8 @@ root
       │    └── semi-join (hash)
       │         ├── columns: self.a:13!null b:14
       │         ├── scan self
-      │         │    └── columns: self.a:13!null b:14
+      │         │    ├── columns: self.a:13!null b:14
+      │         │    └── flags: disabled not visible index feature
       │         ├── with-scan &1
       │         │    ├── columns: a:17!null
       │         │    └── mapping:
@@ -388,7 +403,8 @@ root
            │    └── semi-join (hash)
            │         ├── columns: self.a:22!null b:23
            │         ├── scan self
-           │         │    └── columns: self.a:22!null b:23
+           │         │    ├── columns: self.a:22!null b:23
+           │         │    └── flags: disabled not visible index feature
            │         ├── with-scan &2
            │         │    ├── columns: a:26!null
            │         │    └── mapping:
@@ -405,7 +421,8 @@ root
                      └── semi-join (hash)
                           ├── columns: self.a:31!null b:32
                           ├── scan self
-                          │    └── columns: self.a:31!null b:32
+                          │    ├── columns: self.a:31!null b:32
+                          │    └── flags: disabled not visible index feature
                           ├── with-scan &3
                           │    ├── columns: a:35!null
                           │    └── mapping:
@@ -465,7 +482,8 @@ root
       │    └── semi-join (hash)
       │         ├── columns: e:13!null f:14
       │         ├── scan ef
-      │         │    └── columns: e:13!null f:14
+      │         │    ├── columns: e:13!null f:14
+      │         │    └── flags: disabled not visible index feature
       │         ├── with-scan &1
       │         │    ├── columns: a:17!null
       │         │    └── mapping:
@@ -482,7 +500,8 @@ root
            │    └── semi-join (hash)
            │         ├── columns: c:22!null d:23
            │         ├── scan cd
-           │         │    └── columns: c:22!null d:23
+           │         │    ├── columns: c:22!null d:23
+           │         │    └── flags: disabled not visible index feature
            │         ├── with-scan &2
            │         │    ├── columns: e:26!null
            │         │    └── mapping:
@@ -499,7 +518,8 @@ root
                      └── semi-join (hash)
                           ├── columns: ab.a:31!null b:32
                           ├── scan ab
-                          │    └── columns: ab.a:31!null b:32
+                          │    ├── columns: ab.a:31!null b:32
+                          │    └── flags: disabled not visible index feature
                           ├── with-scan &3
                           │    ├── columns: c:35!null
                           │    └── mapping:
@@ -555,7 +575,8 @@ root
       │    └── select
       │         ├── columns: f2.a:14!null b:15!null f2.data:16
       │         ├── scan f2
-      │         │    └── columns: f2.a:14!null b:15!null f2.data:16
+      │         │    ├── columns: f2.a:14!null b:15!null f2.data:16
+      │         │    └── flags: disabled not visible index feature
       │         └── filters
       │              └── (f2.a:14 >= 1) AND (f2.a:14 <= 4)
       └── cascade
@@ -565,7 +586,8 @@ root
                 └── select
                      ├── columns: f3.a:25!null f3.b:26!null c:27!null f3.data:28
                      ├── scan f3
-                     │    └── columns: f3.a:25!null f3.b:26!null c:27!null f3.data:28
+                     │    ├── columns: f3.a:25!null f3.b:26!null c:27!null f3.data:28
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           └── (f3.a:25 >= 1) AND (f3.a:25 <= 4)
 
@@ -596,7 +618,8 @@ root
       │    └── semi-join (hash)
       │         ├── columns: f2.a:14!null b:15!null f2.data:16
       │         ├── scan f2
-      │         │    └── columns: f2.a:14!null b:15!null f2.data:16
+      │         │    ├── columns: f2.a:14!null b:15!null f2.data:16
+      │         │    └── flags: disabled not visible index feature
       │         ├── with-scan &1
       │         │    ├── columns: a:19!null
       │         │    └── mapping:
@@ -610,7 +633,8 @@ root
                 └── semi-join (hash)
                      ├── columns: f3.a:26!null f3.b:27!null c:28!null f3.data:29
                      ├── scan f3
-                     │    └── columns: f3.a:26!null f3.b:27!null c:28!null f3.data:29
+                     │    ├── columns: f3.a:26!null f3.b:27!null c:28!null f3.data:29
+                     │    └── flags: disabled not visible index feature
                      ├── with-scan &2
                      │    ├── columns: a:32!null b:33!null
                      │    └── mapping:
@@ -657,7 +681,8 @@ root
  │         └── select
  │              ├── columns: g2a.a:16!null data:17 g2a.rowid:18!null
  │              ├── scan g2a
- │              │    └── columns: g2a.a:16 data:17 g2a.rowid:18!null
+ │              │    ├── columns: g2a.a:16 data:17 g2a.rowid:18!null
+ │              │    └── flags: disabled not visible index feature
  │              └── filters
  │                   ├── g2a.a:16 = 1
  │                   └── g2a.a:16 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -668,7 +693,8 @@ root
            └── semi-join (hash)
                 ├── columns: g2b.b:26 g2b.data:27 g2b.rowid:28!null
                 ├── scan g2b
-                │    └── columns: g2b.b:26 g2b.data:27 g2b.rowid:28!null
+                │    ├── columns: g2b.b:26 g2b.data:27 g2b.rowid:28!null
+                │    └── flags: disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: b:31
                 │    └── mapping:
@@ -700,7 +726,8 @@ root
  │         └── semi-join (hash)
  │              ├── columns: g2a.a:16 data:17 g2a.rowid:18!null
  │              ├── scan g2a
- │              │    └── columns: g2a.a:16 data:17 g2a.rowid:18!null
+ │              │    ├── columns: g2a.a:16 data:17 g2a.rowid:18!null
+ │              │    └── flags: disabled not visible index feature
  │              ├── with-scan &1
  │              │    ├── columns: a:21
  │              │    └── mapping:
@@ -714,7 +741,8 @@ root
            └── select
                 ├── columns: g2b.b:27!null g2b.data:28 g2b.rowid:29!null
                 ├── scan g2b
-                │    └── columns: g2b.b:27 g2b.data:28 g2b.rowid:29!null
+                │    ├── columns: g2b.b:27 g2b.data:28 g2b.rowid:29!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── g2b.b:27 = 1
                      └── g2b.b:27 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -753,7 +781,8 @@ root
            └── semi-join (hash)
                 ├── columns: c:11!null h2.p:12
                 ├── scan h2
-                │    └── columns: c:11!null h2.p:12
+                │    ├── columns: c:11!null h2.p:12
+                │    └── flags: disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: p:15!null
                 │    └── mapping:
@@ -784,7 +813,8 @@ root
            └── select
                 ├── columns: c:11!null h2.p:12!null
                 ├── scan h2
-                │    └── columns: c:11!null h2.p:12
+                │    ├── columns: c:11!null h2.p:12
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── h2.p:12 = 1
                      └── h2.p:12 IS DISTINCT FROM CAST(NULL AS DECIMAL)
@@ -830,7 +860,8 @@ root
            └── select
                 ├── columns: m2.a:19!null m2.b:20!null m2.c:21!null m2.rowid:22!null
                 ├── scan m2
-                │    └── columns: m2.a:19 m2.b:20!null m2.c:21 m2.rowid:22!null
+                │    ├── columns: m2.a:19 m2.b:20!null m2.c:21 m2.rowid:22!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── ((m2.a:19 + m2.b:20) + m2.c:21) = 1
                      ├── m2.a:19 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -859,7 +890,8 @@ root
            └── select
                 ├── columns: m2.a:19!null m2.b:20!null m2.c:21!null m2.rowid:22!null
                 ├── scan m2
-                │    └── columns: m2.a:19 m2.b:20!null m2.c:21 m2.rowid:22!null
+                │    ├── columns: m2.a:19 m2.b:20!null m2.c:21 m2.rowid:22!null
+                │    └── flags: disabled not visible index feature
                 └── filters
                      ├── m2.a:19 IS NULL
                      ├── m2.a:19 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -907,11 +939,12 @@ root
                 │    ├── columns: c:12!null child_partial.p:13!null i:14
                 │    ├── scan child_partial
                 │    │    ├── columns: c:12!null child_partial.p:13 i:14
-                │    │    └── partial index predicates
-                │    │         ├── child_partial_p_idx: filters
-                │    │         │    └── i:14 > 0
-                │    │         └── child_partial_i_idx: filters
-                │    │              └── child_partial.p:13 > 0
+                │    │    ├── partial index predicates
+                │    │    │    ├── child_partial_p_idx: filters
+                │    │    │    │    └── i:14 > 0
+                │    │    │    └── child_partial_i_idx: filters
+                │    │    │         └── child_partial.p:13 > 0
+                │    │    └── flags: disabled not visible index feature
                 │    └── filters
                 │         ├── child_partial.p:13 > 1
                 │         └── child_partial.p:13 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -947,11 +980,12 @@ root
                 │    ├── columns: c:12!null child_partial.p:13 i:14
                 │    ├── scan child_partial
                 │    │    ├── columns: c:12!null child_partial.p:13 i:14
-                │    │    └── partial index predicates
-                │    │         ├── child_partial_p_idx: filters
-                │    │         │    └── i:14 > 0
-                │    │         └── child_partial_i_idx: filters
-                │    │              └── child_partial.p:13 > 0
+                │    │    ├── partial index predicates
+                │    │    │    ├── child_partial_p_idx: filters
+                │    │    │    │    └── i:14 > 0
+                │    │    │    └── child_partial_i_idx: filters
+                │    │    │         └── child_partial.p:13 > 0
+                │    │    └── flags: disabled not visible index feature
                 │    ├── with-scan &1
                 │    │    ├── columns: p:17!null
                 │    │    └── mapping:
@@ -985,11 +1019,12 @@ root
                 │    ├── columns: c:12!null child_partial.p:13!null i:14
                 │    ├── scan child_partial
                 │    │    ├── columns: c:12!null child_partial.p:13 i:14
-                │    │    └── partial index predicates
-                │    │         ├── child_partial_p_idx: filters
-                │    │         │    └── i:14 > 0
-                │    │         └── child_partial_i_idx: filters
-                │    │              └── child_partial.p:13 > 0
+                │    │    ├── partial index predicates
+                │    │    │    ├── child_partial_p_idx: filters
+                │    │    │    │    └── i:14 > 0
+                │    │    │    └── child_partial_i_idx: filters
+                │    │    │         └── child_partial.p:13 > 0
+                │    │    └── flags: disabled not visible index feature
                 │    └── filters
                 │         └── child_partial.p:13 IS DISTINCT FROM CAST(NULL AS INT8)
                 └── projections
@@ -1036,11 +1071,12 @@ root
                 │    ├── columns: v:15 v2:16!null c:13!null child_virt.p:14
                 │    ├── scan child_virt
                 │    │    ├── columns: c:13!null child_virt.p:14
-                │    │    └── computed column expressions
-                │    │         ├── v:15
-                │    │         │    └── child_virt.p:14
-                │    │         └── v2:16
-                │    │              └── c:13::STRING
+                │    │    ├── computed column expressions
+                │    │    │    ├── v:15
+                │    │    │    │    └── child_virt.p:14
+                │    │    │    └── v2:16
+                │    │    │         └── c:13::STRING
+                │    │    └── flags: disabled not visible index feature
                 │    └── projections
                 │         ├── child_virt.p:14 [as=v:15]
                 │         └── c:13::STRING [as=v2:16]
@@ -1075,11 +1111,12 @@ root
                 │    ├── columns: v:15 v2:16!null c:13!null child_virt.p:14
                 │    ├── scan child_virt
                 │    │    ├── columns: c:13!null child_virt.p:14
-                │    │    └── computed column expressions
-                │    │         ├── v:15
-                │    │         │    └── child_virt.p:14
-                │    │         └── v2:16
-                │    │              └── c:13::STRING
+                │    │    ├── computed column expressions
+                │    │    │    ├── v:15
+                │    │    │    │    └── child_virt.p:14
+                │    │    │    └── v2:16
+                │    │    │         └── c:13::STRING
+                │    │    └── flags: disabled not visible index feature
                 │    └── projections
                 │         ├── child_virt.p:14 [as=v:15]
                 │         └── c:13::STRING [as=v2:16]

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
@@ -34,7 +34,8 @@ root
            │    ├── semi-join (hash)
            │    │    ├── columns: c:11!null child.p:12
            │    │    ├── scan child
-           │    │    │    └── columns: c:11!null child.p:12
+           │    │    │    ├── columns: c:11!null child.p:12
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── with-scan &1
            │    │    │    ├── columns: p:15!null
            │    │    │    └── mapping:
@@ -52,7 +53,8 @@ root
                           │    └── mapping:
                           │         └──  p_new:16 => p:17
                           ├── scan parent
-                          │    └── columns: parent.p:18!null
+                          │    ├── columns: parent.p:18!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:17 = parent.p:18
 
@@ -93,7 +95,8 @@ root
                 ├── semi-join (hash)
                 │    ├── columns: c:11!null child_null.p:12
                 │    ├── scan child_null
-                │    │    └── columns: c:11!null child_null.p:12
+                │    │    ├── columns: c:11!null child_null.p:12
+                │    │    └── flags: disabled not visible index feature
                 │    ├── with-scan &1
                 │    │    ├── columns: p:15!null
                 │    │    └── mapping:
@@ -159,9 +162,10 @@ root
            │    │    │    │    ├── columns: c:18!null child_multicol.p:19 child_multicol.q:20 child_multicol.r:21 x:22
            │    │    │    │    ├── scan child_multicol
            │    │    │    │    │    ├── columns: c:18!null child_multicol.p:19 child_multicol.q:20 child_multicol.r:21 x:22
-           │    │    │    │    │    └── computed column expressions
-           │    │    │    │    │         └── x:22
-           │    │    │    │    │              └── (child_multicol.p:19 + child_multicol.q:20) + child_multicol.r:21
+           │    │    │    │    │    ├── computed column expressions
+           │    │    │    │    │    │    └── x:22
+           │    │    │    │    │    │         └── (child_multicol.p:19 + child_multicol.q:20) + child_multicol.r:21
+           │    │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    │    ├── with-scan &1
            │    │    │    │    │    ├── columns: p:25!null q:26!null r:27!null
            │    │    │    │    │    └── mapping:
@@ -195,7 +199,8 @@ root
                           │         ├── q:33 IS NOT NULL
                           │         └── r:34 IS NOT NULL
                           ├── scan parent_multicol
-                          │    └── columns: parent_multicol.p:35!null parent_multicol.q:36!null parent_multicol.r:37!null
+                          │    ├── columns: parent_multicol.p:35!null parent_multicol.q:36!null parent_multicol.r:37!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:32 = parent_multicol.p:35
                                ├── q:33 = parent_multicol.q:36
@@ -249,11 +254,12 @@ root
            │    │    │    ├── columns: c:12!null child_partial.p:13 i:14
            │    │    │    ├── scan child_partial
            │    │    │    │    ├── columns: c:12!null child_partial.p:13 i:14
-           │    │    │    │    └── partial index predicates
-           │    │    │    │         ├── child_partial_p_idx: filters
-           │    │    │    │         │    └── i:14 > 0
-           │    │    │    │         └── child_partial_i_idx: filters
-           │    │    │    │              └── child_partial.p:13 > 0
+           │    │    │    │    ├── partial index predicates
+           │    │    │    │    │    ├── child_partial_p_idx: filters
+           │    │    │    │    │    │    └── i:14 > 0
+           │    │    │    │    │    └── child_partial_i_idx: filters
+           │    │    │    │    │         └── child_partial.p:13 > 0
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    ├── with-scan &1
            │    │    │    │    ├── columns: p:17!null
            │    │    │    │    └── mapping:
@@ -275,7 +281,8 @@ root
                           │    └── mapping:
                           │         └──  p_new:18 => p:22
                           ├── scan parent_partial
-                          │    └── columns: parent_partial.p:23!null
+                          │    ├── columns: parent_partial.p:23!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:22 = parent_partial.p:23
 
@@ -324,9 +331,10 @@ root
            │    │    │    ├── columns: v:14 c:12!null child_virt.p:13
            │    │    │    ├── scan child_virt
            │    │    │    │    ├── columns: c:12!null child_virt.p:13
-           │    │    │    │    └── computed column expressions
-           │    │    │    │         └── v:14
-           │    │    │    │              └── child_virt.p:13
+           │    │    │    │    ├── computed column expressions
+           │    │    │    │    │    └── v:14
+           │    │    │    │    │         └── child_virt.p:13
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    └── projections
            │    │    │         └── child_virt.p:13 [as=v:14]
            │    │    ├── with-scan &1
@@ -346,6 +354,7 @@ root
                           │    └── mapping:
                           │         └──  p_new:18 => p:19
                           ├── scan parent_virt
-                          │    └── columns: parent_virt.p:20!null
+                          │    ├── columns: parent_virt.p:20!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:19 = parent_virt.p:20

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
@@ -33,7 +33,8 @@ root
                 ├── semi-join (hash)
                 │    ├── columns: c:11!null child.p:12
                 │    ├── scan child
-                │    │    └── columns: c:11!null child.p:12
+                │    │    ├── columns: c:11!null child.p:12
+                │    │    └── flags: disabled not visible index feature
                 │    ├── with-scan &1
                 │    │    ├── columns: p:15!null
                 │    │    └── mapping:
@@ -99,9 +100,10 @@ root
                 │    │    │    │    ├── columns: c:18!null child_multicol.p:19 child_multicol.q:20 child_multicol.r:21 x:22
                 │    │    │    │    ├── check constraint expressions
                 │    │    │    │    │    └── (c:18 > 100) OR (child_multicol.p:19 IS NOT NULL)
-                │    │    │    │    └── computed column expressions
-                │    │    │    │         └── x:22
-                │    │    │    │              └── (child_multicol.p:19 + child_multicol.q:20) + child_multicol.r:21
+                │    │    │    │    ├── computed column expressions
+                │    │    │    │    │    └── x:22
+                │    │    │    │    │         └── (child_multicol.p:19 + child_multicol.q:20) + child_multicol.r:21
+                │    │    │    │    └── flags: disabled not visible index feature
                 │    │    │    ├── with-scan &1
                 │    │    │    │    ├── columns: p:25!null q:26!null r:27!null
                 │    │    │    │    └── mapping:
@@ -166,11 +168,12 @@ root
                 │    │    ├── columns: c:12!null child_partial.p:13 i:14
                 │    │    ├── scan child_partial
                 │    │    │    ├── columns: c:12!null child_partial.p:13 i:14
-                │    │    │    └── partial index predicates
-                │    │    │         ├── child_partial_p_idx: filters
-                │    │    │         │    └── i:14 > 0
-                │    │    │         └── child_partial_i_idx: filters
-                │    │    │              └── child_partial.p:13 > 0
+                │    │    │    ├── partial index predicates
+                │    │    │    │    ├── child_partial_p_idx: filters
+                │    │    │    │    │    └── i:14 > 0
+                │    │    │    │    └── child_partial_i_idx: filters
+                │    │    │    │         └── child_partial.p:13 > 0
+                │    │    │    └── flags: disabled not visible index feature
                 │    │    ├── with-scan &1
                 │    │    │    ├── columns: p:17!null
                 │    │    │    └── mapping:
@@ -228,9 +231,10 @@ root
                 │    │    ├── columns: v:14 c:12!null child_virt.p:13
                 │    │    ├── scan child_virt
                 │    │    │    ├── columns: c:12!null child_virt.p:13
-                │    │    │    └── computed column expressions
-                │    │    │         └── v:14
-                │    │    │              └── child_virt.p:13
+                │    │    │    ├── computed column expressions
+                │    │    │    │    └── v:14
+                │    │    │    │         └── child_virt.p:13
+                │    │    │    └── flags: disabled not visible index feature
                 │    │    └── projections
                 │    │         └── child_virt.p:13 [as=v:14]
                 │    ├── with-scan &1

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -38,7 +38,8 @@ root
            ├── inner-join (hash)
            │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
            │    ├── scan child
-           │    │    └── columns: c:12!null child.p:13!null
+           │    │    ├── columns: c:12!null child.p:13!null
+           │    │    └── flags: disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:16!null p_new:17!null
            │    │    ├── with-scan &1
@@ -59,7 +60,8 @@ root
                           │    └── mapping:
                           │         └──  p_new:17 => p:18
                           ├── scan parent
-                          │    └── columns: parent.p:19!null
+                          │    ├── columns: parent.p:19!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:18 = parent.p:19
 
@@ -118,7 +120,8 @@ root
            ├── inner-join (hash)
            │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
            │    ├── scan child_multi
-           │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
+           │    │    ├── columns: c:18!null child_multi.p:19 child_multi.q:20
+           │    │    └── flags: disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
            │    │    ├── with-scan &1
@@ -148,7 +151,8 @@ root
                           │         ├── p:27 IS NOT NULL
                           │         └── q:28 IS NOT NULL
                           ├── scan parent_multi
-                          │    └── columns: parent_multi.p:30 parent_multi.q:31
+                          │    ├── columns: parent_multi.p:30 parent_multi.q:31
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:27 = parent_multi.p:30
                                └── q:28 = parent_multi.q:31
@@ -188,7 +192,8 @@ root
            ├── inner-join (hash)
            │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
            │    ├── scan child_multi
-           │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+           │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
+           │    │    └── flags: disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
            │    │    ├── with-scan &1
@@ -217,7 +222,8 @@ root
                           │    └── filters
                           │         └── q:27 IS NOT NULL
                           ├── scan parent_multi
-                          │    └── columns: parent_multi.p:29 parent_multi.q:30
+                          │    ├── columns: parent_multi.p:29 parent_multi.q:30
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:26 = parent_multi.p:29
                                └── q:27 = parent_multi.q:30
@@ -258,7 +264,8 @@ root
  │         │    │         └── first-agg [as=column3:8]
  │         │    │              └── column3:8
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -274,7 +281,8 @@ root
            ├── inner-join (hash)
            │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
            │    ├── scan child_multi
-           │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
+           │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
+           │    │    └── flags: disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
            │    │    ├── with-scan &1
@@ -299,7 +307,8 @@ root
                           │         ├──  p_new:26 => p:29
                           │         └──  q_new:28 => q:30
                           ├── scan parent_multi
-                          │    └── columns: parent_multi.p:32 parent_multi.q:33
+                          │    ├── columns: parent_multi.p:32 parent_multi.q:33
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:29 = parent_multi.p:32
                                └── q:30 = parent_multi.q:33
@@ -344,7 +353,8 @@ root
  │         │    │         └── first-agg [as=q_default:8]
  │         │    │              └── q_default:8
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -361,7 +371,8 @@ root
            ├── inner-join (hash)
            │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
            │    ├── scan child_multi
-           │    │    └── columns: c:21!null child_multi.p:22 child_multi.q:23
+           │    │    ├── columns: c:21!null child_multi.p:22 child_multi.q:23
+           │    │    └── flags: disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
            │    │    ├── with-scan &1
@@ -390,7 +401,8 @@ root
                           │    └── filters
                           │         └── q:31 IS NOT NULL
                           ├── scan parent_multi
-                          │    └── columns: parent_multi.p:33 parent_multi.q:34
+                          │    ├── columns: parent_multi.p:33 parent_multi.q:34
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:30 = parent_multi.p:33
                                └── q:31 = parent_multi.q:34
@@ -430,7 +442,8 @@ root
  │         │    │    │         └── first-agg [as=column1:6]
  │         │    │    │              └── column1:6
  │         │    │    ├── scan parent_multi
- │         │    │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    │    └── flags: disabled not visible index feature
  │         │    │    └── filters
  │         │    │         ├── column2:7 = p:10
  │         │    │         └── column3:8 = q:11
@@ -451,7 +464,8 @@ root
            ├── inner-join (hash)
            │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
            │    ├── scan child_multi
-           │    │    └── columns: c:23!null child_multi.p:24 child_multi.q:25
+           │    │    ├── columns: c:23!null child_multi.p:24 child_multi.q:25
+           │    │    └── flags: disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
            │    │    ├── with-scan &1
@@ -480,7 +494,8 @@ root
                           │    └── filters
                           │         └── q:33 IS NOT NULL
                           ├── scan parent_multi
-                          │    └── columns: parent_multi.p:35 parent_multi.q:36
+                          │    ├── columns: parent_multi.p:35 parent_multi.q:36
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:32 = parent_multi.p:35
                                └── q:33 = parent_multi.q:36
@@ -529,7 +544,8 @@ root
       │    ├── inner-join (hash)
       │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │    │    ├── scan child_multi
-      │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │    │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │    │    │    └── flags: disabled not visible index feature
       │    │    ├── select
       │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │    │    │    ├── with-scan &1
@@ -558,7 +574,8 @@ root
       │                   │    └── filters
       │                   │         └── q:27 IS NOT NULL
       │                   ├── scan parent_multi
-      │                   │    └── columns: parent_multi.p:29 parent_multi.q:30
+      │                   │    ├── columns: parent_multi.p:29 parent_multi.q:30
+      │                   │    └── flags: disabled not visible index feature
       │                   └── filters
       │                        ├── p:26 = parent_multi.p:29
       │                        └── q:27 = parent_multi.q:30
@@ -573,7 +590,8 @@ root
                 ├── inner-join (hash)
                 │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
                 │    ├── scan grandchild
-                │    │    └── columns: g:38!null grandchild.c:39 grandchild.q:40
+                │    │    ├── columns: g:38!null grandchild.c:39 grandchild.q:40
+                │    │    └── flags: disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
                 │    │    ├── with-scan &2
@@ -602,7 +620,8 @@ root
                                │    └── filters
                                │         └── q:48 IS NOT NULL
                                ├── scan child_multi
-                               │    └── columns: child_multi.c:49!null child_multi.q:51
+                               │    ├── columns: child_multi.c:49!null child_multi.q:51
+                               │    └── flags: disabled not visible index feature
                                └── filters
                                     ├── c:47 = child_multi.c:49
                                     └── q:48 = child_multi.q:51
@@ -643,7 +662,8 @@ root
  │         │    │         └── first-agg [as=column3:8]
  │         │    │              └── column3:8
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -661,7 +681,8 @@ root
       │    ├── inner-join (hash)
       │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │    │    ├── scan child_multi
-      │    │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
+      │    │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
+      │    │    │    └── flags: disabled not visible index feature
       │    │    ├── select
       │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │    │    │    ├── with-scan &1
@@ -686,7 +707,8 @@ root
       │                   │         ├──  p_new:26 => p:29
       │                   │         └──  q_new:28 => q:30
       │                   ├── scan parent_multi
-      │                   │    └── columns: parent_multi.p:32 parent_multi.q:33
+      │                   │    ├── columns: parent_multi.p:32 parent_multi.q:33
+      │                   │    └── flags: disabled not visible index feature
       │                   └── filters
       │                        ├── p:29 = parent_multi.p:32
       │                        └── q:30 = parent_multi.q:33
@@ -701,7 +723,8 @@ root
                 ├── inner-join (hash)
                 │    ├── columns: g:41!null grandchild.c:42!null grandchild.q:43!null c_old:46!null c_new:47!null q_old:48!null q_new:49!null
                 │    ├── scan grandchild
-                │    │    └── columns: g:41!null grandchild.c:42 grandchild.q:43
+                │    │    ├── columns: g:41!null grandchild.c:42 grandchild.q:43
+                │    │    └── flags: disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: c_old:46!null c_new:47!null q_old:48!null q_new:49!null
                 │    │    ├── with-scan &2
@@ -726,7 +749,8 @@ root
                                │         ├──  c_new:47 => c:50
                                │         └──  q_new:49 => q:51
                                ├── scan child_multi
-                               │    └── columns: child_multi.c:52!null child_multi.q:54
+                               │    ├── columns: child_multi.c:52!null child_multi.q:54
+                               │    └── flags: disabled not visible index feature
                                └── filters
                                     ├── c:50 = child_multi.c:52
                                     └── q:51 = child_multi.q:54
@@ -783,7 +807,8 @@ root
            │    ├── inner-join (hash)
            │    │    ├── columns: c:15!null child_assn_cast.p:16!null p_old:19!null p_new:20!null
            │    │    ├── scan child_assn_cast
-           │    │    │    └── columns: c:15!null child_assn_cast.p:16
+           │    │    │    ├── columns: c:15!null child_assn_cast.p:16
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:19!null p_new:20!null
            │    │    │    ├── with-scan &1
@@ -807,7 +832,8 @@ root
                           │    └── mapping:
                           │         └──  p_cast:21 => p:22
                           ├── scan parent_assn_cast
-                          │    └── columns: parent_assn_cast.p:23!null
+                          │    ├── columns: parent_assn_cast.p:23!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:22 = parent_assn_cast.p:23
 
@@ -856,7 +882,8 @@ root
  │         │    │         └── first-agg [as=p2_cast:8]
  │         │    │              └── p2_cast:8
  │         │    ├── scan parent_assn_cast
- │         │    │    └── columns: p:9!null p2:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    ├── columns: p:9!null p2:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── p_cast:7 = p:9
  │         └── projections
@@ -873,7 +900,8 @@ root
            │    ├── inner-join (hash)
            │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
            │    │    ├── scan child_assn_cast_p2
-           │    │    │    └── columns: c:18!null child_assn_cast_p2.p2:19
+           │    │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p2_old:22 p2_new:23!null
            │    │    │    ├── with-scan &1
@@ -897,7 +925,8 @@ root
                           │    └── mapping:
                           │         └──  p2_cast:24 => p2:25
                           ├── scan parent_assn_cast
-                          │    └── columns: parent_assn_cast.p2:27
+                          │    ├── columns: parent_assn_cast.p2:27
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p2:25 = parent_assn_cast.p2:27
 
@@ -943,7 +972,8 @@ root
  │         │    │    │    │         └── first-agg [as=p2_cast:8]
  │         │    │    │    │              └── p2_cast:8
  │         │    │    │    ├── scan parent_assn_cast
- │         │    │    │    │    └── columns: p:9!null p2:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    │    │    ├── columns: p:9!null p2:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    │    │    └── flags: disabled not visible index feature
  │         │    │    │    └── filters
  │         │    │    │         └── p_cast:7 = p:9
  │         │    │    └── projections
@@ -966,7 +996,8 @@ root
            │    ├── inner-join (hash)
            │    │    ├── columns: c:21!null child_assn_cast_p2.p2:22!null p2_old:25!null p2_new:26!null
            │    │    ├── scan child_assn_cast_p2
-           │    │    │    └── columns: c:21!null child_assn_cast_p2.p2:22
+           │    │    │    ├── columns: c:21!null child_assn_cast_p2.p2:22
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p2_old:25 p2_new:26!null
            │    │    │    ├── with-scan &1
@@ -990,7 +1021,8 @@ root
                           │    └── mapping:
                           │         └──  p2_cast:27 => p2:28
                           ├── scan parent_assn_cast
-                          │    └── columns: parent_assn_cast.p2:30
+                          │    ├── columns: parent_assn_cast.p2:30
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p2:28 = parent_assn_cast.p2:30
 
@@ -1046,11 +1078,12 @@ root
            │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
            │    │    ├── scan child_partial
            │    │    │    ├── columns: c:13!null child_partial.p:14 i:15
-           │    │    │    └── partial index predicates
-           │    │    │         ├── child_partial_p_idx: filters
-           │    │    │         │    └── i:15 > 0
-           │    │    │         └── child_partial_i_idx: filters
-           │    │    │              └── child_partial.p:14 > 0
+           │    │    │    ├── partial index predicates
+           │    │    │    │    ├── child_partial_p_idx: filters
+           │    │    │    │    │    └── i:15 > 0
+           │    │    │    │    └── child_partial_i_idx: filters
+           │    │    │    │         └── child_partial.p:14 > 0
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    ├── with-scan &1
@@ -1075,7 +1108,8 @@ root
                           │    └── mapping:
                           │         └──  p_new:19 => p:23
                           ├── scan parent_partial
-                          │    └── columns: parent_partial.p:24!null
+                          │    ├── columns: parent_partial.p:24!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:23 = parent_partial.p:24
 
@@ -1130,9 +1164,10 @@ root
            │    │    ├── columns: c:13!null child_partial_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
            │    │    ├── scan child_partial_ambig
            │    │    │    ├── columns: c:13!null child_partial_ambig.p_new:14 i:15
-           │    │    │    └── partial index predicates
-           │    │    │         └── child_partial_ambig_i_idx: filters
-           │    │    │              └── child_partial_ambig.p_new:14 > 0
+           │    │    │    ├── partial index predicates
+           │    │    │    │    └── child_partial_ambig_i_idx: filters
+           │    │    │    │         └── child_partial_ambig.p_new:14 > 0
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
            │    │    │    ├── with-scan &1
@@ -1156,7 +1191,8 @@ root
                           │    └── mapping:
                           │         └──  p_new_new:19 => p_new:22
                           ├── scan parent_partial_ambig
-                          │    └── columns: p:23!null
+                          │    ├── columns: p:23!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p_new:22 = p:23
 
@@ -1222,7 +1258,8 @@ root
  │         │    │         └── first-agg [as=p_default:7]
  │         │    │              └── p_default:7
  │         │    ├── scan parent_multi_partial
- │         │    │    └── columns: pk:8!null p:9 q:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    ├── columns: pk:8!null p:9 q:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:8
  │         └── projections
@@ -1243,11 +1280,12 @@ root
            │    │    ├── columns: c:20!null child_multi_partial.p:21!null child_multi_partial.q:22!null i:23 p_old:26!null p_new:27 q_old:28!null q_new:29
            │    │    ├── scan child_multi_partial
            │    │    │    ├── columns: c:20!null child_multi_partial.p:21 child_multi_partial.q:22 i:23
-           │    │    │    └── partial index predicates
-           │    │    │         ├── child_multi_partial_p_q_idx: filters
-           │    │    │         │    └── i:23 > 0
-           │    │    │         └── child_multi_partial_i_idx: filters
-           │    │    │              └── (child_multi_partial.p:21 > 0) AND (child_multi_partial.q:22 > 0)
+           │    │    │    ├── partial index predicates
+           │    │    │    │    ├── child_multi_partial_p_q_idx: filters
+           │    │    │    │    │    └── i:23 > 0
+           │    │    │    │    └── child_multi_partial_i_idx: filters
+           │    │    │    │         └── (child_multi_partial.p:21 > 0) AND (child_multi_partial.q:22 > 0)
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:26 p_new:27 q_old:28 q_new:29
            │    │    │    ├── with-scan &1
@@ -1281,7 +1319,8 @@ root
                           │         ├── p:33 IS NOT NULL
                           │         └── q:34 IS NOT NULL
                           ├── scan parent_multi_partial
-                          │    └── columns: parent_multi_partial.p:36 parent_multi_partial.q:37
+                          │    ├── columns: parent_multi_partial.p:36 parent_multi_partial.q:37
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:33 = parent_multi_partial.p:36
                                └── q:34 = parent_multi_partial.q:37
@@ -1343,9 +1382,10 @@ root
            │    │    │    ├── columns: c:13!null child_check_ambig.p_new:14!null i:15 p_new_old:18!null p_new_new:19!null
            │    │    │    ├── scan child_check_ambig
            │    │    │    │    ├── columns: c:13!null child_check_ambig.p_new:14 i:15
-           │    │    │    │    └── computed column expressions
-           │    │    │    │         └── i:15
-           │    │    │    │              └── child_check_ambig.p_new:14 * 2
+           │    │    │    │    ├── computed column expressions
+           │    │    │    │    │    └── i:15
+           │    │    │    │    │         └── child_check_ambig.p_new:14 * 2
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
            │    │    │    │    ├── with-scan &1
@@ -1370,7 +1410,8 @@ root
                           │    └── mapping:
                           │         └──  p_new_new:19 => p_new:22
                           ├── scan parent_check_ambig
-                          │    └── columns: p:23!null
+                          │    ├── columns: p:23!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p_new:22 = p:23
 
@@ -1423,9 +1464,10 @@ root
            │    │    ├── columns: v:15 c:13!null child_virt.p:14
            │    │    ├── scan child_virt
            │    │    │    ├── columns: c:13!null child_virt.p:14
-           │    │    │    └── computed column expressions
-           │    │    │         └── v:15
-           │    │    │              └── child_virt.p:14
+           │    │    │    ├── computed column expressions
+           │    │    │    │    └── v:15
+           │    │    │    │         └── child_virt.p:14
+           │    │    │    └── flags: disabled not visible index feature
            │    │    └── projections
            │    │         └── child_virt.p:14 [as=v:15]
            │    ├── select
@@ -1448,7 +1490,8 @@ root
                           │    └── mapping:
                           │         └──  p_new:19 => p:20
                           ├── scan parent_virt
-                          │    └── columns: parent_virt.p:21!null
+                          │    ├── columns: parent_virt.p:21!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:20 = parent_virt.p:21
 
@@ -1529,6 +1572,7 @@ root
            │    │    ├── fd: ()-->(13,16,17), (13)==(16), (16)==(13)
            │    │    ├── scan t.public.child_diff_type
            │    │    │    ├── columns: t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2)
+           │    │    │    ├── flags: disabled not visible index feature
            │    │    │    ├── stats: [rows=1000, distinct(12)=1000, null(12)=0, avgsize(12)=4, distinct(13)=100, null(13)=10, avgsize(13)=4]
            │    │    │    ├── key: (12)
            │    │    │    ├── fd: (12)-->(13)
@@ -1579,6 +1623,7 @@ root
                           │         └── &2: count=1 used-columns=(18)
                           ├── scan t.public.parent_diff_type
                           │    ├── columns: t.public.parent_diff_type.p:20(int!null)
+                          │    ├── flags: disabled not visible index feature
                           │    ├── stats: [rows=1000, distinct(20)=1000, null(20)=0, avgsize(20)=4]
                           │    ├── key: (20)
                           │    └── prune: (20)
@@ -1628,7 +1673,8 @@ root
  │         │    │    │         ├── columns: column1:4!null
  │         │    │    │         └── (0,)
  │         │    │    ├── scan parent_diff_type
- │         │    │    │    └── columns: p:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+ │         │    │    │    ├── columns: p:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+ │         │    │    │    └── flags: disabled not visible index feature
  │         │    │    └── filters
  │         │    │         └── column1:4 = p:5
  │         │    └── projections
@@ -1647,7 +1693,8 @@ root
            │    ├── inner-join (hash)
            │    │    ├── columns: c:14!null child_diff_type.p:15!null p_old:18!null p_new:19!null
            │    │    ├── scan child_diff_type
-           │    │    │    └── columns: c:14!null child_diff_type.p:15
+           │    │    │    ├── columns: c:14!null child_diff_type.p:15
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:18 p_new:19!null
            │    │    │    ├── with-scan &1
@@ -1671,6 +1718,7 @@ root
                           │    └── mapping:
                           │         └──  p_cast:20 => p:21
                           ├── scan parent_diff_type
-                          │    └── columns: parent_diff_type.p:22!null
+                          │    ├── columns: parent_diff_type.p:22!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:21 = parent_diff_type.p:22

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -40,7 +40,8 @@ root
            │    ├── inner-join (hash)
            │    │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
            │    │    ├── scan child
-           │    │    │    └── columns: c:12!null child.p:13!null
+           │    │    │    ├── columns: c:12!null child.p:13!null
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:16!null p_new:17!null
            │    │    │    ├── with-scan &1
@@ -63,7 +64,8 @@ root
                           │    └── mapping:
                           │         └──  p_new:18 => p:19
                           ├── scan parent
-                          │    └── columns: parent.p:20!null
+                          │    ├── columns: parent.p:20!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:19 = parent.p:20
 
@@ -125,7 +127,8 @@ root
            │    ├── inner-join (hash)
            │    │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
            │    │    ├── scan child_multi
-           │    │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
+           │    │    │    ├── columns: c:18!null child_multi.p:19 child_multi.q:20
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
            │    │    │    ├── with-scan &1
@@ -153,7 +156,8 @@ root
                           │         ├──  p_new:27 => p:29
                           │         └──  q_new:28 => q:30
                           ├── scan parent_multi
-                          │    └── columns: parent_multi.p:32 parent_multi.q:33
+                          │    ├── columns: parent_multi.p:32 parent_multi.q:33
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:29 = parent_multi.p:32
                                └── q:30 = parent_multi.q:33
@@ -195,7 +199,8 @@ root
            │    ├── inner-join (hash)
            │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
            │    │    ├── scan child_multi
-           │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+           │    │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
+           │    │    │    └── flags: disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
            │    │    │    ├── with-scan &1
@@ -223,7 +228,8 @@ root
                           │         ├──  p_new:26 => p:28
                           │         └──  q_new:27 => q:29
                           ├── scan parent_multi
-                          │    └── columns: parent_multi.p:31 parent_multi.q:32
+                          │    ├── columns: parent_multi.p:31 parent_multi.q:32
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                ├── p:28 = parent_multi.p:31
                                └── q:29 = parent_multi.q:32
@@ -274,7 +280,8 @@ root
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │    │    │    ├── scan child_multi
-      │    │    │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │    │    │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    ├── select
       │    │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │    │    │    │    ├── with-scan &1
@@ -302,7 +309,8 @@ root
       │                   │         ├──  p_new:26 => p:28
       │                   │         └──  q_new:27 => q:29
       │                   ├── scan parent_multi
-      │                   │    └── columns: parent_multi.p:31 parent_multi.q:32
+      │                   │    ├── columns: parent_multi.p:31 parent_multi.q:32
+      │                   │    └── flags: disabled not visible index feature
       │                   └── filters
       │                        ├── p:28 = parent_multi.p:31
       │                        └── q:29 = parent_multi.q:32
@@ -319,7 +327,8 @@ root
                 │    ├── inner-join (hash)
                 │    │    ├── columns: g:40!null grandchild.c:41!null grandchild.q:42!null c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    │    ├── scan grandchild
-                │    │    │    └── columns: g:40!null grandchild.c:41 grandchild.q:42
+                │    │    │    ├── columns: g:40!null grandchild.c:41 grandchild.q:42
+                │    │    │    └── flags: disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    │    │    ├── with-scan &2
@@ -347,7 +356,8 @@ root
                                │         ├──  c_new:49 => c:51
                                │         └──  q_new:50 => q:52
                                ├── scan child_multi
-                               │    └── columns: child_multi.c:53!null child_multi.q:55
+                               │    ├── columns: child_multi.c:53!null child_multi.q:55
+                               │    └── flags: disabled not visible index feature
                                └── filters
                                     ├── c:51 = child_multi.c:53
                                     └── q:52 = child_multi.q:55
@@ -388,7 +398,8 @@ root
  │         │    │         └── first-agg [as=column3:8]
  │         │    │              └── column3:8
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -408,7 +419,8 @@ root
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │    │    │    ├── scan child_multi
-      │    │    │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
+      │    │    │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    ├── select
       │    │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │    │    │    │    ├── with-scan &1
@@ -436,7 +448,8 @@ root
       │                   │         ├──  p_new:29 => p:31
       │                   │         └──  q_new:30 => q:32
       │                   ├── scan parent_multi
-      │                   │    └── columns: parent_multi.p:34 parent_multi.q:35
+      │                   │    ├── columns: parent_multi.p:34 parent_multi.q:35
+      │                   │    └── flags: disabled not visible index feature
       │                   └── filters
       │                        ├── p:31 = parent_multi.p:34
       │                        └── q:32 = parent_multi.q:35
@@ -453,7 +466,8 @@ root
                 │    ├── inner-join (hash)
                 │    │    ├── columns: g:43!null grandchild.c:44!null grandchild.q:45!null c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    │    ├── scan grandchild
-                │    │    │    └── columns: g:43!null grandchild.c:44 grandchild.q:45
+                │    │    │    ├── columns: g:43!null grandchild.c:44 grandchild.q:45
+                │    │    │    └── flags: disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    │    │    ├── with-scan &2
@@ -481,7 +495,8 @@ root
                                │         ├──  c_new:52 => c:54
                                │         └──  q_new:53 => q:55
                                ├── scan child_multi
-                               │    └── columns: child_multi.c:56!null child_multi.q:58
+                               │    ├── columns: child_multi.c:56!null child_multi.q:58
+                               │    └── flags: disabled not visible index feature
                                └── filters
                                     ├── c:54 = child_multi.c:56
                                     └── q:55 = child_multi.q:58
@@ -526,7 +541,8 @@ root
  │         │    │         └── first-agg [as=q_default:8]
  │         │    │              └── q_default:8
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -547,7 +563,8 @@ root
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │    │    │    ├── scan child_multi
-      │    │    │    │    └── columns: c:21!null child_multi.p:22 child_multi.q:23
+      │    │    │    │    ├── columns: c:21!null child_multi.p:22 child_multi.q:23
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    ├── select
       │    │    │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
       │    │    │    │    ├── with-scan &1
@@ -575,7 +592,8 @@ root
       │                   │         ├──  p_new:30 => p:32
       │                   │         └──  q_new:31 => q:33
       │                   ├── scan parent_multi
-      │                   │    └── columns: parent_multi.p:35 parent_multi.q:36
+      │                   │    ├── columns: parent_multi.p:35 parent_multi.q:36
+      │                   │    └── flags: disabled not visible index feature
       │                   └── filters
       │                        ├── p:32 = parent_multi.p:35
       │                        └── q:33 = parent_multi.q:36
@@ -592,7 +610,8 @@ root
                 │    ├── inner-join (hash)
                 │    │    ├── columns: g:44!null grandchild.c:45!null grandchild.q:46!null c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    │    ├── scan grandchild
-                │    │    │    └── columns: g:44!null grandchild.c:45 grandchild.q:46
+                │    │    │    ├── columns: g:44!null grandchild.c:45 grandchild.q:46
+                │    │    │    └── flags: disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    │    │    ├── with-scan &2
@@ -620,7 +639,8 @@ root
                                │         ├──  c_new:53 => c:55
                                │         └──  q_new:54 => q:56
                                ├── scan child_multi
-                               │    └── columns: child_multi.c:57!null child_multi.q:59
+                               │    ├── columns: child_multi.c:57!null child_multi.q:59
+                               │    └── flags: disabled not visible index feature
                                └── filters
                                     ├── c:55 = child_multi.c:57
                                     └── q:56 = child_multi.q:59
@@ -660,7 +680,8 @@ root
  │         │    │    │         └── first-agg [as=column1:6]
  │         │    │    │              └── column1:6
  │         │    │    ├── scan parent_multi
- │         │    │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    │    └── flags: disabled not visible index feature
  │         │    │    └── filters
  │         │    │         ├── column2:7 = p:10
  │         │    │         └── column3:8 = q:11
@@ -685,7 +706,8 @@ root
       │    │    ├── inner-join (hash)
       │    │    │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │    │    │    ├── scan child_multi
-      │    │    │    │    └── columns: c:23!null child_multi.p:24 child_multi.q:25
+      │    │    │    │    ├── columns: c:23!null child_multi.p:24 child_multi.q:25
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    ├── select
       │    │    │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
       │    │    │    │    ├── with-scan &1
@@ -713,7 +735,8 @@ root
       │                   │         ├──  p_new:32 => p:34
       │                   │         └──  q_new:33 => q:35
       │                   ├── scan parent_multi
-      │                   │    └── columns: parent_multi.p:37 parent_multi.q:38
+      │                   │    ├── columns: parent_multi.p:37 parent_multi.q:38
+      │                   │    └── flags: disabled not visible index feature
       │                   └── filters
       │                        ├── p:34 = parent_multi.p:37
       │                        └── q:35 = parent_multi.q:38
@@ -730,7 +753,8 @@ root
                 │    ├── inner-join (hash)
                 │    │    ├── columns: g:46!null grandchild.c:47!null grandchild.q:48!null c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    │    ├── scan grandchild
-                │    │    │    └── columns: g:46!null grandchild.c:47 grandchild.q:48
+                │    │    │    ├── columns: g:46!null grandchild.c:47 grandchild.q:48
+                │    │    │    └── flags: disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    │    │    ├── with-scan &2
@@ -758,7 +782,8 @@ root
                                │         ├──  c_new:55 => c:57
                                │         └──  q_new:56 => q:58
                                ├── scan child_multi
-                               │    └── columns: child_multi.c:59!null child_multi.q:61
+                               │    ├── columns: child_multi.c:59!null child_multi.q:61
+                               │    └── flags: disabled not visible index feature
                                └── filters
                                     ├── c:57 = child_multi.c:59
                                     └── q:58 = child_multi.q:61
@@ -813,7 +838,8 @@ root
            │    │    ├── inner-join (cross)
            │    │    │    ├── columns: c:14!null child_assn_cast.p:15!null p_old:18!null p_new:19!null
            │    │    │    ├── scan child_assn_cast
-           │    │    │    │    └── columns: c:14!null child_assn_cast.p:15
+           │    │    │    │    ├── columns: c:14!null child_assn_cast.p:15
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    │    ├── with-scan &1
@@ -839,7 +865,8 @@ root
                           │    └── mapping:
                           │         └──  p_cast:21 => p:22
                           ├── scan parent_assn_cast
-                          │    └── columns: parent_assn_cast.p:23!null
+                          │    ├── columns: parent_assn_cast.p:23!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:22 = parent_assn_cast.p:23
 
@@ -881,7 +908,8 @@ root
  │         │    │         └── first-agg [as=column2:6]
  │         │    │              └── column2:6
  │         │    ├── scan parent_assn_cast
- │         │    │    └── columns: p:7!null p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: p:7!null p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:5 = p:7
  │         └── projections
@@ -900,7 +928,8 @@ root
            │    │    ├── inner-join (cross)
            │    │    │    ├── columns: c:16!null child_assn_cast_p2.p2:17!null p2_old:20!null p2_new:21!null
            │    │    │    ├── scan child_assn_cast_p2
-           │    │    │    │    └── columns: c:16!null child_assn_cast_p2.p2:17
+           │    │    │    │    ├── columns: c:16!null child_assn_cast_p2.p2:17
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p2_old:20 p2_new:21!null
            │    │    │    │    ├── with-scan &1
@@ -926,7 +955,8 @@ root
                           │    └── mapping:
                           │         └──  p2_cast:23 => p2:24
                           ├── scan parent_assn_cast
-                          │    └── columns: parent_assn_cast.p2:26
+                          │    ├── columns: parent_assn_cast.p2:26
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p2:24 = parent_assn_cast.p2:26
 
@@ -963,7 +993,8 @@ root
  │         │    │    │         └── first-agg [as=column2:6]
  │         │    │    │              └── column2:6
  │         │    │    ├── scan parent_assn_cast
- │         │    │    │    └── columns: p:7!null p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    │    ├── columns: p:7!null p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    │    └── flags: disabled not visible index feature
  │         │    │    └── filters
  │         │    │         └── column1:5 = p:7
  │         │    └── projections
@@ -985,7 +1016,8 @@ root
            │    │    ├── inner-join (cross)
            │    │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
            │    │    │    ├── scan child_assn_cast_p2
-           │    │    │    │    └── columns: c:18!null child_assn_cast_p2.p2:19
+           │    │    │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p2_old:22 p2_new:23!null
            │    │    │    │    ├── with-scan &1
@@ -1011,7 +1043,8 @@ root
                           │    └── mapping:
                           │         └──  p2_cast:25 => p2:26
                           ├── scan parent_assn_cast
-                          │    └── columns: parent_assn_cast.p2:28
+                          │    ├── columns: parent_assn_cast.p2:28
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p2:26 = parent_assn_cast.p2:28
 
@@ -1069,11 +1102,12 @@ root
            │    │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
            │    │    │    ├── scan child_partial
            │    │    │    │    ├── columns: c:13!null child_partial.p:14!null i:15
-           │    │    │    │    └── partial index predicates
-           │    │    │    │         ├── child_partial_p_idx: filters
-           │    │    │    │         │    └── i:15 > 0
-           │    │    │    │         └── child_partial_i_idx: filters
-           │    │    │    │              └── child_partial.p:14 > 0
+           │    │    │    │    ├── partial index predicates
+           │    │    │    │    │    ├── child_partial_p_idx: filters
+           │    │    │    │    │    │    └── i:15 > 0
+           │    │    │    │    │    └── child_partial_i_idx: filters
+           │    │    │    │    │         └── child_partial.p:14 > 0
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    │    ├── with-scan &1
@@ -1100,7 +1134,8 @@ root
                           │    └── mapping:
                           │         └──  p_new:20 => p:24
                           ├── scan parent_partial
-                          │    └── columns: parent_partial.p:25!null
+                          │    ├── columns: parent_partial.p:25!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:24 = parent_partial.p:25
 
@@ -1155,9 +1190,10 @@ root
            │    │    │    ├── columns: v:15!null c:13!null child_virt.p:14!null
            │    │    │    ├── scan child_virt
            │    │    │    │    ├── columns: c:13!null child_virt.p:14!null
-           │    │    │    │    └── computed column expressions
-           │    │    │    │         └── v:15
-           │    │    │    │              └── child_virt.p:14
+           │    │    │    │    ├── computed column expressions
+           │    │    │    │    │    └── v:15
+           │    │    │    │    │         └── child_virt.p:14
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    └── projections
            │    │    │         └── child_virt.p:14 [as=v:15]
            │    │    ├── select
@@ -1182,6 +1218,7 @@ root
                           │    └── mapping:
                           │         └──  p_new:20 => p:21
                           ├── scan parent_virt
-                          │    └── columns: parent_virt.p:22!null
+                          │    ├── columns: parent_virt.p:22!null
+                          │    └── flags: disabled not visible index feature
                           └── filters
                                └── p:21 = parent_virt.p:22

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -39,7 +39,8 @@ root
                 ├── inner-join (hash)
                 │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
                 │    ├── scan child
-                │    │    └── columns: c:12!null child.p:13!null
+                │    │    ├── columns: c:12!null child.p:13!null
+                │    │    └── flags: disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: p_old:16!null p_new:17!null
                 │    │    ├── with-scan &1
@@ -110,7 +111,8 @@ root
                 ├── inner-join (hash)
                 │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
                 │    ├── scan child_multi
-                │    │    └── columns: c:18!null child_multi.p:19 child_multi.q:20
+                │    │    ├── columns: c:18!null child_multi.p:19 child_multi.q:20
+                │    │    └── flags: disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
                 │    │    ├── with-scan &1
@@ -163,7 +165,8 @@ root
                 ├── inner-join (hash)
                 │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
                 │    ├── scan child_multi
-                │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+                │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
+                │    │    └── flags: disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
                 │    │    ├── with-scan &1
@@ -227,7 +230,8 @@ root
       │         ├── inner-join (hash)
       │         │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │         │    ├── scan child_multi
-      │         │    │    └── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │         │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
+      │         │    │    └── flags: disabled not visible index feature
       │         │    ├── select
       │         │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │         │    │    ├── with-scan &1
@@ -256,7 +260,8 @@ root
                      ├── inner-join (hash)
                      │    ├── columns: g:32!null grandchild.c:33!null grandchild.q:34!null c_old:37!null c_new:38!null q_old:39!null q_new:40
                      │    ├── scan grandchild
-                     │    │    └── columns: g:32!null grandchild.c:33 grandchild.q:34
+                     │    │    ├── columns: g:32!null grandchild.c:33 grandchild.q:34
+                     │    │    └── flags: disabled not visible index feature
                      │    ├── select
                      │    │    ├── columns: c_old:37!null c_new:38!null q_old:39!null q_new:40
                      │    │    ├── with-scan &2
@@ -310,7 +315,8 @@ root
  │         │    │         └── first-agg [as=column3:8]
  │         │    │              └── column3:8
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -330,7 +336,8 @@ root
       │         ├── inner-join (hash)
       │         │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │         │    ├── scan child_multi
-      │         │    │    └── columns: c:20!null child_multi.p:21 child_multi.q:22
+      │         │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
+      │         │    │    └── flags: disabled not visible index feature
       │         │    ├── select
       │         │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │         │    │    ├── with-scan &1
@@ -359,7 +366,8 @@ root
                      ├── inner-join (hash)
                      │    ├── columns: g:35!null grandchild.c:36!null grandchild.q:37!null c_old:40!null c_new:41!null q_old:42!null q_new:43
                      │    ├── scan grandchild
-                     │    │    └── columns: g:35!null grandchild.c:36 grandchild.q:37
+                     │    │    ├── columns: g:35!null grandchild.c:36 grandchild.q:37
+                     │    │    └── flags: disabled not visible index feature
                      │    ├── select
                      │    │    ├── columns: c_old:40!null c_new:41!null q_old:42!null q_new:43
                      │    │    ├── with-scan &2
@@ -417,7 +425,8 @@ root
  │         │    │         └── first-agg [as=q_default:8]
  │         │    │              └── q_default:8
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    └── flags: disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -438,7 +447,8 @@ root
       │         ├── inner-join (hash)
       │         │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │         │    ├── scan child_multi
-      │         │    │    └── columns: c:21!null child_multi.p:22 child_multi.q:23
+      │         │    │    ├── columns: c:21!null child_multi.p:22 child_multi.q:23
+      │         │    │    └── flags: disabled not visible index feature
       │         │    ├── select
       │         │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
       │         │    │    ├── with-scan &1
@@ -467,7 +477,8 @@ root
                      ├── inner-join (hash)
                      │    ├── columns: g:36!null grandchild.c:37!null grandchild.q:38!null c_old:41!null c_new:42!null q_old:43!null q_new:44
                      │    ├── scan grandchild
-                     │    │    └── columns: g:36!null grandchild.c:37 grandchild.q:38
+                     │    │    ├── columns: g:36!null grandchild.c:37 grandchild.q:38
+                     │    │    └── flags: disabled not visible index feature
                      │    ├── select
                      │    │    ├── columns: c_old:41!null c_new:42!null q_old:43!null q_new:44
                      │    │    ├── with-scan &2
@@ -520,7 +531,8 @@ root
  │         │    │    │         └── first-agg [as=column1:6]
  │         │    │    │              └── column1:6
  │         │    │    ├── scan parent_multi
- │         │    │    │    └── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    │    └── flags: disabled not visible index feature
  │         │    │    └── filters
  │         │    │         ├── column2:7 = p:10
  │         │    │         └── column3:8 = q:11
@@ -545,7 +557,8 @@ root
       │         ├── inner-join (hash)
       │         │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │         │    ├── scan child_multi
-      │         │    │    └── columns: c:23!null child_multi.p:24 child_multi.q:25
+      │         │    │    ├── columns: c:23!null child_multi.p:24 child_multi.q:25
+      │         │    │    └── flags: disabled not visible index feature
       │         │    ├── select
       │         │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
       │         │    │    ├── with-scan &1
@@ -574,7 +587,8 @@ root
                      ├── inner-join (hash)
                      │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
                      │    ├── scan grandchild
-                     │    │    └── columns: g:38!null grandchild.c:39 grandchild.q:40
+                     │    │    ├── columns: g:38!null grandchild.c:39 grandchild.q:40
+                     │    │    └── flags: disabled not visible index feature
                      │    ├── select
                      │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
                      │    │    ├── with-scan &2
@@ -645,11 +659,12 @@ root
                 │    │    ├── columns: c:13!null child_partial.p:14!null i:15 p_old:18!null p_new:19!null
                 │    │    ├── scan child_partial
                 │    │    │    ├── columns: c:13!null child_partial.p:14!null i:15
-                │    │    │    └── partial index predicates
-                │    │    │         ├── child_partial_p_idx: filters
-                │    │    │         │    └── i:15 > 0
-                │    │    │         └── child_partial_i_idx: filters
-                │    │    │              └── child_partial.p:14 > 0
+                │    │    │    ├── partial index predicates
+                │    │    │    │    ├── child_partial_p_idx: filters
+                │    │    │    │    │    └── i:15 > 0
+                │    │    │    │    └── child_partial_i_idx: filters
+                │    │    │    │         └── child_partial.p:14 > 0
+                │    │    │    └── flags: disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: p_old:18!null p_new:19!null
                 │    │    │    ├── with-scan &1
@@ -718,9 +733,10 @@ root
                 │    │    ├── columns: v:15!null c:13!null child_virt.p:14!null
                 │    │    ├── scan child_virt
                 │    │    │    ├── columns: c:13!null child_virt.p:14!null
-                │    │    │    └── computed column expressions
-                │    │    │         └── v:15
-                │    │    │              └── child_virt.p:14
+                │    │    │    ├── computed column expressions
+                │    │    │    │    └── v:15
+                │    │    │    │         └── child_virt.p:14
+                │    │    │    └── flags: disabled not visible index feature
                 │    │    └── projections
                 │    │         └── child_virt.p:14 [as=v:15]
                 │    ├── select

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -77,7 +77,8 @@ upsert kj
       │    │         └── first-agg [as=column2:7]
       │    │              └── column2:7
       │    ├── scan kj
-      │    │    └── columns: k:8!null j:9 crdb_internal_mvcc_timestamp:10 tableoid:11
+      │    │    ├── columns: k:8!null j:9 crdb_internal_mvcc_timestamp:10 tableoid:11
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:6 = k:8
       └── projections
@@ -101,7 +102,8 @@ insert kj
       │    │    ├── columns: column1:6!null column2:7!null
       │    │    └── (1, '{"a": 2}')
       │    ├── scan kj
-      │    │    └── columns: k:8!null j:9
+      │    │    ├── columns: k:8!null j:9
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:6 = k:8
       └── aggregations
@@ -137,7 +139,8 @@ upsert kj
       │    │    │         └── first-agg [as=column2:7]
       │    │    │              └── column2:7
       │    │    ├── scan kj
-      │    │    │    └── columns: k:8!null j:9 crdb_internal_mvcc_timestamp:10 tableoid:11
+      │    │    │    ├── columns: k:8!null j:9 crdb_internal_mvcc_timestamp:10 tableoid:11
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = k:8
       │    └── projections

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -616,28 +616,30 @@ insert partial_indexes
       │    │    │    │    │    └── (2, 1, 'bar')
       │    │    │    │    ├── scan partial_indexes
       │    │    │    │    │    ├── columns: a:9!null b:10 c:11
-      │    │    │    │    │    └── partial index predicates
-      │    │    │    │    │         ├── partial_indexes_b_idx1: filters
-      │    │    │    │    │         │    └── c:11 = 'foo'
-      │    │    │    │    │         ├── partial_indexes_c_idx: filters
-      │    │    │    │    │         │    └── (a:9 > b:10) AND (c:11 = 'bar')
-      │    │    │    │    │         ├── b: filters
-      │    │    │    │    │         │    └── c:11 = 'delete-only'
-      │    │    │    │    │         └── b: filters
-      │    │    │    │    │              └── c:11 = 'write-only'
+      │    │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    │    ├── partial_indexes_b_idx1: filters
+      │    │    │    │    │    │    │    └── c:11 = 'foo'
+      │    │    │    │    │    │    ├── partial_indexes_c_idx: filters
+      │    │    │    │    │    │    │    └── (a:9 > b:10) AND (c:11 = 'bar')
+      │    │    │    │    │    │    ├── b: filters
+      │    │    │    │    │    │    │    └── c:11 = 'delete-only'
+      │    │    │    │    │    │    └── b: filters
+      │    │    │    │    │    │         └── c:11 = 'write-only'
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:6 = a:9
       │    │    │    ├── scan partial_indexes
       │    │    │    │    ├── columns: a:14!null b:15 c:16
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── partial_indexes_b_idx1: filters
-      │    │    │    │         │    └── c:16 = 'foo'
-      │    │    │    │         ├── partial_indexes_c_idx: filters
-      │    │    │    │         │    └── (a:14 > b:15) AND (c:16 = 'bar')
-      │    │    │    │         ├── b: filters
-      │    │    │    │         │    └── c:16 = 'delete-only'
-      │    │    │    │         └── b: filters
-      │    │    │    │              └── c:16 = 'write-only'
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── partial_indexes_b_idx1: filters
+      │    │    │    │    │    │    └── c:16 = 'foo'
+      │    │    │    │    │    ├── partial_indexes_c_idx: filters
+      │    │    │    │    │    │    └── (a:14 > b:15) AND (c:16 = 'bar')
+      │    │    │    │    │    ├── b: filters
+      │    │    │    │    │    │    └── c:16 = 'delete-only'
+      │    │    │    │    │    └── b: filters
+      │    │    │    │    │         └── c:16 = 'write-only'
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = b:15
       │    │    │         └── column3:8 = c:16
@@ -691,15 +693,16 @@ upsert partial_indexes
       │    │    │    │              └── column1:6
       │    │    │    ├── scan partial_indexes
       │    │    │    │    ├── columns: a:9!null b:10 c:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── partial_indexes_b_idx1: filters
-      │    │    │    │         │    └── c:11 = 'foo'
-      │    │    │    │         ├── partial_indexes_c_idx: filters
-      │    │    │    │         │    └── (a:9 > b:10) AND (c:11 = 'bar')
-      │    │    │    │         ├── b: filters
-      │    │    │    │         │    └── c:11 = 'delete-only'
-      │    │    │    │         └── b: filters
-      │    │    │    │              └── c:11 = 'write-only'
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── partial_indexes_b_idx1: filters
+      │    │    │    │    │    │    └── c:11 = 'foo'
+      │    │    │    │    │    ├── partial_indexes_c_idx: filters
+      │    │    │    │    │    │    └── (a:9 > b:10) AND (c:11 = 'bar')
+      │    │    │    │    │    ├── b: filters
+      │    │    │    │    │    │    └── c:11 = 'delete-only'
+      │    │    │    │    │    └── b: filters
+      │    │    │    │    │         └── c:11 = 'write-only'
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = b:10
       │    │    │         └── column3:8 = c:11
@@ -756,15 +759,16 @@ upsert partial_indexes
       │    │    │              └── column3:8
       │    │    ├── scan partial_indexes
       │    │    │    ├── columns: a:9!null b:10 c:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    └── partial index predicates
-      │    │    │         ├── partial_indexes_b_idx1: filters
-      │    │    │         │    └── c:11 = 'foo'
-      │    │    │         ├── partial_indexes_c_idx: filters
-      │    │    │         │    └── (a:9 > b:10) AND (c:11 = 'bar')
-      │    │    │         ├── b: filters
-      │    │    │         │    └── c:11 = 'delete-only'
-      │    │    │         └── b: filters
-      │    │    │              └── c:11 = 'write-only'
+      │    │    │    ├── partial index predicates
+      │    │    │    │    ├── partial_indexes_b_idx1: filters
+      │    │    │    │    │    └── c:11 = 'foo'
+      │    │    │    │    ├── partial_indexes_c_idx: filters
+      │    │    │    │    │    └── (a:9 > b:10) AND (c:11 = 'bar')
+      │    │    │    │    ├── b: filters
+      │    │    │    │    │    └── c:11 = 'delete-only'
+      │    │    │    │    └── b: filters
+      │    │    │    │         └── c:11 = 'write-only'
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = a:9
       │    └── projections
@@ -824,11 +828,12 @@ insert comp
       │    │    │    │    │    │    └── lower(c:15)
       │    │    │    │    │    └── e:17
       │    │    │    │    │         └── upper(c:15)
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── comp_b_idx: filters
-      │    │    │    │         │    └── lower(c:15) = 'foo'
-      │    │    │    │         └── comp_b_idx1: filters
-      │    │    │    │              └── e:17 = 'FOO'
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── comp_b_idx: filters
+      │    │    │    │    │    │    └── lower(c:15) = 'foo'
+      │    │    │    │    │    └── comp_b_idx1: filters
+      │    │    │    │    │         └── e:17 = 'FOO'
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── lower(c:15) [as=d:16]
       │    │    └── filters
@@ -906,11 +911,12 @@ upsert comp
       │    │    │    │    │    │    │    │    └── lower(c:15)
       │    │    │    │    │    │    │    └── e:17
       │    │    │    │    │    │    │         └── upper(c:15)
-      │    │    │    │    │    │    └── partial index predicates
-      │    │    │    │    │    │         ├── comp_b_idx: filters
-      │    │    │    │    │    │         │    └── lower(c:15) = 'foo'
-      │    │    │    │    │    │         └── comp_b_idx1: filters
-      │    │    │    │    │    │              └── e:17 = 'FOO'
+      │    │    │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    │    │    ├── comp_b_idx: filters
+      │    │    │    │    │    │    │    │    └── lower(c:15) = 'foo'
+      │    │    │    │    │    │    │    └── comp_b_idx1: filters
+      │    │    │    │    │    │    │         └── e:17 = 'FOO'
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── lower(c:15) [as=d:16]
       │    │    │    │    └── filters
@@ -989,11 +995,12 @@ upsert comp
       │    │    │    │    │    │    └── lower(c:15)
       │    │    │    │    │    └── e:17
       │    │    │    │    │         └── upper(c:15)
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── comp_b_idx: filters
-      │    │    │    │         │    └── lower(c:15) = 'foo'
-      │    │    │    │         └── comp_b_idx1: filters
-      │    │    │    │              └── e:17 = 'FOO'
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── comp_b_idx: filters
+      │    │    │    │    │    │    └── lower(c:15) = 'foo'
+      │    │    │    │    │    └── comp_b_idx1: filters
+      │    │    │    │    │         └── e:17 = 'FOO'
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── lower(c:15) [as=d:16]
       │    │    └── filters
@@ -1038,18 +1045,20 @@ insert uniq
       │         │    │    │    │    │    └── (1, 1, 'bar')
       │         │    │    │    │    ├── scan uniq
       │         │    │    │    │    │    ├── columns: a:9!null b:10 c:11
-      │         │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │         └── uniq_b_key: filters
-      │         │    │    │    │    │              └── c:11 = 'foo'
+      │         │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    └── uniq_b_key: filters
+      │         │    │    │    │    │    │         └── c:11 = 'foo'
+      │         │    │    │    │    │    └── flags: disabled not visible index feature
       │         │    │    │    │    └── filters
       │         │    │    │    │         └── column1:6 = a:9
       │         │    │    │    ├── select
       │         │    │    │    │    ├── columns: a:14!null b:15 c:16!null
       │         │    │    │    │    ├── scan uniq
       │         │    │    │    │    │    ├── columns: a:14!null b:15 c:16
-      │         │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │         └── uniq_b_key: filters
-      │         │    │    │    │    │              └── c:16 = 'foo'
+      │         │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    └── uniq_b_key: filters
+      │         │    │    │    │    │    │         └── c:16 = 'foo'
+      │         │    │    │    │    │    └── flags: disabled not visible index feature
       │         │    │    │    │    └── filters
       │         │    │    │    │         └── c:16 = 'foo'
       │         │    │    │    └── filters
@@ -1113,11 +1122,12 @@ insert uniq
       │         │    │         │    │    │    │    ├── columns: a:9!null b:10 c:11!null
       │         │    │         │    │    │    │    ├── scan uniq
       │         │    │         │    │    │    │    │    ├── columns: a:9!null b:10 c:11
-      │         │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │    │         ├── uniq_b_key: filters
-      │         │    │         │    │    │    │    │         │    └── c:11 = 'foo'
-      │         │    │         │    │    │    │    │         └── u2: filters
-      │         │    │         │    │    │    │    │              └── c:11 = 'bar'
+      │         │    │         │    │    │    │    │    ├── partial index predicates
+      │         │    │         │    │    │    │    │    │    ├── uniq_b_key: filters
+      │         │    │         │    │    │    │    │    │    │    └── c:11 = 'foo'
+      │         │    │         │    │    │    │    │    │    └── u2: filters
+      │         │    │         │    │    │    │    │    │         └── c:11 = 'bar'
+      │         │    │         │    │    │    │    │    └── flags: disabled not visible index feature
       │         │    │         │    │    │    │    └── filters
       │         │    │         │    │    │    │         └── c:11 = 'foo'
       │         │    │         │    │    │    └── filters
@@ -1127,11 +1137,12 @@ insert uniq
       │         │    │         │    │    │    ├── columns: a:14!null b:15 c:16!null
       │         │    │         │    │    │    ├── scan uniq
       │         │    │         │    │    │    │    ├── columns: a:14!null b:15 c:16
-      │         │    │         │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │         ├── uniq_b_key: filters
-      │         │    │         │    │    │    │         │    └── c:16 = 'foo'
-      │         │    │         │    │    │    │         └── u2: filters
-      │         │    │         │    │    │    │              └── c:16 = 'bar'
+      │         │    │         │    │    │    │    ├── partial index predicates
+      │         │    │         │    │    │    │    │    ├── uniq_b_key: filters
+      │         │    │         │    │    │    │    │    │    └── c:16 = 'foo'
+      │         │    │         │    │    │    │    │    └── u2: filters
+      │         │    │         │    │    │    │    │         └── c:16 = 'bar'
+      │         │    │         │    │    │    │    └── flags: disabled not visible index feature
       │         │    │         │    │    │    └── filters
       │         │    │         │    │    │         └── c:16 = 'bar'
       │         │    │         │    │    └── filters
@@ -1193,11 +1204,12 @@ insert uniq
       │    │    │    └── (1, 1, 'bar')
       │    │    ├── scan uniq
       │    │    │    ├── columns: a:9!null b:10 c:11
-      │    │    │    └── partial index predicates
-      │    │    │         ├── uniq_b_key: filters
-      │    │    │         │    └── c:11 = 'foo'
-      │    │    │         └── u2: filters
-      │    │    │              └── c:11 = 'bar'
+      │    │    │    ├── partial index predicates
+      │    │    │    │    ├── uniq_b_key: filters
+      │    │    │    │    │    └── c:11 = 'foo'
+      │    │    │    │    └── u2: filters
+      │    │    │    │         └── c:11 = 'bar'
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column2:7 = b:10
       │    └── aggregations
@@ -1246,7 +1258,8 @@ insert uniq
       │    │    └── (1, 1, 'bar')
       │    ├── scan uniq@u4,partial
       │    │    ├── columns: b:10!null
-      │    │    └── constraint: /10: [/1 - /1]
+      │    │    ├── constraint: /10: [/1 - /1]
+      │    │    └── flags: disabled not visible index feature
       │    └── filters (true)
       └── projections
            ├── column3:8 = 'foo' [as=partial_index_put1:15]
@@ -1308,11 +1321,12 @@ upsert uniq
       │    │    │    │    ├── columns: a:10!null b:11 c:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    │    ├── scan uniq
       │    │    │    │    │    ├── columns: a:10!null b:11 c:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    │    └── partial index predicates
-      │    │    │    │    │         ├── uniq_b_key: filters
-      │    │    │    │    │         │    └── c:12 = 'foo'
-      │    │    │    │    │         └── u2: filters
-      │    │    │    │    │              └── c:12 = 'bar'
+      │    │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    │    ├── uniq_b_key: filters
+      │    │    │    │    │    │    │    └── c:12 = 'foo'
+      │    │    │    │    │    │    └── u2: filters
+      │    │    │    │    │    │         └── c:12 = 'bar'
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── c:12 = 'foo'
       │    │    │    └── filters
@@ -1391,13 +1405,14 @@ upsert ambig
       │    │    │    │    │    ├── columns: ambig.partial_index_put1:12!null ambig.partial_index_del1:13 ambig.check1:14 rowid:15!null crdb_internal_mvcc_timestamp:16 tableoid:17
       │    │    │    │    │    ├── scan ambig
       │    │    │    │    │    │    ├── columns: ambig.partial_index_put1:12 ambig.partial_index_del1:13 ambig.check1:14 rowid:15!null crdb_internal_mvcc_timestamp:16 tableoid:17
-      │    │    │    │    │    │    └── partial index predicates
-      │    │    │    │    │    │         ├── ambig_partial_index_put1_key: filters
-      │    │    │    │    │    │         │    └── ambig.partial_index_put1:12 > 0
-      │    │    │    │    │    │         ├── ambig_partial_index_del1_key: filters
-      │    │    │    │    │    │         │    └── ambig.partial_index_del1:13 > 0
-      │    │    │    │    │    │         └── ambig_partial_index_put1_idx: filters
-      │    │    │    │    │    │              └── ambig.check1:14 > 0
+      │    │    │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    │    │    ├── ambig_partial_index_put1_key: filters
+      │    │    │    │    │    │    │    │    └── ambig.partial_index_put1:12 > 0
+      │    │    │    │    │    │    │    ├── ambig_partial_index_del1_key: filters
+      │    │    │    │    │    │    │    │    └── ambig.partial_index_del1:13 > 0
+      │    │    │    │    │    │    │    └── ambig_partial_index_put1_idx: filters
+      │    │    │    │    │    │    │         └── ambig.check1:14 > 0
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── ambig.partial_index_put1:12 > 0
       │    │    │    │    └── filters
@@ -1471,13 +1486,14 @@ insert comp
       │         │    │    │    │    │    │    │    │    └── lower(c:15)
       │         │    │    │    │    │    │    │    └── e:17
       │         │    │    │    │    │    │    │         └── upper(c:15)
-      │         │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │    │         ├── comp_b_idx: filters
-      │         │    │    │    │    │    │         │    └── lower(c:15) = 'foo'
-      │         │    │    │    │    │    │         ├── comp_b_idx1: filters
-      │         │    │    │    │    │    │         │    └── e:17 = 'FOO'
-      │         │    │    │    │    │    │         └── u1: filters
-      │         │    │    │    │    │    │              └── lower(c:15) = 'foo'
+      │         │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    │    ├── comp_b_idx: filters
+      │         │    │    │    │    │    │    │    │    └── lower(c:15) = 'foo'
+      │         │    │    │    │    │    │    │    ├── comp_b_idx1: filters
+      │         │    │    │    │    │    │    │    │    └── e:17 = 'FOO'
+      │         │    │    │    │    │    │    │    └── u1: filters
+      │         │    │    │    │    │    │    │         └── lower(c:15) = 'foo'
+      │         │    │    │    │    │    │    └── flags: disabled not visible index feature
       │         │    │    │    │    │    └── projections
       │         │    │    │    │    │         └── lower(c:15) [as=d:16]
       │         │    │    │    │    └── filters
@@ -1493,13 +1509,14 @@ insert comp
       │         │    │    │    │    │    │    │    │    └── lower(c:22)
       │         │    │    │    │    │    │    │    └── e:24
       │         │    │    │    │    │    │    │         └── upper(c:22)
-      │         │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │    │         ├── comp_b_idx: filters
-      │         │    │    │    │    │    │         │    └── lower(c:22) = 'foo'
-      │         │    │    │    │    │    │         ├── comp_b_idx1: filters
-      │         │    │    │    │    │    │         │    └── e:24 = 'FOO'
-      │         │    │    │    │    │    │         └── u1: filters
-      │         │    │    │    │    │    │              └── lower(c:22) = 'foo'
+      │         │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    │    ├── comp_b_idx: filters
+      │         │    │    │    │    │    │    │    │    └── lower(c:22) = 'foo'
+      │         │    │    │    │    │    │    │    ├── comp_b_idx1: filters
+      │         │    │    │    │    │    │    │    │    └── e:24 = 'FOO'
+      │         │    │    │    │    │    │    │    └── u1: filters
+      │         │    │    │    │    │    │    │         └── lower(c:22) = 'foo'
+      │         │    │    │    │    │    │    └── flags: disabled not visible index feature
       │         │    │    │    │    │    └── projections
       │         │    │    │    │    │         └── lower(c:22) [as=d:23]
       │         │    │    │    │    └── filters
@@ -1589,15 +1606,16 @@ insert comp
       │         │    │         │    │    │    │    │    │    │    │    └── lower(c:15)
       │         │    │         │    │    │    │    │    │    │    └── e:17
       │         │    │         │    │    │    │    │    │    │         └── upper(c:15)
-      │         │    │         │    │    │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │    │    │         ├── comp_b_idx: filters
-      │         │    │         │    │    │    │    │    │         │    └── lower(c:15) = 'foo'
-      │         │    │         │    │    │    │    │    │         ├── comp_b_idx1: filters
-      │         │    │         │    │    │    │    │    │         │    └── e:17 = 'FOO'
-      │         │    │         │    │    │    │    │    │         ├── u1: filters
-      │         │    │         │    │    │    │    │    │         │    └── lower(c:15) = 'foo'
-      │         │    │         │    │    │    │    │    │         └── u2: filters
-      │         │    │         │    │    │    │    │    │              └── e:17 = 'bar'
+      │         │    │         │    │    │    │    │    │    ├── partial index predicates
+      │         │    │         │    │    │    │    │    │    │    ├── comp_b_idx: filters
+      │         │    │         │    │    │    │    │    │    │    │    └── lower(c:15) = 'foo'
+      │         │    │         │    │    │    │    │    │    │    ├── comp_b_idx1: filters
+      │         │    │         │    │    │    │    │    │    │    │    └── e:17 = 'FOO'
+      │         │    │         │    │    │    │    │    │    │    ├── u1: filters
+      │         │    │         │    │    │    │    │    │    │    │    └── lower(c:15) = 'foo'
+      │         │    │         │    │    │    │    │    │    │    └── u2: filters
+      │         │    │         │    │    │    │    │    │    │         └── e:17 = 'bar'
+      │         │    │         │    │    │    │    │    │    └── flags: disabled not visible index feature
       │         │    │         │    │    │    │    │    └── projections
       │         │    │         │    │    │    │    │         └── lower(c:15) [as=d:16]
       │         │    │         │    │    │    │    └── filters
@@ -1616,15 +1634,16 @@ insert comp
       │         │    │         │    │    │    │    │    │    │    └── lower(c:22)
       │         │    │         │    │    │    │    │    │    └── e:24
       │         │    │         │    │    │    │    │    │         └── upper(c:22)
-      │         │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │    │         ├── comp_b_idx: filters
-      │         │    │         │    │    │    │    │         │    └── lower(c:22) = 'foo'
-      │         │    │         │    │    │    │    │         ├── comp_b_idx1: filters
-      │         │    │         │    │    │    │    │         │    └── e:24 = 'FOO'
-      │         │    │         │    │    │    │    │         ├── u1: filters
-      │         │    │         │    │    │    │    │         │    └── lower(c:22) = 'foo'
-      │         │    │         │    │    │    │    │         └── u2: filters
-      │         │    │         │    │    │    │    │              └── e:24 = 'bar'
+      │         │    │         │    │    │    │    │    ├── partial index predicates
+      │         │    │         │    │    │    │    │    │    ├── comp_b_idx: filters
+      │         │    │         │    │    │    │    │    │    │    └── lower(c:22) = 'foo'
+      │         │    │         │    │    │    │    │    │    ├── comp_b_idx1: filters
+      │         │    │         │    │    │    │    │    │    │    └── e:24 = 'FOO'
+      │         │    │         │    │    │    │    │    │    ├── u1: filters
+      │         │    │         │    │    │    │    │    │    │    └── lower(c:22) = 'foo'
+      │         │    │         │    │    │    │    │    │    └── u2: filters
+      │         │    │         │    │    │    │    │    │         └── e:24 = 'bar'
+      │         │    │         │    │    │    │    │    └── flags: disabled not visible index feature
       │         │    │         │    │    │    │    └── projections
       │         │    │         │    │    │    │         └── lower(c:22) [as=d:23]
       │         │    │         │    │    │    └── filters
@@ -1711,15 +1730,16 @@ insert comp
       │    │    │    │    │    │    └── lower(c:15)
       │    │    │    │    │    └── e:17
       │    │    │    │    │         └── upper(c:15)
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── comp_b_idx: filters
-      │    │    │    │         │    └── lower(c:15) = 'foo'
-      │    │    │    │         ├── comp_b_idx1: filters
-      │    │    │    │         │    └── e:17 = 'FOO'
-      │    │    │    │         ├── u1: filters
-      │    │    │    │         │    └── lower(c:15) = 'foo'
-      │    │    │    │         └── u2: filters
-      │    │    │    │              └── e:17 = 'bar'
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── comp_b_idx: filters
+      │    │    │    │    │    │    └── lower(c:15) = 'foo'
+      │    │    │    │    │    ├── comp_b_idx1: filters
+      │    │    │    │    │    │    └── e:17 = 'FOO'
+      │    │    │    │    │    ├── u1: filters
+      │    │    │    │    │    │    └── lower(c:15) = 'foo'
+      │    │    │    │    │    └── u2: filters
+      │    │    │    │    │         └── e:17 = 'bar'
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── lower(c:15) [as=d:16]
       │    │    └── filters
@@ -1819,15 +1839,16 @@ upsert comp
       │    │    │    │    │    │    │    │    │    └── lower(c:16)
       │    │    │    │    │    │    │    │    └── e:18
       │    │    │    │    │    │    │    │         └── upper(c:16)
-      │    │    │    │    │    │    │    └── partial index predicates
-      │    │    │    │    │    │    │         ├── comp_b_idx: filters
-      │    │    │    │    │    │    │         │    └── lower(c:16) = 'foo'
-      │    │    │    │    │    │    │         ├── comp_b_idx1: filters
-      │    │    │    │    │    │    │         │    └── e:18 = 'FOO'
-      │    │    │    │    │    │    │         ├── u1: filters
-      │    │    │    │    │    │    │         │    └── lower(c:16) = 'foo'
-      │    │    │    │    │    │    │         └── u2: filters
-      │    │    │    │    │    │    │              └── e:18 = 'bar'
+      │    │    │    │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    │    │    │    ├── comp_b_idx: filters
+      │    │    │    │    │    │    │    │    │    └── lower(c:16) = 'foo'
+      │    │    │    │    │    │    │    │    ├── comp_b_idx1: filters
+      │    │    │    │    │    │    │    │    │    └── e:18 = 'FOO'
+      │    │    │    │    │    │    │    │    ├── u1: filters
+      │    │    │    │    │    │    │    │    │    └── lower(c:16) = 'foo'
+      │    │    │    │    │    │    │    │    └── u2: filters
+      │    │    │    │    │    │    │    │         └── e:18 = 'bar'
+      │    │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         └── lower(c:16) [as=d:17]
       │    │    │    │    │    └── filters

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -41,7 +41,8 @@ insert uniq
       │              │         ├──  column4:11 => x:23
       │              │         └──  column5:12 => y:24
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+      │              │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:22 = uniq.w:15
       │                   └── k:20 != uniq.k:13
@@ -59,7 +60,8 @@ insert uniq
                      │         ├──  column4:11 => x:35
                      │         └──  column5:12 => y:36
                      ├── scan uniq
-                     │    └── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
+                     │    ├── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:35 = uniq.x:28
                           ├── y:36 = uniq.y:29
@@ -98,7 +100,8 @@ insert uniq
       │              │         ├──  column4:11 => x:23
       │              │         └──  column5:12 => y:24
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+      │              │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:22 = uniq.w:15
       │                   └── k:20 != uniq.k:13
@@ -116,7 +119,8 @@ insert uniq
                      │         ├──  column4:11 => x:35
                      │         └──  column5:12 => y:36
                      ├── scan uniq
-                     │    └── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
+                     │    ├── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:35 = uniq.x:28
                           ├── y:36 = uniq.y:29
@@ -154,7 +158,8 @@ insert uniq
                      │         ├──  column4:11 => x:23
                      │         └──  column5:12 => y:24
                      ├── scan uniq
-                     │    └── columns: uniq.k:13!null uniq.x:16 uniq.y:17
+                     │    ├── columns: uniq.k:13!null uniq.x:16 uniq.y:17
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:23 = uniq.x:16
                           ├── y:24 = uniq.y:17
@@ -191,7 +196,8 @@ insert uniq
                      │         ├──  column1:8 => k:20
                      │         └──  column3:10 => w:22
                      ├── scan uniq
-                     │    └── columns: uniq.k:13!null uniq.w:15
+                     │    ├── columns: uniq.k:13!null uniq.w:15
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── w:22 = uniq.w:15
                           └── k:20 != uniq.k:13
@@ -227,7 +233,8 @@ insert uniq
                      │         ├──  column1:8 => k:20
                      │         └──  column3:10 => w:22
                      ├── scan uniq
-                     │    └── columns: uniq.k:13!null uniq.w:15
+                     │    ├── columns: uniq.k:13!null uniq.w:15
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── w:22 = uniq.w:15
                           └── k:20 != uniq.k:13
@@ -290,19 +297,23 @@ insert uniq
       │    │    │    │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
       │    │    │    │    │    │    │    │    └── (1, 2, 3, 4, 5)
       │    │    │    │    │    │    │    ├── scan uniq
-      │    │    │    │    │    │    │    │    └── columns: k:13!null v:14 w:15 x:16 y:17
+      │    │    │    │    │    │    │    │    ├── columns: k:13!null v:14 w:15 x:16 y:17
+      │    │    │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │         └── column1:8 = k:13
       │    │    │    │    │    │    ├── scan uniq
-      │    │    │    │    │    │    │    └── columns: k:20!null v:21 w:22 x:23 y:24
+      │    │    │    │    │    │    │    ├── columns: k:20!null v:21 w:22 x:23 y:24
+      │    │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── column2:9 = v:21
       │    │    │    │    │    ├── scan uniq
-      │    │    │    │    │    │    └── columns: k:27!null v:28 w:29 x:30 y:31
+      │    │    │    │    │    │    ├── columns: k:27!null v:28 w:29 x:30 y:31
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column3:10 = w:29
       │    │    │    │    ├── scan uniq
-      │    │    │    │    │    └── columns: k:34!null v:35 w:36 x:37 y:38
+      │    │    │    │    │    ├── columns: k:34!null v:35 w:36 x:37 y:38
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         ├── column4:11 = x:37
       │    │    │    │         └── column5:12 = y:38
@@ -364,7 +375,8 @@ insert uniq
  │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
  │    │    │    └── (1, 2, 3, 4, 5)
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+ │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column3:10 = uniq.w:15
  │    └── aggregations
@@ -386,7 +398,8 @@ insert uniq
                      │    ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
                      │    └── (1, 2, 3, 4, 5)
                      ├── scan uniq
-                     │    └── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
+                     │    ├── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:30 = uniq.x:23
                           ├── y:31 = uniq.y:24
@@ -417,7 +430,8 @@ insert uniq
  │    │    │    ├── (1, 2, 3, 4, 5)
  │    │    │    └── (6, 7, 8, 9, 10)
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+ │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column3:10 = uniq.w:15
  │    └── aggregations
@@ -444,7 +458,8 @@ insert uniq
                      │         ├──  column4:11 => x:30
                      │         └──  column5:12 => y:31
                      ├── scan uniq
-                     │    └── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
+                     │    ├── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:30 = uniq.x:23
                           ├── y:31 = uniq.y:24
@@ -472,7 +487,8 @@ insert uniq
  │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null column5:12!null
  │    │    │    └── (1, 2, 3, 4, 5)
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+ │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column3:10 = uniq.w:15
  │    └── aggregations
@@ -494,7 +510,8 @@ insert uniq
                      │    ├── columns: k:27!null v:28!null w:29!null x:30!null y:31!null
                      │    └── (1, 2, 3, 4, 5)
                      ├── scan uniq
-                     │    └── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
+                     │    ├── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:30 = uniq.x:23
                           ├── y:31 = uniq.y:24
@@ -536,7 +553,8 @@ insert uniq
       │              │         ├──  other.x:11 => x:26
       │              │         └──  other.y:12 => y:27
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:16!null uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20
+      │              │    ├── columns: uniq.k:16!null uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:25 = uniq.w:18
       │                   └── k:23 != uniq.k:16
@@ -554,7 +572,8 @@ insert uniq
                      │         ├──  other.x:11 => x:38
                      │         └──  other.y:12 => y:39
                      ├── scan uniq
-                     │    └── columns: uniq.k:28!null uniq.v:29 uniq.w:30 uniq.x:31 uniq.y:32
+                     │    ├── columns: uniq.k:28!null uniq.v:29 uniq.w:30 uniq.x:31 uniq.y:32
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:38 = uniq.x:31
                           ├── y:39 = uniq.y:32
@@ -606,7 +625,8 @@ insert uniq_overlaps_pk
       │              │         ├──  column3:9 => c:19
       │              │         └──  column4:10 => d:20
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14
+      │              │    ├── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:18 = uniq_overlaps_pk.b:12
       │                   ├── c:19 = uniq_overlaps_pk.c:13
@@ -624,7 +644,8 @@ insert uniq_overlaps_pk
       │              │         ├──  column3:9 => c:29
       │              │         └──  column4:10 => d:30
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
+      │              │    ├── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:27 = uniq_overlaps_pk.a:21
       │                   └── b:28 != uniq_overlaps_pk.b:22
@@ -641,7 +662,8 @@ insert uniq_overlaps_pk
                      │         ├──  column3:9 => c:39
                      │         └──  column4:10 => d:40
                      ├── scan uniq_overlaps_pk
-                     │    └── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
+                     │    ├── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── c:39 = uniq_overlaps_pk.c:33
                           ├── d:40 = uniq_overlaps_pk.d:34
@@ -679,7 +701,8 @@ insert uniq_overlaps_pk
       │              │         ├──  x:10 => c:23
       │              │         └──  y:11 => d:24
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:15!null uniq_overlaps_pk.b:16!null uniq_overlaps_pk.c:17 uniq_overlaps_pk.d:18
+      │              │    ├── columns: uniq_overlaps_pk.a:15!null uniq_overlaps_pk.b:16!null uniq_overlaps_pk.c:17 uniq_overlaps_pk.d:18
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:22 = uniq_overlaps_pk.b:16
       │                   ├── c:23 = uniq_overlaps_pk.c:17
@@ -697,7 +720,8 @@ insert uniq_overlaps_pk
       │              │         ├──  x:10 => c:33
       │              │         └──  y:11 => d:34
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:25!null uniq_overlaps_pk.b:26!null uniq_overlaps_pk.c:27 uniq_overlaps_pk.d:28
+      │              │    ├── columns: uniq_overlaps_pk.a:25!null uniq_overlaps_pk.b:26!null uniq_overlaps_pk.c:27 uniq_overlaps_pk.d:28
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:31 = uniq_overlaps_pk.a:25
       │                   └── b:32 != uniq_overlaps_pk.b:26
@@ -714,7 +738,8 @@ insert uniq_overlaps_pk
                      │         ├──  x:10 => c:43
                      │         └──  y:11 => d:44
                      ├── scan uniq_overlaps_pk
-                     │    └── columns: uniq_overlaps_pk.a:35!null uniq_overlaps_pk.b:36!null uniq_overlaps_pk.c:37 uniq_overlaps_pk.d:38
+                     │    ├── columns: uniq_overlaps_pk.a:35!null uniq_overlaps_pk.b:36!null uniq_overlaps_pk.c:37 uniq_overlaps_pk.d:38
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── c:43 = uniq_overlaps_pk.c:37
                           ├── d:44 = uniq_overlaps_pk.d:38
@@ -769,7 +794,8 @@ insert uniq_hidden_pk
       │              │         ├──  column4:11 => d:23
       │              │         └──  rowid_default:12 => rowid:24
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null
+      │              │    ├── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:21 = uniq_hidden_pk.b:14
       │                   ├── c:22 = uniq_hidden_pk.c:15
@@ -788,7 +814,8 @@ insert uniq_hidden_pk
       │              │         ├──  column4:11 => d:35
       │              │         └──  rowid_default:12 => rowid:36
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:25 uniq_hidden_pk.b:26 uniq_hidden_pk.c:27 uniq_hidden_pk.d:28 uniq_hidden_pk.rowid:29!null
+      │              │    ├── columns: uniq_hidden_pk.a:25 uniq_hidden_pk.b:26 uniq_hidden_pk.c:27 uniq_hidden_pk.d:28 uniq_hidden_pk.rowid:29!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:32 = uniq_hidden_pk.a:25
       │                   ├── b:33 = uniq_hidden_pk.b:26
@@ -808,7 +835,8 @@ insert uniq_hidden_pk
                      │         ├──  column4:11 => d:47
                      │         └──  rowid_default:12 => rowid:48
                      ├── scan uniq_hidden_pk
-                     │    └── columns: uniq_hidden_pk.a:37 uniq_hidden_pk.b:38 uniq_hidden_pk.c:39 uniq_hidden_pk.d:40 uniq_hidden_pk.rowid:41!null
+                     │    ├── columns: uniq_hidden_pk.a:37 uniq_hidden_pk.b:38 uniq_hidden_pk.c:39 uniq_hidden_pk.d:40 uniq_hidden_pk.rowid:41!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:44 = uniq_hidden_pk.a:37
                           └── rowid:48 != uniq_hidden_pk.rowid:41
@@ -850,7 +878,8 @@ insert uniq_hidden_pk
       │              │         ├──  y:12 => d:27
       │              │         └──  rowid_default:16 => rowid:28
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:17 uniq_hidden_pk.b:18 uniq_hidden_pk.c:19 uniq_hidden_pk.d:20 uniq_hidden_pk.rowid:21!null
+      │              │    ├── columns: uniq_hidden_pk.a:17 uniq_hidden_pk.b:18 uniq_hidden_pk.c:19 uniq_hidden_pk.d:20 uniq_hidden_pk.rowid:21!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:25 = uniq_hidden_pk.b:18
       │                   ├── c:26 = uniq_hidden_pk.c:19
@@ -869,7 +898,8 @@ insert uniq_hidden_pk
       │              │         ├──  y:12 => d:39
       │              │         └──  rowid_default:16 => rowid:40
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:29 uniq_hidden_pk.b:30 uniq_hidden_pk.c:31 uniq_hidden_pk.d:32 uniq_hidden_pk.rowid:33!null
+      │              │    ├── columns: uniq_hidden_pk.a:29 uniq_hidden_pk.b:30 uniq_hidden_pk.c:31 uniq_hidden_pk.d:32 uniq_hidden_pk.rowid:33!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:36 = uniq_hidden_pk.a:29
       │                   ├── b:37 = uniq_hidden_pk.b:30
@@ -889,7 +919,8 @@ insert uniq_hidden_pk
                      │         ├──  y:12 => d:51
                      │         └──  rowid_default:16 => rowid:52
                      ├── scan uniq_hidden_pk
-                     │    └── columns: uniq_hidden_pk.a:41 uniq_hidden_pk.b:42 uniq_hidden_pk.c:43 uniq_hidden_pk.d:44 uniq_hidden_pk.rowid:45!null
+                     │    ├── columns: uniq_hidden_pk.a:41 uniq_hidden_pk.b:42 uniq_hidden_pk.c:43 uniq_hidden_pk.d:44 uniq_hidden_pk.rowid:45!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:48 = uniq_hidden_pk.a:41
                           └── rowid:52 != uniq_hidden_pk.rowid:45
@@ -931,7 +962,8 @@ insert uniq_partial
                      │         ├──  column2:7 => a:15
                      │         └──  column3:8 => b:16
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
+                     │    ├── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:15 = uniq_partial.a:10
                           ├── b:16 > 0
@@ -967,7 +999,8 @@ insert uniq_partial
                      │         ├──  column2:7 => a:15
                      │         └──  column3:8 => b:16
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
+                     │    ├── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:15 = uniq_partial.a:10
                           ├── b:16 > 0
@@ -1023,13 +1056,15 @@ insert uniq_partial
            │    │    │    │    │    ├── (1, 2, 3)
            │    │    │    │    │    └── (2, 2, 3)
            │    │    │    │    ├── scan uniq_partial
-           │    │    │    │    │    └── columns: k:9!null a:10 b:11
+           │    │    │    │    │    ├── columns: k:9!null a:10 b:11
+           │    │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    │    └── filters
            │    │    │    │         └── column1:6 = k:9
            │    │    │    ├── select
            │    │    │    │    ├── columns: k:14!null a:15 b:16!null
            │    │    │    │    ├── scan uniq_partial
-           │    │    │    │    │    └── columns: k:14!null a:15 b:16
+           │    │    │    │    │    ├── columns: k:14!null a:15 b:16
+           │    │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    │    └── filters
            │    │    │    │         └── b:16 > 0
            │    │    │    └── filters
@@ -1088,7 +1123,8 @@ insert uniq_partial
            │    │    ├── select
            │    │    │    ├── columns: k:9!null a:10 b:11!null
            │    │    │    ├── scan uniq_partial
-           │    │    │    │    └── columns: k:9!null a:10 b:11
+           │    │    │    │    ├── columns: k:9!null a:10 b:11
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    └── filters
            │    │    │         └── b:11 > 0
            │    │    └── filters
@@ -1130,7 +1166,8 @@ insert uniq_partial
                      │         ├──  v:7 => a:20
                      │         └──  w:8 => b:21
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16
+                     │    ├── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:20 = uniq_partial.a:15
                           ├── b:21 > 0
@@ -1184,7 +1221,8 @@ insert uniq_partial_overlaps_pk
       │              │         ├──  column3:9 => c:19
       │              │         └──  column4:10 => d:20
       │              ├── scan uniq_partial_overlaps_pk
-      │              │    └── columns: uniq_partial_overlaps_pk.a:11!null uniq_partial_overlaps_pk.b:12!null uniq_partial_overlaps_pk.c:13 uniq_partial_overlaps_pk.d:14
+      │              │    ├── columns: uniq_partial_overlaps_pk.a:11!null uniq_partial_overlaps_pk.b:12!null uniq_partial_overlaps_pk.c:13 uniq_partial_overlaps_pk.d:14
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── c:19 = uniq_partial_overlaps_pk.c:13
       │                   ├── d:20 > 0
@@ -1203,7 +1241,8 @@ insert uniq_partial_overlaps_pk
       │              │         ├──  column3:9 => c:29
       │              │         └──  column4:10 => d:30
       │              ├── scan uniq_partial_overlaps_pk
-      │              │    └── columns: uniq_partial_overlaps_pk.a:21!null uniq_partial_overlaps_pk.b:22!null uniq_partial_overlaps_pk.c:23 uniq_partial_overlaps_pk.d:24
+      │              │    ├── columns: uniq_partial_overlaps_pk.a:21!null uniq_partial_overlaps_pk.b:22!null uniq_partial_overlaps_pk.c:23 uniq_partial_overlaps_pk.d:24
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:27 = uniq_partial_overlaps_pk.a:21
       │                   ├── d:30 > 0
@@ -1222,7 +1261,8 @@ insert uniq_partial_overlaps_pk
                      │         ├──  column3:9 => c:39
                      │         └──  column4:10 => d:40
                      ├── scan uniq_partial_overlaps_pk
-                     │    └── columns: uniq_partial_overlaps_pk.a:31!null uniq_partial_overlaps_pk.b:32!null uniq_partial_overlaps_pk.c:33 uniq_partial_overlaps_pk.d:34
+                     │    ├── columns: uniq_partial_overlaps_pk.a:31!null uniq_partial_overlaps_pk.b:32!null uniq_partial_overlaps_pk.c:33 uniq_partial_overlaps_pk.d:34
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── b:38 = uniq_partial_overlaps_pk.b:32
                           ├── c:39 = uniq_partial_overlaps_pk.c:33
@@ -1262,7 +1302,8 @@ insert uniq_partial_overlaps_pk
       │              │         ├──  x:10 => c:23
       │              │         └──  y:11 => d:24
       │              ├── scan uniq_partial_overlaps_pk
-      │              │    └── columns: uniq_partial_overlaps_pk.a:15!null uniq_partial_overlaps_pk.b:16!null uniq_partial_overlaps_pk.c:17 uniq_partial_overlaps_pk.d:18
+      │              │    ├── columns: uniq_partial_overlaps_pk.a:15!null uniq_partial_overlaps_pk.b:16!null uniq_partial_overlaps_pk.c:17 uniq_partial_overlaps_pk.d:18
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── c:23 = uniq_partial_overlaps_pk.c:17
       │                   ├── d:24 > 0
@@ -1281,7 +1322,8 @@ insert uniq_partial_overlaps_pk
       │              │         ├──  x:10 => c:33
       │              │         └──  y:11 => d:34
       │              ├── scan uniq_partial_overlaps_pk
-      │              │    └── columns: uniq_partial_overlaps_pk.a:25!null uniq_partial_overlaps_pk.b:26!null uniq_partial_overlaps_pk.c:27 uniq_partial_overlaps_pk.d:28
+      │              │    ├── columns: uniq_partial_overlaps_pk.a:25!null uniq_partial_overlaps_pk.b:26!null uniq_partial_overlaps_pk.c:27 uniq_partial_overlaps_pk.d:28
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:31 = uniq_partial_overlaps_pk.a:25
       │                   ├── d:34 > 0
@@ -1300,7 +1342,8 @@ insert uniq_partial_overlaps_pk
                      │         ├──  x:10 => c:43
                      │         └──  y:11 => d:44
                      ├── scan uniq_partial_overlaps_pk
-                     │    └── columns: uniq_partial_overlaps_pk.a:35!null uniq_partial_overlaps_pk.b:36!null uniq_partial_overlaps_pk.c:37 uniq_partial_overlaps_pk.d:38
+                     │    ├── columns: uniq_partial_overlaps_pk.a:35!null uniq_partial_overlaps_pk.b:36!null uniq_partial_overlaps_pk.c:37 uniq_partial_overlaps_pk.d:38
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── b:42 = uniq_partial_overlaps_pk.b:36
                           ├── c:43 = uniq_partial_overlaps_pk.c:37
@@ -1353,7 +1396,8 @@ insert uniq_partial_hidden_pk
                      │         ├──  c_default:9 => c:19
                      │         └──  rowid_default:10 => rowid:20
                      ├── scan uniq_partial_hidden_pk
-                     │    └── columns: uniq_partial_hidden_pk.a:11 uniq_partial_hidden_pk.b:12 uniq_partial_hidden_pk.c:13 uniq_partial_hidden_pk.rowid:14!null
+                     │    ├── columns: uniq_partial_hidden_pk.a:11 uniq_partial_hidden_pk.b:12 uniq_partial_hidden_pk.c:13 uniq_partial_hidden_pk.rowid:14!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── b:18 = uniq_partial_hidden_pk.b:12
                           ├── c:19 > 0
@@ -1395,7 +1439,8 @@ insert uniq_partial_hidden_pk
                      │         ├──  c_default:15 => c:25
                      │         └──  rowid_default:16 => rowid:26
                      ├── scan uniq_partial_hidden_pk
-                     │    └── columns: uniq_partial_hidden_pk.a:17 uniq_partial_hidden_pk.b:18 uniq_partial_hidden_pk.c:19 uniq_partial_hidden_pk.rowid:20!null
+                     │    ├── columns: uniq_partial_hidden_pk.a:17 uniq_partial_hidden_pk.b:18 uniq_partial_hidden_pk.c:19 uniq_partial_hidden_pk.rowid:20!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── b:24 = uniq_partial_hidden_pk.b:18
                           ├── c:25 > 0
@@ -1445,8 +1490,9 @@ insert uniq_partial_constraint_and_index
  │    │    │    ├── columns: uniq_partial_constraint_and_index.a:10!null
  │    │    │    ├── scan uniq_partial_constraint_and_index
  │    │    │    │    ├── columns: uniq_partial_constraint_and_index.a:10
- │    │    │    │    └── partial index predicates
- │    │    │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
+ │    │    │    │    ├── partial index predicates
+ │    │    │    │    │    └── uniq_partial_constraint_and_index_a_key: filters (true)
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── uniq_partial_constraint_and_index.a:10 = 1
  │    │    └── filters (true)
@@ -1493,9 +1539,10 @@ insert uniq_constraint_and_partial_index
       │    │    ├── columns: a:10!null
       │    │    ├── scan uniq_constraint_and_partial_index
       │    │    │    ├── columns: a:10
-      │    │    │    └── partial index predicates
-      │    │    │         └── uniq_constraint_and_partial_index_a_key: filters
-      │    │    │              └── b:11 > 0
+      │    │    │    ├── partial index predicates
+      │    │    │    │    └── uniq_constraint_and_partial_index_a_key: filters
+      │    │    │    │         └── b:11 > 0
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── a:10 = 1
       │    └── filters (true)
@@ -1554,9 +1601,10 @@ insert uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    │    ├── columns: k:9!null a:10 b:11!null
       │         │    │         │    │    │    │    ├── scan uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    │    │    ├── columns: k:9!null a:10 b:11
-      │         │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │    │         └── uniq_partial_constraint_and_partial_index_a_key: filters
-      │         │    │         │    │    │    │    │              └── b:11 > 0
+      │         │    │         │    │    │    │    │    ├── partial index predicates
+      │         │    │         │    │    │    │    │    │    └── uniq_partial_constraint_and_partial_index_a_key: filters
+      │         │    │         │    │    │    │    │    │         └── b:11 > 0
+      │         │    │         │    │    │    │    │    └── flags: disabled not visible index feature
       │         │    │         │    │    │    │    └── filters
       │         │    │         │    │    │    │         └── b:11 > 0
       │         │    │         │    │    │    └── filters
@@ -1566,9 +1614,10 @@ insert uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    ├── columns: k:14!null a:15 b:16!null
       │         │    │         │    │    │    ├── scan uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    │    ├── columns: k:14!null a:15 b:16
-      │         │    │         │    │    │    │    └── partial index predicates
-      │         │    │         │    │    │    │         └── uniq_partial_constraint_and_partial_index_a_key: filters
-      │         │    │         │    │    │    │              └── b:16 > 0
+      │         │    │         │    │    │    │    ├── partial index predicates
+      │         │    │         │    │    │    │    │    └── uniq_partial_constraint_and_partial_index_a_key: filters
+      │         │    │         │    │    │    │    │         └── b:16 > 0
+      │         │    │         │    │    │    │    └── flags: disabled not visible index feature
       │         │    │         │    │    │    └── filters
       │         │    │         │    │    │         └── b:16 > 10
       │         │    │         │    │    └── filters
@@ -1655,15 +1704,16 @@ insert uniq_computed_pk
                      │    ├── columns: uniq_computed_pk.c_s:37 uniq_computed_pk.i:33!null uniq_computed_pk.s:34 uniq_computed_pk.d:35 uniq_computed_pk.c_i_expr:36!null uniq_computed_pk.c_d:38 uniq_computed_pk.c_d_expr:39
                      │    ├── scan uniq_computed_pk
                      │    │    ├── columns: uniq_computed_pk.i:33!null uniq_computed_pk.s:34 uniq_computed_pk.d:35 uniq_computed_pk.c_i_expr:36!null uniq_computed_pk.c_d:38 uniq_computed_pk.c_d_expr:39
-                     │    │    └── computed column expressions
-                     │    │         ├── uniq_computed_pk.c_i_expr:36
-                     │    │         │    └── CASE WHEN uniq_computed_pk.i:33 < 0 THEN 'foo' ELSE 'bar' END
-                     │    │         ├── uniq_computed_pk.c_s:37
-                     │    │         │    └── uniq_computed_pk.s:34
-                     │    │         ├── uniq_computed_pk.c_d:38
-                     │    │         │    └── uniq_computed_pk.d:35
-                     │    │         └── uniq_computed_pk.c_d_expr:39
-                     │    │              └── uniq_computed_pk.d:35::STRING
+                     │    │    ├── computed column expressions
+                     │    │    │    ├── uniq_computed_pk.c_i_expr:36
+                     │    │    │    │    └── CASE WHEN uniq_computed_pk.i:33 < 0 THEN 'foo' ELSE 'bar' END
+                     │    │    │    ├── uniq_computed_pk.c_s:37
+                     │    │    │    │    └── uniq_computed_pk.s:34
+                     │    │    │    ├── uniq_computed_pk.c_d:38
+                     │    │    │    │    └── uniq_computed_pk.d:35
+                     │    │    │    └── uniq_computed_pk.c_d_expr:39
+                     │    │    │         └── uniq_computed_pk.d:35::STRING
+                     │    │    └── flags: disabled not visible index feature
                      │    └── projections
                      │         └── uniq_computed_pk.s:34 [as=uniq_computed_pk.c_s:37]
                      └── filters
@@ -1705,7 +1755,8 @@ insert uniq_default
                 ├── select
                 │    ├── columns: uniq_default.k:9!null uniq_default.a:10!null uniq_default.b:11!null
                 │    ├── scan uniq_default
-                │    │    └── columns: uniq_default.k:9!null uniq_default.a:10 uniq_default.b:11
+                │    │    ├── columns: uniq_default.k:9!null uniq_default.a:10 uniq_default.b:11
+                │    │    └── flags: disabled not visible index feature
                 │    └── filters
                 │         ├── uniq_default.a:10 = 10
                 │         ├── uniq_default.b:11 = 100

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-update
@@ -42,7 +42,8 @@ update uniq
       │              │         ├──  x_new:16 => x:27
       │              │         └──  uniq.y:12 => y:28
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
+      │              │    ├── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:26 = uniq.w:19
       │                   └── k:24 != uniq.k:17
@@ -60,7 +61,8 @@ update uniq
                      │         ├──  x_new:16 => x:39
                      │         └──  uniq.y:12 => y:40
                      ├── scan uniq
-                     │    └── columns: uniq.k:29!null uniq.v:30 uniq.w:31 uniq.x:32 uniq.y:33
+                     │    ├── columns: uniq.k:29!null uniq.v:30 uniq.w:31 uniq.x:32 uniq.y:33
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:39 = uniq.x:32
                           ├── y:40 = uniq.y:33
@@ -99,7 +101,8 @@ update uniq
                      │         ├──  x_new:16 => x:27
                      │         └──  uniq.y:12 => y:28
                      ├── scan uniq
-                     │    └── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
+                     │    ├── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:27 = uniq.x:20
                           ├── y:28 = uniq.y:21
@@ -141,7 +144,8 @@ update uniq
                      │         ├──  x_new:17 => x:28
                      │         └──  uniq.y:12 => y:29
                      ├── scan uniq
-                     │    └── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
+                     │    ├── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── w:27 = uniq.w:20
                           └── k:25 != uniq.k:18
@@ -183,7 +187,8 @@ update uniq
                      │         ├──  uniq.x:11 => x:27
                      │         └──  y_new:16 => y:28
                      ├── scan uniq
-                     │    └── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
+                     │    ├── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── w:26 = uniq.w:19
                           └── k:24 != uniq.k:17
@@ -275,7 +280,8 @@ update uniq
       │              │         ├──  other.x:18 => x:33
       │              │         └──  uniq.y:12 => y:34
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
+      │              │    ├── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:32 = uniq.w:25
       │                   └── k:30 != uniq.k:23
@@ -293,7 +299,8 @@ update uniq
                      │         ├──  other.x:18 => x:45
                      │         └──  uniq.y:12 => y:46
                      ├── scan uniq
-                     │    └── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
+                     │    ├── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:45 = uniq.x:38
                           ├── y:46 = uniq.y:39
@@ -355,7 +362,8 @@ update uniq_overlaps_pk
       │              │         ├──  c_new:15 => c:25
       │              │         └──  d_new:16 => d:26
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:17!null uniq_overlaps_pk.b:18!null uniq_overlaps_pk.c:19 uniq_overlaps_pk.d:20
+      │              │    ├── columns: uniq_overlaps_pk.a:17!null uniq_overlaps_pk.b:18!null uniq_overlaps_pk.c:19 uniq_overlaps_pk.d:20
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:24 = uniq_overlaps_pk.b:18
       │                   ├── c:25 = uniq_overlaps_pk.c:19
@@ -373,7 +381,8 @@ update uniq_overlaps_pk
       │              │         ├──  c_new:15 => c:35
       │              │         └──  d_new:16 => d:36
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:27!null uniq_overlaps_pk.b:28!null uniq_overlaps_pk.c:29 uniq_overlaps_pk.d:30
+      │              │    ├── columns: uniq_overlaps_pk.a:27!null uniq_overlaps_pk.b:28!null uniq_overlaps_pk.c:29 uniq_overlaps_pk.d:30
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:33 = uniq_overlaps_pk.a:27
       │                   └── b:34 != uniq_overlaps_pk.b:28
@@ -390,7 +399,8 @@ update uniq_overlaps_pk
                      │         ├──  c_new:15 => c:45
                      │         └──  d_new:16 => d:46
                      ├── scan uniq_overlaps_pk
-                     │    └── columns: uniq_overlaps_pk.a:37!null uniq_overlaps_pk.b:38!null uniq_overlaps_pk.c:39 uniq_overlaps_pk.d:40
+                     │    ├── columns: uniq_overlaps_pk.a:37!null uniq_overlaps_pk.b:38!null uniq_overlaps_pk.c:39 uniq_overlaps_pk.d:40
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── c:45 = uniq_overlaps_pk.c:39
                           ├── d:46 = uniq_overlaps_pk.d:40
@@ -459,7 +469,8 @@ update uniq_overlaps_pk
       │              │         ├──  uniq_overlaps_pk.c:9 => c:29
       │              │         └──  v:14 => d:30
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
+      │              │    ├── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:27 = uniq_overlaps_pk.a:21
       │                   └── b:28 != uniq_overlaps_pk.b:22
@@ -476,7 +487,8 @@ update uniq_overlaps_pk
                      │         ├──  uniq_overlaps_pk.c:9 => c:39
                      │         └──  v:14 => d:40
                      ├── scan uniq_overlaps_pk
-                     │    └── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
+                     │    ├── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── c:39 = uniq_overlaps_pk.c:33
                           ├── d:40 = uniq_overlaps_pk.d:34
@@ -527,7 +539,8 @@ update uniq_hidden_pk
       │              │         ├──  uniq_hidden_pk.d:11 => d:26
       │              │         └──  uniq_hidden_pk.rowid:12 => rowid:27
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:16 uniq_hidden_pk.b:17 uniq_hidden_pk.c:18 uniq_hidden_pk.d:19 uniq_hidden_pk.rowid:20!null
+      │              │    ├── columns: uniq_hidden_pk.a:16 uniq_hidden_pk.b:17 uniq_hidden_pk.c:18 uniq_hidden_pk.d:19 uniq_hidden_pk.rowid:20!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:23 = uniq_hidden_pk.a:16
       │                   ├── b:24 = uniq_hidden_pk.b:17
@@ -547,7 +560,8 @@ update uniq_hidden_pk
                      │         ├──  uniq_hidden_pk.d:11 => d:38
                      │         └──  uniq_hidden_pk.rowid:12 => rowid:39
                      ├── scan uniq_hidden_pk
-                     │    └── columns: uniq_hidden_pk.a:28 uniq_hidden_pk.b:29 uniq_hidden_pk.c:30 uniq_hidden_pk.d:31 uniq_hidden_pk.rowid:32!null
+                     │    ├── columns: uniq_hidden_pk.a:28 uniq_hidden_pk.b:29 uniq_hidden_pk.c:30 uniq_hidden_pk.d:31 uniq_hidden_pk.rowid:32!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:35 = uniq_hidden_pk.a:28
                           └── rowid:39 != uniq_hidden_pk.rowid:32
@@ -586,7 +600,8 @@ update uniq_hidden_pk
       │              │         ├──  uniq_hidden_pk.d:11 => d:33
       │              │         └──  uniq_hidden_pk.rowid:12 => rowid:34
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:23 uniq_hidden_pk.b:24 uniq_hidden_pk.c:25 uniq_hidden_pk.d:26 uniq_hidden_pk.rowid:27!null
+      │              │    ├── columns: uniq_hidden_pk.a:23 uniq_hidden_pk.b:24 uniq_hidden_pk.c:25 uniq_hidden_pk.d:26 uniq_hidden_pk.rowid:27!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:30 = uniq_hidden_pk.a:23
       │                   ├── b:31 = uniq_hidden_pk.b:24
@@ -606,7 +621,8 @@ update uniq_hidden_pk
                      │         ├──  uniq_hidden_pk.d:11 => d:45
                      │         └──  uniq_hidden_pk.rowid:12 => rowid:46
                      ├── scan uniq_hidden_pk
-                     │    └── columns: uniq_hidden_pk.a:35 uniq_hidden_pk.b:36 uniq_hidden_pk.c:37 uniq_hidden_pk.d:38 uniq_hidden_pk.rowid:39!null
+                     │    ├── columns: uniq_hidden_pk.a:35 uniq_hidden_pk.b:36 uniq_hidden_pk.c:37 uniq_hidden_pk.d:38 uniq_hidden_pk.rowid:39!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:42 = uniq_hidden_pk.a:35
                           └── rowid:46 != uniq_hidden_pk.rowid:39
@@ -651,7 +667,8 @@ update uniq_partial
                      │         ├──  uniq_partial.b:9 => b:22
                      │         └──  uniq_partial.c:10 => c:23
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16 uniq_partial.c:17
+                     │    ├── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16 uniq_partial.c:17
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:21 = uniq_partial.a:15
                           ├── b:22 > 0
@@ -688,7 +705,8 @@ update uniq_partial
                      │         ├──  b_new:13 => b:22
                      │         └──  uniq_partial.c:10 => c:23
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16 uniq_partial.c:17
+                     │    ├── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16 uniq_partial.c:17
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:21 = uniq_partial.a:15
                           ├── b:22 > 0
@@ -812,7 +830,8 @@ update uniq_partial
                      │         ├──  x:16 => b:29
                      │         └──  uniq_partial.c:10 => c:30
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:21!null uniq_partial.a:22 uniq_partial.b:23 uniq_partial.c:24
+                     │    ├── columns: uniq_partial.k:21!null uniq_partial.a:22 uniq_partial.b:23 uniq_partial.c:24
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:28 = uniq_partial.a:22
                           ├── b:29 > 0
@@ -878,7 +897,8 @@ update uniq_partial_overlaps_pk
       │              │         ├──  c_new:15 => c:25
       │              │         └──  d_new:16 => d:26
       │              ├── scan uniq_partial_overlaps_pk
-      │              │    └── columns: uniq_partial_overlaps_pk.a:17!null uniq_partial_overlaps_pk.b:18!null uniq_partial_overlaps_pk.c:19 uniq_partial_overlaps_pk.d:20
+      │              │    ├── columns: uniq_partial_overlaps_pk.a:17!null uniq_partial_overlaps_pk.b:18!null uniq_partial_overlaps_pk.c:19 uniq_partial_overlaps_pk.d:20
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── c:25 = uniq_partial_overlaps_pk.c:19
       │                   ├── d:26 > 0
@@ -897,7 +917,8 @@ update uniq_partial_overlaps_pk
       │              │         ├──  c_new:15 => c:35
       │              │         └──  d_new:16 => d:36
       │              ├── scan uniq_partial_overlaps_pk
-      │              │    └── columns: uniq_partial_overlaps_pk.a:27!null uniq_partial_overlaps_pk.b:28!null uniq_partial_overlaps_pk.c:29 uniq_partial_overlaps_pk.d:30
+      │              │    ├── columns: uniq_partial_overlaps_pk.a:27!null uniq_partial_overlaps_pk.b:28!null uniq_partial_overlaps_pk.c:29 uniq_partial_overlaps_pk.d:30
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:33 = uniq_partial_overlaps_pk.a:27
       │                   ├── d:36 > 0
@@ -916,7 +937,8 @@ update uniq_partial_overlaps_pk
                      │         ├──  c_new:15 => c:45
                      │         └──  d_new:16 => d:46
                      ├── scan uniq_partial_overlaps_pk
-                     │    └── columns: uniq_partial_overlaps_pk.a:37!null uniq_partial_overlaps_pk.b:38!null uniq_partial_overlaps_pk.c:39 uniq_partial_overlaps_pk.d:40
+                     │    ├── columns: uniq_partial_overlaps_pk.a:37!null uniq_partial_overlaps_pk.b:38!null uniq_partial_overlaps_pk.c:39 uniq_partial_overlaps_pk.d:40
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── b:44 = uniq_partial_overlaps_pk.b:38
                           ├── c:45 = uniq_partial_overlaps_pk.c:39
@@ -988,7 +1010,8 @@ update uniq_partial_overlaps_pk
                      │         ├──  uniq_partial_overlaps_pk.c:9 => c:29
                      │         └──  uniq_partial_overlaps_pk.d:10 => d:30
                      ├── scan uniq_partial_overlaps_pk
-                     │    └── columns: uniq_partial_overlaps_pk.a:21!null uniq_partial_overlaps_pk.b:22!null uniq_partial_overlaps_pk.c:23 uniq_partial_overlaps_pk.d:24
+                     │    ├── columns: uniq_partial_overlaps_pk.a:21!null uniq_partial_overlaps_pk.b:22!null uniq_partial_overlaps_pk.c:23 uniq_partial_overlaps_pk.d:24
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:27 = uniq_partial_overlaps_pk.a:21
                           ├── d:30 > 0
@@ -1033,7 +1056,8 @@ update uniq_partial_hidden_pk
                      │         ├──  uniq_partial_hidden_pk.b:7 => b:18
                      │         └──  uniq_partial_hidden_pk.rowid:8 => rowid:19
                      ├── scan uniq_partial_hidden_pk
-                     │    └── columns: uniq_partial_hidden_pk.a:12 uniq_partial_hidden_pk.b:13 uniq_partial_hidden_pk.rowid:14!null
+                     │    ├── columns: uniq_partial_hidden_pk.a:12 uniq_partial_hidden_pk.b:13 uniq_partial_hidden_pk.rowid:14!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:17 = uniq_partial_hidden_pk.a:12
                           ├── b:18 > 0
@@ -1071,7 +1095,8 @@ update uniq_partial_hidden_pk
                      │         ├──  uniq_partial_hidden_pk.b:7 => b:25
                      │         └──  uniq_partial_hidden_pk.rowid:8 => rowid:26
                      ├── scan uniq_partial_hidden_pk
-                     │    └── columns: uniq_partial_hidden_pk.a:19 uniq_partial_hidden_pk.b:20 uniq_partial_hidden_pk.rowid:21!null
+                     │    ├── columns: uniq_partial_hidden_pk.a:19 uniq_partial_hidden_pk.b:20 uniq_partial_hidden_pk.rowid:21!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:24 = uniq_partial_hidden_pk.a:19
                           ├── b:25 > 0
@@ -1160,15 +1185,16 @@ update uniq_computed_pk
                      │    ├── columns: uniq_computed_pk.c_s:46 uniq_computed_pk.i:42!null uniq_computed_pk.s:43 uniq_computed_pk.d:44 uniq_computed_pk.c_i_expr:45!null uniq_computed_pk.c_d:47 uniq_computed_pk.c_d_expr:48
                      │    ├── scan uniq_computed_pk
                      │    │    ├── columns: uniq_computed_pk.i:42!null uniq_computed_pk.s:43 uniq_computed_pk.d:44 uniq_computed_pk.c_i_expr:45!null uniq_computed_pk.c_d:47 uniq_computed_pk.c_d_expr:48
-                     │    │    └── computed column expressions
-                     │    │         ├── uniq_computed_pk.c_i_expr:45
-                     │    │         │    └── CASE WHEN uniq_computed_pk.i:42 < 0 THEN 'foo' ELSE 'bar' END
-                     │    │         ├── uniq_computed_pk.c_s:46
-                     │    │         │    └── uniq_computed_pk.s:43
-                     │    │         ├── uniq_computed_pk.c_d:47
-                     │    │         │    └── uniq_computed_pk.d:44
-                     │    │         └── uniq_computed_pk.c_d_expr:48
-                     │    │              └── uniq_computed_pk.d:44::STRING
+                     │    │    ├── computed column expressions
+                     │    │    │    ├── uniq_computed_pk.c_i_expr:45
+                     │    │    │    │    └── CASE WHEN uniq_computed_pk.i:42 < 0 THEN 'foo' ELSE 'bar' END
+                     │    │    │    ├── uniq_computed_pk.c_s:46
+                     │    │    │    │    └── uniq_computed_pk.s:43
+                     │    │    │    ├── uniq_computed_pk.c_d:47
+                     │    │    │    │    └── uniq_computed_pk.d:44
+                     │    │    │    └── uniq_computed_pk.c_d_expr:48
+                     │    │    │         └── uniq_computed_pk.d:44::STRING
+                     │    │    └── flags: disabled not visible index feature
                      │    └── projections
                      │         └── uniq_computed_pk.s:43 [as=uniq_computed_pk.c_s:46]
                      └── filters

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -55,7 +55,8 @@ upsert uniq
  │    │    │         └── first-agg [as=column5:12]
  │    │    │              └── column5:12
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:8 = uniq.k:13
  │    └── projections
@@ -75,7 +76,8 @@ upsert uniq
       │              │         ├──  column4:11 => x:31
       │              │         └──  column5:12 => y:32
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:21!null uniq.v:22 uniq.w:23 uniq.x:24 uniq.y:25
+      │              │    ├── columns: uniq.k:21!null uniq.v:22 uniq.w:23 uniq.x:24 uniq.y:25
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:30 = uniq.w:23
       │                   └── k:28 != uniq.k:21
@@ -93,7 +95,8 @@ upsert uniq
                      │         ├──  column4:11 => x:43
                      │         └──  column5:12 => y:44
                      ├── scan uniq
-                     │    └── columns: uniq.k:33!null uniq.v:34 uniq.w:35 uniq.x:36 uniq.y:37
+                     │    ├── columns: uniq.k:33!null uniq.v:34 uniq.w:35 uniq.x:36 uniq.y:37
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:43 = uniq.x:36
                           ├── y:44 = uniq.y:37
@@ -145,7 +148,8 @@ upsert uniq
  │    │    │         └── first-agg [as=y_default:12]
  │    │    │              └── y_default:12
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:8 = uniq.k:13
  │    └── projections
@@ -167,7 +171,8 @@ upsert uniq
       │              │         ├──  upsert_x:21 => x:33
       │              │         └──  upsert_y:22 => y:34
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
+      │              │    ├── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:32 = uniq.w:25
       │                   └── k:30 != uniq.k:23
@@ -185,7 +190,8 @@ upsert uniq
                      │         ├──  upsert_x:21 => x:45
                      │         └──  upsert_y:22 => y:46
                      ├── scan uniq
-                     │    └── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
+                     │    ├── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:45 = uniq.x:38
                           ├── y:46 = uniq.y:39
@@ -238,7 +244,8 @@ upsert uniq
  │    │    │         └── first-agg [as=y_default:12]
  │    │    │              └── y_default:12
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:8 = uniq.k:13
  │    └── projections
@@ -260,7 +267,8 @@ upsert uniq
       │              │         ├──  column3:10 => x:33
       │              │         └──  upsert_y:22 => y:34
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
+      │              │    ├── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:32 = uniq.w:25
       │                   └── k:30 != uniq.k:23
@@ -278,7 +286,8 @@ upsert uniq
                      │         ├──  column3:10 => x:45
                      │         └──  upsert_y:22 => y:46
                      ├── scan uniq
-                     │    └── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
+                     │    ├── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:45 = uniq.x:38
                           ├── y:46 = uniq.y:39
@@ -333,7 +342,8 @@ upsert uniq
  │    │    │         └── first-agg [as=y_default:17]
  │    │    │              └── y_default:17
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22 uniq.crdb_internal_mvcc_timestamp:23 uniq.tableoid:24
+ │    │    │    ├── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22 uniq.crdb_internal_mvcc_timestamp:23 uniq.tableoid:24
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── other.k:8 = uniq.k:18
  │    └── projections
@@ -353,7 +363,8 @@ upsert uniq
       │              │         ├──  x_default:16 => x:36
       │              │         └──  y_default:17 => y:37
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
+      │              │    ├── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:35 = uniq.w:28
       │                   └── k:33 != uniq.k:26
@@ -371,7 +382,8 @@ upsert uniq
                      │         ├──  x_default:16 => x:48
                      │         └──  y_default:17 => y:49
                      ├── scan uniq
-                     │    └── columns: uniq.k:38!null uniq.v:39 uniq.w:40 uniq.x:41 uniq.y:42
+                     │    ├── columns: uniq.k:38!null uniq.v:39 uniq.w:40 uniq.x:41 uniq.y:42
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:48 = uniq.x:41
                           ├── y:49 = uniq.y:42
@@ -424,7 +436,8 @@ upsert uniq
  │    │    │    │         └── first-agg [as=y_default:11]
  │    │    │    │              └── y_default:11
  │    │    │    ├── scan uniq
- │    │    │    │    └── columns: uniq.k:12!null uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+ │    │    │    │    ├── columns: uniq.k:12!null uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:8 = uniq.k:12
  │    │    └── projections
@@ -450,7 +463,8 @@ upsert uniq
       │              │         ├──  upsert_x:23 => x:35
       │              │         └──  upsert_y:24 => y:36
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
+      │              │    ├── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:34 = uniq.w:27
       │                   └── k:32 != uniq.k:25
@@ -468,7 +482,8 @@ upsert uniq
                      │         ├──  upsert_x:23 => x:47
                      │         └──  upsert_y:24 => y:48
                      ├── scan uniq
-                     │    └── columns: uniq.k:37!null uniq.v:38 uniq.w:39 uniq.x:40 uniq.y:41
+                     │    ├── columns: uniq.k:37!null uniq.v:38 uniq.w:39 uniq.x:40 uniq.y:41
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:47 = uniq.x:40
                           ├── y:48 = uniq.y:41
@@ -520,7 +535,8 @@ upsert uniq
  │    │    │    │         └── first-agg [as=y_default:17]
  │    │    │    │              └── y_default:17
  │    │    │    ├── scan uniq
- │    │    │    │    └── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22 uniq.crdb_internal_mvcc_timestamp:23 uniq.tableoid:24
+ │    │    │    │    ├── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22 uniq.crdb_internal_mvcc_timestamp:23 uniq.tableoid:24
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── other.k:8 = uniq.k:18
  │    │    └── projections
@@ -546,7 +562,8 @@ upsert uniq
       │              │         ├──  upsert_x:29 => x:41
       │              │         └──  upsert_y:30 => y:42
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:31!null uniq.v:32 uniq.w:33 uniq.x:34 uniq.y:35
+      │              │    ├── columns: uniq.k:31!null uniq.v:32 uniq.w:33 uniq.x:34 uniq.y:35
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:40 = uniq.w:33
       │                   └── k:38 != uniq.k:31
@@ -564,7 +581,8 @@ upsert uniq
                      │         ├──  upsert_x:29 => x:53
                      │         └──  upsert_y:30 => y:54
                      ├── scan uniq
-                     │    └── columns: uniq.k:43!null uniq.v:44 uniq.w:45 uniq.x:46 uniq.y:47
+                     │    ├── columns: uniq.k:43!null uniq.v:44 uniq.w:45 uniq.x:46 uniq.y:47
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:53 = uniq.x:46
                           ├── y:54 = uniq.y:47
@@ -617,7 +635,8 @@ upsert uniq
  │    │    │    │         └── first-agg [as=y_default:12]
  │    │    │    │              └── y_default:12
  │    │    │    ├── scan uniq
- │    │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column3:10 = uniq.w:15
  │    │    └── projections
@@ -643,7 +662,8 @@ upsert uniq
       │              │         ├──  upsert_x:24 => x:36
       │              │         └──  upsert_y:25 => y:37
       │              ├── scan uniq
-      │              │    └── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
+      │              │    ├── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── w:35 = uniq.w:28
       │                   └── k:33 != uniq.k:26
@@ -661,7 +681,8 @@ upsert uniq
                      │         ├──  upsert_x:24 => x:48
                      │         └──  upsert_y:25 => y:49
                      ├── scan uniq
-                     │    └── columns: uniq.k:38!null uniq.v:39 uniq.w:40 uniq.x:41 uniq.y:42
+                     │    ├── columns: uniq.k:38!null uniq.v:39 uniq.w:40 uniq.x:41 uniq.y:42
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:48 = uniq.x:41
                           ├── y:49 = uniq.y:42
@@ -706,7 +727,8 @@ upsert uniq
  │    │    │    │         └── first-agg [as=column3:10]
  │    │    │    │              └── column3:10
  │    │    │    ├── scan uniq
- │    │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         ├── column4:11 = uniq.x:16
  │    │    │         └── column5:12 = uniq.y:17
@@ -733,7 +755,8 @@ upsert uniq
                      │         ├──  upsert_x:24 => x:36
                      │         └──  upsert_y:25 => y:37
                      ├── scan uniq
-                     │    └── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
+                     │    ├── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── w:35 = uniq.w:28
                           └── k:33 != uniq.k:26
@@ -796,7 +819,8 @@ upsert uniq_overlaps_pk
       │              │         ├──  column3:9 => c:19
       │              │         └──  column4:10 => d:20
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14
+      │              │    ├── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:18 = uniq_overlaps_pk.b:12
       │                   ├── c:19 = uniq_overlaps_pk.c:13
@@ -814,7 +838,8 @@ upsert uniq_overlaps_pk
       │              │         ├──  column3:9 => c:29
       │              │         └──  column4:10 => d:30
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
+      │              │    ├── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:27 = uniq_overlaps_pk.a:21
       │                   └── b:28 != uniq_overlaps_pk.b:22
@@ -831,7 +856,8 @@ upsert uniq_overlaps_pk
                      │         ├──  column3:9 => c:39
                      │         └──  column4:10 => d:40
                      ├── scan uniq_overlaps_pk
-                     │    └── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
+                     │    ├── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── c:39 = uniq_overlaps_pk.c:33
                           ├── d:40 = uniq_overlaps_pk.d:34
@@ -874,7 +900,8 @@ upsert uniq_overlaps_pk
       │              │         ├──  x:10 => c:24
       │              │         └──  d_default:15 => d:25
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:16!null uniq_overlaps_pk.b:17!null uniq_overlaps_pk.c:18 uniq_overlaps_pk.d:19
+      │              │    ├── columns: uniq_overlaps_pk.a:16!null uniq_overlaps_pk.b:17!null uniq_overlaps_pk.c:18 uniq_overlaps_pk.d:19
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:23 = uniq_overlaps_pk.b:17
       │                   ├── c:24 = uniq_overlaps_pk.c:18
@@ -892,7 +919,8 @@ upsert uniq_overlaps_pk
                      │         ├──  x:10 => c:34
                      │         └──  d_default:15 => d:35
                      ├── scan uniq_overlaps_pk
-                     │    └── columns: uniq_overlaps_pk.a:26!null uniq_overlaps_pk.b:27!null uniq_overlaps_pk.c:28 uniq_overlaps_pk.d:29
+                     │    ├── columns: uniq_overlaps_pk.a:26!null uniq_overlaps_pk.b:27!null uniq_overlaps_pk.c:28 uniq_overlaps_pk.d:29
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:32 = uniq_overlaps_pk.a:26
                           └── b:33 != uniq_overlaps_pk.b:27
@@ -936,7 +964,8 @@ upsert uniq_overlaps_pk
  │    │    │    │         └── first-agg [as=column4:10]
  │    │    │    │              └── column4:10
  │    │    │    ├── scan uniq_overlaps_pk
- │    │    │    │    └── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+ │    │    │    │    ├── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:7 = uniq_overlaps_pk.a:11
  │    │    └── projections
@@ -960,7 +989,8 @@ upsert uniq_overlaps_pk
       │              │         ├──  upsert_c:20 => c:30
       │              │         └──  upsert_d:21 => d:31
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:22!null uniq_overlaps_pk.b:23!null uniq_overlaps_pk.c:24 uniq_overlaps_pk.d:25
+      │              │    ├── columns: uniq_overlaps_pk.a:22!null uniq_overlaps_pk.b:23!null uniq_overlaps_pk.c:24 uniq_overlaps_pk.d:25
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:29 = uniq_overlaps_pk.b:23
       │                   ├── c:30 = uniq_overlaps_pk.c:24
@@ -978,7 +1008,8 @@ upsert uniq_overlaps_pk
       │              │         ├──  upsert_c:20 => c:40
       │              │         └──  upsert_d:21 => d:41
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:32!null uniq_overlaps_pk.b:33!null uniq_overlaps_pk.c:34 uniq_overlaps_pk.d:35
+      │              │    ├── columns: uniq_overlaps_pk.a:32!null uniq_overlaps_pk.b:33!null uniq_overlaps_pk.c:34 uniq_overlaps_pk.d:35
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:38 = uniq_overlaps_pk.a:32
       │                   └── b:39 != uniq_overlaps_pk.b:33
@@ -995,7 +1026,8 @@ upsert uniq_overlaps_pk
                      │         ├──  upsert_c:20 => c:50
                      │         └──  upsert_d:21 => d:51
                      ├── scan uniq_overlaps_pk
-                     │    └── columns: uniq_overlaps_pk.a:42!null uniq_overlaps_pk.b:43!null uniq_overlaps_pk.c:44 uniq_overlaps_pk.d:45
+                     │    ├── columns: uniq_overlaps_pk.a:42!null uniq_overlaps_pk.b:43!null uniq_overlaps_pk.c:44 uniq_overlaps_pk.d:45
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── c:50 = uniq_overlaps_pk.c:44
                           ├── d:51 = uniq_overlaps_pk.d:45
@@ -1037,7 +1069,8 @@ upsert uniq_overlaps_pk
  │    │    │    │         └── first-agg [as=column2:8]
  │    │    │    │              └── column2:8
  │    │    │    ├── scan uniq_overlaps_pk
- │    │    │    │    └── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+ │    │    │    │    ├── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         ├── column3:9 = uniq_overlaps_pk.c:13
  │    │    │         └── column4:10 = uniq_overlaps_pk.d:14
@@ -1062,7 +1095,8 @@ upsert uniq_overlaps_pk
       │              │         ├──  upsert_c:20 => c:30
       │              │         └──  upsert_d:21 => d:31
       │              ├── scan uniq_overlaps_pk
-      │              │    └── columns: uniq_overlaps_pk.a:22!null uniq_overlaps_pk.b:23!null uniq_overlaps_pk.c:24 uniq_overlaps_pk.d:25
+      │              │    ├── columns: uniq_overlaps_pk.a:22!null uniq_overlaps_pk.b:23!null uniq_overlaps_pk.c:24 uniq_overlaps_pk.d:25
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:29 = uniq_overlaps_pk.b:23
       │                   ├── c:30 = uniq_overlaps_pk.c:24
@@ -1080,7 +1114,8 @@ upsert uniq_overlaps_pk
                      │         ├──  upsert_c:20 => c:40
                      │         └──  upsert_d:21 => d:41
                      ├── scan uniq_overlaps_pk
-                     │    └── columns: uniq_overlaps_pk.a:32!null uniq_overlaps_pk.b:33!null uniq_overlaps_pk.c:34 uniq_overlaps_pk.d:35
+                     │    ├── columns: uniq_overlaps_pk.a:32!null uniq_overlaps_pk.b:33!null uniq_overlaps_pk.c:34 uniq_overlaps_pk.d:35
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:38 = uniq_overlaps_pk.a:32
                           └── b:39 != uniq_overlaps_pk.b:33
@@ -1144,7 +1179,8 @@ upsert uniq_hidden_pk
  │    │    │         └── first-agg [as=c_default:11]
  │    │    │              └── c_default:11
  │    │    ├── scan uniq_hidden_pk
- │    │    │    └── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    ├── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── rowid_default:12 = uniq_hidden_pk.rowid:17
  │    └── projections
@@ -1165,7 +1201,8 @@ upsert uniq_hidden_pk
       │              │         ├──  column3:10 => d:32
       │              │         └──  upsert_rowid:21 => rowid:33
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:22 uniq_hidden_pk.b:23 uniq_hidden_pk.c:24 uniq_hidden_pk.d:25 uniq_hidden_pk.rowid:26!null
+      │              │    ├── columns: uniq_hidden_pk.a:22 uniq_hidden_pk.b:23 uniq_hidden_pk.c:24 uniq_hidden_pk.d:25 uniq_hidden_pk.rowid:26!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:30 = uniq_hidden_pk.b:23
       │                   ├── c:31 = uniq_hidden_pk.c:24
@@ -1184,7 +1221,8 @@ upsert uniq_hidden_pk
       │              │         ├──  column3:10 => d:44
       │              │         └──  upsert_rowid:21 => rowid:45
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:34 uniq_hidden_pk.b:35 uniq_hidden_pk.c:36 uniq_hidden_pk.d:37 uniq_hidden_pk.rowid:38!null
+      │              │    ├── columns: uniq_hidden_pk.a:34 uniq_hidden_pk.b:35 uniq_hidden_pk.c:36 uniq_hidden_pk.d:37 uniq_hidden_pk.rowid:38!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:41 = uniq_hidden_pk.a:34
       │                   ├── b:42 = uniq_hidden_pk.b:35
@@ -1204,7 +1242,8 @@ upsert uniq_hidden_pk
                      │         ├──  column3:10 => d:56
                      │         └──  upsert_rowid:21 => rowid:57
                      ├── scan uniq_hidden_pk
-                     │    └── columns: uniq_hidden_pk.a:46 uniq_hidden_pk.b:47 uniq_hidden_pk.c:48 uniq_hidden_pk.d:49 uniq_hidden_pk.rowid:50!null
+                     │    ├── columns: uniq_hidden_pk.a:46 uniq_hidden_pk.b:47 uniq_hidden_pk.c:48 uniq_hidden_pk.d:49 uniq_hidden_pk.rowid:50!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:53 = uniq_hidden_pk.a:46
                           └── rowid:57 != uniq_hidden_pk.rowid:50
@@ -1246,7 +1285,8 @@ upsert uniq_hidden_pk
       │              │         ├──  y:12 => d:27
       │              │         └──  rowid_default:16 => rowid:28
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:17 uniq_hidden_pk.b:18 uniq_hidden_pk.c:19 uniq_hidden_pk.d:20 uniq_hidden_pk.rowid:21!null
+      │              │    ├── columns: uniq_hidden_pk.a:17 uniq_hidden_pk.b:18 uniq_hidden_pk.c:19 uniq_hidden_pk.d:20 uniq_hidden_pk.rowid:21!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:25 = uniq_hidden_pk.b:18
       │                   ├── c:26 = uniq_hidden_pk.c:19
@@ -1265,7 +1305,8 @@ upsert uniq_hidden_pk
       │              │         ├──  y:12 => d:39
       │              │         └──  rowid_default:16 => rowid:40
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:29 uniq_hidden_pk.b:30 uniq_hidden_pk.c:31 uniq_hidden_pk.d:32 uniq_hidden_pk.rowid:33!null
+      │              │    ├── columns: uniq_hidden_pk.a:29 uniq_hidden_pk.b:30 uniq_hidden_pk.c:31 uniq_hidden_pk.d:32 uniq_hidden_pk.rowid:33!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:36 = uniq_hidden_pk.a:29
       │                   ├── b:37 = uniq_hidden_pk.b:30
@@ -1285,7 +1326,8 @@ upsert uniq_hidden_pk
                      │         ├──  y:12 => d:51
                      │         └──  rowid_default:16 => rowid:52
                      ├── scan uniq_hidden_pk
-                     │    └── columns: uniq_hidden_pk.a:41 uniq_hidden_pk.b:42 uniq_hidden_pk.c:43 uniq_hidden_pk.d:44 uniq_hidden_pk.rowid:45!null
+                     │    ├── columns: uniq_hidden_pk.a:41 uniq_hidden_pk.b:42 uniq_hidden_pk.c:43 uniq_hidden_pk.d:44 uniq_hidden_pk.rowid:45!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:48 = uniq_hidden_pk.a:41
                           └── rowid:52 != uniq_hidden_pk.rowid:45
@@ -1331,7 +1373,8 @@ upsert uniq_hidden_pk
  │    │    │    │         └── first-agg [as=rowid_default:12]
  │    │    │    │              └── rowid_default:12
  │    │    │    ├── scan uniq_hidden_pk
- │    │    │    │    └── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    │    ├── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         ├── column1:8 = uniq_hidden_pk.a:13
  │    │    │         ├── column2:9 = uniq_hidden_pk.b:14
@@ -1359,7 +1402,8 @@ upsert uniq_hidden_pk
       │              │         ├──  upsert_d:24 => d:36
       │              │         └──  upsert_rowid:25 => rowid:37
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:26 uniq_hidden_pk.b:27 uniq_hidden_pk.c:28 uniq_hidden_pk.d:29 uniq_hidden_pk.rowid:30!null
+      │              │    ├── columns: uniq_hidden_pk.a:26 uniq_hidden_pk.b:27 uniq_hidden_pk.c:28 uniq_hidden_pk.d:29 uniq_hidden_pk.rowid:30!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── b:34 = uniq_hidden_pk.b:27
       │                   ├── c:35 = uniq_hidden_pk.c:28
@@ -1378,7 +1422,8 @@ upsert uniq_hidden_pk
       │              │         ├──  upsert_d:24 => d:48
       │              │         └──  upsert_rowid:25 => rowid:49
       │              ├── scan uniq_hidden_pk
-      │              │    └── columns: uniq_hidden_pk.a:38 uniq_hidden_pk.b:39 uniq_hidden_pk.c:40 uniq_hidden_pk.d:41 uniq_hidden_pk.rowid:42!null
+      │              │    ├── columns: uniq_hidden_pk.a:38 uniq_hidden_pk.b:39 uniq_hidden_pk.c:40 uniq_hidden_pk.d:41 uniq_hidden_pk.rowid:42!null
+      │              │    └── flags: disabled not visible index feature
       │              └── filters
       │                   ├── a:45 = uniq_hidden_pk.a:38
       │                   ├── b:46 = uniq_hidden_pk.b:39
@@ -1398,7 +1443,8 @@ upsert uniq_hidden_pk
                      │         ├──  upsert_d:24 => d:60
                      │         └──  upsert_rowid:25 => rowid:61
                      ├── scan uniq_hidden_pk
-                     │    └── columns: uniq_hidden_pk.a:50 uniq_hidden_pk.b:51 uniq_hidden_pk.c:52 uniq_hidden_pk.d:53 uniq_hidden_pk.rowid:54!null
+                     │    ├── columns: uniq_hidden_pk.a:50 uniq_hidden_pk.b:51 uniq_hidden_pk.c:52 uniq_hidden_pk.d:53 uniq_hidden_pk.rowid:54!null
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:57 = uniq_hidden_pk.a:50
                           └── rowid:61 != uniq_hidden_pk.rowid:54
@@ -1455,7 +1501,8 @@ upsert uniq_fk_parent
  │    │    │         └── first-agg [as=column1:5]
  │    │    │              └── column1:5
  │    │    ├── scan uniq_fk_parent
- │    │    │    └── columns: uniq_fk_parent.a:7 uniq_fk_parent.rowid:8!null uniq_fk_parent.crdb_internal_mvcc_timestamp:9 uniq_fk_parent.tableoid:10
+ │    │    │    ├── columns: uniq_fk_parent.a:7 uniq_fk_parent.rowid:8!null uniq_fk_parent.crdb_internal_mvcc_timestamp:9 uniq_fk_parent.tableoid:10
+ │    │    │    └── flags: disabled not visible index feature
  │    │    └── filters
  │    │         └── rowid_default:6 = uniq_fk_parent.rowid:8
  │    └── projections
@@ -1472,7 +1519,8 @@ upsert uniq_fk_parent
  │                   │         ├──  column1:5 => a:16
  │                   │         └──  upsert_rowid:11 => rowid:17
  │                   ├── scan uniq_fk_parent
- │                   │    └── columns: uniq_fk_parent.a:12 uniq_fk_parent.rowid:13!null
+ │                   │    ├── columns: uniq_fk_parent.a:12 uniq_fk_parent.rowid:13!null
+ │                   │    └── flags: disabled not visible index feature
  │                   └── filters
  │                        ├── a:16 = uniq_fk_parent.a:12
  │                        └── rowid:17 != uniq_fk_parent.rowid:13
@@ -1493,7 +1541,8 @@ upsert uniq_fk_parent
                 │         └── mapping:
                 │              └──  column1:5 => a:19
                 ├── scan uniq_fk_child
-                │    └── columns: uniq_fk_child.a:21
+                │    ├── columns: uniq_fk_child.a:21
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── a:18 = uniq_fk_child.a:21
 
@@ -1520,7 +1569,8 @@ upsert uniq_fk_child
                 │    └── mapping:
                 │         └──  column2:6 => a:7
                 ├── scan uniq_fk_parent
-                │    └── columns: uniq_fk_parent.a:8
+                │    ├── columns: uniq_fk_parent.a:8
+                │    └── flags: disabled not visible index feature
                 └── filters
                      └── a:7 = uniq_fk_parent.a:8
 
@@ -1572,9 +1622,10 @@ upsert t
  │    │    │    │    │              └── rowid_default:6
  │    │    │    │    ├── scan t
  │    │    │    │    │    ├── columns: t.i:7 t.rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
- │    │    │    │    │    └── partial index predicates
- │    │    │    │    │         └── i1: filters
- │    │    │    │    │              └── t.i:7 > 0
+ │    │    │    │    │    ├── partial index predicates
+ │    │    │    │    │    │    └── i1: filters
+ │    │    │    │    │    │         └── t.i:7 > 0
+ │    │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    │    └── filters
  │    │    │    │         └── column1:5 = t.i:7
  │    │    │    └── projections
@@ -1598,9 +1649,10 @@ upsert t
                      │         └──  upsert_rowid:13 => rowid:21
                      ├── scan t
                      │    ├── columns: t.i:16 t.rowid:17!null
-                     │    └── partial index predicates
-                     │         └── i1: filters
-                     │              └── t.i:16 > 0
+                     │    ├── partial index predicates
+                     │    │    └── i1: filters
+                     │    │         └── t.i:16 > 0
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── i:20 = t.i:16
                           └── rowid:21 != t.rowid:17
@@ -1645,7 +1697,8 @@ upsert uniq
  │    │    │    │         └── first-agg [as=column5:12]
  │    │    │    │              └── column5:12
  │    │    │    ├── scan uniq
- │    │    │    │    └── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column3:10 = uniq.w:15
  │    │    └── projections
@@ -1671,7 +1724,8 @@ upsert uniq
                      │         ├──  upsert_x:24 => x:36
                      │         └──  upsert_y:25 => y:37
                      ├── scan uniq
-                     │    └── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
+                     │    ├── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── x:36 = uniq.x:29
                           ├── y:37 = uniq.y:30
@@ -1714,7 +1768,8 @@ upsert uniq_partial
                      │         ├──  column2:7 => a:15
                      │         └──  column3:8 => b:16
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
+                     │    ├── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:15 = uniq_partial.a:10
                           ├── b:16 > 0
@@ -1764,7 +1819,8 @@ upsert uniq_partial
                      │         ├──  v:7 => a:20
                      │         └──  w:8 => b:21
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16
+                     │    ├── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:20 = uniq_partial.a:15
                           ├── b:21 > 0
@@ -1815,7 +1871,8 @@ upsert uniq_partial
  │    │    │    ├── select
  │    │    │    │    ├── columns: uniq_partial.k:10!null uniq_partial.a:11 uniq_partial.b:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
  │    │    │    │    ├── scan uniq_partial
- │    │    │    │    │    └── columns: uniq_partial.k:10!null uniq_partial.a:11 uniq_partial.b:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    │    │    │    ├── columns: uniq_partial.k:10!null uniq_partial.a:11 uniq_partial.b:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    │    └── filters
  │    │    │    │         └── uniq_partial.b:12 > 0
  │    │    │    └── filters
@@ -1840,7 +1897,8 @@ upsert uniq_partial
                      │         ├──  upsert_a:17 => a:25
                      │         └──  upsert_b:18 => b:26
                      ├── scan uniq_partial
-                     │    └── columns: uniq_partial.k:19!null uniq_partial.a:20 uniq_partial.b:21
+                     │    ├── columns: uniq_partial.k:19!null uniq_partial.a:20 uniq_partial.b:21
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:25 = uniq_partial.a:20
                           ├── b:26 > 0
@@ -1903,8 +1961,9 @@ upsert uniq_partial_constraint_and_index
  │    │    │    ├── columns: uniq_partial_constraint_and_index.k:10!null uniq_partial_constraint_and_index.a:11!null uniq_partial_constraint_and_index.b:12
  │    │    │    ├── scan uniq_partial_constraint_and_index
  │    │    │    │    ├── columns: uniq_partial_constraint_and_index.k:10!null uniq_partial_constraint_and_index.a:11 uniq_partial_constraint_and_index.b:12
- │    │    │    │    └── partial index predicates
- │    │    │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
+ │    │    │    │    ├── partial index predicates
+ │    │    │    │    │    └── uniq_partial_constraint_and_index_a_key: filters (true)
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── uniq_partial_constraint_and_index.a:11 = 1
  │    │    └── filters (true)
@@ -1933,8 +1992,9 @@ upsert uniq_partial_constraint_and_index
                      │    ├── columns: uniq_partial_constraint_and_index.k:20!null uniq_partial_constraint_and_index.a:21 uniq_partial_constraint_and_index.b:22!null
                      │    ├── scan uniq_partial_constraint_and_index
                      │    │    ├── columns: uniq_partial_constraint_and_index.k:20!null uniq_partial_constraint_and_index.a:21 uniq_partial_constraint_and_index.b:22
-                     │    │    └── partial index predicates
-                     │    │         └── uniq_partial_constraint_and_index_a_key: filters (true)
+                     │    │    ├── partial index predicates
+                     │    │    │    └── uniq_partial_constraint_and_index_a_key: filters (true)
+                     │    │    └── flags: disabled not visible index feature
                      │    └── filters
                      │         └── uniq_partial_constraint_and_index.b:22 > 10
                      └── filters
@@ -1983,9 +2043,10 @@ upsert uniq_constraint_and_partial_index
  │    │    │    ├── columns: uniq_constraint_and_partial_index.k:10!null uniq_constraint_and_partial_index.a:11!null uniq_constraint_and_partial_index.b:12
  │    │    │    ├── scan uniq_constraint_and_partial_index
  │    │    │    │    ├── columns: uniq_constraint_and_partial_index.k:10!null uniq_constraint_and_partial_index.a:11 uniq_constraint_and_partial_index.b:12
- │    │    │    │    └── partial index predicates
- │    │    │    │         └── uniq_constraint_and_partial_index_a_key: filters
- │    │    │    │              └── uniq_constraint_and_partial_index.b:12 > 0
+ │    │    │    │    ├── partial index predicates
+ │    │    │    │    │    └── uniq_constraint_and_partial_index_a_key: filters
+ │    │    │    │    │         └── uniq_constraint_and_partial_index.b:12 > 0
+ │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── uniq_constraint_and_partial_index.a:11 = 1
  │    │    └── filters (true)
@@ -2007,9 +2068,10 @@ upsert uniq_constraint_and_partial_index
                      │         └──  upsert_a:17 => a:27
                      ├── scan uniq_constraint_and_partial_index
                      │    ├── columns: uniq_constraint_and_partial_index.k:21!null uniq_constraint_and_partial_index.a:22
-                     │    └── partial index predicates
-                     │         └── uniq_constraint_and_partial_index_a_key: filters
-                     │              └── uniq_constraint_and_partial_index.b:23 > 0
+                     │    ├── partial index predicates
+                     │    │    └── uniq_constraint_and_partial_index_a_key: filters
+                     │    │         └── uniq_constraint_and_partial_index.b:23 > 0
+                     │    └── flags: disabled not visible index feature
                      └── filters
                           ├── a:27 = uniq_constraint_and_partial_index.a:22
                           └── k:26 != uniq_constraint_and_partial_index.k:21
@@ -2105,15 +2167,16 @@ upsert uniq_computed_pk
  │    │    │    │    ├── columns: uniq_computed_pk.c_s:19 uniq_computed_pk.i:15!null uniq_computed_pk.s:16 uniq_computed_pk.d:17 uniq_computed_pk.c_i_expr:18!null uniq_computed_pk.c_d:20 uniq_computed_pk.c_d_expr:21 crdb_internal_mvcc_timestamp:22 tableoid:23
  │    │    │    │    ├── scan uniq_computed_pk
  │    │    │    │    │    ├── columns: uniq_computed_pk.i:15!null uniq_computed_pk.s:16 uniq_computed_pk.d:17 uniq_computed_pk.c_i_expr:18!null uniq_computed_pk.c_d:20 uniq_computed_pk.c_d_expr:21 crdb_internal_mvcc_timestamp:22 tableoid:23
- │    │    │    │    │    └── computed column expressions
- │    │    │    │    │         ├── uniq_computed_pk.c_i_expr:18
- │    │    │    │    │         │    └── CASE WHEN uniq_computed_pk.i:15 < 0 THEN 'foo' ELSE 'bar' END
- │    │    │    │    │         ├── uniq_computed_pk.c_s:19
- │    │    │    │    │         │    └── uniq_computed_pk.s:16
- │    │    │    │    │         ├── uniq_computed_pk.c_d:20
- │    │    │    │    │         │    └── uniq_computed_pk.d:17
- │    │    │    │    │         └── uniq_computed_pk.c_d_expr:21
- │    │    │    │    │              └── uniq_computed_pk.d:17::STRING
+ │    │    │    │    │    ├── computed column expressions
+ │    │    │    │    │    │    ├── uniq_computed_pk.c_i_expr:18
+ │    │    │    │    │    │    │    └── CASE WHEN uniq_computed_pk.i:15 < 0 THEN 'foo' ELSE 'bar' END
+ │    │    │    │    │    │    ├── uniq_computed_pk.c_s:19
+ │    │    │    │    │    │    │    └── uniq_computed_pk.s:16
+ │    │    │    │    │    │    ├── uniq_computed_pk.c_d:20
+ │    │    │    │    │    │    │    └── uniq_computed_pk.d:17
+ │    │    │    │    │    │    └── uniq_computed_pk.c_d_expr:21
+ │    │    │    │    │    │         └── uniq_computed_pk.d:17::STRING
+ │    │    │    │    │    └── flags: disabled not visible index feature
  │    │    │    │    └── projections
  │    │    │    │         └── uniq_computed_pk.s:16 [as=uniq_computed_pk.c_s:19]
  │    │    │    └── filters
@@ -2144,15 +2207,16 @@ upsert uniq_computed_pk
                      │    ├── columns: uniq_computed_pk.c_s:49 uniq_computed_pk.i:45!null uniq_computed_pk.s:46 uniq_computed_pk.d:47 uniq_computed_pk.c_i_expr:48!null uniq_computed_pk.c_d:50 uniq_computed_pk.c_d_expr:51
                      │    ├── scan uniq_computed_pk
                      │    │    ├── columns: uniq_computed_pk.i:45!null uniq_computed_pk.s:46 uniq_computed_pk.d:47 uniq_computed_pk.c_i_expr:48!null uniq_computed_pk.c_d:50 uniq_computed_pk.c_d_expr:51
-                     │    │    └── computed column expressions
-                     │    │         ├── uniq_computed_pk.c_i_expr:48
-                     │    │         │    └── CASE WHEN uniq_computed_pk.i:45 < 0 THEN 'foo' ELSE 'bar' END
-                     │    │         ├── uniq_computed_pk.c_s:49
-                     │    │         │    └── uniq_computed_pk.s:46
-                     │    │         ├── uniq_computed_pk.c_d:50
-                     │    │         │    └── uniq_computed_pk.d:47
-                     │    │         └── uniq_computed_pk.c_d_expr:51
-                     │    │              └── uniq_computed_pk.d:47::STRING
+                     │    │    ├── computed column expressions
+                     │    │    │    ├── uniq_computed_pk.c_i_expr:48
+                     │    │    │    │    └── CASE WHEN uniq_computed_pk.i:45 < 0 THEN 'foo' ELSE 'bar' END
+                     │    │    │    ├── uniq_computed_pk.c_s:49
+                     │    │    │    │    └── uniq_computed_pk.s:46
+                     │    │    │    ├── uniq_computed_pk.c_d:50
+                     │    │    │    │    └── uniq_computed_pk.d:47
+                     │    │    │    └── uniq_computed_pk.c_d_expr:51
+                     │    │    │         └── uniq_computed_pk.d:47::STRING
+                     │    │    └── flags: disabled not visible index feature
                      │    └── projections
                      │         └── uniq_computed_pk.s:46 [as=uniq_computed_pk.c_s:49]
                      └── filters

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -165,9 +165,10 @@ upsert abc
       │    │    │    │              └── c_comp:13
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:14!null b:15 c:16 rowid:17!null abc.crdb_internal_mvcc_timestamp:18 abc.tableoid:19
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── c:16
-      │    │    │    │              └── b:15 + 1
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── c:16
+      │    │    │    │    │         └── b:15 + 1
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── x:7 = a:14
       │    │    └── projections
@@ -236,9 +237,10 @@ project
            │    │    │    │              └── z:9
            │    │    │    ├── scan abc
            │    │    │    │    ├── columns: a:13!null b:14 c:15 rowid:16!null abc.crdb_internal_mvcc_timestamp:17 abc.tableoid:18
-           │    │    │    │    └── computed column expressions
-           │    │    │    │         └── c:15
-           │    │    │    │              └── b:14 + 1
+           │    │    │    │    ├── computed column expressions
+           │    │    │    │    │    └── c:15
+           │    │    │    │    │         └── b:14 + 1
+           │    │    │    │    └── flags: disabled not visible index feature
            │    │    │    └── filters
            │    │    │         ├── y:8 = b:14
            │    │    │         └── c_comp:12 = c:15
@@ -309,9 +311,10 @@ upsert abc
       │    │    │    │    │              └── c_comp:13
       │    │    │    │    ├── scan abc
       │    │    │    │    │    ├── columns: a:14!null b:15 c:16 rowid:17!null abc.crdb_internal_mvcc_timestamp:18 abc.tableoid:19
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── c:16
-      │    │    │    │    │              └── b:15 + 1
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── c:16
+      │    │    │    │    │    │         └── b:15 + 1
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── x:7 = a:14
       │    │    │    └── filters
@@ -389,9 +392,10 @@ sort
       │              │    │    │    │              └── c_comp:10
       │              │    │    │    ├── scan abc
       │              │    │    │    │    ├── columns: abc.a:11!null abc.b:12 abc.c:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │              │    │    │    │    └── computed column expressions
-      │              │    │    │    │         └── abc.c:13
-      │              │    │    │    │              └── abc.b:12 + 1
+      │              │    │    │    │    ├── computed column expressions
+      │              │    │    │    │    │    └── abc.c:13
+      │              │    │    │    │    │         └── abc.b:12 + 1
+      │              │    │    │    │    └── flags: disabled not visible index feature
       │              │    │    │    └── filters
       │              │    │    │         └── column1:7 = abc.a:11
       │              │    │    └── projections
@@ -460,9 +464,10 @@ upsert abc [as=tab]
       │    │    │    │              └── c_comp:10
       │    │    │    ├── scan abc [as=tab]
       │    │    │    │    ├── columns: a:11!null b:12 c:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── c:13
-      │    │    │    │              └── b:12 + 1
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── c:13
+      │    │    │    │    │         └── b:12 + 1
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:11
       │    │    └── projections
@@ -523,9 +528,10 @@ upsert abc
       │    │    │    │              └── rowid_default:9
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:11!null b:12 c:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── c:13
-      │    │    │    │              └── b:12 + 1
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── c:13
+      │    │    │    │    │         └── b:12 + 1
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:8 = b:12
       │    │    │         └── c_comp:10 = c:13
@@ -603,16 +609,19 @@ insert xyz
       │    │    │    │    │    │    ├── (1, 2, 3)
       │    │    │    │    │    │    └── (4, 5, 6)
       │    │    │    │    │    ├── scan xyz
-      │    │    │    │    │    │    └── columns: x:9!null y:10 z:11
+      │    │    │    │    │    │    ├── columns: x:9!null y:10 z:11
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:6 = x:9
       │    │    │    │    ├── scan xyz
-      │    │    │    │    │    └── columns: x:14!null y:15 z:16
+      │    │    │    │    │    ├── columns: x:14!null y:15 z:16
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         ├── column2:7 = y:15
       │    │    │    │         └── column3:8 = z:16
       │    │    │    ├── scan xyz
-      │    │    │    │    └── columns: x:19!null y:20 z:21
+      │    │    │    │    ├── columns: x:19!null y:20 z:21
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = y:20
       │    │    │         └── column3:8 = z:21
@@ -651,7 +660,8 @@ insert xyz
       │    │    ├── (1, 2, 3)
       │    │    └── (4, 5, 6)
       │    ├── scan xyz
-      │    │    └── columns: x:9!null y:10 z:11
+      │    │    ├── columns: x:9!null y:10 z:11
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         ├── column2:7 = y:10
       │         └── column3:8 = z:11
@@ -691,15 +701,18 @@ insert uniq
       │    │    │    │    │    │    ├── ('x2', 'y2', 'z2')
       │    │    │    │    │    │    └── ('x2', 'y2', 'z2')
       │    │    │    │    │    ├── scan uniq
-      │    │    │    │    │    │    └── columns: x:9!null y:10 z:11
+      │    │    │    │    │    │    ├── columns: x:9!null y:10 z:11
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:6 = x:9
       │    │    │    │    ├── scan uniq
-      │    │    │    │    │    └── columns: x:14!null y:15 z:16
+      │    │    │    │    │    ├── columns: x:14!null y:15 z:16
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column2:7 = y:15
       │    │    │    ├── scan uniq
-      │    │    │    │    └── columns: x:19!null y:20 z:21
+      │    │    │    │    ├── columns: x:19!null y:20 z:21
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column3:8 = z:21
       │    │    └── aggregations
@@ -768,7 +781,8 @@ project
  │         │    │    │    │         └── first-agg [as=column1:6]
  │         │    │    │    │              └── column1:6
  │         │    │    │    ├── scan xyz
- │         │    │    │    │    └── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+ │         │    │    │    │    └── flags: disabled not visible index feature
  │         │    │    │    └── filters
  │         │    │    │         ├── column2:7 = y:10
  │         │    │    │         └── column3:8 = z:11
@@ -861,9 +875,10 @@ upsert abc
       │    │    │    │              └── c_comp:10
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:11!null b:12 c:13 rowid:14!null abc.crdb_internal_mvcc_timestamp:15 abc.tableoid:16
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── c:13
-      │    │    │    │              └── b:12 + 1
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── c:13
+      │    │    │    │    │         └── b:12 + 1
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:11
       │    │    ├── max1-row
@@ -939,9 +954,10 @@ upsert abc
       │    │    │    │              └── c_comp:10
       │    │    │    ├── scan abc
       │    │    │    │    ├── columns: a:11!null b:12 c:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── c:13
-      │    │    │    │              └── b:12 + 1
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── c:13
+      │    │    │    │    │         └── b:12 + 1
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:11
       │    │    └── projections
@@ -1013,8 +1029,9 @@ upsert mutation
       │    │    │    │    │              └── p_comp:11
       │    │    │    │    ├── scan mutation
       │    │    │    │    │    ├── columns: m:12!null n:13 o:14 p:15 q:16 crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    │    │    └── check constraint expressions
-      │    │    │    │    │         └── m:12 > 0
+      │    │    │    │    │    ├── check constraint expressions
+      │    │    │    │    │    │    └── m:12 > 0
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:8 = m:12
       │    │    │    └── projections
@@ -1066,7 +1083,8 @@ upsert xyz
       │    │         └── first-agg [as=y_default:7]
       │    │              └── y_default:7
       │    ├── scan xyz
-      │    │    └── columns: x:8!null y:9 z:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── columns: x:8!null y:9 z:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:6 = x:8
       └── projections
@@ -1139,9 +1157,10 @@ with &1
  │              │    │              └── c_comp:10
  │              │    ├── scan abc
  │              │    │    ├── columns: abc.a:11!null abc.b:12 abc.c:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
- │              │    │    └── computed column expressions
- │              │    │         └── abc.c:13
- │              │    │              └── abc.b:12 + 1
+ │              │    │    ├── computed column expressions
+ │              │    │    │    └── abc.c:13
+ │              │    │    │         └── abc.b:12 + 1
+ │              │    │    └── flags: disabled not visible index feature
  │              │    └── filters
  │              │         └── rowid_default:9 = rowid:14
  │              └── projections
@@ -1186,7 +1205,8 @@ upsert xyz
       │    │         └── first-agg [as=column3:8]
       │    │              └── column3:8
       │    ├── scan xyz
-      │    │    └── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column2:7 = x:9
       └── projections
@@ -1255,9 +1275,10 @@ upsert checks
       │    │    │    ├── columns: a:11!null b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    │    ├── check constraint expressions
       │    │    │    │    └── a:11 > 0
-      │    │    │    └── computed column expressions
-      │    │    │         └── d:14
-      │    │    │              └── c:13 + 1
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d:14
+      │    │    │    │         └── c:13 + 1
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = a:11
       │    └── projections
@@ -1315,8 +1336,9 @@ upsert mutation
       │    │    │              └── p_comp:11
       │    │    ├── scan mutation
       │    │    │    ├── columns: m:12!null n:13 o:14 p:15 q:16 crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    └── check constraint expressions
-      │    │    │         └── m:12 > 0
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    └── m:12 > 0
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:8 = m:12
       │    └── projections
@@ -1373,8 +1395,9 @@ upsert mutation
       │    │    │              └── p_comp:11
       │    │    ├── scan mutation
       │    │    │    ├── columns: m:12!null n:13 o:14 p:15 q:16 crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    └── check constraint expressions
-      │    │    │         └── m:12 > 0
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    └── m:12 > 0
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:8 = m:12
       │    └── projections
@@ -1446,9 +1469,10 @@ upsert checks
       │    │    │    │    │    ├── columns: a:11!null b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    │    │    │    ├── check constraint expressions
       │    │    │    │    │    │    └── a:11 > 0
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:14
-      │    │    │    │    │              └── c:13 + 1
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d:14
+      │    │    │    │    │    │         └── c:13 + 1
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:7 = a:11
       │    │    │    └── projections
@@ -1500,9 +1524,10 @@ insert checks
       │    │    │    ├── columns: a:11!null b:12 c:13 d:14
       │    │    │    ├── check constraint expressions
       │    │    │    │    └── a:11 > 0
-      │    │    │    └── computed column expressions
-      │    │    │         └── d:14
-      │    │    │              └── c:13 + 1
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d:14
+      │    │    │    │         └── c:13 + 1
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = a:11
       │    └── aggregations
@@ -1566,9 +1591,10 @@ upsert checks
       │    │    │    │    ├── columns: a:11!null b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    │    │    ├── check constraint expressions
       │    │    │    │    │    └── a:11 > 0
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── d:14
-      │    │    │    │              └── c:13 + 1
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d:14
+      │    │    │    │    │         └── c:13 + 1
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:11
       │    │    └── projections
@@ -1640,9 +1666,10 @@ upsert checks
       │    │    │    │    │    ├── columns: checks.a:15!null checks.b:16 checks.c:17 d:18 checks.crdb_internal_mvcc_timestamp:19 checks.tableoid:20
       │    │    │    │    │    ├── check constraint expressions
       │    │    │    │    │    │    └── checks.a:15 > 0
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:18
-      │    │    │    │    │              └── checks.c:17 + 1
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d:18
+      │    │    │    │    │    │         └── checks.c:17 + 1
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── abc.a:7 = checks.a:15
       │    │    │    └── projections
@@ -1704,7 +1731,8 @@ upsert xyz
       │    │    │         └── first-agg [as=a:6]
       │    │    │              └── a:6
       │    │    ├── scan xyz
-      │    │    │    └── columns: x:12!null y:13 z:14 xyz.crdb_internal_mvcc_timestamp:15 xyz.tableoid:16
+      │    │    │    ├── columns: x:12!null y:13 z:14 xyz.crdb_internal_mvcc_timestamp:15 xyz.tableoid:16
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         ├── b:7 = y:13
       │    │         └── c:8 = z:14
@@ -1784,9 +1812,10 @@ upsert decimals
       │    │    │    │              └── d_cast:14
       │    │    │    ├── scan decimals
       │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── d:18
-      │    │    │    │              └── a:15 + c:17
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d:18
+      │    │    │    │    │         └── a:15 + c:17
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:9 = a:15
       │    │    └── projections
@@ -1861,9 +1890,10 @@ upsert decimals
       │    │    │    │              └── d_cast:13
       │    │    │    ├── scan decimals
       │    │    │    │    ├── columns: a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── d:17
-      │    │    │    │              └── a:14 + c:16
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d:17
+      │    │    │    │    │         └── a:14 + c:16
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:8 = a:14
       │    │    └── projections
@@ -1939,9 +1969,10 @@ upsert decimals
       │    │    │    │              └── d_cast:13
       │    │    │    ├── scan decimals
       │    │    │    │    ├── columns: a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── d:17
-      │    │    │    │              └── a:14 + c:16
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d:17
+      │    │    │    │    │         └── a:14 + c:16
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:8 = a:14
       │    │    └── projections
@@ -2026,9 +2057,10 @@ upsert decimals
       │    │    │    │    │    │              └── d_cast:14
       │    │    │    │    │    ├── scan decimals
       │    │    │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
-      │    │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │    │         └── d:18
-      │    │    │    │    │    │              └── a:15 + c:17
+      │    │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    │    └── d:18
+      │    │    │    │    │    │    │         └── a:15 + c:17
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a_cast:9 = a:15
       │    │    │    │    └── projections
@@ -2118,9 +2150,10 @@ upsert decimals
       │    │    │    │    │    │              └── d_cast:14
       │    │    │    │    │    ├── scan decimals
       │    │    │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
-      │    │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │    │         └── d:18
-      │    │    │    │    │    │              └── a:15 + c:17
+      │    │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    │    └── d:18
+      │    │    │    │    │    │    │         └── a:15 + c:17
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a_cast:9 = a:15
       │    │    │    │    └── projections
@@ -2212,9 +2245,10 @@ upsert assn_cast
       │    │    │              └── d_comp_cast:21
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: k:22!null c:23 qc:24 i:25 s:26 d:27 d_comp:28 crdb_internal_mvcc_timestamp:29 tableoid:30
-      │    │    │    └── computed column expressions
-      │    │    │         └── d_comp:28
-      │    │    │              └── d:27 + 10.0
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d_comp:28
+      │    │    │    │         └── d:27 + 10.0
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── k_cast:15 = k:22
       │    └── projections
@@ -2295,9 +2329,10 @@ upsert assn_cast
       │    │    │              └── d_comp_cast:20
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: k:21!null c:22 qc:23 i:24 s:25 d:26 d_comp:27 crdb_internal_mvcc_timestamp:28 tableoid:29
-      │    │    │    └── computed column expressions
-      │    │    │         └── d_comp:27
-      │    │    │              └── d:26 + 10.0
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d_comp:27
+      │    │    │    │         └── d:26 + 10.0
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── k_cast:14 = k:21
       │    └── projections
@@ -2357,9 +2392,10 @@ insert assn_cast
       │    │              └── d_comp_comp:20
       │    ├── scan assn_cast
       │    │    ├── columns: k:22!null c:23 qc:24 i:25 s:26 d:27 d_comp:28
-      │    │    └── computed column expressions
-      │    │         └── d_comp:28
-      │    │              └── d:27 + 10.0
+      │    │    ├── computed column expressions
+      │    │    │    └── d_comp:28
+      │    │    │         └── d:27 + 10.0
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── k_cast:15 = k:22
       └── aggregations
@@ -2452,9 +2488,10 @@ upsert assn_cast
       │    │    │    │    │              └── d_comp_cast:20
       │    │    │    │    ├── scan assn_cast
       │    │    │    │    │    ├── columns: k:21!null c:22 qc:23 i:24 s:25 d:26 d_comp:27 crdb_internal_mvcc_timestamp:28 tableoid:29
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d_comp:27
-      │    │    │    │    │              └── d:26 + 10.0
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d_comp:27
+      │    │    │    │    │    │         └── d:26 + 10.0
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── k_cast:15 = k:21
       │    │    │    └── projections
@@ -2547,9 +2584,10 @@ upsert assn_cast
       │    │    │              └── d_comp_cast:18
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: k:19!null c:20 qc:21 i:22 s:23 d:24 d_comp:25 crdb_internal_mvcc_timestamp:26 tableoid:27
-      │    │    │    └── computed column expressions
-      │    │    │         └── d_comp:25
-      │    │    │              └── d:24 + 10.0
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d_comp:25
+      │    │    │    │         └── d:24 + 10.0
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:10 = k:19
       │    └── projections
@@ -2628,9 +2666,10 @@ upsert assn_cast
       │    │    │    │    │              └── d_comp_cast:17
       │    │    │    │    ├── scan assn_cast
       │    │    │    │    │    ├── columns: k:18!null c:19 qc:20 i:21 s:22 d:23 d_comp:24 crdb_internal_mvcc_timestamp:25 tableoid:26
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d_comp:24
-      │    │    │    │    │              └── d:23 + 10.0
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d_comp:24
+      │    │    │    │    │    │         └── d:23 + 10.0
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:10 = k:18
       │    │    │    └── projections
@@ -2721,9 +2760,10 @@ upsert assn_cast
       │    │              └── d_comp_cast:19
       │    ├── scan assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    └── computed column expressions
-      │    │         └── d_comp:26
-      │    │              └── d:25 + 10.0
+      │    │    ├── computed column expressions
+      │    │    │    └── d_comp:26
+      │    │    │         └── d:25 + 10.0
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
       └── projections
@@ -2805,9 +2845,10 @@ upsert assn_cast
       │    │              └── d_comp_cast:19
       │    ├── scan assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    └── computed column expressions
-      │    │         └── d_comp:26
-      │    │              └── d:25 + 10.0
+      │    │    ├── computed column expressions
+      │    │    │    └── d_comp:26
+      │    │    │         └── d:25 + 10.0
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
       └── projections
@@ -2869,9 +2910,10 @@ insert assn_cast
       │    │              └── d_comp_comp:18
       │    ├── scan assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26
-      │    │    └── computed column expressions
-      │    │         └── d_comp:26
-      │    │              └── d:25 + 10.0
+      │    │    ├── computed column expressions
+      │    │    │    └── d_comp:26
+      │    │    │         └── d:25 + 10.0
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
       └── aggregations
@@ -2968,9 +3010,10 @@ upsert assn_cast
       │    │    │    │    │    │              └── d_comp_cast:19
       │    │    │    │    │    ├── scan assn_cast
       │    │    │    │    │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
-      │    │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │    │         └── d_comp:26
-      │    │    │    │    │    │              └── d:25 + 10.0
+      │    │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    │    └── d_comp:26
+      │    │    │    │    │    │    │         └── d:25 + 10.0
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:10 = k:20
       │    │    │    │    └── projections
@@ -3048,9 +3091,10 @@ upsert assn_cast_on_update
       │    │    │    │    │    │              └── d_comp_cast:11
       │    │    │    │    │    ├── scan assn_cast_on_update
       │    │    │    │    │    │    ├── columns: k:12!null i:13 d:14 d2:15 d_comp:16 crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │    │         └── d_comp:16
-      │    │    │    │    │    │              └── d:14
+      │    │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    │    └── d_comp:16
+      │    │    │    │    │    │    │         └── d:14
+      │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:8 = k:12
       │    │    │    │    └── projections
@@ -3172,7 +3216,8 @@ upsert on_update_bare
       │    │    │         └── first-agg [as=v_default:6]
       │    │    │              └── v_default:6
       │    │    ├── scan on_update_bare
-      │    │    │    └── columns: a:7!null v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    ├── columns: a:7!null v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:5 = a:7
       │    └── projections
@@ -3231,7 +3276,8 @@ upsert on_update_with_default
       │    │    │         └── first-agg [as=v_default:8]
       │    │    │              └── v_default:8
       │    │    ├── scan on_update_with_default
-      │    │    │    └── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    ├── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = a:9
       │    └── projections
@@ -3280,7 +3326,8 @@ upsert on_update_with_default
       │    │    │         └── first-agg [as=b_default:8]
       │    │    │              └── b_default:8
       │    │    ├── scan on_update_with_default
-      │    │    │    └── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    ├── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = a:9
       │    └── projections
@@ -3334,7 +3381,8 @@ upsert on_update_with_default
       │    │    │    │         └── first-agg [as=v_default:8]
       │    │    │    │              └── v_default:8
       │    │    │    ├── scan on_update_with_default
-      │    │    │    │    └── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    │    ├── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:6 = a:9
       │    │    └── projections
@@ -3409,7 +3457,8 @@ upsert generated_as_identity
       │    │         └── first-agg [as=c_default:9]
       │    │              └── c_default:9
       │    ├── scan generated_as_identity
-      │    │    └── columns: a:11 b:12!null c:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    ├── columns: a:11 b:12!null c:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── rowid_default:10 = rowid:14
       └── projections
@@ -3461,7 +3510,8 @@ upsert generated_as_identity
       │    │         └── first-agg [as=b_default:9]
       │    │              └── b_default:9
       │    ├── scan generated_as_identity
-      │    │    └── columns: a:11 b:12!null c:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    ├── columns: a:11 b:12!null c:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── rowid_default:10 = rowid:14
       └── projections
@@ -3510,7 +3560,8 @@ upsert xyz
       │    │    │         └── first-agg [as=z_default:8]
       │    │    │              └── z_default:8
       │    │    ├── scan xyz
-      │    │    │    └── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = x:9
       │    └── projections
@@ -3557,7 +3608,8 @@ upsert xyz
       │    │    │         └── first-agg [as=column1:6]
       │    │    │              └── column1:6
       │    │    ├── scan xyz
-      │    │    │    └── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         ├── column2:7 = y:10
       │    │         └── z_default:8 = z:11
@@ -3605,7 +3657,8 @@ upsert xyz
       │    │    │         └── first-agg [as=column1:6]
       │    │    │              └── column1:6
       │    │    ├── scan xyz
-      │    │    │    └── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         ├── column2:7 = y:10
       │    │         └── z_default:8 = z:11

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -750,9 +750,10 @@ upsert t
       │    │    │    ├── columns: v:11 a:9!null b:10 crdb_internal_mvcc_timestamp:12 tableoid:13
       │    │    │    ├── scan t
       │    │    │    │    ├── columns: a:9!null b:10 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── v:11
-      │    │    │    │              └── a:9 + b:10
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── v:11
+      │    │    │    │    │         └── a:9 + b:10
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── a:9 + b:10 [as=v:11]
       │    │    └── filters
@@ -841,9 +842,10 @@ project
            │    │    ├── columns: v:11 a:9!null b:10
            │    │    ├── scan t
            │    │    │    ├── columns: a:9!null b:10
-           │    │    │    └── computed column expressions
-           │    │    │         └── v:11
-           │    │    │              └── a:9 + b:10
+           │    │    │    ├── computed column expressions
+           │    │    │    │    └── v:11
+           │    │    │    │         └── a:9 + b:10
+           │    │    │    └── flags: disabled not visible index feature
            │    │    └── projections
            │    │         └── a:9 + b:10 [as=v:11]
            │    └── filters
@@ -883,11 +885,12 @@ insert t_idx2
       │    │    ├── columns: v:16 w:17 a:13!null b:14 c:15
       │    │    ├── scan t_idx2
       │    │    │    ├── columns: a:13!null b:14 c:15
-      │    │    │    └── computed column expressions
-      │    │    │         ├── v:16
-      │    │    │         │    └── a:13 + b:14
-      │    │    │         └── w:17
-      │    │    │              └── c:15 + 1
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── v:16
+      │    │    │    │    │    └── a:13 + b:14
+      │    │    │    │    └── w:17
+      │    │    │    │         └── c:15 + 1
+      │    │    │    └── flags: disabled not visible index feature
       │    │    └── projections
       │    │         ├── a:13 + b:14 [as=v:16]
       │    │         └── c:15 + 1 [as=w:17]
@@ -937,11 +940,12 @@ insert t_idx2
       │    │    │    │    ├── columns: v:16 w:17 a:13!null b:14 c:15
       │    │    │    │    ├── scan t_idx2
       │    │    │    │    │    ├── columns: a:13!null b:14 c:15
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         ├── v:16
-      │    │    │    │    │         │    └── a:13 + b:14
-      │    │    │    │    │         └── w:17
-      │    │    │    │    │              └── c:15 + 1
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    ├── v:16
+      │    │    │    │    │    │    │    └── a:13 + b:14
+      │    │    │    │    │    │    └── w:17
+      │    │    │    │    │    │         └── c:15 + 1
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         ├── a:13 + b:14 [as=v:16]
       │    │    │    │         └── c:15 + 1 [as=w:17]
@@ -951,11 +955,12 @@ insert t_idx2
       │    │    │    ├── columns: v:23 w:24 a:20!null b:21 c:22
       │    │    │    ├── scan t_idx2
       │    │    │    │    ├── columns: a:20!null b:21 c:22
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         ├── v:23
-      │    │    │    │         │    └── a:20 + b:21
-      │    │    │    │         └── w:24
-      │    │    │    │              └── c:22 + 1
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    ├── v:23
+      │    │    │    │    │    │    └── a:20 + b:21
+      │    │    │    │    │    └── w:24
+      │    │    │    │    │         └── c:22 + 1
+      │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── projections
       │    │    │         ├── a:20 + b:21 [as=v:23]
       │    │    │         └── c:22 + 1 [as=w:24]
@@ -1022,9 +1027,10 @@ upsert t
       │    │    │    │    ├── columns: v:11 a:9!null b:10 crdb_internal_mvcc_timestamp:12 tableoid:13
       │    │    │    │    ├── scan t
       │    │    │    │    │    ├── columns: a:9!null b:10 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── v:11
-      │    │    │    │    │              └── a:9 + b:10
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── v:11
+      │    │    │    │    │    │         └── a:9 + b:10
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         └── a:9 + b:10 [as=v:11]
       │    │    │    └── filters
@@ -1080,9 +1086,10 @@ upsert t
       │    │    │    │    ├── columns: v:11 a:9!null b:10 crdb_internal_mvcc_timestamp:12 tableoid:13
       │    │    │    │    ├── scan t
       │    │    │    │    │    ├── columns: a:9!null b:10 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── v:11
-      │    │    │    │    │              └── a:9 + b:10
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── v:11
+      │    │    │    │    │    │         └── a:9 + b:10
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         └── a:9 + b:10 [as=v:11]
       │    │    │    └── filters
@@ -1145,11 +1152,12 @@ upsert t_idx2
       │    │    │    │    ├── columns: v:16 w:17 a:13!null b:14 c:15 crdb_internal_mvcc_timestamp:18 tableoid:19
       │    │    │    │    ├── scan t_idx2
       │    │    │    │    │    ├── columns: a:13!null b:14 c:15 crdb_internal_mvcc_timestamp:18 tableoid:19
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         ├── v:16
-      │    │    │    │    │         │    └── a:13 + b:14
-      │    │    │    │    │         └── w:17
-      │    │    │    │    │              └── c:15 + 1
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    ├── v:16
+      │    │    │    │    │    │    │    └── a:13 + b:14
+      │    │    │    │    │    │    └── w:17
+      │    │    │    │    │    │         └── c:15 + 1
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         ├── a:13 + b:14 [as=v:16]
       │    │    │    │         └── c:15 + 1 [as=w:17]
@@ -1216,11 +1224,12 @@ upsert t_idx2
       │    │    │    │    ├── columns: v:16 w:17 a:13!null b:14 c:15 crdb_internal_mvcc_timestamp:18 tableoid:19
       │    │    │    │    ├── scan t_idx2
       │    │    │    │    │    ├── columns: a:13!null b:14 c:15 crdb_internal_mvcc_timestamp:18 tableoid:19
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         ├── v:16
-      │    │    │    │    │         │    └── a:13 + b:14
-      │    │    │    │    │         └── w:17
-      │    │    │    │    │              └── c:15 + 1
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    ├── v:16
+      │    │    │    │    │    │    │    └── a:13 + b:14
+      │    │    │    │    │    │    └── w:17
+      │    │    │    │    │    │         └── c:15 + 1
+      │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         ├── a:13 + b:14 [as=v:16]
       │    │    │    │         └── c:15 + 1 [as=w:17]

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -88,20 +88,21 @@ var (
 	)
 
 	formatFlags = map[string]memo.ExprFmtFlags{
-		"miscprops":   memo.ExprFmtHideMiscProps,
-		"constraints": memo.ExprFmtHideConstraints,
-		"funcdeps":    memo.ExprFmtHideFuncDeps,
-		"ruleprops":   memo.ExprFmtHideRuleProps,
-		"stats":       memo.ExprFmtHideStats,
-		"hist":        memo.ExprFmtHideHistograms,
-		"cost":        memo.ExprFmtHideCost,
-		"qual":        memo.ExprFmtHideQualifications,
-		"scalars":     memo.ExprFmtHideScalars,
-		"physprops":   memo.ExprFmtHidePhysProps,
-		"types":       memo.ExprFmtHideTypes,
-		"notnull":     memo.ExprFmtHideNotNull,
-		"columns":     memo.ExprFmtHideColumns,
-		"all":         memo.ExprFmtHideAll,
+		"miscprops":       memo.ExprFmtHideMiscProps,
+		"constraints":     memo.ExprFmtHideConstraints,
+		"funcdeps":        memo.ExprFmtHideFuncDeps,
+		"ruleprops":       memo.ExprFmtHideRuleProps,
+		"stats":           memo.ExprFmtHideStats,
+		"hist":            memo.ExprFmtHideHistograms,
+		"cost":            memo.ExprFmtHideCost,
+		"qual":            memo.ExprFmtHideQualifications,
+		"scalars":         memo.ExprFmtHideScalars,
+		"physprops":       memo.ExprFmtHidePhysProps,
+		"types":           memo.ExprFmtHideTypes,
+		"notnull":         memo.ExprFmtHideNotNull,
+		"columns":         memo.ExprFmtHideColumns,
+		"all":             memo.ExprFmtHideAll,
+		"notvisibleindex": memo.ExprFmtHideNotVisibleIndexInfo,
 	}
 )
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester_test.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestOptTester(t *testing.T) {
 	const fmtFlags = memo.ExprFmtHideStats | memo.ExprFmtHideCost | memo.ExprFmtHideRuleProps |
-		memo.ExprFmtHideQualifications
+		memo.ExprFmtHideQualifications | memo.ExprFmtHideNotVisibleIndexInfo
 
 	datadriven.Walk(t, testutils.TestDataPath(t), func(t *testing.T, path string) {
 		if strings.HasSuffix(path, ".json") {

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -143,7 +143,7 @@ func TestCoster(t *testing.T) {
 	runDataDrivenTest(
 		t, tu.TestDataPath(t, "coster", ""),
 		memo.ExprFmtHideRuleProps|memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|
-			memo.ExprFmtHideTypes,
+			memo.ExprFmtHideTypes|memo.ExprFmtHideNotVisibleIndexInfo,
 	)
 }
 
@@ -162,7 +162,8 @@ func TestPhysicalProps(t *testing.T) {
 			memo.ExprFmtHideCost|
 			memo.ExprFmtHideQualifications|
 			memo.ExprFmtHideScalars|
-			memo.ExprFmtHideTypes,
+			memo.ExprFmtHideTypes|
+			memo.ExprFmtHideNotVisibleIndexInfo,
 	)
 }
 
@@ -176,7 +177,7 @@ func TestRuleProps(t *testing.T) {
 		t,
 		tu.TestDataPath(t, "ruleprops"),
 		memo.ExprFmtHideStats|memo.ExprFmtHideCost|memo.ExprFmtHideQualifications|
-			memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
+			memo.ExprFmtHideScalars|memo.ExprFmtHideTypes|memo.ExprFmtHideNotVisibleIndexInfo,
 	)
 }
 
@@ -191,7 +192,8 @@ func TestRules(t *testing.T) {
 		t,
 		tu.TestDataPath(t, "rules"),
 		memo.ExprFmtHideStats|memo.ExprFmtHideCost|memo.ExprFmtHideRuleProps|
-			memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
+			memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes|
+			memo.ExprFmtHideNotVisibleIndexInfo,
 	)
 }
 
@@ -217,7 +219,8 @@ func TestExternal(t *testing.T) {
 		t,
 		*externalTestData,
 		memo.ExprFmtHideStats|memo.ExprFmtHideCost|memo.ExprFmtHideRuleProps|
-			memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
+			memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes|
+			memo.ExprFmtHideNotVisibleIndexInfo,
 	)
 }
 
@@ -228,7 +231,8 @@ func TestPlaceholderFastPath(t *testing.T) {
 		t,
 		tu.TestDataPath(t, "placeholder-fast-path"),
 		memo.ExprFmtHideCost|memo.ExprFmtHideRuleProps|
-			memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes,
+			memo.ExprFmtHideQualifications|memo.ExprFmtHideScalars|memo.ExprFmtHideTypes|
+			memo.ExprFmtHideNotVisibleIndexInfo,
 	)
 }
 

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1916,7 +1916,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2)) (distinct-on G2 G3 cols=(2),ordering=+2)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2]" G3 cols=(2),ordering=+2)
@@ -1938,7 +1938,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (v) u, v, w FROM kuvw
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(3)) (distinct-on G2 G3 cols=(3),ordering=+3)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +3]" G3 cols=(3),ordering=+3)
@@ -1960,7 +1960,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (w) u, v, w FROM kuvw
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(4)) (distinct-on G2 G3 cols=(4),ordering=+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +4]" G3 cols=(4),ordering=+4)
@@ -1982,7 +1982,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw ORDER BY u, w
 ----
-memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
+memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -6905,7 +6905,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~33KB, required=[presentation: name:16,popn_per_sqkm:22])
+memo (optimized, ~34KB, required=[presentation: name:16,popn_per_sqkm:22])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:16,popn_per_sqkm:22]
  │         ├── best: (project G2 G3 name)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -521,7 +521,7 @@ inner-join (cross)
 memo join-limit=0
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~28KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~29KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+2,+6)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G2 G3 G4)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -2037,7 +2037,7 @@ memo (optimized, ~14KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+
 memo expect=GeneratePartialOrderTopK disable=GenerateLimitedTopKScans
 SELECT d, f, g FROM defg ORDER BY d, g LIMIT 10
 ----
-memo (optimized, ~4KB, required=[presentation: d:1,f:3,g:4] [ordering: +1,+4])
+memo (optimized, ~5KB, required=[presentation: d:1,f:3,g:4] [ordering: +1,+4])
  ├── G1: (limit G2 G3 ordering=+1,+4) (top-k G2 &{10 +1,+4 }) (top-k G2 &{10 +1,+4 +1})
  │    ├── [presentation: d:1,f:3,g:4] [ordering: +1,+4]
  │    │    ├── best: (top-k G2="[ordering: +1] [limit hint: 104.58]" &{10 +1,+4 +1})

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -47,7 +47,7 @@ scan a,rev
 memo
 SELECT k,f FROM a ORDER BY k DESC LIMIT 10
 ----
-memo (optimized, ~4KB, required=[presentation: k:1,f:3] [ordering: -1])
+memo (optimized, ~5KB, required=[presentation: k:1,f:3] [ordering: -1])
  ├── G1: (limit G2 G3 ordering=-1) (scan a,rev,cols=(1,3),lim=10(rev)) (top-k G2 &{10 -1 })
  │    ├── [presentation: k:1,f:3] [ordering: -1]
  │    │    ├── best: (scan a,rev,cols=(1,3),lim=10(rev))

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -849,7 +849,7 @@ index-join b
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
-memo (optimized, ~9KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~10KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G6 b,cols=(1-4))
@@ -1301,7 +1301,7 @@ memo (optimized, ~8KB, required=[presentation: j:5])
 memo
 SELECT i, k FROM kifs WHERE s >= 'foo'
 ----
-memo (optimized, ~7KB, required=[presentation: i:2,k:1])
+memo (optimized, ~8KB, required=[presentation: i:2,k:1])
  ├── G1: (project G2 G3 k i)
  │    └── [presentation: i:2,k:1]
  │         ├── best: (project G2 G3 k i)
@@ -6236,7 +6236,7 @@ memo (optimized, ~10KB, required=[presentation: q:2,t:5])
 memo
 SELECT c FROM zz_redundant WHERE b = 1
 ----
-memo (optimized, ~7KB, required=[presentation: c:3])
+memo (optimized, ~8KB, required=[presentation: c:3])
  ├── G1: (project G2 G3 c)
  │    └── [presentation: c:3]
  │         ├── best: (project G2 G3 c)

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -21,7 +21,7 @@ CREATE TABLE kuvw (
 memo expect=GenerateStreamingSetOp
 SELECT u,v,w FROM kuvw UNION SELECT w,v,u FROM kuvw
 ----
-memo (optimized, ~10KB, required=[presentation: u:13,v:14,w:15])
+memo (optimized, ~11KB, required=[presentation: u:13,v:14,w:15])
  ├── G1: (union G2 G3) (union G2 G3 ordering=+13,+14,+15) (union G2 G3 ordering=+15,+14,+13) (union G2 G3 ordering=+14,+15,+13) (union G2 G3 ordering=+14,+13,+15)
  │    └── [presentation: u:13,v:14,w:15]
  │         ├── best: (union G2="[ordering: +2,+3,+4]" G3="[ordering: +10,+9,+8]" ordering=+13,+14,+15)


### PR DESCRIPTION
This commit adds a flag to ScanFlags to indicate when the invisible index
feature should be enabled in buildScan. The invisible index feature should be
enabled by default but temporarily disabled during any unique or foreign key
constraint check. More details on how the decision was made and which flag to
pass in `docs/RFCS/20220628_invisible_index.md`. Note that no logic has been
added to the optimizer yet. This commit just passes the correct flag to
buildScan and shows the effect of the flag in the output of test data.

Assists: https://github.com/cockroachdb/cockroach/issues/72576

See also: https://github.com/cockroachdb/cockroach/pull/85354

Release note: none