### PR TITLE
logictest: add TestLogic_tmp for testing untracked logic test files

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=50
+DEV_VERSION=51
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
@@ -78,6 +78,25 @@ func runExecBuildLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(execBuildLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+}
+
 func TestTenantLogic_distsql_tenant(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -92,6 +92,27 @@ func runExecBuildLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(execBuildLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+}
+
 func TestTenantLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/5node/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/5node/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_distsql_partitioning(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_new_schema_changer(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_new_schema_changer(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_new_schema_changer(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-21.2-22.1/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-21.2-22.1/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_create_changefeed_mixed_versions(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_new_schema_changer(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_as_of(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_secondary_region(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_multi_region_zone_configs_long_regions(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_alter_table_locality(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_multi_region(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_global_placement_restricted(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -59,6 +59,20 @@ func runCCLLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestCCLLogic_alter_table_locality(
 	t *testing.T,
 ) {

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -36,7 +36,6 @@ const (
 	stressArgsFlag   = "stress-args"
 	raceFlag         = "race"
 	ignoreCacheFlag  = "ignore-cache"
-	noGenFlag        = "no-gen"
 	rewriteFlag      = "rewrite"
 	streamOutputFlag = "stream-output"
 	testArgsFlag     = "test-args"
@@ -102,7 +101,6 @@ pkg/kv/kvserver:kvserver_test) instead.`,
 	testCmd.Flags().Bool(raceFlag, false, "run tests using race builds")
 	testCmd.Flags().Bool(ignoreCacheFlag, false, "ignore cached test runs")
 	testCmd.Flags().Bool(rewriteFlag, false, "rewrite test files using results from test run (only applicable to certain tests)")
-	testCmd.Flags().Bool(noGenFlag, false, "skip generating logic test files before running logic tests")
 	testCmd.Flags().Bool(streamOutputFlag, false, "stream test output during run")
 	testCmd.Flags().String(testArgsFlag, "", "additional arguments to pass to the go test binary")
 	testCmd.Flags().String(vModuleFlag, "", "comma-separated list of pattern=N settings for file-filtered logging")
@@ -125,7 +123,6 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		stressCmdArgs = mustGetFlagString(cmd, stressArgsFlag)
 		timeout       = mustGetFlagDuration(cmd, timeoutFlag)
 		verbose       = mustGetFlagBool(cmd, vFlag)
-		noGen         = mustGetFlagBool(cmd, noGenFlag)
 		changed       = mustGetFlagBool(cmd, changedFlag)
 		showLogs      = mustGetFlagBool(cmd, showLogsFlag)
 		count         = mustGetFlagInt(cmd, countFlag)
@@ -221,27 +218,6 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, "--nocache_test_results")
 	}
 	args = append(args, "--test_env=GOTRACEBACK=all")
-
-	// We need to re-generate logictest files if we're testing a
-	// logictest target.
-	if !noGen {
-		var shouldGenerateLogicTestFiles bool
-		for _, testTarget := range testTargets {
-			for _, logicTestPath := range logicTestPaths {
-				if strings.Contains(testTarget, logicTestPath) {
-					shouldGenerateLogicTestFiles = true
-					break
-				}
-			}
-		}
-
-		if shouldGenerateLogicTestFiles {
-			err := d.generateLogicTest(cmd)
-			if err != nil {
-				return err
-			}
-		}
-	}
 
 	if rewrite {
 		if stress {

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -28,6 +28,7 @@ const (
 	subtestsFlag = "subtests"
 	configFlag   = "config"
 	showSQLFlag  = "show-sql"
+	noGenFlag    = "no-gen"
 )
 
 func makeTestLogicCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {

--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -199,6 +199,12 @@ func (t *testdir) dump() error {
 }
 
 func dumpTestForFile(f io.Writer, prefix, file string, whichFunc string) {
+	if strings.HasPrefix(file, "_") {
+		// Ignore test files that start with "_", which are reserved as
+		// temporary files used during development and debugging. Tests in these
+		// files can be tested with the auto-generated TestLogic_tmp test.
+		return
+	}
 	mungedFile := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(file, "/", ""), "-", "_"), ".", "_")
 	fmt.Fprintf(f, "\nfunc %s_%s(\n", prefix, mungedFile)
 	fmt.Fprintln(f, "\tt *testing.T,\n) {")

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -211,7 +211,34 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-{{ template "declareTestdataSetupFunctions" . }}`
+{{ template "declareTestdataSetupFunctions" . }}{{- if not .SqliteLogicTest }}
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	{{- if .LogicTest}}
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+	{{- end}}
+	{{- if .CclLogicTest }}
+	glob = filepath.Join(cclLogicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+	{{- end }}
+	{{- if .ExecBuildLogicTest }}
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+	{{- end }}
+}
+{{ end }}`
 
 // There is probably room for optimization here. Among other things:
 // some tests may declare a testdata dependency they don't actually need, and

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -3606,6 +3607,19 @@ type TestServerArgs struct {
 	ForceProductionValues bool
 	// If set, then sql.distsql.temp_storage.workmem is not randomized.
 	DisableWorkmemRandomization bool
+}
+
+// RunLogicTests runs logic tests for all files matching the given glob.
+func RunLogicTests(
+	t *testing.T, serverArgs TestServerArgs, configIdx logictestbase.ConfigIdx, glob string,
+) {
+	paths, err := filepath.Glob(glob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range paths {
+		RunLogicTest(t, serverArgs, configIdx, p)
+	}
 }
 
 // RunLogicTest is the main entry point for the logic test.

--- a/pkg/sql/logictest/tests/5node-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/5node-disk/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_contention_event(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/5node/generated_test.go
+++ b/pkg/sql/logictest/tests/5node/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_contention_event(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-21.2-22.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-21.2-22.1/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_row_level_ttl_mixed_21_2_22_1(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.1-22.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.1-22.2/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_system_privileges_mixed(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-udf/generated_test.go
+++ b/pkg/sql/logictest/tests/local-udf/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_udf(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-v1.1-at-v1.0-noupgrade/generated_test.go
+++ b/pkg/sql/logictest/tests/local-v1.1-at-v1.0-noupgrade/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_active_version(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_multi_region(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/multiregion-invalid-locality/generated_test.go
+++ b/pkg/sql/logictest/tests/multiregion-invalid-locality/generated_test.go
@@ -58,6 +58,20 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(logicTestDir, "_*")
+	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
+}
+
 func TestLogic_multiregion_invalid_locality(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
@@ -64,6 +64,23 @@ func runExecBuildLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(execBuildLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+}
+
 func TestExecBuild_dist_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
@@ -64,6 +64,23 @@ func runExecBuildLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(execBuildLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
@@ -64,6 +64,23 @@ func runExecBuildLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(execBuildLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
@@ -64,6 +64,23 @@ func runExecBuildLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(execBuildLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
@@ -64,6 +64,23 @@ func runExecBuildLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(execBuildLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -64,6 +64,23 @@ func runExecBuildLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(execBuildLogicTestDir, file))
 }
 
+// TestLogic_tmp runs any tests that are prefixed with "_", in which a dedicated
+// test is not generated for. This allows developers to create and run temporary
+// test files that are not checked into the repository, without repeatedly
+// regenerating and reverting changes to this file, generated_test.go.
+//
+// TODO(mgartner): Add file filtering so that individual files can be run,
+// instead of all files with the "_" prefix.
+func TestLogic_tmp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var glob string
+	glob = filepath.Join(execBuildLogicTestDir, "_*")
+	serverArgs := logictest.TestServerArgs{
+		DisableWorkmemRandomization: true,
+	}
+	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
+}
+
 func TestExecBuild_aggregate(
 	t *testing.T,
 ) {


### PR DESCRIPTION
This commit improves the developer experience when working with logic
tests. The logic test generator no longer generates a dedicated test for
logic tests files prefixed with "_". The hard-coded `TestLogic_tmp` test
has been added which runs all such logic test files. This allows
developers to create and run temporary test files that are not checked
into the repository, without repeatedly regenerating and reverting
changes to the `generated_test.go` files.

For example, if you add a git-ignored file logic test file,
`pkg/sql/logictest/testdata/logic_test/__test`, you can run it with the
`local` config with the command:

    ./dev test pkg/sql/logictest/tests/local -f TestLogic_tmp

Previously, to facilitate running these types of tests, `./dev test`
would automatically regenerate logic tests every time tests were run.
This was primarily motivated by the desire to make testing temporary
logic test files easier - a developer would not have to run
`./dev gen logictest` every time they wanted to test a temporary file.

However, this was a poor experience because it made running tests
significantly slower, and logic tests generated for temporary logic test
files would have to be reverted repeatedly. `TestLogic_tmp` eliminates
the need for this automatic regeneration, so it has been removed. The
`--no-gen` flag, which disabled automatic regeneration, has also been
removed. When committing a new logic test file to the repository,
developers must now run `./dev gen testlogic` to generate logic tests
for it.

Release note: None