### PR TITLE
streamingccl: skip TestSinklessReplicationClient on 21.2

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//pkg/server",
         "//pkg/sql/catalog/catalogkv",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/ccl/streamingccl/streamclient/cockroach_sinkless_replication_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/cockroach_sinkless_replication_client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamingtest"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamproducer" // Ensure we can start replication stream.
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkv"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,8 @@ func TestSinklessReplicationClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	defer log.Scope(t).Close(t)
+	// Skipped as this feature is not released in 21.2.
+	skip.WithIssue(t, 84119)
 	h, cleanup := streamingtest.NewReplicationHelper(t)
 	defer cleanup()
 


### PR DESCRIPTION
Skip this flaky test on release 21.2 branch as tenant
streaming is not released in 21.2.

Release note (bug fix): skip TestSinklessReplicationClient on
release 21.2

Closes: https://github.com/cockroachdb/cockroach/issues/84119