### PR TITLE
roachtest: add KV/YCSB benchmarks with global MVCC range tombstones

### DIFF
--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",
+        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -359,6 +360,9 @@ func (f *RangeFeed) processEvents(
 				f.onSSTable(ctx, ev.SST)
 			case ev.DeleteRange != nil:
 				if f.onDeleteRange == nil {
+					if kvserverbase.GlobalMVCCRangeTombstoneForTesting {
+						continue
+					}
 					return errors.AssertionFailedf(
 						"received unexpected rangefeed DeleteRange event with no OnDeleteRange handler: %s", ev)
 				}

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 )
@@ -31,6 +32,10 @@ func InitPut(
 ) (result.Result, error) {
 	args := cArgs.Args.(*roachpb.InitPutRequest)
 	h := cArgs.Header
+
+	if args.FailOnTombstones && kvserverbase.GlobalMVCCRangeTombstoneForTesting {
+		args.FailOnTombstones = false
+	}
 
 	var err error
 	if args.Blind {

--- a/pkg/kv/kvserver/kvserverbase/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverbase/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/util/envutil",
         "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/quotapool",

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -227,3 +228,10 @@ var SplitByLoadMergeDelay = settings.RegisterDurationSetting(
 // MaxCommandSizeDefault is the default for the kv.raft.command.max_size
 // cluster setting.
 const MaxCommandSizeDefault = 64 << 20
+
+// GlobalMVCCRangeTombstoneForTesting will write an MVCC range tombstone at the
+// bottom of the SQL table data keyspace during cluster bootstrapping, for
+// performance and correctness testing. This shouldn't affect data written above
+// it, but activates range key-specific code paths in the storage layer.
+var GlobalMVCCRangeTombstoneForTesting = envutil.EnvOrDefaultBool(
+	"COCKROACH_GLOBAL_MVCC_RANGE_TOMBSTONE", false)


### PR DESCRIPTION
**kvserver: add env var to write global MVCC range tombstone**

This patch adds the envvar `COCKROACH_GLOBAL_MVCC_RANGE_TOMBSTONE`.
When enabled, it will write a global MVCC range tombstone across the
entire table data keyspan during cluster bootstrapping. This can be used
to test performance and correctness in the presence of MVCC range
tombstones, by activating range key-specific code paths while not
semantically affecting the data above it.

Touches #84384.

Release note: None

**roachtest: add KV/YCSB benchmarks with global MVCC range tombstones**

This patch adds a set of benchmark variants that write a single MVCC
range tombstone across the entire SQL keyspan at cluster start, via the
`COCKROACH_GLOBAL_MVCC_RANGE_TOMBSTONE` env var. Even though this range
tombstone will not affect the data written during the benchmarks, it
activates range key-specific code paths in the storage layer which can
have a significant impact on performance.

The new benchmarks are:

* `kv0/enc=false/nodes=3/cpu=32/mvcc-range-keys=global`
* `kv95/enc=false/nodes=3/cpu=32/mvcc-range-keys=global`
* `ycsb/A/nodes=3/cpu=32/mvcc-range-keys=global`
* `ycsb/B/nodes=3/cpu=32/mvcc-range-keys=global`
* `ycsb/C/nodes=3/cpu=32/mvcc-range-keys=global`
* `ycsb/D/nodes=3/cpu=32/mvcc-range-keys=global`
* `ycsb/E/nodes=3/cpu=32/mvcc-range-keys=global`
* `ycsb/F/nodes=3/cpu=32/mvcc-range-keys=global`

Resolves #84384.


Release note: None