### PR TITLE
insights: concerns

### DIFF
--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -15,6 +15,15 @@ option go_package = "insights";
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 
+enum Concern {
+  // SlowExecution is for statement executions that either take longer than a predetermined
+  // threshold, configured by the sql.stats.insights.experimental.latency_threshold
+  // cluster setting, or that take significantly "longer than usual" for their statement
+  // fingerprint, based on some heuristics we're developing, which can be enabled by the
+  // sql.stats.insights.experimental.latency_quantile_detection.enabled cluster setting.
+  SlowExecution = 0;
+}
+
 message Session {
   bytes id = 1 [(gogoproto.customname) = "ID",
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/clusterunique.ID",
@@ -57,4 +66,6 @@ message Insight {
   Session session = 1;
   Transaction transaction = 2;
   Statement statement = 3;
+
+  repeated Concern concerns = 4;
 }

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -46,6 +46,7 @@ func TestRegistry(t *testing.T) {
 			Session:     session,
 			Transaction: transaction,
 			Statement:   statement,
+			Concerns:    []Concern{Concern_SlowExecution},
 		}}
 		var actual []*Insight
 
@@ -119,10 +120,12 @@ func TestRegistry(t *testing.T) {
 			Session:     session,
 			Transaction: transaction,
 			Statement:   statement,
+			Concerns:    []Concern{Concern_SlowExecution},
 		}, {
 			Session:     otherSession,
 			Transaction: otherTransaction,
 			Statement:   otherStatement,
+			Concerns:    []Concern{Concern_SlowExecution},
 		}}
 		var actual []*Insight
 		registry.IterateInsights(


### PR DESCRIPTION
As we expand the previous outliers system to handle more insights, we
add a field to start capturing our "concerns," things we detect that
might be amiss.

Note that we don't yet expose these values in the `crdb_internal` virtual
tables of execution insights. We can do that next.

Release note: None