### PR TITLE
opt: revert data race fix

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1497,13 +1497,9 @@ func (b *logicalPropsBuilder) buildFiltersItemProps(item *FiltersItem, scalar *p
 	// Constraints
 	// -----------
 	cb := constraintsBuilder{md: b.mem.Metadata(), evalCtx: b.evalCtx}
-	// TODO(rytaft): Using local variables here to avoid a data race. It would be
-	// better to avoid lazy building of props altogether.
-	constraints, tightConstraints := cb.buildConstraints(item.Condition)
-	if constraints.IsUnconstrained() {
+	scalar.Constraints, scalar.TightConstraints = cb.buildConstraints(item.Condition)
+	if scalar.Constraints.IsUnconstrained() {
 		scalar.Constraints, scalar.TightConstraints = nil, false
-	} else {
-		scalar.Constraints, scalar.TightConstraints = constraints, tightConstraints
 	}
 
 	// Functional Dependencies

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -220,9 +220,9 @@ define Filters {
 
 # FiltersItem contains a filter condition that's evaluated to determine whether
 # Select or Join rows should be filtered. In addition, the FiltersItem caches a
-# set of scalar properties that are lazily calculated by traversing the
-# Condition scalar expression. This allows the properties for the entire
-# expression subtree to be calculated once and then repeatedly reused.
+# set of scalar properties that are calculated by traversing the Condition
+# scalar expression. This allows the properties for the entire expression
+# subtree to be calculated once and then repeatedly reused.
 [Scalar, Bool, ListItem, ScalarProps]
 define FiltersItem {
     Condition ScalarExpr


### PR DESCRIPTION
This commit reverts #37972. We no longer lazily build filter props and
share them across multiple threads.

Release note: None