### PR TITLE
storage: consolidate MVCC stats handling for range keys

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -1286,8 +1286,9 @@ func TestComputeSplitRangeKeyStatsDelta(t *testing.T) {
 
 			tc.expect.LastUpdateNanos = nowNanos
 
-			msDelta, err := computeSplitRangeKeyStatsDelta(engine, lhsDesc, rhsDesc, nowNanos)
+			msDelta, err := computeSplitRangeKeyStatsDelta(engine, lhsDesc, rhsDesc)
 			require.NoError(t, err)
+			msDelta.AgeTo(nowNanos)
 			require.Equal(t, tc.expect, msDelta)
 		})
 	}

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -544,10 +544,10 @@ func (i *MVCCIncrementalIterator) RangeKeys() MVCCRangeKeyStack {
 	// for the same range key. However, callers may avoid calling RangeKeys()
 	// unnecessarily, and we may optimize parent iterators, so let's measure.
 	rangeKeys := i.iter.RangeKeys()
-	if i.ignoringTime {
-		return rangeKeys
+	if !i.ignoringTime {
+		rangeKeys.Trim(i.startTime.Next(), i.endTime)
 	}
-	return rangeKeys.Trim(i.startTime.Next(), i.endTime)
+	return rangeKeys
 }
 
 // UnsafeValue implements SimpleMVCCIterator.


### PR DESCRIPTION
**storage: consolidate MVCC stats handling for range keys**

This patch consolidates and cleans up MVCC stats calculations for MVCC
range keys, by adding several utility functions. There are no behavioral
changes.

Resolves #83897.

Release note: None
  
**kvserver/gc: migrate GC to `MVCCRangeKeyStack` and stats helpers**

This patch migrates the MVCC GC code to the new `MVCCRangeKeyStack` data
structure and stats helpers. There are no functional changes.

Release note: None