### PR TITLE
dev: fix `test --changed` when no files are changed

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=47
+DEV_VERSION=48
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -454,7 +454,11 @@ func (d *dev) determineAffectedTargets(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	changedFilesList := strings.Split(strings.TrimSpace(string(changedFiles)), "\n")
+	trimmedOutput := strings.TrimSpace(string(changedFiles))
+	if trimmedOutput == "" {
+		return nil, nil
+	}
+	changedFilesList := strings.Split(trimmedOutput, "\n")
 	// Each file in this list needs to be munged somewhat to match up to the
 	// Bazel target syntax.
 	for idx, file := range changedFilesList {


### PR DESCRIPTION
With the previous version of the code this would fail with a confusing
error message if no files were changed.

Release note: None