### PR TITLE
sql: assign incremental OIDs to builtin functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -1271,8 +1271,8 @@ SELECT i, i::oid, i::oid::text,
   i::oid::regproc, i::oid::regprocedure, i::oid::regnamespace, i::oid::regclass, i::oid::regtype, i::oid::regrole
 FROM (VALUES (0), (1)) v(i)
 ----
-0  0  0  -  -  -  -  -  -
-1  1  1  1  1  1  1  1  1
+0  0  0  -          -          -  -  -  -
+1  1  1  array_agg  array_agg  1  1  1  1
 
 query TOOOOOOOOOOOO
 SELECT i, i::regproc::oid, i::regprocedure::oid, i::regnamespace::oid, i::regtype::oid, i::regclass::oid, i::regrole::oid,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4630,7 +4630,7 @@ FROM pg_proc p
 JOIN pg_type t ON t.typinput = p.oid
 WHERE t.typname = '_int4'
 ----
-780513238  array_in  array_in
+2004  array_in  array_in
 
 ## #16285
 ## int2vectors should be 0-indexed
@@ -4640,8 +4640,19 @@ SELECT count(*) FROM pg_catalog.pg_index WHERE indkey[0] IS NULL;
 0
 
 ## Ensure no two builtins have the same oid.
-query I
-SELECT c FROM (SELECT oid, count(*) as c FROM pg_catalog.pg_proc GROUP BY oid) WHERE c > 1
+query TI
+WITH r AS (
+  SELECT oid, c FROM (SELECT oid, count(*) as c FROM pg_catalog.pg_proc GROUP BY oid) WHERE c > 1
+)
+SELECT proname, l.oid::int AS id
+FROM pg_catalog.pg_proc l
+JOIN r on l.oid = r.oid
+ORDER BY id
+----
+
+## Ensure no builtin has zero oid.
+query T
+SELECT proname FROM pg_catalog.pg_proc WHERE oid = 0
 ----
 
 ## Ensure that unnest works with oid wrapper arrays

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -11,12 +11,12 @@ SELECT 3::OID::INT::OID
 query OOOOOOO
 SELECT 1::OID, 1::REGCLASS, 1::REGNAMESPACE, 1::REGPROC, 1::REGPROCEDURE, 1::REGROLE, 1::REGTYPE
 ----
-1  1  1  1  1  1  1
+1  1  1  array_agg  array_agg  1  1
 
 query OOOOOO
 SELECT 1::OID::REGCLASS, 1::OID::REGNAMESPACE, 1::OID::REGPROC, 1::OID::REGPROCEDURE, 1::OID::REGROLE, 1::OID::REGTYPE
 ----
-1  1  1  1  1  1
+1  1  array_agg  array_agg  1  1
 
 query TTT
 SELECT pg_typeof(1::OID), pg_typeof(1::REGCLASS), pg_typeof(1::REGNAMESPACE)
@@ -83,7 +83,7 @@ WHERE relname = 'pg_constraint'
 query OOOO
 SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'pg_catalog.upper'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----
-upper  upper  upper  3615042040
+upper  upper  upper  827
 
 query error invalid function name
 SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
@@ -91,7 +91,7 @@ SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
 query OOO
 SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE, 'upper(int)'::REGPROC::OID
 ----
-upper  upper  3615042040
+upper  upper  827
 
 query error unknown function: blah\(\)
 SELECT 'blah(ignored, ignored)'::REGPROC, 'blah(ignored, ignored)'::REGPROCEDURE

--- a/pkg/sql/oidext/oidext.go
+++ b/pkg/sql/oidext/oidext.go
@@ -16,14 +16,14 @@ package oidext
 
 import "github.com/lib/pq/oid"
 
-// CockroachPredefinedOIDMax defines the maximum OID allowed for use by
-// non user defined types. OIDs for user defined types will start at
-// CockroachPrefixedOIDMax and increase as new types are created.
-// User defined type descriptors have a cluster-wide unique stable ID.
-// CockroachPredefinedOIDMax defines the mapping from this stable ID to
-// a type OID. In particular, stable ID + CockroachPredefinedOIDMax = type OID.
-// types.StableTypeIDToOID and types.UserDefinedTypeOIDToID should be used when
-// converting between stable ID's and type OIDs.
+// CockroachPredefinedOIDMax defines the maximum OID allowed for use by non user
+// defined types/functions. OIDs for user defined types/functions will start at
+// CockroachPrefixedOIDMax and increase as new types are created. User defined
+// type/function descriptors have a cluster-wide unique stable ID.
+// CockroachPredefinedOIDMax defines the mapping from this stable ID to a
+// type/function OID. In particular, stable ID + CockroachPredefinedOIDMax =
+// type OID. types.StableTypeIDToOID and types.UserDefinedTypeOIDToID should be
+// used when converting between stable ID's and type/function OIDs.
 const CockroachPredefinedOIDMax = 100000
 
 // OIDs in this block are extensions of postgres, thus having no official OID.

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//pkg/sql/lex",
         "//pkg/sql/lexbase",
         "//pkg/sql/memsize",
