### PR TITLE
release-22.1: sql: add estimated and actual statistics to telemetry logging

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2439,6 +2439,14 @@ contains common SQL event/execution details.
 | `StatementID` | Statement ID of the query. | no |
 | `TransactionID` | Transaction ID of the query. | no |
 | `StatementFingerprintID` | Statement fingerprint ID of the query. | no |
+| `MaxFullScanRowsEstimate` | Maximum number of rows scanned by a full scan, as estimated by the optimizer. | no |
+| `TotalScanRowsEstimate` | Total number of rows read by all scans in the query, as estimated by the optimizer. | no |
+| `OutputRowsEstimate` | The number of rows output by the query, as estimated by the optimizer. | no |
+| `StatsAvailable` | Whether table statistics were available to the optimizer when planning the query. | no |
+| `NanosSinceStatsCollected` | The maximum number of nanoseconds that have passed since stats were collected on any table scanned by this query. | no |
+| `BytesRead` | The number of bytes read from disk. | no |
+| `RowsRead` | The number of rows read from disk. | no |
+| `RowsWritten` | The number of rows written. | no |
 
 
 #### Common fields

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1054,6 +1054,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	}
 
 	var stmtFingerprintID roachpb.StmtFingerprintID
+	var stats topLevelQueryStats
 	defer func() {
 		planner.maybeLogStatement(
 			ctx,
@@ -1066,6 +1067,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
 			stmtFingerprintID,
+			&stats,
 		)
 	}()
 
@@ -1144,7 +1146,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		distribute = DistributionTypeSystemTenantOnly
 	}
 	ex.sessionTracing.TraceExecStart(ctx, "distributed")
