### PR TITLE
sql: fix explain gist output to show number of scan span constraints

### DIFF
--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -415,8 +415,10 @@ func (f *PlanGistFactory) decodeScanParams() exec.ScanParams {
 	if l > 0 {
 		idxConstraint = new(constraint.Constraint)
 		idxConstraint.Spans.Alloc(l)
-		var sp constraint.Span
-		idxConstraint.Spans.Append(&sp)
+		for i := 0; i < l; i++ {
+			var sp constraint.Span
+			idxConstraint.Spans.Append(&sp)
+		}
 	}
 
 	var invertedConstraint inverted.Spans

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -1119,3 +1119,17 @@ explain(shape):
 • explain
 explain(gist):
 • explain
+
+# Regression test for #85324
+explain-plan-gist
+AgHyAQIA//8HHgAAByoFKiHyAQAA
+----
+• update
+│ table: ?
+│ set
+│
+└── • render
+    │
+    └── • scan
+          table: ?@?
+          spans: 15 spans


### PR DESCRIPTION
If there were span constraints we would always print 1, need to actually
append them to get the count right.

Fixes: #85324

Release note: None