+        "//pkg/sql/oidext",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/sem/builtins/all_builtins.go
+++ b/pkg/sql/sem/builtins/all_builtins.go
@@ -35,6 +35,9 @@ var AllAggregateBuiltinNames []string
 var AllWindowBuiltinNames []string
 
 func init() {
+	// Note: changing the order of these init functions will cause changes to OIDs
+	// of builtin functions. In general, it won't cause internal problems other
+	// than causing failures in tests which make assumption of OIDs.
 	initRegularBuiltins()
 	initAggregateBuiltins()
 	initWindowBuiltins()
@@ -132,8 +135,5 @@ func collectOverloads(
 			r = append(r, f(t))
 		}
 	}
-	return builtinDefinition{
-		props:     props,
-		overloads: r,
-	}
+	return makeBuiltin(props, r...)
 }

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7242,7 +7242,10 @@ func initGeoBuiltins() {
 		if _, ok := geoBuiltins[alias.builtinName]; !ok {
 			panic("expected builtin definition for alias: " + alias.builtinName)
 		}
-		geoBuiltins[alias.alias] = geoBuiltins[alias.builtinName]
+
+		newOverloads := make([]tree.Overload, len(geoBuiltins[alias.builtinName].overloads))
+		copy(newOverloads, geoBuiltins[alias.builtinName].overloads)
+		geoBuiltins[alias.alias] = makeBuiltin(geoBuiltins[alias.builtinName].props, newOverloads...)
 	}
 
 	// Indexed functions have an alternative version with an underscore prepended
@@ -7468,8 +7471,7 @@ This variant will cast all geometry_str arguments into Geometry types.
 		newOverloads = append(newOverloads, newOverload)
 	}
 
-	def.overloads = newOverloads
-	return def
+	return makeBuiltin(def.props, newOverloads...)
 }
 
 // stAsGeoJSONFromTuple returns a *tree.DString representing JSON output

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -44,20 +44,18 @@ const notUsableInfo = "Not usable; exposed only for compatibility with PostgreSQ
 // makeNotUsableFalseBuiltin creates a builtin that takes no arguments and
 // always returns a boolean with the value false.
 func makeNotUsableFalseBuiltin() builtinDefinition {
-	return builtinDefinition{
-		props: defProps(),
-		overloads: []tree.Overload{
-			{
-				Types:      tree.ArgTypes{},
-				ReturnType: tree.FixedReturnType(types.Bool),
-				Fn: func(*eval.Context, tree.Datums) (tree.Datum, error) {
-					return tree.DBoolFalse, nil
-				},
-				Info:       notUsableInfo,
-				Volatility: volatility.Volatile,
+	return makeBuiltin(
+		defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(*eval.Context, tree.Datums) (tree.Datum, error) {
+				return tree.DBoolFalse, nil
 			},
+			Info:       notUsableInfo,
+			Volatility: volatility.Volatile,
 		},
-	}
+	)
 }
 
 // typeBuiltinsHaveUnderscore is a map to keep track of which types have i/o
@@ -152,26 +150,24 @@ func initPGBuiltins() {
 var errUnimplemented = pgerror.New(pgcode.FeatureNotSupported, "unimplemented")
 
 func makeTypeIOBuiltin(argTypes tree.TypeList, returnType *types.T) builtinDefinition {
-	return builtinDefinition{
-		props: tree.FunctionProperties{
+	return makeBuiltin(
+		tree.FunctionProperties{
 			Category: builtinconstants.CategoryCompatibility,
 		},
-		overloads: []tree.Overload{
-			{
-				Types:      argTypes,
-				ReturnType: tree.FixedReturnType(returnType),
-				Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
-					return nil, errUnimplemented
-				},
-				Info:       notUsableInfo,
-				Volatility: volatility.Volatile,
-				// Ignore validity checks for typeio builtins. We don't
-				// implement these anyway, and they are very hard to special
-				// case.
-				IgnoreVolatilityCheck: true,
+		tree.Overload{
+			Types:      argTypes,
+			ReturnType: tree.FixedReturnType(returnType),
+			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+				return nil, errUnimplemented
 			},
+			Info:       notUsableInfo,
+			Volatility: volatility.Volatile,
+			// Ignore validity checks for typeio builtins. We don't
+			// implement these anyway, and they are very hard to special
+			// case.
+			IgnoreVolatilityCheck: true,
 		},
-	}
+	)
 }
 
 // makeTypeIOBuiltins generates the 4 i/o builtins that Postgres implements for
@@ -420,12 +416,12 @@ func makePGPrivilegeInquiryDef(
 			Volatility: volatility.Stable,
 		})
 	}
-	return builtinDefinition{
-		props: tree.FunctionProperties{
+	return makeBuiltin(
+		tree.FunctionProperties{
 			DistsqlBlocklist: true,
 		},
-		overloads: variants,
-	}
+		variants...,
+	)
 }
 
 // getNameForArg determines the object name for the specified argument, which

--- a/pkg/sql/sem/builtins/pgcrypto_builtins.go
+++ b/pkg/sql/sem/builtins/pgcrypto_builtins.go
@@ -104,7 +104,7 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 		},
 	),
 
-	"gen_random_uuid": generateRandomUUID4Impl,
+	"gen_random_uuid": generateRandomUUID4Impl(),
 
 	"gen_salt": makeBuiltin(
 		tree.FunctionProperties{Category: builtinconstants.CategoryCrypto},


### PR DESCRIPTION
With UDFs being introduced, getting OIDs by hashing on function
signature could cause conflicts. In this commit, fixed OIDs are
assigned to builtin functions during init time.

Release note: None