### PR TITLE
kv: Bump timeout on test

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -4787,7 +4787,7 @@ func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing
 
 		// Set a relatively short timeout so that this test doesn't take too long.
 		// We should always hit it.
-		withTimeout, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+		withTimeout, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
 		// Write to the liveness range on the System class.


### PR DESCRIPTION
The timeout on
TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic
was artifically short (20ms) which seems to cause failures in some
docker test environments. The test does not expect to hit this timer, so
bumping up the time is safe.

Release note: None