### PR TITLE
sql: initialize connExecutor with use_declarative_schema_changer

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -694,7 +694,6 @@ go_test(
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/rowexec",
         "//pkg/sql/rowinfra",
-        "//pkg/sql/schemachanger/scexec",
         "//pkg/sql/scrub",
         "//pkg/sql/scrub/scrubtestutils",
         "//pkg/sql/sem/builtins",

--- a/pkg/sql/alter_column_type_test.go
+++ b/pkg/sql/alter_column_type_test.go
@@ -396,6 +396,7 @@ CREATE TABLE t.test (x INT);
 	go func() {
 		sqlDB.ExecMultiple(t,
 			`SET enable_experimental_alter_column_type_general = true;`,
+			`SET use_declarative_schema_changer = off;`,
 			`ALTER TABLE t.test ALTER COLUMN x TYPE STRING;`,
 		)
 		wg.Done()
@@ -405,6 +406,7 @@ CREATE TABLE t.test (x INT);
 
 	expected := fmt.Sprintf(`pq: relation "test" \(%d\): unimplemented: cannot perform a schema change operation while an ALTER COLUMN TYPE schema change is in progress`, tableID)
 	sqlDB.ExpectErr(t, expected, `
+SET use_declarative_schema_changer = off;
 ALTER TABLE t.test ADD COLUMN y INT;
 	`)
 

--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -396,9 +396,6 @@ func TestIndexStrictColumnIDs(t *testing.T) {
 	idx.Version = descpb.StrictIndexColumnIDGuaranteesVersion
 	expected = fmt.Sprintf(`relation "t" (%d): index "sec" has duplicates in KeySuffixColumnIDs: [2 2 2 2]`, mut.GetID())
 	require.EqualError(t, validate.Self(clusterversion.TestingClusterVersion, mut), expected)
-
-	_, err = conn.Exec(`ALTER TABLE d.t DROP COLUMN c2`)
-	require.NoError(t, err)
 }
 
 // TestLatestIndexDescriptorVersionValues tests the correct behavior of the

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -960,6 +960,9 @@ func (s *Server) newConnExecutor(
 	ex.extraTxnState.descCollection = s.cfg.CollectionFactory.MakeCollection(ctx, descs.NewTemporarySchemaProvider(sdMutIterator.sds), ex.sessionMon)
 	ex.extraTxnState.txnRewindPos = -1
 	ex.extraTxnState.schemaChangeJobRecords = make(map[descpb.ID]*jobs.Record)
+	ex.extraTxnState.schemaChangerState = SchemaChangerState{
+		mode: ex.sessionData().NewSchemaChangerMode,
+	}
 	ex.queryCancelKey = pgwirecancel.MakeBackendKeyData(ex.rng, ex.server.cfg.NodeInfo.NodeID.SQLInstanceID())
 	ex.mu.ActiveQueries = make(map[clusterunique.ID]*queryMeta)
 	ex.machine = fsm.MakeMachine(TxnStateTransitions, stateNoTxn{}, &ex.state)

--- a/pkg/sql/importer/client_import_test.go
+++ b/pkg/sql/importer/client_import_test.go
@@ -86,7 +86,9 @@ func TestDropDatabaseCascadeDuringImportsFails(t *testing.T) {
 		t.Fatalf("err %v", err)
 	}
 
-	_, err := db.Exec(`DROP DATABASE "fooBarBaz" CASCADE`)
+	_, err := db.Exec(`
+SET use_declarative_schema_changer=off;
+DROP DATABASE "fooBarBaz" CASCADE`)
 	require.Regexp(t, `cannot drop a database or a schema with OFFLINE tables, ensure `+
 		dbName+`\.public\.`+tableName+` is dropped or made public before dropping`, err)
 	pgErr := new(pq.Error)


### PR DESCRIPTION
Previously, we forget to initialize
`connExecutor.extraTxnState.schemaChangerState`. It was inadequate
because it can cause the system to use lagacy schema changer even if
the session variable is set to `use_declarative_schema_changer=on`. This
PR fixes this.

fix: #85240

Release note (bug fix): Fixed a bug that we forgot to initialize a
connExecutor's schemaChangerState from the corresponding session
variable (`use_declarative_schema_changer`), which can cause DDL
statements to be executed under the legacy schema changer unknowningly.