### PR TITLE
sql: add index join flag to planner and telemetry log

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2472,6 +2472,7 @@ contains common SQL event/execution details.
 | `BytesRead` | The number of bytes read from disk. | no |
 | `RowsRead` | The number of rows read from disk. | no |
 | `RowsWritten` | The number of rows written. | no |
+| `HasIndexJoin` | Whether the query contains an index join. | no |
 
 
 #### Common fields

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -409,6 +409,7 @@ func (p *planner) maybeLogStatementInternal(
 				BytesRead:                queryStats.bytesRead,
 				RowsRead:                 queryStats.rowsRead,
 				RowsWritten:              queryStats.rowsWritten,
+				HasIndexJoin:             p.curPlan.flags.IsSet(planFlagContainsIndexJoin),
 			}
 			p.logOperationalEventsOnlyExternally(ctx, eventLogEntry{event: &sampledQuery})
 		} else {

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -131,6 +131,9 @@ type Builder struct {
 	// ContainsMutation is set to true if the whole plan contains any mutations.
 	ContainsMutation bool
 
+	// ContainsIndexJoin is set to true if the query contains an index join.
+	ContainsIndexJoin bool
+
 	// MaxFullScanRows is the maximum number of rows scanned by a full scan, as
 	// estimated by the optimizer.
 	MaxFullScanRows float64

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1731,6 +1731,10 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 		locking = forUpdateLocking
 	}
 
+	if !tab.IsVirtualTable() {
+		b.ContainsIndexJoin = true
+	}
+
 	res := execPlan{outputCols: output}
 	res.root, err = b.factory.ConstructIndexJoin(
 		input.root, tab, keyCols, needed, res.reqOrdering(join), locking, join.RequiredPhysical().LimitHintInt64(),

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -602,6 +602,9 @@ const (
 
 	// planFlagContainsMutation is set if the plan has any mutations.
 	planFlagContainsMutation
+
+	// planFlagContainsIndexJoin is set if the plan involves an index join.
+	planFlagContainsIndexJoin
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -610,6 +610,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 	var containsLargeFullTableScan bool
 	var containsLargeFullIndexScan bool
 	var containsMutation bool
+	var containsIndexJoin bool
 	var gf *explain.PlanGistFactory
 	if !opc.p.SessionData().DisablePlanGists {
 		gf = explain.NewPlanGistFactory(f)
@@ -628,6 +629,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 		containsLargeFullTableScan = bld.ContainsLargeFullTableScan
 		containsLargeFullIndexScan = bld.ContainsLargeFullIndexScan
 		containsMutation = bld.ContainsMutation
+		containsIndexJoin = bld.ContainsIndexJoin
 		planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
 		planTop.instrumentation.totalScanRows = bld.TotalScanRows
 		planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
@@ -649,10 +651,10 @@ func (opc *optPlanningCtx) runExecBuilder(
 		containsLargeFullTableScan = bld.ContainsLargeFullTableScan
 		containsLargeFullIndexScan = bld.ContainsLargeFullIndexScan
 		containsMutation = bld.ContainsMutation
+		containsIndexJoin = bld.ContainsIndexJoin
 		planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
 		planTop.instrumentation.totalScanRows = bld.TotalScanRows
 		planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
-
 		planTop.instrumentation.RecordExplainPlan(explainPlan)
 	}
 	if gf != nil {
@@ -692,6 +694,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 	}
 	if containsMutation {
 		planTop.flags.Set(planFlagContainsMutation)
+	}
+	if containsIndexJoin {
+		planTop.flags.Set(planFlagContainsIndexJoin)
 	}
 	if planTop.instrumentation.ShouldSaveMemo() {
 		planTop.mem = mem

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -555,3 +555,102 @@ func TestNoTelemetryLogOnTroubleshootMode(t *testing.T) {
 		}
 	}
 }
+
+func TestTelemetryLogHasIndexJoin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	cleanup := installTelemetryLogFileSink(sc, t)
+	defer cleanup()
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	defer s.Stopper().Stop(context.Background())
+
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
+	db.Exec(t, "CREATE TABLE t("+
+		"num INT PRIMARY KEY,"+
+		"first STRING,"+
+		"second STRING,"+
+		"INDEX first_index (first),"+
+		"INDEX second_index (second)"+
+		");")
+	db.Exec(t, "SHOW INDEX FROM t")
+	db.Exec(t, "INSERT INTO t (num, first, second) VALUES (1, 'first', 'second'), (2, 'another_first', 'another_second')")
+
+	stubMaxEventFrequency := int64(1000000)
+	telemetryMaxEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, stubMaxEventFrequency)
+
+	/*
+		Test Cases:
+			- run query w/o index join
+				- check that log HasIndexJoin = false
+			- run query with index join
+				- check that log HasIndexJoin = true
+	*/
+
+	testData := []struct {
+		name                 string
+		query                string
+		expectedLogStatement string
+		expectedNumLogs      int
+		expectHasIndexJoin   bool
+	}{
+		{
+			"select-no-index-join",
+			"SELECT * FROM t LIMIT 1;",
+			`SELECT * FROM \"\".\"\".t LIMIT ‹1›`,
+			1,
+			false,
+		},
+		{
+			"select-index-join",
+			"SELECT * FROM t WHERE second='second';",
+			`"SELECT * FROM \"\".\"\".t WHERE second = ‹'second'›"`,
+			1,
+			true,
+		},
+	}
+
+	for _, tc := range testData {
+		db.Exec(t, tc.query)
+	}
+
+	log.Flush()
+
+	entries, err := log.FetchEntriesFromFiles(
+		0,
+		math.MaxInt64,
+		10000,
+		regexp.MustCompile(`"EventType":"sampled_query"`),
+		log.WithMarkedSensitiveData,
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatal(errors.Newf("no entries found"))
+	}
+
+	for _, tc := range testData {
+		numLogsFound := 0
+		for i := len(entries) - 1; i >= 0; i-- {
+			e := entries[i]
+			if strings.Contains(e.Message, tc.expectedLogStatement) {
+				numLogsFound++
+				containsHasIndexJoin := strings.Contains(e.Message, "\"HasIndexJoin\":true")
+				if tc.expectHasIndexJoin && !containsHasIndexJoin {
+					t.Errorf("%s: expected \"HasIndexJoin\" to be found, but found none", tc.name)
+				} else if !tc.expectHasIndexJoin && containsHasIndexJoin {
+					t.Errorf("%s: unexpected \"HasIndexJoin\" found", tc.name)
+				}
+			}
+		}
+		if numLogsFound != tc.expectedNumLogs {
+			t.Errorf("%s: expected %d log entries, found %d", tc.name, tc.expectedNumLogs, numLogsFound)
+		}
+	}
+}

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3413,6 +3413,14 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = strconv.AppendInt(b, int64(m.RowsWritten), 10)
 	}
 
+	if m.HasIndexJoin {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"HasIndexJoin\":true"...)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -90,6 +90,9 @@ message SampledQuery {
   // The number of rows written.
   int64 rows_written = 21 [(gogoproto.jsontag) = ",omitempty"];
 
+  // Whether the query contains an index join.
+  bool has_index_join = 22 [(gogoproto.jsontag) = ",omitempty"];
+
   reserved 12;
 }
 


### PR DESCRIPTION
This change introduces a `planFlagContainsIndexJoin` flag to the
planner. The new planner flag is read when logging statement execution
details, specifically when setting the value `HasIndexJoin`, a new field
in the `CommonSQLExecDetails` proto message, which in turn, is embedded
in the `SampledQuery` telemetry log.

Release note (sql change): Introduce `HasIndexJoin` field to the
`SampledQuery` telemetry log, giving visibility as to whether a query
used an index join.