### PR TITLE
sql: improve physical planning of window functions

### DIFF
--- a/pkg/sql/catalog/colinfo/ordering.go
+++ b/pkg/sql/catalog/colinfo/ordering.go
@@ -30,6 +30,19 @@ type ColumnOrderInfo struct {
 // represents an ordering first by column 3 (descending), then by column 1 (ascending).
 type ColumnOrdering []ColumnOrderInfo
 
+// Equal returns whether two ColumnOrderings are the same.
+func (ordering ColumnOrdering) Equal(other ColumnOrdering) bool {
+	if len(ordering) != len(other) {
+		return false
+	}
+	for i, o := range ordering {
+		if o.ColIdx != other[i].ColIdx || o.Direction != other[i].Direction {
+			return false
+		}
+	}
+	return true
+}
+
 func (ordering ColumnOrdering) String(columns ResultColumns) string {
 	var buf bytes.Buffer
 	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -312,11 +312,8 @@ const (
 	// cannotDistribute indicates that a plan cannot be distributed.
 	cannotDistribute distRecommendation = iota
 
-	// shouldNotDistribute indicates that a plan could suffer if distributed.
-	shouldNotDistribute
-
-	// canDistribute indicates that a plan will probably not benefit but will
-	// probably not suffer if distributed.
+	// canDistribute indicates that a plan can be distributed, but it's not
+	// clear whether it'll be benefit from that.
 	canDistribute
 
 	// shouldDistribute indicates that a plan will likely benefit if distributed.
@@ -324,14 +321,10 @@ const (
 )
 
 // compose returns the recommendation for a plan given recommendations for two
-// parts of it: if we shouldNotDistribute either part, then we
-// shouldNotDistribute the overall plan either.
+// parts of it.
 func (a distRecommendation) compose(b distRecommendation) distRecommendation {
 	if a == cannotDistribute || b == cannotDistribute {
 		return cannotDistribute
-	}
-	if a == shouldNotDistribute || b == shouldNotDistribute {
-		return shouldNotDistribute
 	}
 	if a == shouldDistribute || b == shouldDistribute {
 		return shouldDistribute

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -621,7 +621,18 @@ func checkSupportForPlanNode(node planNode) (distRecommendation, error) {
 		return canDistribute, nil
 
 	case *windowNode:
-		return checkSupportForPlanNode(n.plan)
+		rec, err := checkSupportForPlanNode(n.plan)
+		if err != nil {
+			return cannotDistribute, err
+		}
+		for _, f := range n.funcs {
+			if len(f.partitionIdxs) > 0 {
+				// If at least one function has PARTITION BY clause, then we
+				// should distribute the execution.
+				return rec.compose(shouldDistribute), nil
+			}
+		}
+		return rec.compose(canDistribute), nil
 
 	case *zeroNode:
 		return canDistribute, nil
@@ -3730,9 +3741,8 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 	return p, nil
 }
 
-// createPlanForWindow creates a physical plan for computing window functions.
-// We add a new stage of windower processors for each different partitioning
-// scheme found in the query's window functions.
+// createPlanForWindow creates a physical plan for computing window functions
+// that have the same PARTITION BY and ORDER BY clauses.
 func (dsp *DistSQLPlanner) createPlanForWindow(
 	ctx context.Context, planCtx *PlanningCtx, n *windowNode,
 ) (*PhysicalPlan, error) {
@@ -3741,122 +3751,122 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 		return nil, err
 	}
 
-	numWindowFuncProcessed := 0
-	windowPlanState := createWindowPlanState(n, planCtx, plan)
-	// Each iteration of this loop adds a new stage of windowers. The steps taken:
-	// 1. find a set of unprocessed window functions that have the same PARTITION BY
-	//    clause. All of these will be computed using the single stage of windowers.
-	// 2. a) populate output types of the current stage of windowers. All input
-	//       columns are being passed through, and windower will append output
-	//       columns for each window function processed at the stage.
-	//    b) create specs for all window functions in the set.
-	// 3. decide whether to put windowers on a single or on multiple nodes.
-	//    a) if we're putting windowers on multiple nodes, we'll put them onto
-	//       every node that participated in the previous stage. We leverage hash
-	//       routers to partition the data based on PARTITION BY clause of window
-	//       functions in the set.
-	for numWindowFuncProcessed < len(n.funcs) {
-		samePartitionFuncs, partitionIdxs := windowPlanState.findUnprocessedWindowFnsWithSamePartition()
-		numWindowFuncProcessed += len(samePartitionFuncs)
-		windowerSpec := execinfrapb.WindowerSpec{
-			PartitionBy: partitionIdxs,
-			WindowFns:   make([]execinfrapb.WindowerSpec_WindowFn, len(samePartitionFuncs)),
-		}
+	partitionIdxs := make([]uint32, len(n.funcs[0].partitionIdxs))
+	for i := range partitionIdxs {
+		partitionIdxs[i] = uint32(n.funcs[0].partitionIdxs[i])
+	}
 
-		newResultTypes := make([]*types.T, len(plan.GetResultTypes())+len(samePartitionFuncs))
-		copy(newResultTypes, plan.GetResultTypes())
-		for windowFnSpecIdx, windowFn := range samePartitionFuncs {
-			windowFnSpec, outputType, err := windowPlanState.createWindowFnSpec(windowFn)
-			if err != nil {
-				return nil, err
-			}
-			newResultTypes[windowFn.outputColIdx] = outputType
-			windowerSpec.WindowFns[windowFnSpecIdx] = windowFnSpec
-		}
-
-		// Check if the previous stage is all on one node.
-		prevStageNode := plan.Processors[plan.ResultRouters[0]].SQLInstanceID
-		for i := 1; i < len(plan.ResultRouters); i++ {
-			if n := plan.Processors[plan.ResultRouters[i]].SQLInstanceID; n != prevStageNode {
-				prevStageNode = 0
-				break
-			}
-		}
-
-		// Get all sqlInstanceIDs from the previous stage.
-		sqlInstanceIDs := getSQLInstanceIDsOfRouters(plan.ResultRouters, plan.Processors)
-		if len(partitionIdxs) == 0 || len(sqlInstanceIDs) == 1 {
-			// No PARTITION BY or we have a single node. Use a single windower.
-			// If the previous stage was all on a single node, put the windower
-			// there. Otherwise, bring the results back on this node.
-			sqlInstanceID := dsp.gatewaySQLInstanceID
-			if len(sqlInstanceIDs) == 1 {
-				sqlInstanceID = sqlInstanceIDs[0]
-			}
-			plan.AddSingleGroupStage(
-				sqlInstanceID,
-				execinfrapb.ProcessorCoreUnion{Windower: &windowerSpec},
-				execinfrapb.PostProcessSpec{},
-				newResultTypes,
+	// Check that all window functions have the same PARTITION BY and ORDER BY
+	// clauses. We can assume that because the optbuilder ensures that all
+	// window functions in the windowNode have the same PARTITION BY and ORDER
+	// BY clauses.
+	for _, f := range n.funcs[1:] {
+		if !n.funcs[0].samePartition(f) {
+			return nil, errors.AssertionFailedf(
+				"PARTITION BY clauses of window functions handled by the same "+
+					"windowNode are different: %v, %v", n.funcs[0].partitionIdxs, f.partitionIdxs,
 			)
-		} else {
-			// Set up the output routers from the previous stage.
-			// We use hash routers with hashing on the columns
-			// from PARTITION BY clause of window functions
-			// we're processing in the current stage.
-			for _, resultProc := range plan.ResultRouters {
-				plan.Processors[resultProc].Spec.Output[0] = execinfrapb.OutputRouterSpec{
-					Type:        execinfrapb.OutputRouterSpec_BY_HASH,
-					HashColumns: partitionIdxs,
-				}
-			}
-			// We have multiple streams, so we definitely have a processor planned
-			// on a remote node.
-			stageID := plan.NewStage(true /* containsRemoteProcessor */, false /* allowPartialDistribution */)
-
-			// We put a windower on each node and we connect it
-			// with all hash routers from the previous stage in
-			// a such way that each node has its designated
-			// SourceRouterSlot - namely, position in which
-			// a node appears in nodes.
-			prevStageRouters := plan.ResultRouters
-			prevStageResultTypes := plan.GetResultTypes()
-			plan.ResultRouters = make([]physicalplan.ProcessorIdx, 0, len(sqlInstanceIDs))
-			for bucket, sqlInstanceID := range sqlInstanceIDs {
-				proc := physicalplan.Processor{
-					SQLInstanceID: sqlInstanceID,
-					Spec: execinfrapb.ProcessorSpec{
-						Input: []execinfrapb.InputSyncSpec{{
-							Type:        execinfrapb.InputSyncSpec_PARALLEL_UNORDERED,
-							ColumnTypes: prevStageResultTypes,
-						}},
-						Core: execinfrapb.ProcessorCoreUnion{Windower: &windowerSpec},
-						Post: execinfrapb.PostProcessSpec{},
-						Output: []execinfrapb.OutputRouterSpec{{
-							Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
-						}},
-						StageID:     stageID,
-						ResultTypes: newResultTypes,
-					},
-				}
-				pIdx := plan.AddProcessor(proc)
-
-				for _, router := range prevStageRouters {
-					plan.Streams = append(plan.Streams, physicalplan.Stream{
-						SourceProcessor:  router,
-						SourceRouterSlot: bucket,
-						DestProcessor:    pIdx,
-						DestInput:        0,
-					})
-				}
-				plan.ResultRouters = append(plan.ResultRouters, pIdx)
-			}
+		}
+		if !n.funcs[0].columnOrdering.Equal(f.columnOrdering) {
+			return nil, errors.AssertionFailedf(
+				"ORDER BY clauses of window functions handled by the same "+
+					"windowNode are different: %v, %v", n.funcs[0].columnOrdering, f.columnOrdering,
+			)
 		}
 	}
 
-	// We definitely added columns throughout all the stages of windowers, so we
-	// need to update PlanToStreamColMap. We need to update the map before adding
-	// rendering or projection because it is used there.
+	// All window functions in the windowNode will be computed using the single
+	// stage of windowers (because they have the same PARTITION BY and ORDER BY
+	// clauses). All input columns are being passed through, and windower will
+	// append output columns for each window function processed at the current
+	// stage.
+	windowerSpec := execinfrapb.WindowerSpec{
+		PartitionBy: partitionIdxs,
+		WindowFns:   make([]execinfrapb.WindowerSpec_WindowFn, len(n.funcs)),
+	}
+
+	newResultTypes := make([]*types.T, len(plan.GetResultTypes())+len(n.funcs))
+	copy(newResultTypes, plan.GetResultTypes())
+	for windowFnSpecIdx, windowFn := range n.funcs {
+		windowFnSpec, outputType, err := createWindowFnSpec(planCtx, plan, windowFn)
+		if err != nil {
+			return nil, err
+		}
+		newResultTypes[windowFn.outputColIdx] = outputType
+		windowerSpec.WindowFns[windowFnSpecIdx] = windowFnSpec
+	}
+
+	// Get all sqlInstanceIDs from the previous stage.
+	sqlInstanceIDs := getSQLInstanceIDsOfRouters(plan.ResultRouters, plan.Processors)
+	if len(partitionIdxs) == 0 || len(sqlInstanceIDs) == 1 {
+		// No PARTITION BY or we have a single node. Use a single windower. If
+		// the previous stage was all on a single node, put the windower there.
+		// Otherwise, bring the results back on this node.
+		sqlInstanceID := dsp.gatewaySQLInstanceID
+		if len(sqlInstanceIDs) == 1 {
+			sqlInstanceID = sqlInstanceIDs[0]
+		}
+		plan.AddSingleGroupStage(
+			sqlInstanceID,
+			execinfrapb.ProcessorCoreUnion{Windower: &windowerSpec},
+			execinfrapb.PostProcessSpec{},
+			newResultTypes,
+		)
+	} else {
+		// Set up the output routers from the previous stage. We use hash
+		// routers with hashing on the columns from PARTITION BY clause of
+		// window functions we're processing in the current stage.
+		for _, resultProc := range plan.ResultRouters {
+			plan.Processors[resultProc].Spec.Output[0] = execinfrapb.OutputRouterSpec{
+				Type:        execinfrapb.OutputRouterSpec_BY_HASH,
+				HashColumns: partitionIdxs,
+			}
+		}
+		// We have multiple streams, so we definitely have a processor planned
+		// on a remote node.
+		stageID := plan.NewStage(true /* containsRemoteProcessor */, false /* allowPartialDistribution */)
+
+		// We put a windower on each node and we connect it with all hash
+		// routers from the previous stage in a such way that each node has its
+		// designated SourceRouterSlot - namely, position in which a node
+		// appears in nodes.
+		prevStageRouters := plan.ResultRouters
+		prevStageResultTypes := plan.GetResultTypes()
+		plan.ResultRouters = make([]physicalplan.ProcessorIdx, 0, len(sqlInstanceIDs))
+		for bucket, sqlInstanceID := range sqlInstanceIDs {
+			proc := physicalplan.Processor{
+				SQLInstanceID: sqlInstanceID,
+				Spec: execinfrapb.ProcessorSpec{
+					Input: []execinfrapb.InputSyncSpec{{
+						Type:        execinfrapb.InputSyncSpec_PARALLEL_UNORDERED,
+						ColumnTypes: prevStageResultTypes,
+					}},
+					Core: execinfrapb.ProcessorCoreUnion{Windower: &windowerSpec},
+					Post: execinfrapb.PostProcessSpec{},
+					Output: []execinfrapb.OutputRouterSpec{{
+						Type: execinfrapb.OutputRouterSpec_PASS_THROUGH,
+					}},
+					StageID:     stageID,
+					ResultTypes: newResultTypes,
+				},
+			}
+			pIdx := plan.AddProcessor(proc)
+
+			for _, router := range prevStageRouters {
+				plan.Streams = append(plan.Streams, physicalplan.Stream{
+					SourceProcessor:  router,
+					SourceRouterSlot: bucket,
+					DestProcessor:    pIdx,
+					DestInput:        0,
+				})
+			}
+			plan.ResultRouters = append(plan.ResultRouters, pIdx)
+		}
+	}
+
+	// We definitely added new columns, so we need to update PlanToStreamColMap.
+	// We need to update the map before adding rendering or projection because
+	// it is used there.
 	plan.PlanToStreamColMap = identityMap(plan.PlanToStreamColMap, len(plan.GetResultTypes()))
 
 	// windowers do not guarantee maintaining the order at the moment, so we
@@ -3864,9 +3874,9 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 	// defensively (see #35179).
 	plan.SetMergeOrdering(execinfrapb.Ordering{})
 
-	// After all window functions are computed, we need to add rendering or
+	// After the window functions are computed, we need to add rendering or
 	// projection.
-	if err := windowPlanState.addRenderingOrProjection(); err != nil {
+	if err := addRenderingOrProjection(n, planCtx, plan); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -304,7 +304,7 @@ func (e *distSQLSpecExecFactory) checkExprsAndMaybeMergeLastStage(
 	// of processors (if there is such).
 	recommendation := shouldDistribute
 	if physPlan != nil && !physPlan.IsLastStageDistributed() {
-		recommendation = shouldNotDistribute
+		recommendation = cannotDistribute
 	}
 	for _, expr := range exprs {
 		if err := checkExpr(expr); err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_window
@@ -1,0 +1,87 @@
+# LogicTest: 5node
+
+statement ok
+CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, _bool BOOL, _bytes BYTES, _bit BIT, PRIMARY KEY (a, b, c, d))
+
+# Split into ten parts.
+statement ok
+ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)
+
+# Relocate the ten parts to the five nodes.
+statement ok
+ALTER TABLE data EXPERIMENTAL_RELOCATE
+  SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
+
+# Verify data placement.
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM TABLE data]
+----
+start_key  end_key  replicas  lease_holder
+NULL       /1       {1}       1
+/1         /2       {2}       2
+/2         /3       {3}       3
+/3         /4       {4}       4
+/4         /5       {5}       5
+/5         /6       {1}       1
+/6         /7       {2}       2
+/7         /8       {3}       3
+/8         /9       {4}       4
+/9         NULL     {5}       5
+
+# Verify that the window functions with the same PARTITION BY clause are
+# evaluated as a single distributed windower stage followed by a couple of
+# single-node stages.
+query T
+EXPLAIN (DISTSQL) SELECT
+  avg(a) OVER (),
+  min(b) OVER (PARTITION BY a),
+  avg(c) OVER (ORDER BY b),
+  max(c) OVER (PARTITION BY a)
+FROM data
+----
+distribution: full
+vectorized: true
+·
+• window
+│
+└── • window
+    │
+    └── • window
+        │
+        └── • scan
+              missing stats
+              table: data@data_pkey
+              spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy8lVFv2jwUhu-_X2Gdq0TfQcFOgDZXZi2bIrXQBdR1mtBkiNWi0YQlYWtV8d8nh1aUCGxGyG6qJs7j857nWPgFsp9z8KF3d3PVDfrEugyGo-HnK5sMe1e9ixERv-4tYZPBbS8klo3kcRZbk7fnm244CkbBoE8-fCXCxuLr6dvqILzshWplojjxtFkpceRjOLgmkcgFIMRJJPviUWbgfwMKCAwQXEDwAKEFY4RFmkxlliWp-uSlAILoCfwmwixeLHP1eowwTVIJ_gvks3wuwYeRmMxlKEUkU6cJCJHMxWxelFGlufrzffFDPgPCRTJfPsaZTwSSCZIpIAwXQr1oOJSIOCKUJPmDTGG8QkiW-WvZTbXJM3kQ2cN2HU5hvBojZLm4l-DTFe6Jv9lnGSdpJFMZbe1U7FJu8MssjpLfMnVa21Xf2_YJV06vg77Fma3-695Z3LVLfWwyspoy0tIIurefLE5VosEyVymRM-Qu8jZyD3lrb0B3b0BtebqjvGu_O7Sc_b9JoxIg7yBv783hbeWgh59FevRZdGjDYTWdRnqySbdrO43scMnseMms4bg1SWYnk9ypTbJ7uGT3eMluw_FqkuyeTPJZbZK9wyV7x0v2Gk6rJsneySSf_5PLa0eCUGaLJM5kKevunZuqBxndy3XDWbJMp_ImTaZFmfXjoOCKn9JIZvl69fUhiNdLKuDhcKsK3KkCn1eBqaFpWqab72mmh5kWdrfgZhl2tTBletqrMmk9bJi0HjZMWg8bJm3o2dB0q8qk21V062GDbj1s0K2HDboNPRua7lTRfVZFtx426NbDBt162KDb0LOh6fMqummle8NAG4QbaINxA21Qburb1PjfXR7j1X9_AgAA__-og3q5
+
+# Verify that all window functions with the PARTITION BY clause are distributed.
+query T
+EXPLAIN (DISTSQL) SELECT
+  avg(a) OVER (),
+  min(b) OVER (PARTITION BY a),
+  max(c) OVER (PARTITION BY a ORDER BY b),
+  avg(c) OVER (ORDER BY b),
+  max(d) OVER (PARTITION BY b ORDER BY c),
+  min(d) OVER (PARTITION BY a)
+FROM data
+----
+distribution: full
+vectorized: true
+·
+• window
+│
+└── • window
+    │
+    └── • window
+        │
+        └── • window
+            │
+            └── • window
+                │
+                └── • scan
+                      missing stats
+                      table: data@data_pkey
+                      spans: FULL SCAN
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJzMmN9v4kYQx9_7V6zmCdRFsGvz82nTO1oh5UJK0PWqClULXiWoxKa2ae8U5X-v7CSXmB8zoLEbXhDG_uzMd2e_o8EPkPy9ggEMv1xfXoyuRO3j6GZ68-tlXdwML4cfpsL-c1uzdTH-PJyIWl2K-2VYm79cX19MpqPpaHwlfvpd2Oyu_Vpb7L8rxpOPw0n2dV6X-bLfHyzcyZYI9i4xf11i8ZzJ_gdtXfw8GX8SgU0tSAijwF3Ze5fA4A9QIEGDBA8k-CChDTMJ6zhauCSJ4uyRhxwYBV9h0JKwDNebNPt5JmERxQ4GD5Au05WDAUztfOUmzgYubrZAQuBSu1zlYbLQJvv4c_2X-wYSPkSrzX2YDISVYi7FQooAJNysbfZbo6mEDQOhRJTeuRhmjxKiTfoc-TXg_Ju4s8ldMZRRMHucSUhSe-tgoB7lAQWv62zCKA5c7ILCSvkq2xp_W4ZB9K-Lm-1i1LcbPhAm29ZPo6ua0fWXb36dpUNXpEO1aCEXX2rGq785mEb_mOkab9LsEWm0NJ40vjRtabrSdE5UqgtKvaqU4iXTL0r9glLvsNKOND1pultiX4X4FQnRWyW7-PxLzaj9afZfMu1K0zuYaftgpmgeak8eh8_J9zxUK9-4_sF0OoV01PFdR3G6TlM1mrqivqNKK37nXftOeTqUOu--U6JSvGRV9x19vH00yz660fQqso8urRjdd7VPeTqUPm_7lKgUL1nV9vGOt4_Hso_XaPoV2ccrrRi9d7VPeTqUd972KVEpXrKq7eMfbx-fZR-_0WxXZB-_tGL039U-5elQ_nnbp0SleMn-zz-Ne9KcuGQdhYnbErR_5VYm1AW37mlXkmgTL9x1HC3yME-X45zLp9_AJenT3eeLUfh0K0vweLjLgRUrtGqz6D5OK5TWHLjHgRUrtOqwVLdwWqO0x4GJauGwYoVWxBnHaU2ccW-bbr2lfRz2Ubjoj9Y23EZhrXG6w-kpOEzsNxGZFZrqKQRNnNIup6fgMNFTcJjqKQRN9BRCNdFTepyegsNEtXCY6ikETZxxnKZ6Sp_TUxRrWiBoQjYVmxecMjeFUxMDb2TgzQzMoYE5NfDGBsWaGwiaKhpvcqBw6rzzZgfFGh7UzvRwktFxmhJOxOYFJ41O4NSZ2ZmcTjI6TlNGx2nS6AROGZ1QThkdH58or-E0VTRidOMFJ42O46TRd2aok4xOzCIsmhJOxOYFJ41O4NSZ2RmkTjI6TlNGx2nS6AROGZ1QTr0IwCcp6u84TlOvAogpjhecfBmA45TR9c4khRp99vjDfwEAAP__ad9y-A==

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
@@ -169,6 +169,13 @@ func TestExecBuild_distsql_union(
 	runExecBuildLogicTest(t, "distsql_union")
 }
 
+func TestExecBuild_distsql_window(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "distsql_window")
+}
+
 func TestExecBuild_experimental_distsql_planning_5node(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -1334,22 +1334,22 @@ FROM kv WINDOW w as (ORDER BY v), w2 as (PARTITION BY v)
 ----
 project
  ├── columns: rank:10 rank:11 row_number:12 row_number:13 row_number:14
- └── window partition=(2) ordering=+4
+ └── window partition=() ordering=+2
       ├── columns: k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9 rank:10 rank:11 row_number:12 row_number:13 row_number:14
-      ├── window partition=(2)
-      │    ├── columns: k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9 rank:10 rank:11 row_number:12 row_number:14
-      │    ├── window partition=() ordering=+2
-      │    │    ├── columns: k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9 rank:10 rank:11
+      ├── window partition=(2) ordering=+4
+      │    ├── columns: k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9 row_number:12 row_number:13 row_number:14
+      │    ├── window partition=(2)
+      │    │    ├── columns: k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9 row_number:12 row_number:14
       │    │    ├── scan kv
       │    │    │    └── columns: k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9
       │    │    └── windows
-      │    │         ├── rank [as=rank:10]
-      │    │         └── rank [as=rank:11]
+      │    │         ├── row-number [as=row_number:12]
+      │    │         └── row-number [as=row_number:14]
       │    └── windows
-      │         ├── row-number [as=row_number:12]
-      │         └── row-number [as=row_number:14]
+      │         └── row-number [as=row_number:13]
       └── windows
-           └── row-number [as=row_number:13]
+           ├── rank [as=rank:10]
+           └── rank [as=rank:11]
 
 build
 SELECT

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -202,7 +202,19 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 		)
 	}
 
+	// First construct all frames with the PARTITION BY clause - this allows the
+	// execution to be more distributed.
 	for _, f := range frames {
+		if f.Partition.Empty() {
+			continue
+		}
+		outScope.expr = b.factory.ConstructWindow(outScope.expr, f.Windows, &f.WindowPrivate)
+	}
+	// Now construct all frames without the PARTITION BY clause.
+	for _, f := range frames {
+		if !f.Partition.Empty() {
+			continue
+		}
 		outScope.expr = b.factory.ConstructWindow(outScope.expr, f.Windows, &f.WindowPrivate)
 	}
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1087,7 +1087,6 @@ func (ef *execFactory) ConstructWindow(root exec.Node, wi exec.WindowInfo) (exec
 			expr:           wi.Exprs[i],
 			args:           wi.Exprs[i].Exprs,
 			argsIdxs:       argsIdxs,
-			window:         p,
 			filterColIdx:   wi.FilterIdxs[i],
 			outputColIdx:   wi.OutputIdxs[i],
 			partitionIdxs:  partitionIdxs,

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -74,8 +74,6 @@ var _ tree.TypedExpr = &windowFuncHolder{}
 var _ tree.VariableExpr = &windowFuncHolder{}
 
 type windowFuncHolder struct {
-	window *windowNode
-
 	expr *tree.FuncExpr
 	args []tree.Expr
 
@@ -88,7 +86,7 @@ type windowFuncHolder struct {
 	frame          *tree.WindowFrame
 }
 
-// samePartition returns whether f and other have the same PARTITION BY clause.
+// samePartition returns whether w and other have the same PARTITION BY clause.
 func (w *windowFuncHolder) samePartition(other *windowFuncHolder) bool {
 	if len(w.partitionIdxs) != len(other.partitionIdxs) {
 		return false


### PR DESCRIPTION
**sql: remove shouldNotDistribute recommendation**

It doesn't seem to be used much.

Release note: None

**sql: improve physical planning of window functions**

This commit improves the physical planning of window functions in
several ways.

First, the optimizer is updated so that all window functions with a
PARTITION BY clause are constructed first followed by the remaining
window functions without PARTITION BY. This is needed by the execution
which can only evaluate functions with PARTITION BY in the distributed
fashion - as a result of this change, we are now more likely to get
partial distributed execution (previously things depended on the order
in which window functions were mentioned in the query).

Second, the physical planner now thinks that we "should distribute" the
plan if it finds at least one window function with PARTITION BY clause.
Previously, we didn't make any recommendation about the distribution
based on the presence of the window functions (i.e. we relied on the
rest of the plan to do so), but they can be quite computation-intensive,
so whenever we can distribute the execution, we should do so.

Additionally, this commit removes some of the code in the physical
planner which tries to find window functions with the same PARTITION BY
and ORDER BY clauses - that code has been redundant for long time given
that the optimizer does that too.

Release note: None