-	stats, err := ex.execWithDistSQLEngine(
+	stats, err = ex.execWithDistSQLEngine(
 		ctx, planner, stmt.AST.StatementReturnType(), res, distribute, progAtomic,
 	)
 	if res.Err() == nil {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -128,6 +129,26 @@ type instrumentationHelper struct {
 	// indexRecommendations is a string slice containing index recommendations for
 	// the planned statement. This is only set for EXPLAIN statements.
 	indexRecommendations []string
+
+	// maxFullScanRows is the maximum number of rows scanned by a full scan, as
+	// estimated by the optimizer.
+	maxFullScanRows float64
+
+	// totalScanRows is the total number of rows read by all scans in the query,
+	// as estimated by the optimizer.
+	totalScanRows float64
+
+	// outputRows is the number of rows output by the query, as estimated by the
+	// optimizer.
+	outputRows float64
+
+	// statsAvailable is true if table statistics were available to the optimizer
+	// when planning the query.
+	statsAvailable bool
+
+	// nanosSinceStatsCollected is the maximum number of nanoseconds that have
+	// passed since stats were collected on any table scanned by this query.
+	nanosSinceStatsCollected time.Duration
 }
 
 // outputMode indicates how the statement output needs to be populated (for

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/timeutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -11,6 +11,8 @@
 package execbuilder
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -112,6 +114,18 @@ type Builder struct {
 
 	// ContainsMutation is set to true if the whole plan contains any mutations.
 	ContainsMutation bool
+
+	// MaxFullScanRows is the maximum number of rows scanned by a full scan, as
+	// estimated by the optimizer.
+	MaxFullScanRows float64
+
+	// TotalScanRows is the total number of rows read by all scans in the query,
+	// as estimated by the optimizer.
+	TotalScanRows float64
+
+	// NanosSinceStatsCollected is the maximum number of nanoseconds that have
+	// passed since stats were collected on any table scanned by this query.
+	NanosSinceStatsCollected time.Duration
 }
 
 // New constructs an instance of the execution node builder using the

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -685,8 +686,8 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 
 	// Save if we planned a full table/index scan on the builder so that the
 	// planner can be made aware later. We only do this for non-virtual tables.
+	stats := scan.Relational().Stats
 	if !tab.IsVirtualTable() && isUnfiltered {
-		stats := scan.Relational().Stats
 		large := !stats.Available || stats.RowCount > b.evalCtx.SessionData().LargeFullScanRows
 		if scan.Index == cat.PrimaryIndex {
 			b.ContainsFullTableScan = true
@@ -694,6 +695,22 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		} else {
 			b.ContainsFullIndexScan = true
 			b.ContainsLargeFullIndexScan = b.ContainsLargeFullIndexScan || large
+		}
+		if stats.Available && stats.RowCount > b.MaxFullScanRows {
+			b.MaxFullScanRows = stats.RowCount
+		}
+	}
+
+	// Save the total estimated number of rows scanned and the time since stats
+	// were collected.
+	if stats.Available {
+		b.TotalScanRows += stats.RowCount
+		if tab.StatisticCount() > 0 {
+			// The first stat is the most recent one.
+			nanosSinceStatsCollected := timeutil.Since(tab.Statistic(0).CreatedAt())
+			if nanosSinceStatsCollected > b.NanosSinceStatsCollected {
+				b.NanosSinceStatsCollected = nanosSinceStatsCollected
+			}
 		}
 	}
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -621,6 +621,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 		containsLargeFullTableScan = bld.ContainsLargeFullTableScan
 		containsLargeFullIndexScan = bld.ContainsLargeFullIndexScan
 		containsMutation = bld.ContainsMutation
+		planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
+		planTop.instrumentation.totalScanRows = bld.TotalScanRows
+		planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
 	} else {
 		// Create an explain factory and record the explain.Plan.
 		explainFactory := explain.NewFactory(f)
@@ -639,6 +642,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 		containsLargeFullTableScan = bld.ContainsLargeFullTableScan
 		containsLargeFullIndexScan = bld.ContainsLargeFullIndexScan
 		containsMutation = bld.ContainsMutation
+		planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
+		planTop.instrumentation.totalScanRows = bld.TotalScanRows
+		planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
 
 		planTop.instrumentation.RecordExplainPlan(explainPlan)
 	}
@@ -646,6 +652,11 @@ func (opc *optPlanningCtx) runExecBuilder(
 		planTop.instrumentation.planGist = gf.PlanGist()
 	}
 	planTop.instrumentation.costEstimate = float64(mem.RootExpr().(memo.RelExpr).Cost())
+	available := mem.RootExpr().(memo.RelExpr).Relational().Stats.Available
+	planTop.instrumentation.statsAvailable = available
+	if available {
+		planTop.instrumentation.outputRows = mem.RootExpr().(memo.RelExpr).Relational().Stats.RowCount
+	}
 
 	if stmt.ExpectedTypes != nil {
 		cols := result.main.planColumns()

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -103,6 +103,17 @@ func TestTelemetryLogging(t *testing.T) {
 	db.Exec(t, `SET application_name = 'telemetry-logging-test'`)
 	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
 	db.Exec(t, "CREATE TABLE t();")
+	db.Exec(t, "CREATE TABLE u(x int);")
+	db.Exec(t, "INSERT INTO u SELECT generate_series(1, 100);")
+	// Use INJECT STATISTICS instead of ANALYZE to avoid test flakes.
+	db.Exec(t, `ALTER TABLE u INJECT STATISTICS '[{
+      "avg_size": 3,
+      "columns": ["x"],
+      "created_at": "2022-07-28 12:54:13.915054",
+      "distinct_count": 100,
+      "null_count": 0,
+      "row_count": 100
+  }]';`)
 
 	// Testing Cases:
 	// - entries that are NOT sampled
@@ -122,61 +133,115 @@ func TestTelemetryLogging(t *testing.T) {
 		expectedSkipped         []int // Expected skipped query count per expected log line.
 		expectedUnredactedTags  []string
 		expectedApplicationName string
+		expectedFullScan        bool
+		expectedStatsAvailable  bool
+		expectedRead            bool
+		expectedWrite           bool
 	}{
 		{
 			// Test case with statement that is not of type DML.
 			// Even though the queries are executed within the required
 			// elapsed interval, we should still see that they were all
 			// logged since  we log all statements that are not of type DML.
-			"truncate-table-query",
-			"TRUNCATE t;",
-			"TRUNCATE TABLE t",
-			[]float64{1, 1.1, 1.2, 2},
-			`TRUNCATE TABLE`,
-			1,
-			[]int{0, 0, 0, 0},
-			[]string{"client"},
-			"telemetry-logging-test",
+			name:                    "truncate-table-query",
+			query:                   "TRUNCATE t;",
+			queryNoConstants:        "TRUNCATE TABLE t",
+			execTimestampsSeconds:   []float64{1, 1.1, 1.2, 2},
+			expectedLogStatement:    `TRUNCATE TABLE`,
+			stubMaxEventFrequency:   1,
+			expectedSkipped:         []int{0, 0, 0, 0},
+			expectedUnredactedTags:  []string{"client"},
+			expectedApplicationName: "telemetry-logging-test",
+			expectedFullScan:        false,
+			expectedStatsAvailable:  false,
+			expectedRead:            false,
+			expectedWrite:           false,
 		},
 		{
 			// Test case with statement that is of type DML.
 			// The first statement should be logged.
-			"select-*-limit-1-query",
-			"SELECT * FROM t LIMIT 1;",
-			"SELECT * FROM t LIMIT _",
-			[]float64{3},
-			`SELECT * FROM \"\".\"\".t LIMIT ‹1›`,
-			1,
-			[]int{0},
-			[]string{"client"},
-			"telemetry-logging-test",
+			name:                    "select-*-limit-1-query",
+			query:                   "SELECT * FROM t LIMIT 1;",
+			queryNoConstants:        "SELECT * FROM t LIMIT _",
+			execTimestampsSeconds:   []float64{3},
+			expectedLogStatement:    `SELECT * FROM \"\".\"\".t LIMIT ‹1›`,
+			stubMaxEventFrequency:   1,
+			expectedSkipped:         []int{0},
+			expectedUnredactedTags:  []string{"client"},
+			expectedApplicationName: "telemetry-logging-test",
+			expectedFullScan:        false,
+			expectedStatsAvailable:  false,
+			expectedRead:            false,
+			expectedWrite:           false,
 		},
 		{
 			// Test case with statement that is of type DML.
 			// Two timestamps are within the required elapsed interval,
 			// thus 2 log statements are expected, with 2 skipped queries.
-			"select-*-limit-2-query",
-			"SELECT * FROM t LIMIT 2;",
-			"SELECT * FROM t LIMIT _",
-			[]float64{4, 4.1, 4.2, 5},
-			`SELECT * FROM \"\".\"\".t LIMIT ‹2›`,
-			1,
-			[]int{0, 2},
-			[]string{"client"},
-			"telemetry-logging-test",
+			name:                    "select-*-limit-2-query",
+			query:                   "SELECT * FROM u LIMIT 2;",
+			queryNoConstants:        "SELECT * FROM u LIMIT _",
+			execTimestampsSeconds:   []float64{4, 4.1, 4.2, 5},
+			expectedLogStatement:    `SELECT * FROM \"\".\"\".u LIMIT ‹2›`,
+			stubMaxEventFrequency:   1,
+			expectedSkipped:         []int{0, 2},
+			expectedUnredactedTags:  []string{"client"},
+			expectedApplicationName: "telemetry-logging-test",
+			expectedFullScan:        false,
+			expectedStatsAvailable:  true,
+			expectedRead:            true,
+			expectedWrite:           false,
 		},
 		{
 			// Test case with statement that is of type DML.
 			// Once required time has elapsed, the next statement should be logged.
-			"select-*-limit-3-query",
-			"SELECT * FROM t LIMIT 3;",
-			"SELECT * FROM t LIMIT _",
-			[]float64{6, 6.01, 6.05, 6.06, 6.1, 6.2},
-			`SELECT * FROM \"\".\"\".t LIMIT ‹3›`,
-			10,
-			[]int{0, 3, 0},
-			[]string{"client"},
-			"telemetry-logging-test",
+			name:                    "select-*-limit-3-query",
+			query:                   "SELECT * FROM u LIMIT 3;",
+			queryNoConstants:        "SELECT * FROM u LIMIT _",
+			execTimestampsSeconds:   []float64{6, 6.01, 6.05, 6.06, 6.1, 6.2},
+			expectedLogStatement:    `SELECT * FROM \"\".\"\".u LIMIT ‹3›`,
+			stubMaxEventFrequency:   10,
+			expectedSkipped:         []int{0, 3, 0},
+			expectedUnredactedTags:  []string{"client"},
+			expectedApplicationName: "telemetry-logging-test",
+			expectedFullScan:        false,
+			expectedStatsAvailable:  true,
+			expectedRead:            true,
+			expectedWrite:           false,
+		},
+		{
+			// Test case with a full scan.
+			// The first statement should be logged.
+			name:                    "select-x-query",
+			query:                   "SELECT x FROM u;",
+			queryNoConstants:        "SELECT x FROM u",
+			execTimestampsSeconds:   []float64{7},
+			expectedLogStatement:    `SELECT x FROM \"\".\"\".u`,
+			stubMaxEventFrequency:   10,
+			expectedSkipped:         []int{0},
+			expectedUnredactedTags:  []string{"client"},
+			expectedApplicationName: "telemetry-logging-test",
+			expectedFullScan:        true,
+			expectedStatsAvailable:  true,
+			expectedRead:            true,
+			expectedWrite:           false,
+		},
+		{
+			// Test case with a write.
+			// The first statement should be logged.
+			name:                    "update-u-query",
+			query:                   "UPDATE u SET x = 5 WHERE x > 50 RETURNING x;",
+			queryNoConstants:        "UPDATE u SET x = _ WHERE x > _ RETURNING x",
+			execTimestampsSeconds:   []float64{8},
+			expectedLogStatement:    `UPDATE \"\".\"\".u SET x = ‹5› WHERE x > ‹50› RETURNING x`,
+			stubMaxEventFrequency:   10,
+			expectedSkipped:         []int{0},
+			expectedUnredactedTags:  []string{"client"},
+			expectedApplicationName: "telemetry-logging-test",
+			expectedFullScan:        true,
+			expectedStatsAvailable:  true,
+			expectedRead:            true,
+			expectedWrite:           true,
 		},
 	}
 
@@ -278,6 +343,72 @@ func TestTelemetryLogging(t *testing.T) {
 				stmtFingerprintID := roachpb.ConstructStatementFingerprintID(tc.queryNoConstants, false, true, databaseName)
 				if !strings.Contains(e.Message, "\"StatementFingerprintID\":"+strconv.FormatUint(uint64(stmtFingerprintID), 10)) {
 					t.Errorf("expected to find StatementFingerprintID: %v", stmtFingerprintID)
+				}
+				maxFullScanRowsRe := regexp.MustCompile("\"MaxFullScanRowsEstimate\":[0-9]*")
+				foundFullScan := maxFullScanRowsRe.MatchString(e.Message)
+				if tc.expectedFullScan && !foundFullScan {
+					t.Errorf("expected to find MaxFullScanRowsEstimate but none was found in: %s", e.Message)
+				} else if !tc.expectedFullScan && foundFullScan {
+					t.Errorf("expected not to find MaxFullScanRowsEstimate but it was found in: %s", e.Message)
+				}
+				totalScanRowsRe := regexp.MustCompile("\"TotalScanRowsEstimate\":[0-9]*")
+				outputRowsRe := regexp.MustCompile("\"OutputRowsEstimate\":[0-9]*")
+				statsAvailableRe := regexp.MustCompile("\"StatsAvailable\":(true|false)")
+				nanosSinceStatsCollectedRe := regexp.MustCompile("\"NanosSinceStatsCollected\":[0-9]*")
+				if tc.expectedStatsAvailable {
+					if !totalScanRowsRe.MatchString(e.Message) {
+						t.Errorf("expected to find TotalScanRowsEstimate but none was found in: %s", e.Message)
+					}
+					if !outputRowsRe.MatchString(e.Message) {
+						t.Errorf("expected to find OutputRowsEstimate but none was found in: %s", e.Message)
+					}
+					if !statsAvailableRe.MatchString(e.Message) {
+						t.Errorf("expected to find StatsAvailable but none was found in: %s", e.Message)
+					}
+					if !nanosSinceStatsCollectedRe.MatchString(e.Message) {
+						t.Errorf("expected to find NanosSinceStatsCollected but none was found in: %s", e.Message)
+					}
+				} else {
+					if totalScanRowsRe.MatchString(e.Message) {
+						t.Errorf("expected not to find TotalScanRowsEstimate but it was found in: %s", e.Message)
+					}
+					if outputRowsRe.MatchString(e.Message) {
+						t.Errorf("expected not to find OutputRowsEstimate but it was found in: %s", e.Message)
+					}
+					if statsAvailableRe.MatchString(e.Message) {
+						t.Errorf("expected not to find StatsAvailable but it was found in: %s", e.Message)
+					}
+					if nanosSinceStatsCollectedRe.MatchString(e.Message) {
+						t.Errorf("expected not to find NanosSinceStatsCollected but it was found in: %s", e.Message)
+					}
+				}
+				BytesReadRe := regexp.MustCompile("\"BytesRead\":[0-9]*")
+				RowsReadRe := regexp.MustCompile("\"RowsRead\":[0-9]*")
+				if tc.expectedRead {
+					if !BytesReadRe.MatchString(e.Message) {
+						t.Errorf("expected to find BytesRead but none was found in: %s", e.Message)
+					}
+					if !RowsReadRe.MatchString(e.Message) {
+						t.Errorf("expected to find RowsRead but none was found in: %s", e.Message)
+					}
+				} else {
+					if BytesReadRe.MatchString(e.Message) {
+						t.Errorf("expected not to find BytesRead but it was found in: %s", e.Message)
+					}
+					if RowsReadRe.MatchString(e.Message) {
+						t.Errorf("expected not to find RowsRead but it was found in: %s", e.Message)
+					}
+
+				}
+				RowsWrittenRe := regexp.MustCompile("\"RowsWritten\":[0-9]*")
+				if tc.expectedWrite {
+					if !RowsWrittenRe.MatchString(e.Message) {
+						t.Errorf("expected to find RowsWritten but none was found in: %s", e.Message)
+					}
+				} else {
+					if RowsWrittenRe.MatchString(e.Message) {
+						t.Errorf("expected not to find RowsWritten but it was found in: %s", e.Message)
+					}
 				}
 			}
 		}

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3285,6 +3285,77 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = strconv.AppendUint(b, uint64(m.StatementFingerprintID), 10)
 	}
 
+	if m.MaxFullScanRowsEstimate != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MaxFullScanRowsEstimate\":"...)
+		b = strconv.AppendFloat(b, float64(m.MaxFullScanRowsEstimate), 'f', -1, 64)
+	}
+
+	if m.TotalScanRowsEstimate != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TotalScanRowsEstimate\":"...)
+		b = strconv.AppendFloat(b, float64(m.TotalScanRowsEstimate), 'f', -1, 64)
+	}
+
+	if m.OutputRowsEstimate != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"OutputRowsEstimate\":"...)
+		b = strconv.AppendFloat(b, float64(m.OutputRowsEstimate), 'f', -1, 64)
+	}
+
+	if m.StatsAvailable {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StatsAvailable\":true"...)
+	}
+
+	if m.NanosSinceStatsCollected != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NanosSinceStatsCollected\":"...)
+		b = strconv.AppendInt(b, int64(m.NanosSinceStatsCollected), 10)
+	}
+
+	if m.BytesRead != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"BytesRead\":"...)
+		b = strconv.AppendInt(b, int64(m.BytesRead), 10)
+	}
+
+	if m.RowsRead != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RowsRead\":"...)
+		b = strconv.AppendInt(b, int64(m.RowsRead), 10)
+	}
+
+	if m.RowsWritten != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RowsWritten\":"...)
+		b = strconv.AppendInt(b, int64(m.RowsWritten), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -63,6 +63,34 @@ message SampledQuery {
 
   // Statement fingerprint ID of the query.
   uint64 statement_fingerprint_id = 13 [(gogoproto.customname) = "StatementFingerprintID", (gogoproto.jsontag) = ',omitempty'];
+
+  // Maximum number of rows scanned by a full scan, as estimated by the
+  // optimizer.
+  double max_full_scan_rows_estimate = 14 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Total number of rows read by all scans in the query, as estimated by the
+  // optimizer.
+  double total_scan_rows_estimate = 15 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of rows output by the query, as estimated by the optimizer.
+  double output_rows_estimate = 16 [(gogoproto.jsontag) = ",omitempty"];
+
+  // Whether table statistics were available to the optimizer when planning the
+  // query.
+  bool stats_available = 17 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The maximum number of nanoseconds that have passed since stats were
+  // collected on any table scanned by this query.
+  int64 nanos_since_stats_collected = 18 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of bytes read from disk.
+  int64 bytes_read = 19 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of rows read from disk.
+  int64 rows_read = 20 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of rows written.
+  int64 rows_written = 21 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
Backport 1/1 commits from #85169.

/cc @cockroachdb/release

Release justification: Add new telemetry fields

---

This commit adds several new fields to the `SampledQuery` structure used for
telemetry logging.

Closes #71666

Release note (sql change): The structured payloads used for telemetry
logs now include the following new fields:
MaxFullScanRowsEstimate: Maximum number of rows scanned by a full scan,
as estimated by the optimizer.
TotalScanRowsEstimate: Total number of rows read by all scans in the query,
as estimated by the optimizer.
OutputRowsEstimate: The number of rows output by the query, as estimated
by the optimizer.
StatsAvailable: Whether table statistics were available to the optimizer
when planning the query.
NanosSinceStatsCollected: The maximum number of nanoseconds that have
passed since stats were collected on any table scanned by this query.
BytesRead: The number of bytes read from disk.
RowsRead: The number of rows read from disk.
RowsWritten: The number of rows written.
