### PR TITLE
logictest: fix sqlite logic tests

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -64,7 +64,6 @@ func init() {
 	} else {
 		execBuildLogicTestDir = "../../../../sql/opt/exec/execbuilder/testdata"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/5node/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/5node/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-21.2-22.1/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-21.2-22.1/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		cclLogicTestDir = "../../../../ccl/logictestccl/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
@@ -11,6 +11,7 @@
 package test3node_tenant
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,6 +36,10 @@ const configIdx = 9
 var sqliteLogicTestDir string
 
 func init() {
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
 	if *logictest.Bigtest {
 		if bazel.BuiltWithBazel() {
 			var err error
@@ -50,10 +55,6 @@ func init() {
 			}
 		}
 	}
-
-}
-
-func TestMain(m *testing.M) {
 	defer utilccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()

--- a/pkg/sql/logictest/tests/5node-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/5node-disk/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/5node/generated_test.go
+++ b/pkg/sql/logictest/tests/5node/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/local-mixed-21.2-22.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-21.2-22.1/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/local-mixed-22.1-22.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.1-22.2/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/local-v1.1-at-v1.0-noupgrade/generated_test.go
+++ b/pkg/sql/logictest/tests/local-v1.1-at-v1.0-noupgrade/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/logictest/tests/multiregion-invalid-locality/generated_test.go
+++ b/pkg/sql/logictest/tests/multiregion-invalid-locality/generated_test.go
@@ -43,7 +43,6 @@ func init() {
 	} else {
 		logicTestDir = "../../../../sql/logictest/testdata/logic_test"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
@@ -44,7 +44,6 @@ func init() {
 	} else {
 		execBuildLogicTestDir = "../../../../../../sql/opt/exec/execbuilder/testdata"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
@@ -44,7 +44,6 @@ func init() {
 	} else {
 		execBuildLogicTestDir = "../../../../../../sql/opt/exec/execbuilder/testdata"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
@@ -44,7 +44,6 @@ func init() {
 	} else {
 		execBuildLogicTestDir = "../../../../../../sql/opt/exec/execbuilder/testdata"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
@@ -44,7 +44,6 @@ func init() {
 	} else {
 		execBuildLogicTestDir = "../../../../../../sql/opt/exec/execbuilder/testdata"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
@@ -44,7 +44,6 @@ func init() {
 	} else {
 		execBuildLogicTestDir = "../../../../../../sql/opt/exec/execbuilder/testdata"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -44,7 +44,6 @@ func init() {
 	} else {
 		execBuildLogicTestDir = "../../../../../../sql/opt/exec/execbuilder/testdata"
 	}
-
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
@@ -13,6 +13,7 @@
 package testfakedist_disk
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,6 +36,10 @@ const configIdx = 6
 var sqliteLogicTestDir string
 
 func init() {
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
 	if *logictest.Bigtest {
 		if bazel.BuiltWithBazel() {
 			var err error
@@ -50,10 +55,6 @@ func init() {
 			}
 		}
 	}
-
-}
-
-func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
@@ -13,6 +13,7 @@
 package testfakedist_vec_off
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,6 +36,10 @@ const configIdx = 5
 var sqliteLogicTestDir string
 
 func init() {
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
 	if *logictest.Bigtest {
 		if bazel.BuiltWithBazel() {
 			var err error
@@ -50,10 +55,6 @@ func init() {
 			}
 		}
 	}
-
-}
-
-func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)

--- a/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
@@ -13,6 +13,7 @@
 package testfakedist
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,6 +36,10 @@ const configIdx = 4
 var sqliteLogicTestDir string
 
 func init() {
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
 	if *logictest.Bigtest {
 		if bazel.BuiltWithBazel() {
 			var err error
@@ -50,10 +55,6 @@ func init() {
 			}
 		}
 	}
-
-}
-
-func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
@@ -13,6 +13,7 @@
 package testlocal_vec_off
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,6 +36,10 @@ const configIdx = 2
 var sqliteLogicTestDir string
 
 func init() {
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
 	if *logictest.Bigtest {
 		if bazel.BuiltWithBazel() {
 			var err error
@@ -50,10 +55,6 @@ func init() {
 			}
 		}
 	}
-
-}
-
-func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)

--- a/pkg/sql/sqlitelogictest/tests/local/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local/generated_test.go
@@ -13,6 +13,7 @@
 package testlocal
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,6 +36,10 @@ const configIdx = 0
 var sqliteLogicTestDir string
 
 func init() {
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
 	if *logictest.Bigtest {
 		if bazel.BuiltWithBazel() {
 			var err error
@@ -50,10 +55,6 @@ func init() {
 			}
 		}
 	}
-
-}
-
-func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)


### PR DESCRIPTION
The variable logictest.Bigtest can't be used in init() because that
function is called before command-line arguments are parsed. We move the
same logic to `TestMain` instead and call `flag.Parse()` before doing
anything.

Fixes #85186.

Release note: None