### PR TITLE
opt: simplify contradictory filters to false

### DIFF
--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -223,7 +223,7 @@ func TestIsCanonicalFilter(t *testing.T) {
 			want:   true,
 		},
 		{name: "and-eq-lt",
-			filter: "i = 10 AND i < 10",
+			filter: "i = 9 AND i < 10",
 			want:   false,
 		},
 		{name: "or-eq-lt",

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -5,7 +5,8 @@
 # SimplifySelectFilters simplifies the Filters operator in several possible
 # ways:
 #   - Removes True operands
-#   - Replaces the Filters operator with False if any operand is False or Null
+#   - Replaces the Filters operator with False if any operand is False, Null, or
+#     a contradiction
 #   - Flattens nested And operands by merging their conditions into parent
 #   - Simplifies Or operands where one side is a Null to the other side
 #   - Simplifies Is operands where the right side is True or False

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -66,13 +66,21 @@ project
            └── i:2 = 8 [outer=(2), constraints=(/2: [/8 - /8]; tight), fd=()-->(2)]
 
 norm expect=InlineConstVar
-SELECT k FROM b WHERE i=5 AND i IN (1, 2, 3, 4)
+SELECT k FROM b WHERE i=4 AND i IN (1, 2, 3, 4)
 ----
-values
+project
  ├── columns: k:1!null
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1)
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan b
+      │    ├── columns: k:1!null i:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── i:2 = 4 [outer=(2), constraints=(/2: [/4 - /4]; tight), fd=()-->(2)]
 
 # Case that requires multiple iterations to fully inline.
 norm expect=InlineConstVar

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -133,6 +133,18 @@ select
       ├── d:4 [outer=(4), constraints=(/4: [/true - /true]; tight), fd=()-->(4)]
       └── e:5 [outer=(5), constraints=(/5: [/true - /true]; tight), fd=()-->(5)]
 
+# Simplify contradictions to false.
+# This can eliminate non-leakproof expressions from filters, allowing further
+# optimizations to apply, like SimplifyZeroCardinalityGroup.
+norm expect=SimplifySelectFilters
+SELECT * FROM a WHERE i > 0 AND i < 0 AND 1/f = 1
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5)
+
 # Don't simplify the IS because the IS expression is a projection, not a Select
 # filter.
 norm expect-not=SimplifySelectFilters
@@ -1524,15 +1536,6 @@ DROP INDEX partial_idx
 # --------------------------------------------------
 
 norm expect=SimplifyIsNullCondition
-SELECT k FROM b WHERE k IS NULL AND k > 4
-----
-values
- ├── columns: k:1!null
- ├── cardinality: [0 - 0]
- ├── key: ()
- └── fd: ()-->(1)
-
-norm expect=SimplifyIsNullCondition
 SELECT k FROM b WHERE k IS NULL
 ----
 values
@@ -1542,7 +1545,7 @@ values
  └── fd: ()-->(1)
 
 norm expect=SimplifyIsNullCondition
-SELECT k,i FROM b WHERE k IS NULL AND k > 4 AND i < 100 AND i IS NULL
+SELECT k,i FROM b WHERE k IS NULL AND i < 100
 ----
 values
  ├── columns: k:1!null i:2!null


### PR DESCRIPTION
The `SimplifySelectFilters` normalization rule now transforms filters to
`false` if any of the filter items are contradictions. This allows
filters to be simplified in more cases, which can trigger other rules.
This can eliminate non-leakproof expressions in filters and allow
`SimplifyZeroCardinalityGroup` to fire.

For example, consider the query:

    SELECT a, b FROM t WHERE a > 0 AND a < 0 AND 1/b = 1

Prior to this commit, it could not be simplified to an empty values
clause because the non-leakproof division operator prevents
SimplifyZeroCardinalityGroup from applying. The normalized plan would
be:

    select
     ├── columns: a:1 b:2
     ├── cardinality: [0 - 0]
     ├── immutable
     ├── scan t
     │    └── columns: a:1 b:2
     └── filters
          ├── (a:1 > 0) AND (a:1 < 0) [constraints=(contradiction)]
          └── (1 / b:2) = 1 [outer=(2), immutable]

Now, `SimplifySelectFilters` eliminates the division operator, making
the expression leakproof, and allowing `SimplifyZeroCardinalityGroup` to
apply. The normalized plan is now:

    values
     ├── columns: a:1!null b:2!null
     ├── cardinality: [0 - 0]
     ├── key: ()
     └── fd: ()-->(1-2)

Release note (performance improvement): The optimizer can detect
contradictory filters in more cases, leading to more efficient query
plans.