### PR TITLE
storage: improve range key clearing

### DIFF
--- a/docs/tech-notes/mvcc-range-tombstones.md
+++ b/docs/tech-notes/mvcc-range-tombstones.md
@@ -223,6 +223,9 @@ as conflict checks and stats updates, similarly to other `Writer` methods.
 * `PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte)`: Writes
   a raw range key directly to Pebble. Only for specialized low-level use.
 
+* `ClearEngineRangeKey(start, end roachpb.Key, suffix []byte)`: Clears a raw
+  range key directly in Pebble. Only for specialized low-level use.
+
 Other `Writer` methods may also affect range keys, e.g. `ClearMVCCRange`, but
 they rely on these primitives internally. See the interface documentation for
 details.

--- a/docs/tech-notes/mvcc-range-tombstones.md
+++ b/docs/tech-notes/mvcc-range-tombstones.md
@@ -210,11 +210,11 @@ as conflict checks and stats updates, similarly to other `Writer` methods.
   Does not affect range keys at other timestamps (except fragmentation),
   nor point keys.
 
-* `ClearAllRangeKeys(start, end roachpb.Key)`: Deletes all range keys (i.e.
-  at all timestamps) between the given key bounds using a Pebble range
-  tombstone. Can remove sections of range keys, or several range keys. Does
-  not affect point keys.
-
+* `ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys bool)`: Deletes
+  all range keys (i.e. at all timestamps) between the given key bounds using a
+  single Pebble `RANGEKEYDEL` tombstone when `rangeKeys` is true. Can remove
+  sections of range keys, or several range keys. Does not affect point keys.
+  
 * `PutRawMVCCRangeKey(MVCCRangeKey, []byte)`:  Like `PutMVCCRangeKey`, but
   takes an already-encoded `MVCCValue`. Can be used to avoid unnecessary
   decode/encode roundtrips when copying range keys, but should otherwise be

