### PR TITLE
workload: add key size and sfu flags to kv workload

### DIFF
--- a/pkg/workload/kv/BUILD.bazel
+++ b/pkg/workload/kv/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/pgwire/pgcode",
+        "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//pkg/workload",
         "//pkg/workload/histogram",

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -253,6 +253,8 @@ func TypedTuples(count int, typs []*types.T, fn func(int) []interface{}) Batched
 					col.Bool()[0] = d
 				case int:
 					col.Int64()[0] = int64(d)
+				case int64:
+					col.Int64()[0] = d
 				case float64:
 					col.Float64()[0] = d
 				case string:


### PR DESCRIPTION
This diff adds new parameters to kv workload. Those parameters
are useful when using kv workload to reproduce issues.

--key-size turns primary key into a string starting with
an int representation of normal int64 key with added
random filler at the end. random filler is seeded by
key itself to ensure total number of keys is respected.

--sfu-wait-delay allows changing sfu transaction delay
from default 10ms to any duration.

Change is done by introducing "keyTransformer" that would take int
keys provided by generator. It also provides part of the table schema
that defines key type and partition function so that it works with other
kv workload functionality.
Padding is done using random bytes, but they are seeded from the
generator provided key value so that keys are always the same for
the same int.

Release note: None