--- a/pkg/kv/kvserver/abortspan/abortspan.go
+++ b/pkg/kv/kvserver/abortspan/abortspan.go
@@ -78,7 +78,8 @@ func (sc *AbortSpan) max() roachpb.Key {
 func (sc *AbortSpan) ClearData(e storage.Engine) error {
 	b := e.NewUnindexedBatch(false /* writeOnly */)
 	defer b.Close()
-	if err := b.ClearMVCCIteratorRange(sc.min(), sc.max()); err != nil {
+	err := b.ClearMVCCIteratorRange(sc.min(), sc.max(), true /* pointKeys */, false /* rangeKeys */)
+	if err != nil {
 		return err
 	}
 	return b.Commit(false /* sync */)

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -74,7 +74,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		if err := batch.ClearUnversioned(outsideKey.Key); !isWriteSpanErr(err) {
 			t.Errorf("ClearUnversioned: unexpected error %v", err)
 		}
-		if err := batch.ClearRawRange(outsideKey.Key, outsideKey2.Key); !isWriteSpanErr(err) {
+		if err := batch.ClearRawRange(outsideKey.Key, outsideKey2.Key, true, true); !isWriteSpanErr(err) {
 			t.Errorf("ClearRawRange: unexpected error %v", err)
 		}
 		{
@@ -95,7 +95,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		if err := batch.ClearUnversioned(outsideKey3.Key); !isWriteSpanErr(err) {
 			t.Errorf("ClearUnversioned: unexpected error %v", err)
 		}
-		if err := batch.ClearRawRange(insideKey2.Key, outsideKey4.Key); !isWriteSpanErr(err) {
+		if err := batch.ClearRawRange(insideKey2.Key, outsideKey4.Key, true, true); !isWriteSpanErr(err) {
 			t.Errorf("ClearRawRange: unexpected error %v", err)
 		}
 		{

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -78,7 +78,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 			t.Errorf("ClearRawRange: unexpected error %v", err)
 		}
 		{
-			err := batch.ClearMVCCIteratorRange(outsideKey.Key, outsideKey2.Key)
+			err := batch.ClearMVCCIteratorRange(outsideKey.Key, outsideKey2.Key, true, true)
 			if !isWriteSpanErr(err) {
 				t.Errorf("ClearMVCCIteratorRange: unexpected error %v", err)
 			}
@@ -99,7 +99,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 			t.Errorf("ClearRawRange: unexpected error %v", err)
 		}
 		{
-			err := batch.ClearMVCCIteratorRange(outsideKey2.Key, outsideKey4.Key)
+			err := batch.ClearMVCCIteratorRange(outsideKey2.Key, outsideKey4.Key, true, true)
 			if !isWriteSpanErr(err) {
 				t.Errorf("ClearMVCCIteratorRange: unexpected error %v", err)
 			}
@@ -321,7 +321,7 @@ func TestSpanSetBatchTimestamps(t *testing.T) {
 			t.Errorf("ClearUnversioned: unexpected error %v", err)
 		}
 		{
-			err := batch.ClearMVCCIteratorRange(wkey.Key, wkey.Key)
+			err := batch.ClearMVCCIteratorRange(wkey.Key, wkey.Key, true, true)
 			if !isWriteSpanErr(err) {
 				t.Errorf("ClearMVCCIteratorRange: unexpected error %v", err)
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -134,7 +134,13 @@ func ClearRange(
 		return pd, nil
 	}
 
-	if err := readWriter.ClearMVCCRange(from, to); err != nil {
+	// If we're writing Pebble range tombstones, use ClearRangeWithHeuristic to
+	// avoid writing tombstones across empty spans -- in particular, across the
+	// range key span, since we expect range keys to be rare.
+	const pointKeyThreshold, rangeKeyThreshold = 2, 2
+	if err := storage.ClearRangeWithHeuristic(
+		readWriter, readWriter, from, to, pointKeyThreshold, rangeKeyThreshold,
+	); err != nil {
 		return result.Result{}, err
 	}
 	return pd, nil

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -127,7 +127,8 @@ func ClearRange(
 	if statsDelta.ContainsEstimates == 0 && statsDelta.Total() < ClearRangeBytesThreshold {
 		log.VEventf(ctx, 2, "delta=%d < threshold=%d; using non-range clear",
 			statsDelta.Total(), ClearRangeBytesThreshold)
-		if err = readWriter.ClearMVCCIteratorRange(from, to); err != nil {
+		err = readWriter.ClearMVCCIteratorRange(from, to, true /* pointKeys */, true /* rangeKeys */)
+		if err != nil {
 			return result.Result{}, err
 		}
 		return pd, nil

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -37,9 +37,11 @@ type wrappedBatch struct {
 	clearRangeCount int
 }
 
-func (wb *wrappedBatch) ClearMVCCIteratorRange(start, end roachpb.Key) error {
+func (wb *wrappedBatch) ClearMVCCIteratorRange(
+	start, end roachpb.Key, pointKeys, rangeKeys bool,
+) error {
 	wb.clearIterCount++
-	return wb.Batch.ClearMVCCIteratorRange(start, end)
+	return wb.Batch.ClearMVCCIteratorRange(start, end, pointKeys, rangeKeys)
 }
 
 func (wb *wrappedBatch) ClearMVCCRange(start, end roachpb.Key) error {

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -33,8 +33,7 @@ import (
 
 type wrappedBatch struct {
 	storage.Batch
-	clearIterCount  int
-	clearRangeCount int
+	clearIterCount int
 }
 
 func (wb *wrappedBatch) ClearMVCCIteratorRange(
@@ -42,11 +41,6 @@ func (wb *wrappedBatch) ClearMVCCIteratorRange(
 ) error {
 	wb.clearIterCount++
 	return wb.Batch.ClearMVCCIteratorRange(start, end, pointKeys, rangeKeys)
-}
-
-func (wb *wrappedBatch) ClearMVCCRange(start, end roachpb.Key) error {
-	wb.clearRangeCount++
-	return wb.Batch.ClearMVCCRange(start, end)
 }
 
 // TestCmdClearRange verifies that ClearRange clears point and range keys in the
@@ -205,9 +199,8 @@ func TestCmdClearRange(t *testing.T) {
 
 				require.NoError(t, batch.Commit(true /* sync */))
 
-				// Verify that we see the correct counts for ClearMVCCIteratorRange and ClearMVCCRange.
+				// Verify that we see the correct counts for ClearMVCCIteratorRange.
 				require.Equal(t, tc.expClearIter, batch.clearIterCount == 1)
-				require.Equal(t, tc.expClearIter, batch.clearRangeCount == 0)
 
 				// Ensure that the data is gone.
 				iter := eng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3835,7 +3835,12 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			sst := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
 			defer sst.Close()
 			s := rditer.MakeRangeIDLocalKeySpan(rangeID, false /* replicatedOnly */)
-			if err := sst.ClearRawRange(s.Key, s.EndKey, true, true); err != nil {
+			// The snapshot code will use ClearRangeWithHeuristic with a threshold of
+			// 1 to clear the range, but this will truncate the range tombstone to the
+			// first key. In this case, the first key is RangeGCThresholdKey, which
+			// doesn't yet exist in the engine, so we write the Pebble range tombstone
+			// manually.
+			if err := sst.ClearRawRange(keys.RangeGCThresholdKey(rangeID), s.EndKey, true, false); err != nil {
 				return err
 			}
 			tombstoneKey := keys.RangeTombstoneKey(rangeID)
@@ -3861,7 +3866,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			EndKey:   roachpb.RKey(keyEnd),
 		}
 		s := rditer.MakeUserKeySpan(&desc)
-		if err := storage.ClearRangeWithHeuristic(receivingEng, &sst, s.Key, s.EndKey); err != nil {
+		if err := storage.ClearRangeWithHeuristic(receivingEng, &sst, s.Key, s.EndKey, 64, 8); err != nil {
 			return err
 		}
 		if err = sst.Finish(); err != nil {
@@ -3877,6 +3882,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 				return err
 			}
 			if !bytes.Equal(actualSST, expectedSSTs[i]) {
+				t.Logf("%d=%s", i, sstNamesSubset[i])
 				mismatchedSstsIdx = append(mismatchedSstsIdx, i)
 			}
 		}

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3777,7 +3777,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		for _, span := range keySpans {
 			file := &storage.MemFile{}
 			writer := storage.MakeIngestionSSTWriter(ctx, st, file)
-			if err := writer.ClearRawRange(span.Key, span.EndKey); err != nil {
+			if err := writer.ClearRawRange(span.Key, span.EndKey, true, true); err != nil {
 				return err
 			}
 			sstFileWriters[string(span.Key)] = sstFileWriter{
@@ -3835,7 +3835,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 			sst := storage.MakeIngestionSSTWriter(ctx, st, sstFile)
 			defer sst.Close()
 			s := rditer.MakeRangeIDLocalKeySpan(rangeID, false /* replicatedOnly */)
-			if err := sst.ClearRawRange(s.Key, s.EndKey); err != nil {
+			if err := sst.ClearRawRange(s.Key, s.EndKey, true, true); err != nil {
 				return err
 			}
 			tombstoneKey := keys.RangeTombstoneKey(rangeID)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2193,7 +2193,7 @@ func handleTruncatedStateBelowRaftPreApply(
 	if numTruncatedEntries >= raftLogTruncationClearRangeThreshold {
 		start := prefixBuf.RaftLogKey(currentTruncatedState.Index + 1).Clone()
 		end := prefixBuf.RaftLogKey(suggestedTruncatedState.Index + 1).Clone() // end is exclusive
-		if err := readWriter.ClearRawRange(start, end); err != nil {
+		if err := readWriter.ClearRawRange(start, end, true, false); err != nil {
 			return false, errors.Wrapf(err,
 				"unable to clear truncated Raft entries for %+v between indexes %d-%d",
 				suggestedTruncatedState, currentTruncatedState.Index+1, suggestedTruncatedState.Index+1)

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -42,6 +42,26 @@ type replicaRaftStorage Replica
 
 var _ raft.Storage = (*replicaRaftStorage)(nil)
 
+const (
+	// clearRangeThresholdPointKeys is the threshold (as number of point keys)
+	// beyond which we'll clear range data using a Pebble range tombstone rather
+	// than individual Pebble point tombstones.
+	//
+	// It is expensive for there to be many Pebble range tombstones in the same
+	// sstable because all of the tombstones in an sstable are loaded whenever the
+	// sstable is accessed. So we avoid using range deletion unless there is some
+	// minimum number of keys. The value here was pulled out of thin air. It might
+	// be better to make this dependent on the size of the data being deleted. Or
+	// perhaps we should fix Pebble to handle large numbers of range tombstones in
+	// an sstable better.
+	clearRangeThresholdPointKeys = 64
+
+	// clearRangeThresholdRangeKeys is the threshold (as number of range keys)
+	// beyond which we'll clear range data using a single RANGEKEYDEL across the
+	// span rather than clearing individual range keys.
+	clearRangeThresholdRangeKeys = 8
+)
+
 // All calls to raft.RawNode require that both Replica.raftMu and
 // Replica.mu are held. All of the functions exposed via the
 // raft.Storage interface will in turn be called from RawNode, so none
@@ -727,16 +747,18 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 // clearRangeData clears the data associated with a range descriptor. If
 // rangeIDLocalOnly is true, then only the range-id local keys are deleted.
 // Otherwise, the range-id local keys, range local keys, and user keys are all
-// deleted. If mustClearRange is true, ClearRange will always be used to remove
-// the keys. Otherwise, ClearRangeWithHeuristic will be used, which chooses
-// ClearRange or ClearIterRange depending on how many keys there are in the
-// range.
+// deleted.
+//
+// If mustUseClearRange is true, a Pebble range tombstone will always be used to
+// clear the key spans (unless empty). This is typically used when we need to
+// write additional keys to an SST after this clear, e.g. a replica tombstone,
+// since keys must be written in order.
 func clearRangeData(
 	desc *roachpb.RangeDescriptor,
 	reader storage.Reader,
 	writer storage.Writer,
 	rangeIDLocalOnly bool,
-	mustClearRange bool,
+	mustUseClearRange bool,
 ) error {
 	var keySpans []roachpb.Span
 	if rangeIDLocalOnly {
@@ -744,17 +766,16 @@ func clearRangeData(
 	} else {
 		keySpans = rditer.MakeAllKeySpans(desc)
 	}
-	var clearRangeFn func(storage.Reader, storage.Writer, roachpb.Key, roachpb.Key) error
-	if mustClearRange {
-		clearRangeFn = func(reader storage.Reader, writer storage.Writer, start, end roachpb.Key) error {
-			return writer.ClearRawRange(start, end, true, true)
-		}
-	} else {
-		clearRangeFn = storage.ClearRangeWithHeuristic
+
+	pointKeyThreshold, rangeKeyThreshold := clearRangeThresholdPointKeys, clearRangeThresholdRangeKeys
+	if mustUseClearRange {
+		pointKeyThreshold, rangeKeyThreshold = 1, 1
 	}
 
 	for _, keySpan := range keySpans {
-		if err := clearRangeFn(reader, writer, keySpan.Key, keySpan.EndKey); err != nil {
+		if err := storage.ClearRangeWithHeuristic(
+			reader, writer, keySpan.Key, keySpan.EndKey, pointKeyThreshold, rangeKeyThreshold,
+		); err != nil {
 			return err
 		}
 	}
@@ -1175,6 +1196,8 @@ func (r *Replica) clearSubsumedReplicaDiskData(
 				&subsumedReplSST,
 				keySpans[i].EndKey,
 				totalKeySpans[i].EndKey,
+				clearRangeThresholdPointKeys,
+				clearRangeThresholdRangeKeys,
 			); err != nil {
 				subsumedReplSST.Close()
 				return err

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -310,7 +310,7 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 			sstFile := &storage.MemFile{}
 			sst := storage.MakeIngestionSSTWriter(ctx, cluster.MakeTestingClusterSettings(), sstFile)
 			defer sst.Close()
-			err := sst.ClearRawRange(s.Key, s.EndKey)
+			err := sst.ClearRawRange(s.Key, s.EndKey, true, true)
 			require.NoError(t, err)
 			err = sst.Finish()
 			require.NoError(t, err)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -560,9 +560,6 @@ func (s spanSetWriter) ClearIntent(
 }
 
 func (s spanSetWriter) ClearEngineKey(key storage.EngineKey) error {
-	if !s.spansOnly {
-		panic("cannot do timestamp checking for clearing EngineKey")
-	}
 	if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -651,16 +651,6 @@ func (s spanSetWriter) ClearMVCCRangeKey(rangeKey storage.MVCCRangeKey) error {
 	return s.w.ClearMVCCRangeKey(rangeKey)
 }
 
-func (s spanSetWriter) ClearAllRangeKeys(start, end roachpb.Key) error {
-	if !s.spansOnly {
-		panic("cannot do timestamp checking for ClearAllRangeKeys")
-	}
-	if err := s.checkAllowedRange(start, end); err != nil {
-		return err
-	}
-	return s.w.ClearAllRangeKeys(start, end)
-}
-
 func (s spanSetWriter) Merge(key storage.MVCCKey, value []byte) error {
 	if s.spansOnly {
 		if err := s.spans.CheckAllowed(SpanReadWrite, roachpb.Span{Key: key.Key}); err != nil {

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -644,6 +644,16 @@ func (s spanSetWriter) PutEngineRangeKey(start, end roachpb.Key, suffix, value [
 	return s.w.PutEngineRangeKey(start, end, suffix, value)
 }
 
+func (s spanSetWriter) ClearEngineRangeKey(start, end roachpb.Key, suffix []byte) error {
+	if !s.spansOnly {
+		panic("cannot do timestamp checking for ClearEngineRangeKey")
+	}
+	if err := s.checkAllowedRange(start, end); err != nil {
+		return err
+	}
+	return s.w.ClearEngineRangeKey(start, end, suffix)
+}
+
 func (s spanSetWriter) ClearMVCCRangeKey(rangeKey storage.MVCCRangeKey) error {
 	if err := s.checkAllowedRange(rangeKey.StartKey, rangeKey.EndKey); err != nil {
 		return err

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -592,11 +592,11 @@ func (s spanSetWriter) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKey
 	return s.w.ClearRawRange(start, end, pointKeys, rangeKeys)
 }
 
-func (s spanSetWriter) ClearMVCCRange(start, end roachpb.Key) error {
+func (s spanSetWriter) ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ClearMVCCRange(start, end)
+	return s.w.ClearMVCCRange(start, end, pointKeys, rangeKeys)
 }
 
 func (s spanSetWriter) ClearMVCCVersions(start, end storage.MVCCKey) error {

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -588,11 +588,11 @@ func (s spanSetWriter) checkAllowedRange(start, end roachpb.Key) error {
 	return nil
 }
 
-func (s spanSetWriter) ClearRawRange(start, end roachpb.Key) error {
+func (s spanSetWriter) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ClearRawRange(start, end)
+	return s.w.ClearRawRange(start, end, pointKeys, rangeKeys)
 }
 
 func (s spanSetWriter) ClearMVCCRange(start, end roachpb.Key) error {

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -609,11 +609,13 @@ func (s spanSetWriter) ClearMVCCVersions(start, end storage.MVCCKey) error {
 	return s.w.ClearMVCCVersions(start, end)
 }
 
-func (s spanSetWriter) ClearMVCCIteratorRange(start, end roachpb.Key) error {
+func (s spanSetWriter) ClearMVCCIteratorRange(
+	start, end roachpb.Key, pointKeys, rangeKeys bool,
+) error {
 	if err := s.checkAllowedRange(start, end); err != nil {
 		return err
 	}
-	return s.w.ClearMVCCIteratorRange(start, end)
+	return s.w.ClearMVCCIteratorRange(start, end, pointKeys, rangeKeys)
 }
 
 func (s spanSetWriter) PutMVCCRangeKey(

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -181,7 +181,9 @@ func (msstw *multiSSTWriter) initSST(ctx context.Context) error {
 	newSST := storage.MakeIngestionSSTWriter(ctx, msstw.st, newSSTFile)
 	msstw.currSST = newSST
 	if err := msstw.currSST.ClearRawRange(
-		msstw.keySpans[msstw.currSpan].Key, msstw.keySpans[msstw.currSpan].EndKey); err != nil {
+		msstw.keySpans[msstw.currSpan].Key, msstw.keySpans[msstw.currSpan].EndKey,
+		true /* pointKeys */, true, /* rangeKeys */
+	); err != nil {
 		msstw.currSST.Close()
 		return errors.Wrap(err, "failed to clear range on sst file writer")
 	}

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -352,7 +352,7 @@ func BenchmarkClearMVCCVersions_Pebble(b *testing.B) {
 func BenchmarkClearMVCCIteratorRange_Pebble(b *testing.B) {
 	ctx := context.Background()
 	runClearRange(ctx, b, setupMVCCPebble, func(eng Engine, batch Batch, start, end MVCCKey) error {
-		return batch.ClearMVCCIteratorRange(start.Key, end.Key)
+		return batch.ClearMVCCIteratorRange(start.Key, end.Key, true, true)
 	})
 }
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -715,6 +715,13 @@ type Writer interface {
 	// It is safe to modify the contents of the arguments after it returns.
 	PutEngineRangeKey(start, end roachpb.Key, suffix, value []byte) error
 
+	// ClearEngineRangeKey clears the given range key. This is a general-purpose
+	// and low-level method that should be used sparingly, only when the other
+	// Clear* methods are not applicable.
+	//
+	// It is safe to modify the contents of the arguments after it returns.
+	ClearEngineRangeKey(start, end roachpb.Key, suffix []byte) error
+
 	// Merge is a high-performance write operation used for values which are
 	// accumulated over several writes. Multiple values can be merged
 	// sequentially into a single key; a subsequent read will return a "merged"

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -636,17 +636,17 @@ type Writer interface {
 	// It is safe to modify the contents of the arguments after it returns.
 	ClearEngineKey(key EngineKey) error
 
-	// ClearRawRange removes both point keys and range keys from start (inclusive)
-	// to end (exclusive) using a Pebble range tombstone. It can be applied to a
-	// range consisting of MVCCKeys or the more general EngineKeys -- it simply
-	// uses the roachpb.Key parameters as the Key field of an EngineKey. This
-	// implies that it does not clear intents unless the intent lock table is
-	// targeted explicitly.
+	// ClearRawRange removes point and/or range keys from start (inclusive) to end
+	// (exclusive) using Pebble range tombstones. It can be applied to a range
+	// consisting of MVCCKeys or the more general EngineKeys -- it simply uses the
+	// roachpb.Key parameters as the Key field of an EngineKey. This implies that
+	// it does not clear intents unless the intent lock table is targeted
+	// explicitly.
 	//
 	// Similar to the other Clear* methods, this method actually removes entries
 	// from the storage engine. It is safe to modify the contents of the arguments
 	// after it returns.
-	ClearRawRange(start, end roachpb.Key) error
+	ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error
 	// ClearMVCCRange removes MVCC keys from start (inclusive) to end (exclusive)
 	// using a Pebble range tombstone. It will remove everything in the span,
 	// including intents and range keys.
@@ -1224,7 +1224,7 @@ func ClearRangeWithHeuristic(reader Reader, writer Writer, start, end roachpb.Ke
 	for valid {
 		count++
 		if count > clearRangeMinKeys {
-			return writer.ClearRawRange(start, end)
+			return writer.ClearRawRange(start, end, true, true)
 		}
 		valid, err = iter.NextEngineKey()
 	}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -665,14 +665,18 @@ type Writer interface {
 	// from the storage engine. It is safe to modify the contents of the arguments
 	// after it returns.
 	ClearMVCCVersions(start, end MVCCKey) error
-	// ClearMVCCIteratorRange removes all keys in the given span using an MVCC
-	// iterator, by clearing individual keys (including intents) with Pebble point
-	// tombstones. It will also clear all range keys in the span.
+	// ClearMVCCIteratorRange removes all point and/or range keys in the given
+	// span using an MVCC iterator, by clearing individual keys (including
+	// intents).
 	//
 	// Similar to the other Clear* methods, this method actually removes entries
 	// from the storage engine. It is safe to modify the contents of the arguments
 	// after it returns.
-	ClearMVCCIteratorRange(start, end roachpb.Key) error
+	//
+	// TODO(erikgrinaker): This should be a separate function rather than an
+	// interface method, but we keep it for now to make use of UnsafeRawKey() when
+	// clearing keys.
+	ClearMVCCIteratorRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error
 
 	// ClearAllRangeKeys deletes all range keys (and all versions) from start
 	// (inclusive) to end (exclusive). This can be used both for MVCC range keys

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1192,78 +1192,124 @@ func WriteSyncNoop(eng Engine) error {
 }
 
 // ClearRangeWithHeuristic clears the keys from start (inclusive) to end
-// (exclusive), including any range keys. Depending on the number of keys, it
-// will either use ClearRawRange or clear individual keys. It works with
-// EngineKeys, so don't expect it to find and clear separated intents if
-// [start,end) refers to MVCC key space.
-func ClearRangeWithHeuristic(reader Reader, writer Writer, start, end roachpb.Key) error {
-	iter := reader.NewEngineIterator(IterOptions{UpperBound: end})
-	defer iter.Close()
+// (exclusive), including any range keys, but does not clear intents unless the
+// lock table is targeted explicitly. Depending on the number of keys, it will
+// either write a Pebble range tombstone or clear individual keys. If it uses
+// a range tombstone, it will tighten the span to the first encountered key.
+//
+// pointKeyThreshold and rangeKeyThreshold specify the number of point/range
+// keys respectively where it will switch from clearing individual keys to
+// Pebble range tombstones (RANGEDEL or RANGEKEYDEL respectively). A threshold
+// of 0 disables checking for and clearing that key type.
+//
+// NB: An initial scan will be done to determine the type of clear, so a large
+// threshold will potentially involve scanning a large number of keys twice.
+//
+// TODO(erikgrinaker): Consider tightening the end of the range tombstone span
+// too, by doing a SeekLT when we reach the threshold. It's unclear whether it's
+// really worth it.
+func ClearRangeWithHeuristic(
+	r Reader, w Writer, start, end roachpb.Key, pointKeyThreshold, rangeKeyThreshold int,
+) error {
+	clearPointKeys := func(r Reader, w Writer, start, end roachpb.Key, threshold int) error {
+		iter := r.NewEngineIterator(IterOptions{
+			KeyTypes:   IterKeyTypePointsOnly,
+			LowerBound: start,
+			UpperBound: end,
+		})
+		defer iter.Close()
 
-	// It is expensive for there to be many range deletion tombstones in the same
-	// sstable because all of the tombstones in an sstable are loaded whenever the
-	// sstable is accessed. So we avoid using range deletion unless there is some
-	// minimum number of keys. The value here was pulled out of thin air. It might
-	// be better to make this dependent on the size of the data being deleted. Or
-	// perhaps we should fix Pebble to handle large numbers of tombstones in an
-	// sstable better. Note that we are referring to storage-level tombstones here,
-	// and not MVCC tombstones.
-	const clearRangeMinKeys = 64
-	// Peek into the range to see whether it's large enough to justify
-	// ClearRawRange. Note that the work done here is bounded by
-	// clearRangeMinKeys, so it will be fairly cheap even for large
-	// ranges.
-	//
-	// TODO(sumeer): Could add the iterated keys to the batch, so we don't have
-	// to do the scan again. If there are too many keys, this will mean a mix of
-	// point tombstones and range tombstone.
-	count := 0
-	valid, err := iter.SeekEngineKeyGE(EngineKey{Key: start})
-	for valid {
-		count++
-		if count > clearRangeMinKeys {
-			return writer.ClearRawRange(start, end, true, true)
+		// Scan, and drop a RANGEDEL if we reach the threshold. We tighten the span
+		// to the first encountered key, since we can cheaply do so.
+		var ok bool
+		var err error
+		var count int
+		var firstKey roachpb.Key
+		for ok, err = iter.SeekEngineKeyGE(EngineKey{Key: start}); ok; ok, err = iter.NextEngineKey() {
+			count++
+			if len(firstKey) == 0 {
+				key, err := iter.UnsafeEngineKey()
+				if err != nil {
+					return err
+				}
+				firstKey = key.Key.Clone()
+			}
+			if count >= threshold {
+				return w.ClearRawRange(firstKey, end, true /* pointKeys */, false /* rangeKeys */)
+			}
 		}
-		valid, err = iter.NextEngineKey()
-	}
-	if err != nil {
+		if err != nil || count == 0 {
+			return err
+		}
+		// Clear individual points.
+		for ok, err = iter.SeekEngineKeyGE(EngineKey{Key: start}); ok; ok, err = iter.NextEngineKey() {
+			key, err := iter.UnsafeEngineKey()
+			if err != nil {
+				return err
+			}
+			if err = w.ClearEngineKey(key); err != nil {
+				return err
+			}
+		}
 		return err
 	}
-	valid, err = iter.SeekEngineKeyGE(EngineKey{Key: start})
-	for valid {
-		var k EngineKey
-		if k, err = iter.UnsafeEngineKey(); err != nil {
-			break
+
+	clearRangeKeys := func(r Reader, w Writer, start, end roachpb.Key, threshold int) error {
+		iter := r.NewEngineIterator(IterOptions{
+			KeyTypes:   IterKeyTypeRangesOnly,
+			LowerBound: start,
+			UpperBound: end,
+		})
+		defer iter.Close()
+
+		// Scan, and drop a RANGEKEYDEL if we reach the threshold.
+		var ok bool
+		var err error
+		var count int
+		var firstKey roachpb.Key
+		for ok, err = iter.SeekEngineKeyGE(EngineKey{Key: start}); ok; ok, err = iter.NextEngineKey() {
+			count += len(iter.EngineRangeKeys())
+			if len(firstKey) == 0 {
+				bounds, err := iter.EngineRangeBounds()
+				if err != nil {
+					return err
+				}
+				firstKey = bounds.Key.Clone()
+			}
+			if count >= threshold {
+				return w.ClearRawRange(firstKey, end, false /* pointKeys */, true /* rangeKeys */)
+			}
 		}
-		if err = writer.ClearEngineKey(k); err != nil {
-			break
+		if err != nil || count == 0 {
+			return err
 		}
-		valid, err = iter.NextEngineKey()
-	}
-	if err != nil {
+		// Clear individual range keys.
+		for ok, err = iter.SeekEngineKeyGE(EngineKey{Key: start}); ok; ok, err = iter.NextEngineKey() {
+			bounds, err := iter.EngineRangeBounds()
+			if err != nil {
+				return err
+			}
+			for _, v := range iter.EngineRangeKeys() {
+				if err := w.ClearEngineRangeKey(bounds.Key, bounds.EndKey, v.Version); err != nil {
+					return err
+				}
+			}
+		}
 		return err
 	}
 
-	// Use a separate iterator to look for any range keys, to avoid dropping
-	// unnecessary range keys.
-	//
-	// TODO(erikgrinaker): Review the engine clear methods and heuristics to come
-	// up with a better scheme for avoiding dropping unnecessary range tombstones
-	// across range key spans.
-	iter = reader.NewEngineIterator(IterOptions{
-		KeyTypes:   IterKeyTypeRangesOnly,
-		LowerBound: start,
-		UpperBound: end,
-	})
-	defer iter.Close()
+	if pointKeyThreshold > 0 {
+		if err := clearPointKeys(r, w, start, end, pointKeyThreshold); err != nil {
+			return err
+		}
+	}
 
-	valid, err = iter.SeekEngineKeyGE(EngineKey{Key: start})
-	if err != nil {
-		return err
+	if rangeKeyThreshold > 0 {
+		if err := clearRangeKeys(r, w, start, end, rangeKeyThreshold); err != nil {
+			return err
+		}
 	}
-	if valid {
-		return writer.ClearRawRange(start, end, false, true)
-	}
+
 	return nil
 }
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -647,14 +647,13 @@ type Writer interface {
 	// from the storage engine. It is safe to modify the contents of the arguments
 	// after it returns.
 	ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error
-	// ClearMVCCRange removes MVCC keys from start (inclusive) to end (exclusive)
-	// using a Pebble range tombstone. It will remove everything in the span,
-	// including intents and range keys.
+	// ClearMVCCRange removes MVCC point and/or range keys (including intents)
+	// from start (inclusive) to end (exclusive) using Pebble range tombstones.
 	//
 	// Similar to the other Clear* methods, this method actually removes entries
 	// from the storage engine. It is safe to modify the contents of the arguments
 	// after it returns.
-	ClearMVCCRange(start, end roachpb.Key) error
+	ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error
 	// ClearMVCCVersions removes MVCC point key versions from start (inclusive) to
 	// end (exclusive) using a Pebble range tombstone. It is meant for efficiently
 	// clearing a subset of versions of a key, since the parameters are MVCCKeys

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1707,11 +1707,28 @@ func TestEngineClearRange(t *testing.T) {
 
 		"ClearMVCCIteratorRange": {
 			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
-				return rw.ClearMVCCIteratorRange(start, end)
+				return rw.ClearMVCCIteratorRange(start, end, true /* pointKeys */, true /* rangeKeys */)
 			},
 			clearsPointKeys: true,
 			clearsRangeKeys: true,
 			clearsIntents:   true,
+		},
+		"ClearMVCCIteratorRange point keys": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return rw.ClearMVCCIteratorRange(start, end, true /* pointKeys */, false /* rangeKeys */)
+			},
+			clearsPointKeys: true,
+			clearsRangeKeys: false,
+			clearsIntents:   true,
+		},
+
+		"ClearMVCCIteratorRange range keys": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return rw.ClearMVCCIteratorRange(start, end, false /* pointKeys */, true /* rangeKeys */)
+			},
+			clearsPointKeys: false,
+			clearsRangeKeys: true,
+			clearsIntents:   false,
 		},
 
 		"ClearMVCCVersions": {

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1699,11 +1699,27 @@ func TestEngineClearRange(t *testing.T) {
 
 		"ClearMVCCRange": {
 			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
-				return rw.ClearMVCCRange(start, end)
+				return rw.ClearMVCCRange(start, end, true /* pointKeys */, true /* rangeKeys */)
 			},
 			clearsPointKeys: true,
 			clearsRangeKeys: true,
 			clearsIntents:   true,
+		},
+		"ClearMVCCRange point keys": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return rw.ClearMVCCRange(start, end, true /* pointKeys */, false /* rangeKeys */)
+			},
+			clearsPointKeys: true,
+			clearsRangeKeys: false,
+			clearsIntents:   true,
+		},
+		"ClearMVCCRange range keys": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return rw.ClearMVCCRange(start, end, false /* pointKeys */, true /* rangeKeys */)
+			},
+			clearsPointKeys: false,
+			clearsRangeKeys: true,
+			clearsIntents:   false,
 		},
 
 		"ClearMVCCIteratorRange": {

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"path/filepath"
 	"reflect"
@@ -1740,11 +1741,51 @@ func TestEngineClearRange(t *testing.T) {
 			clearsIntents:   false,
 		},
 
-		"ClearRangeWithHeuristic": {
+		"ClearRangeWithHeuristic individual": {
 			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
-				return ClearRangeWithHeuristic(rw, rw, start, end)
+				return ClearRangeWithHeuristic(rw, rw, start, end, math.MaxInt, math.MaxInt)
 			},
 			clearsPointKeys: true,
+			clearsRangeKeys: true,
+			clearsIntents:   false,
+		},
+		"ClearRangeWithHeuristic ranged": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return ClearRangeWithHeuristic(rw, rw, start, end, 1, 1)
+			},
+			clearsPointKeys: true,
+			clearsRangeKeys: true,
+			clearsIntents:   false,
+		},
+		"ClearRangeWithHeuristic point keys individual": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return ClearRangeWithHeuristic(rw, rw, start, end, math.MaxInt, 0)
+			},
+			clearsPointKeys: true,
+			clearsRangeKeys: false,
+			clearsIntents:   false,
+		},
+		"ClearRangeWithHeuristic point keys ranged": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return ClearRangeWithHeuristic(rw, rw, start, end, 1, 0)
+			},
+			clearsPointKeys: true,
+			clearsRangeKeys: false,
+			clearsIntents:   false,
+		},
+		"ClearRangeWithHeuristic range keys individual": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return ClearRangeWithHeuristic(rw, rw, start, end, 0, math.MaxInt)
+			},
+			clearsPointKeys: false,
+			clearsRangeKeys: true,
+			clearsIntents:   false,
+		},
+		"ClearRangeWithHeuristic range keys ranged": {
+			clearRange: func(rw ReadWriter, start, end roachpb.Key) error {
+				return ClearRangeWithHeuristic(rw, rw, start, end, 0, 1)
+			},
+			clearsPointKeys: false,
 			clearsRangeKeys: true,
 			clearsIntents:   false,
 		},

--- a/pkg/storage/intent_reader_writer.go
+++ b/pkg/storage/intent_reader_writer.go
@@ -70,14 +70,20 @@ func (idw intentDemuxWriter) PutIntent(
 // ClearMVCCRange has the same behavior as Writer.ClearMVCCRange. buf is used as
 // scratch-space to avoid allocations -- its contents will be overwritten and
 // not appended to, and a possibly different buf returned.
-func (idw intentDemuxWriter) ClearMVCCRange(start, end roachpb.Key, buf []byte) ([]byte, error) {
-	err := idw.w.ClearRawRange(start, end, true, true)
-	if err != nil {
+func (idw intentDemuxWriter) ClearMVCCRange(
+	start, end roachpb.Key, pointKeys, rangeKeys bool, buf []byte,
+) ([]byte, error) {
+	if err := idw.w.ClearRawRange(start, end, pointKeys, rangeKeys); err != nil {
 		return buf, err
+	}
+	// The lock table only contains point keys, so only clear it when point keys
+	// are requested, and don't clear range keys in it.
+	if !pointKeys {
+		return buf, nil
 	}
 	lstart, buf := keys.LockTableSingleKey(start, buf)
 	lend, _ := keys.LockTableSingleKey(end, nil)
-	return buf, idw.w.ClearRawRange(lstart, lend, true, true)
+	return buf, idw.w.ClearRawRange(lstart, lend, true /* pointKeys */, false /* rangeKeys */)
 }
 
 // wrappableReader is used to implement a wrapped Reader. A wrapped Reader

--- a/pkg/storage/intent_reader_writer.go
+++ b/pkg/storage/intent_reader_writer.go
@@ -71,13 +71,13 @@ func (idw intentDemuxWriter) PutIntent(
 // scratch-space to avoid allocations -- its contents will be overwritten and
 // not appended to, and a possibly different buf returned.
 func (idw intentDemuxWriter) ClearMVCCRange(start, end roachpb.Key, buf []byte) ([]byte, error) {
-	err := idw.w.ClearRawRange(start, end)
+	err := idw.w.ClearRawRange(start, end, true, true)
 	if err != nil {
 		return buf, err
 	}
 	lstart, buf := keys.LockTableSingleKey(start, buf)
 	lend, _ := keys.LockTableSingleKey(end, nil)
-	return buf, idw.w.ClearRawRange(lstart, lend)
+	return buf, idw.w.ClearRawRange(lstart, lend, true, true)
 }
 
 // wrappableReader is used to implement a wrapped Reader. A wrapped Reader

--- a/pkg/storage/intent_reader_writer_test.go
+++ b/pkg/storage/intent_reader_writer_test.go
@@ -246,7 +246,7 @@ func TestIntentDemuxWriter(t *testing.T) {
 				pw.reset()
 				start := scanRoachKey(t, d, "start")
 				end := scanRoachKey(t, d, "end")
-				if scratch, err = w.ClearMVCCRange(start, end, scratch); err != nil {
+				if scratch, err = w.ClearMVCCRange(start, end, true, true, scratch); err != nil {
 					return err.Error()
 				}
 				printEngContents(&pw.b, eng)

--- a/pkg/storage/intent_reader_writer_test.go
+++ b/pkg/storage/intent_reader_writer_test.go
@@ -126,7 +126,7 @@ func (p *printWriter) ClearEngineKey(key EngineKey) error {
 	return p.Writer.ClearEngineKey(key)
 }
 
-func (p *printWriter) ClearRawRange(start, end roachpb.Key) error {
+func (p *printWriter) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	if bytes.HasPrefix(start, keys.LocalRangeLockTablePrefix) {
 		ltStart, err := keys.DecodeLockTableSingleKey(start)
 		if err != nil {
@@ -140,7 +140,7 @@ func (p *printWriter) ClearRawRange(start, end roachpb.Key) error {
 	} else {
 		fmt.Fprintf(&p.b, "ClearRawRange(%s, %s)\n", string(start), string(end))
 	}
-	return p.Writer.ClearRawRange(start, end)
+	return p.Writer.ClearRawRange(start, end, pointKeys, rangeKeys)
 }
 
 func (p *printWriter) PutUnversioned(key roachpb.Key, value []byte) error {

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -734,7 +734,7 @@ func (c clearRangeOp) run(ctx context.Context) string {
 		// Empty range. No-op.
 		return "no-op due to no non-conflicting key range"
 	}
-	err := c.m.engine.ClearMVCCRange(c.key, c.endKey)
+	err := c.m.engine.ClearMVCCRange(c.key, c.endKey, true, true)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err.Error())
 	}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -901,7 +901,7 @@ func cmdClearRange(e *evalCtx) error {
 	// NB: We can't test ClearRawRange or ClearRangeUsingHeuristic here, because
 	// it does not handle separated intents.
 	if util.ConstantWithMetamorphicTestBool("clear-range-using-iterator", false) {
-		return e.engine.ClearMVCCIteratorRange(key, endKey)
+		return e.engine.ClearMVCCIteratorRange(key, endKey, true, true)
 	}
 	return e.engine.ClearMVCCRange(key, endKey)
 }

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1550,7 +1550,7 @@ func cmdSSTPutRangeKey(e *evalCtx) error {
 
 func cmdSSTClearRange(e *evalCtx) error {
 	start, end := e.getKeyRange()
-	return e.sst().ClearRawRange(start, end)
+	return e.sst().ClearRawRange(start, end, true /* pointKeys */, true /* rangeKeys */)
 }
 
 func cmdSSTClearRangeKey(e *evalCtx) error {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -903,7 +903,7 @@ func cmdClearRange(e *evalCtx) error {
 	if util.ConstantWithMetamorphicTestBool("clear-range-using-iterator", false) {
 		return e.engine.ClearMVCCIteratorRange(key, endKey, true, true)
 	}
-	return e.engine.ClearMVCCRange(key, endKey)
+	return e.engine.ClearMVCCRange(key, endKey, true, true)
 }
 
 func cmdClearRangeKey(e *evalCtx) error {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1177,12 +1177,12 @@ func (p *Pebble) ClearMVCCVersions(start, end MVCCKey) error {
 }
 
 // ClearMVCCIteratorRange implements the Engine interface.
-func (p *Pebble) ClearMVCCIteratorRange(start, end roachpb.Key) error {
+func (p *Pebble) ClearMVCCIteratorRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	// Write all the tombstones in one batch.
 	batch := p.NewUnindexedBatch(false /* writeOnly */)
 	defer batch.Close()
 
-	if err := batch.ClearMVCCIteratorRange(start, end); err != nil {
+	if err := batch.ClearMVCCIteratorRange(start, end, pointKeys, rangeKeys); err != nil {
 		return err
 	}
 	return batch.Commit(true)
@@ -2139,7 +2139,9 @@ func (p *pebbleReadOnly) ClearMVCCVersions(start, end MVCCKey) error {
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ClearMVCCIteratorRange(start, end roachpb.Key) error {
+func (p *pebbleReadOnly) ClearMVCCIteratorRange(
+	start, end roachpb.Key, pointKeys, rangeKeys bool,
+) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1166,8 +1166,8 @@ func (p *Pebble) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys bool
 }
 
 // ClearMVCCRange implements the Engine interface.
-func (p *Pebble) ClearMVCCRange(start, end roachpb.Key) error {
-	_, err := p.wrappedIntentWriter.ClearMVCCRange(start, end, nil)
+func (p *Pebble) ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
+	_, err := p.wrappedIntentWriter.ClearMVCCRange(start, end, pointKeys, rangeKeys, nil)
 	return err
 }
 
@@ -2094,7 +2094,7 @@ func (p *pebbleReadOnly) ClearRawRange(start, end roachpb.Key, pointKeys, rangeK
 	panic("not implemented")
 }
 
-func (p *pebbleReadOnly) ClearMVCCRange(start, end roachpb.Key) error {
+func (p *pebbleReadOnly) ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -378,9 +378,9 @@ func (p *pebbleBatch) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys
 }
 
 // ClearMVCCRange implements the Batch interface.
-func (p *pebbleBatch) ClearMVCCRange(start, end roachpb.Key) error {
+func (p *pebbleBatch) ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	var err error
-	p.scratch, err = p.wrappedIntentWriter.ClearMVCCRange(start, end, p.scratch)
+	p.scratch, err = p.wrappedIntentWriter.ClearMVCCRange(start, end, pointKeys, rangeKeys, p.scratch)
 	return err
 }
 

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -874,7 +874,7 @@ func TestPebbleMVCCTimeIntervalWithRangeClears(t *testing.T) {
 	require.NoError(t, eng.Flush())
 
 	// Clear [a-z) in a separate SST.
-	require.NoError(t, eng.ClearMVCCRange(roachpb.Key("a"), roachpb.Key("z")))
+	require.NoError(t, eng.ClearMVCCRange(roachpb.Key("a"), roachpb.Key("z"), true, true))
 	require.NoError(t, eng.Flush())
 
 	testcases := map[string]struct {

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -154,7 +154,7 @@ func (fw *SSTWriter) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys 
 }
 
 // ClearMVCCRange implements the Writer interface.
-func (fw *SSTWriter) ClearMVCCRange(start, end roachpb.Key) error {
+func (fw *SSTWriter) ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -396,7 +396,7 @@ func (fw *SSTWriter) SingleClearEngineKey(key EngineKey) error {
 }
 
 // ClearMVCCIteratorRange implements the Writer interface.
-func (fw *SSTWriter) ClearMVCCIteratorRange(start, end roachpb.Key) error {
+func (fw *SSTWriter) ClearMVCCIteratorRange(_, _ roachpb.Key, _, _ bool) error {
 	panic("not implemented")
 }
 

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -139,6 +139,7 @@ func TestSSTWriterRangeKeysUnsupported(t *testing.T) {
 			require.Contains(t, err.Error(), "range keys not supported")
 			require.NoError(t, w.ClearMVCCRangeKey(rangeKey))
 			require.NoError(t, w.ClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
+			require.NoError(t, w.ClearRawRange(rangeKey.StartKey, rangeKey.EndKey, false, true))
 		})
 	}
 }

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -137,7 +137,15 @@ func TestSSTWriterRangeKeysUnsupported(t *testing.T) {
 			err := w.PutMVCCRangeKey(rangeKey, MVCCValue{})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "range keys not supported")
+
+			err = w.PutEngineRangeKey(rangeKey.StartKey, rangeKey.EndKey,
+				EncodeMVCCTimestampSuffix(rangeKey.Timestamp), nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "range keys not supported")
+
 			require.NoError(t, w.ClearMVCCRangeKey(rangeKey))
+			require.NoError(t, w.ClearEngineRangeKey(rangeKey.StartKey, rangeKey.EndKey,
+				EncodeMVCCTimestampSuffix(rangeKey.Timestamp)))
 			require.NoError(t, w.ClearRawRange(rangeKey.StartKey, rangeKey.EndKey, false, true))
 		})
 	}

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -138,7 +138,6 @@ func TestSSTWriterRangeKeysUnsupported(t *testing.T) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "range keys not supported")
 			require.NoError(t, w.ClearMVCCRangeKey(rangeKey))
-			require.NoError(t, w.ClearAllRangeKeys(rangeKey.StartKey, rangeKey.EndKey))
 			require.NoError(t, w.ClearRawRange(rangeKey.StartKey, rangeKey.EndKey, false, true))
 		})
 	}


### PR DESCRIPTION
This patch set improves clearing of range keys, with the overall goal of avoiding dropping Pebble range tombstones unnecessarily, in particular across range key spans that will most often be empty. The main affected components are:

* `ClearRange` gRPC method: similarly to point keys, it now uses an iterator to clear individual range keys for small data sets. For larger data sets, it will use Pebble range tombstones to clear point or range keys separately, but only if any such keys exist.

* Raft snapshots
  * Unreplicated data: no change, we only write a Pebble range tombstone across the point key span, since we don't expect range keys here.
  * Subsumed replicas' range-local state: iterates and clears any point/range keys (individually or ranged).
  * Snapshot SSTs: every SST (for each key span in the Raft range) unconditionally has a Pebble range tombstone at the bottom, both across point keys and range keys.

* Raft splits: on RHS conflict, iterates and clears any RHS point/range keys (individually or ranged).

* Raft merges: for RHS range-local data, iterates and clears any RHS point/range keys (individually or ranged).

* Raft replica removal: iterates and clears any RHS point/range keys (individually or ranged).

* Raft log truncation: no change, only writes tombstones across point keys.

The iffiest bit is the unconditional Pebble range tombstones at the bottom of Raft snapshot SSTs, both because they're unconditional, and also because they will be fairly common. @jbowens Do you consider this problematic? Specifically, this bit here:

https://github.com/cockroachdb/cockroach/blob/b0e76dc38bdc893ee3ba42131f9718fc855a1dc6/pkg/kv/kvserver/store_snapshot.go#L183-L185

Resolves #83032.

---

**storage: add point/range key params to `Writer.ClearRawRange()`**

This patch adds boolean parameters for point/range keys to
`Writer.ClearRawRange()`. When true, it will unconditionally write
Pebble range tombstones across the point/range key spans. This gives the
caller better control over when to write tombstones, to avoid writing
them unnecessarily.

This is a behavioral change, because the previous `Engine` and `Batch`
implementations would only drop Pebble range key tombstones if there
were range keys present. Later commits will introduce higher-level
functionality to avoid writing these tombstones unnecessarily and adapt
callers.

Release note: None

**storage: clear individual range keys in `ClearMVCCIteratorRange`**

Previously, `Writer.ClearMVCCIteratorRange` would use a Pebble
`RANGEKEYDEL` to clear all range keys within the span. This went against
the intent of the method, which is to iterate across the the span and
clear individual range keys. This patch changes is to do the latter.

Parameters are also added to control whether to clear point and/or range
keys.

Release note: None
  
**storage: remove `Writer.ClearAllRangeKeys`**

This patch removes `Writer.ClearAllRangeKeys()`, which was used to clear
all range keys in a span using a single `RANGEKEYDEL` tombstone.
`ClearRawRange` should be used instead.

This also removes some clumsy `Engine` logic that attempted to detect
and avoid writing range key tombstones if there were no range keys,
which required additional metadata tracking in batches and such. The
responsibility for this is instead placed on callers. It was never
possible to handle this sufficiently inside the writers anyway, because
of e.g. `SSTWriter` which does not have access to a reader.

Release note: None

**storage: add `Writer.ClearEngineRangeKey()`**

This patch adds `Writer.ClearEngineRangeKey()`, and makes
`ClearMVCCRangeKey()` call through to it. It also takes the opportunity
to consolidate the put logic in a similar fashion, by calling through to
the engine method.

Release note: None
  
**storage: improve `ClearRangeWithHeuristic` for range keys**

This patch improves `ClearRangeWithHeuristic()` to take individual,
optional thresholds for point and/or range keys, controlling when to use
`RANGEDEL` or `RANGEKEYDEL` instead of individual tombstones. The Raft
replica clearing code has been adapted to take advantage of this, and in
particular, will no longer drop Pebble range key tombstones unless there
are actual range keys present.

Release note: None

**kvserver/batcheval: improve range key clears in `ClearRange`**

This patch improves range key clearing in `ClearRange`, by using
`ClearRangeWithHeuristic` to only write Pebble range key tombstones if
there are any range keys present.

Release note: None
  
**storage: add point/range key params to `Writer.ClearMVCCRange`**

This patch adds point/range key parameters to `Writer.ClearMVCCRange()`
controlling whether to clear the key type. This can be used by callers
to avoid dropping unnecessary tombstones, particularly across range key
spans that are expected to be empty most of the time.

Release note: None