### PR TITLE
cli: print range keys in `debug keys` and `debug range-data`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1100,9 +1100,9 @@ Base64-encoded Descriptor to use as the table when decoding KVs.`,
 	FilterKeys = FlagInfo{
 		Name: "type",
 		Description: `
-Only show certain types of keys: values, intents, txns. If omitted all keys
-types are shown. Showing transactions will also implicitly limit key range
-to local keys if keys are not specified explicitly.`,
+Only show certain types of keys: values, intents, txns, or rangekeys. If
+omitted, all key types are shown. txns will also implicitly limit the key range
+to local keys, unless specified`,
 	}
 
 	DrainWait = FlagInfo{

--- a/pkg/cli/debug_synctest.go
+++ b/pkg/cli/debug_synctest.go
@@ -133,7 +133,7 @@ func runSyncer(
 		return encoding.EncodeUvarintAscending(buf[:0:0], uint64(seq))
 	}
 
-	check := func(kv storage.MVCCKeyValue) error {
+	check := func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
 		expKey := key()
 		if !bytes.Equal(kv.Key.Key, expKey) {
 			return errors.Errorf(
@@ -144,7 +144,9 @@ func runSyncer(
 	}
 
 	fmt.Fprintf(stderr, "verifying existing sequence numbers...")
-	if err := db.MVCCIterate(roachpb.KeyMin, roachpb.KeyMax, storage.MVCCKeyAndIntentsIterKind, check); err != nil {
+	err = db.MVCCIterate(roachpb.KeyMin, roachpb.KeyMax, storage.MVCCKeyAndIntentsIterKind,
+		storage.IterKeyTypePointsOnly, check)
+	if err != nil {
 		return 0, err
 	}
 	// We must not lose writes, but sometimes we get extra ones (i.e. we caught an

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -212,6 +212,7 @@ const (
 	showValues
 	showIntents
 	showTxns
+	showRangeKeys
 )
 
 // String implements the pflag.Value interface.
@@ -223,6 +224,8 @@ func (f *keyTypeFilter) String() string {
 		return "intents"
 	case showTxns:
 		return "txns"
+	case showRangeKeys:
+		return "rangekeys"
 	}
 	return "all"
 }
@@ -237,6 +240,8 @@ func (f *keyTypeFilter) Set(v string) error {
 		*f = showValues
 	case "intents":
 		*f = showIntents
+	case "rangekeys":
+		*f = showRangeKeys
 	case "txns":
 		*f = showTxns
 	default:

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -123,9 +123,11 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		if _, _, _, err := batch.MVCCGetProto(insideKey, nil); err != nil {
 			t.Errorf("MVCCGetProto: unexpected error %v", err)
 		}
-		if err := batch.MVCCIterate(insideKey.Key, insideKey2.Key, storage.MVCCKeyAndIntentsIterKind, func(v storage.MVCCKeyValue) error {
-			return nil
-		}); err != nil {
+		if err := batch.MVCCIterate(
+			insideKey.Key, insideKey2.Key, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
+			func(v storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
+				return nil
+			}); err != nil {
 			t.Errorf("MVCCIterate: unexpected error %v", err)
 		}
 	})
@@ -144,9 +146,11 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		if _, _, _, err := batch.MVCCGetProto(outsideKey, nil); !isReadSpanErr(err) {
 			t.Errorf("MVCCGetProto: unexpected error %v", err)
 		}
-		if err := batch.MVCCIterate(outsideKey.Key, insideKey2.Key, storage.MVCCKeyAndIntentsIterKind, func(v storage.MVCCKeyValue) error {
-			return errors.Errorf("unexpected callback: %v", v)
-		}); !isReadSpanErr(err) {
+		if err := batch.MVCCIterate(
+			outsideKey.Key, insideKey2.Key, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
+			func(v storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
+				return errors.Errorf("unexpected callback: %v", v)
+			}); !isReadSpanErr(err) {
 			t.Errorf("MVCCIterate: unexpected error %v", err)
 		}
 	})
@@ -160,9 +164,11 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		if _, _, _, err := batch.MVCCGetProto(outsideKey3, nil); !isReadSpanErr(err) {
 			t.Errorf("MVCCGetProto: unexpected error %v", err)
 		}
-		if err := batch.MVCCIterate(insideKey2.Key, outsideKey4.Key, storage.MVCCKeyAndIntentsIterKind, func(v storage.MVCCKeyValue) error {
-			return errors.Errorf("unexpected callback: %v", v)
-		}); !isReadSpanErr(err) {
+		if err := batch.MVCCIterate(
+			insideKey2.Key, outsideKey4.Key, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
+			func(v storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
+				return errors.Errorf("unexpected callback: %v", v)
+			}); !isReadSpanErr(err) {
 			t.Errorf("MVCCIterate: unexpected error %v", err)
 		}
 	})
@@ -358,9 +364,11 @@ func TestSpanSetBatchTimestamps(t *testing.T) {
 		if _, _, _, err := batch.MVCCGetProto(rkey, nil); !isReadSpanErr(err) {
 			t.Errorf("MVCCGetProto: unexpected error %v", err)
 		}
-		if err := batch.MVCCIterate(rkey.Key, rkey.Key, storage.MVCCKeyAndIntentsIterKind, func(v storage.MVCCKeyValue) error {
-			return errors.Errorf("unexpected callback: %v", v)
-		}); !isReadSpanErr(err) {
+		if err := batch.MVCCIterate(
+			rkey.Key, rkey.Key, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
+			func(v storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
+				return errors.Errorf("unexpected callback: %v", v)
+			}); !isReadSpanErr(err) {
 			t.Errorf("MVCCIterate: unexpected error %v", err)
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -33,13 +33,13 @@ import (
 func hashRange(t *testing.T, reader storage.Reader, start, end roachpb.Key) []byte {
 	t.Helper()
 	h := sha256.New()
-	if err := reader.MVCCIterate(start, end, storage.MVCCKeyAndIntentsIterKind, func(kv storage.MVCCKeyValue) error {
-		h.Write(kv.Key.Key)
-		h.Write(kv.Value)
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, reader.MVCCIterate(
+		start, end, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
+		func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
+			h.Write(kv.Key.Key)
+			h.Write(kv.Value)
+			return nil
+		}))
 	return h.Sum(nil)
 }
 

--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -33,10 +33,22 @@ func PrintEngineKeyValue(k storage.EngineKey, v []byte) {
 	fmt.Println(SprintEngineKeyValue(k, v))
 }
 
+// PrintEngineRangeKeyValue attempts to print the given key-value pair to
+// os.Stdout, utilizing SprintMVCCKeyValue in the case of an MVCCRangeKeyValue.
+func PrintEngineRangeKeyValue(s roachpb.Span, v storage.EngineRangeKeyValue) {
+	fmt.Println(SprintEngineRangeKeyValue(s, v))
+}
+
 // PrintMVCCKeyValue attempts to pretty-print the specified MVCCKeyValue to
 // os.Stdout, falling back to '%q' formatting.
 func PrintMVCCKeyValue(kv storage.MVCCKeyValue) {
 	fmt.Println(SprintMVCCKeyValue(kv, true /* printKey */))
+}
+
+// PrintMVCCRangeKeyValue attempts to pretty-print the specified
+// MVCCRangeKeyValue to os.Stdout, falling back to '%q' formatting.
+func PrintMVCCRangeKeyValue(rkv storage.MVCCRangeKeyValue) {
+	fmt.Println(SprintMVCCRangeKeyValue(rkv, true /* printKey */))
 }
 
 // SprintEngineKey pretty-prints the specified EngineKey, using the correct
@@ -54,6 +66,12 @@ func SprintEngineKey(key storage.EngineKey) string {
 // SprintMVCCKey pretty-prints the specified MVCCKey.
 func SprintMVCCKey(key storage.MVCCKey) string {
 	return fmt.Sprintf("%s %s (%#x): ", key.Timestamp, key.Key, storage.EncodeMVCCKey(key))
+}
+
+// SprintMVCCRangeKey pretty-prints the specified MVCCRangeKey.
+func SprintMVCCRangeKey(rangeKey storage.MVCCRangeKey) string {
+	return fmt.Sprintf("%s %s (%#x-%#x): ", rangeKey.Timestamp, rangeKey.Bounds(),
+		storage.EncodeMVCCKeyPrefix(rangeKey.StartKey), storage.EncodeMVCCKeyPrefix(rangeKey.EndKey))
 }
 
 // SprintEngineKeyValue is like PrintEngineKeyValue, but returns a string.  In
@@ -75,8 +93,25 @@ func SprintEngineKeyValue(k storage.EngineKey, v []byte) string {
 	return sb.String()
 }
 
+// SprintEngineRangeKeyValue is like PrintEngineRangeKeyValue, but returns a
+// string. All range keys are currently MVCC range keys, so it will utilize
+// SprintMVCCRangeKeyValue for proper MVCC formatting.
+func SprintEngineRangeKeyValue(s roachpb.Span, v storage.EngineRangeKeyValue) string {
+	if ts, err := storage.DecodeMVCCTimestampSuffix(v.Version); err == nil {
+		rkv := storage.MVCCRangeKeyValue{
+			RangeKey: storage.MVCCRangeKey{StartKey: s.Key, EndKey: s.EndKey, Timestamp: ts},
+			Value:    v.Value,
+		}
+		return SprintMVCCRangeKeyValue(rkv, true /* printKey */)
+	}
+	return fmt.Sprintf("%s %x (%#x-%#x): %x", s, v.Version, s.Key, s.EndKey, v.Value)
+}
+
 // DebugSprintMVCCKeyValueDecoders allows injecting alternative debug decoders.
 var DebugSprintMVCCKeyValueDecoders []func(kv storage.MVCCKeyValue) (string, error)
+
+// DebugSprintMVCCRangeKeyValueDecoders allows injecting alternative debug decoders.
+var DebugSprintMVCCRangeKeyValueDecoders []func(rkv storage.MVCCRangeKeyValue) (string, error)
 
 // SprintMVCCKeyValue is like PrintMVCCKeyValue, but returns a string. If
 // printKey is true, prints the key and the value together; otherwise,
@@ -103,6 +138,33 @@ func SprintMVCCKeyValue(kv storage.MVCCKeyValue, printKey bool) string {
 
 	for _, decoder := range decoders {
 		out, err := decoder(kv)
+		if err != nil {
+			continue
+		}
+		sb.WriteString(out)
+		return sb.String()
+	}
+	panic("unreachable")
+}
+
+// SprintMVCCRangeKeyValue is like PrintMVCCRangeKeyValue, but returns a string.
+// If printKey is true, prints the key and the value together; otherwise, prints
+// just the value.
+func SprintMVCCRangeKeyValue(rkv storage.MVCCRangeKeyValue, printKey bool) string {
+	var sb strings.Builder
+	if printKey {
+		sb.WriteString(SprintMVCCRangeKey(rkv.RangeKey))
+	}
+
+	decoders := append(DebugSprintMVCCRangeKeyValueDecoders,
+		func(rkv storage.MVCCRangeKeyValue) (string, error) {
+			// No better idea, just print raw bytes and hope that folks use `less -S`.
+			return fmt.Sprintf("%q", rkv.Value), nil
+		},
+	)
+
+	for _, decoder := range decoders {
+		out, err := decoder(rkv)
 		if err != nil {
 			continue
 		}

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -457,7 +457,10 @@ func (s spanSetReader) MVCCGetProto(
 }
 
 func (s spanSetReader) MVCCIterate(
-	start, end roachpb.Key, iterKind storage.MVCCIterKind, f func(storage.MVCCKeyValue) error,
+	start, end roachpb.Key,
+	iterKind storage.MVCCIterKind,
+	keyTypes storage.IterKeyType,
+	f func(storage.MVCCKeyValue, storage.MVCCRangeKeyStack) error,
 ) error {
 	if s.spansOnly {
 		if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
@@ -468,7 +471,7 @@ func (s spanSetReader) MVCCIterate(
 			return err
 		}
 	}
-	return s.r.MVCCIterate(start, end, iterKind, f)
+	return s.r.MVCCIterate(start, end, iterKind, keyTypes, f)
 }
 
 func (s spanSetReader) NewMVCCIterator(

--- a/pkg/kv/kvserver/spanset/batch_test.go
+++ b/pkg/kv/kvserver/spanset/batch_test.go
@@ -60,8 +60,8 @@ func TestReadWriterDeclareLockTable(t *testing.T) {
 					defer b.Close()
 					rw := fn(ss, b)
 
-					require.NoError(t, rw.MVCCIterate(ltStartKey, ltEndKey, storage.MVCCKeyIterKind, nil))
-					require.Error(t, rw.MVCCIterate(ltEndKey, ltEndKey.Next(), storage.MVCCKeyIterKind, nil))
+					require.NoError(t, rw.MVCCIterate(ltStartKey, ltEndKey, storage.MVCCKeyIterKind, storage.IterKeyTypePointsOnly, nil))
+					require.Error(t, rw.MVCCIterate(ltEndKey, ltEndKey.Next(), storage.MVCCKeyIterKind, storage.IterKeyTypePointsOnly, nil))
 
 					err := rw.PutUnversioned(ltStartKey, []byte("value"))
 					if sa == spanset.SpanReadWrite {

--- a/pkg/server/settings_cache.go
+++ b/pkg/server/settings_cache.go
@@ -115,7 +115,8 @@ func loadCachedSettingsKVs(_ context.Context, eng storage.Engine) ([]roachpb.Key
 		keys.LocalStoreCachedSettingsKeyMin,
 		keys.LocalStoreCachedSettingsKeyMax,
 		storage.MVCCKeyAndIntentsIterKind,
-		func(kv storage.MVCCKeyValue) error {
+		storage.IterKeyTypePointsOnly,
+		func(kv storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
 			settingKey, err := keys.DecodeStoreCachedSettingsKey(kv.Key.Key)
 			if err != nil {
 				return err

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -177,7 +177,8 @@ func TestReadOnlyBasics(t *testing.T) {
 				func() { _, _ = ro.MVCCGet(a) },
 				func() { _, _, _, _ = ro.MVCCGetProto(a, getVal) },
 				func() {
-					_ = ro.MVCCIterate(a.Key, a.Key, MVCCKeyIterKind, func(MVCCKeyValue) error { return iterutil.StopIteration() })
+					_ = ro.MVCCIterate(a.Key, a.Key, MVCCKeyIterKind, IterKeyTypePointsOnly,
+						func(MVCCKeyValue, MVCCRangeKeyStack) error { return iterutil.StopIteration() })
 				},
 				func() { ro.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: roachpb.KeyMax}).Close() },
 				func() {
@@ -879,7 +880,7 @@ func TestUnindexedBatchThatDoesNotSupportReaderPanics(t *testing.T) {
 			testCases := []func(){
 				func() { _, _ = batch.MVCCGet(a) },
 				func() { _, _, _, _ = batch.MVCCGetProto(a, nil) },
-				func() { _ = batch.MVCCIterate(a.Key, b.Key, MVCCKeyIterKind, nil) },
+				func() { _ = batch.MVCCIterate(a.Key, b.Key, MVCCKeyIterKind, IterKeyTypePointsOnly, nil) },
 				func() { _ = batch.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: roachpb.KeyMax}) },
 			}
 			for i, f := range testCases {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -529,14 +529,18 @@ type Reader interface {
 	//
 	// Deprecated: use MVCCIterator.ValueProto instead.
 	MVCCGetProto(key MVCCKey, msg protoutil.Message) (ok bool, keyBytes, valBytes int64, err error)
-	// MVCCIterate scans from the start key to the end key (exclusive), invoking the
-	// function f on each key value pair. If f returns an error or if the scan
-	// itself encounters an error, the iteration will stop and return the error.
-	// If the first result of f is true, the iteration stops and returns a nil
-	// error. Note that this method is not expected take into account the
-	// timestamp of the end key; all MVCCKeys at end.Key are considered excluded
-	// in the iteration.
-	MVCCIterate(start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error) error
+	// MVCCIterate scans from the start key to the end key (exclusive), invoking
+	// the function f on each key value pair. The inputs are copies, and safe to
+	// retain beyond the function call. It supports interleaved iteration over
+	// point and/or range keys, providing any overlapping range keys for each
+	// point key if requested. If f returns an error or if the scan itself
+	// encounters an error, the iteration will stop and return the error.
+	//
+	// Note that this method is not expected take into account the timestamp of
+	// the end key; all MVCCKeys at end.Key are considered excluded in the
+	// iteration.
+	MVCCIterate(start, end roachpb.Key, iterKind MVCCIterKind, keyTypes IterKeyType,
+		f func(MVCCKeyValue, MVCCRangeKeyStack) error) error
 	// NewMVCCIterator returns a new instance of an MVCCIterator over this engine.
 	// The caller must invoke Close() on it when done to free resources.
 	//
@@ -1118,13 +1122,14 @@ func GetIntent(reader Reader, key roachpb.Key) (*roachpb.Intent, error) {
 // declaration of intentInterleavingIter for details.
 func Scan(reader Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, error) {
 	var kvs []MVCCKeyValue
-	err := reader.MVCCIterate(start, end, MVCCKeyAndIntentsIterKind, func(kv MVCCKeyValue) error {
-		if max != 0 && int64(len(kvs)) >= max {
-			return iterutil.StopIteration()
-		}
-		kvs = append(kvs, kv)
-		return nil
-	})
+	err := reader.MVCCIterate(start, end, MVCCKeyAndIntentsIterKind, IterKeyTypePointsOnly,
+		func(kv MVCCKeyValue, _ MVCCRangeKeyStack) error {
+			if max != 0 && int64(len(kvs)) >= max {
+				return iterutil.StopIteration()
+			}
+			kvs = append(kvs, kv)
+			return nil
+		})
 	return kvs, err
 }
 
@@ -1335,7 +1340,11 @@ func calculatePreIngestDelay(settings *cluster.Settings, metrics *pebble.Metrics
 
 // Helper function to implement Reader.MVCCIterate().
 func iterateOnReader(
-	reader Reader, start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+	reader Reader,
+	start, end roachpb.Key,
+	iterKind MVCCIterKind,
+	keyTypes IterKeyType,
+	f func(MVCCKeyValue, MVCCRangeKeyStack) error,
 ) error {
 	if reader.Closed() {
 		return errors.New("cannot call MVCCIterate on a closed batch")
@@ -1344,18 +1353,30 @@ func iterateOnReader(
 		return nil
 	}
 
-	it := reader.NewMVCCIterator(iterKind, IterOptions{UpperBound: end})
+	it := reader.NewMVCCIterator(iterKind, IterOptions{
+		KeyTypes:   keyTypes,
+		LowerBound: start,
+		UpperBound: end,
+	})
 	defer it.Close()
 
-	it.SeekGE(MakeMVCCMetadataKey(start))
-	for ; ; it.Next() {
-		ok, err := it.Valid()
-		if err != nil {
+	var rangeKeys MVCCRangeKeyStack // cached during iteration
+	for it.SeekGE(MakeMVCCMetadataKey(start)); ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
 			return err
 		} else if !ok {
 			break
 		}
-		if err := f(MVCCKeyValue{Key: it.Key(), Value: it.Value()}); err != nil {
+
+		var kv MVCCKeyValue
+		if hasPoint, _ := it.HasPointAndRange(); hasPoint {
+			kv = MVCCKeyValue{Key: it.Key(), Value: it.Value()}
+		}
+		if !it.RangeBounds().Key.Equal(rangeKeys.Bounds.Key) {
+			rangeKeys = it.RangeKeys().Clone()
+		}
+
+		if err := f(kv, rangeKeys); err != nil {
 			return iterutil.Map(err)
 		}
 	}

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1022,14 +1022,15 @@ func TestSnapshotMethods(t *testing.T) {
 
 			// Verify MVCCIterate.
 			index := 0
-			if err := snap.MVCCIterate(localMax, roachpb.KeyMax, MVCCKeyAndIntentsIterKind, func(kv MVCCKeyValue) error {
-				if !kv.Key.Equal(keys[index]) || !bytes.Equal(kv.Value, vals[index]) {
-					t.Errorf("%d: key/value not equal between expected and snapshot: %s/%s, %s/%s",
-						index, keys[index], vals[index], kv.Key, kv.Value)
-				}
-				index++
-				return nil
-			}); err != nil {
+			if err := snap.MVCCIterate(localMax, roachpb.KeyMax, MVCCKeyAndIntentsIterKind, IterKeyTypePointsOnly,
+				func(kv MVCCKeyValue, _ MVCCRangeKeyStack) error {
+					if !kv.Key.Equal(keys[index]) || !bytes.Equal(kv.Value, vals[index]) {
+						t.Errorf("%d: key/value not equal between expected and snapshot: %s/%s, %s/%s",
+							index, keys[index], vals[index], kv.Key, kv.Value)
+					}
+					index++
+					return nil
+				}); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1036,16 +1036,19 @@ func (p *Pebble) MVCCGetProto(
 
 // MVCCIterate implements the Engine interface.
 func (p *Pebble) MVCCIterate(
-	start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+	start, end roachpb.Key,
+	iterKind MVCCIterKind,
+	keyTypes IterKeyType,
+	f func(MVCCKeyValue, MVCCRangeKeyStack) error,
 ) error {
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		err := iterateOnReader(r, start, end, iterKind, f)
+		err := iterateOnReader(r, start, end, iterKind, keyTypes, f)
 		r.Free()
 		return err
 	}
-	return iterateOnReader(p, start, end, iterKind, f)
+	return iterateOnReader(p, start, end, iterKind, keyTypes, f)
 }
 
 // NewMVCCIterator implements the Engine interface.
@@ -1974,7 +1977,10 @@ func (p *pebbleReadOnly) MVCCGetProto(
 }
 
 func (p *pebbleReadOnly) MVCCIterate(
-	start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+	start, end roachpb.Key,
+	iterKind MVCCIterKind,
+	keyTypes IterKeyType,
+	f func(MVCCKeyValue, MVCCRangeKeyStack) error,
 ) error {
 	if p.closed {
 		panic("using a closed pebbleReadOnly")
@@ -1982,11 +1988,11 @@ func (p *pebbleReadOnly) MVCCIterate(
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		err := iterateOnReader(r, start, end, iterKind, f)
+		err := iterateOnReader(r, start, end, iterKind, keyTypes, f)
 		r.Free()
 		return err
 	}
-	return iterateOnReader(p, start, end, iterKind, f)
+	return iterateOnReader(p, start, end, iterKind, keyTypes, f)
 }
 
 // NewMVCCIterator implements the Engine interface.
@@ -2249,16 +2255,19 @@ func (p *pebbleSnapshot) MVCCGetProto(
 
 // MVCCIterate implements the Reader interface.
 func (p *pebbleSnapshot) MVCCIterate(
-	start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+	start, end roachpb.Key,
+	iterKind MVCCIterKind,
+	keyTypes IterKeyType,
+	f func(MVCCKeyValue, MVCCRangeKeyStack) error,
 ) error {
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		err := iterateOnReader(r, start, end, iterKind, f)
+		err := iterateOnReader(r, start, end, iterKind, keyTypes, f)
 		r.Free()
 		return err
 	}
-	return iterateOnReader(p, start, end, iterKind, f)
+	return iterateOnReader(p, start, end, iterKind, keyTypes, f)
 }
 
 // NewMVCCIterator implements the Reader interface.

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -183,16 +183,19 @@ func (p *pebbleBatch) MVCCGetProto(
 
 // MVCCIterate implements the Batch interface.
 func (p *pebbleBatch) MVCCIterate(
-	start, end roachpb.Key, iterKind MVCCIterKind, f func(MVCCKeyValue) error,
+	start, end roachpb.Key,
+	iterKind MVCCIterKind,
+	keyTypes IterKeyType,
+	f func(MVCCKeyValue, MVCCRangeKeyStack) error,
 ) error {
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
 		// Doing defer r.Free() does not inline.
-		err := iterateOnReader(r, start, end, iterKind, f)
+		err := iterateOnReader(r, start, end, iterKind, keyTypes, f)
 		r.Free()
 		return err
 	}
-	return iterateOnReader(p, start, end, iterKind, f)
+	return iterateOnReader(p, start, end, iterKind, keyTypes, f)
 }
 
 // NewMVCCIterator implements the Batch interface.


### PR DESCRIPTION
**cli: print range keys in `debug range-data`**

This patch outputs MVCC range keys in `debug range-data`. These are
output at the end of each key span, following the usual order of
`rditer.IterateReplicaKeySpans()`.

Output for a point key (r41 range descriptor) followed by a range key
(MVCC range tombstone across table 40) is e.g.:

```
1659220060.993264767,0 /Local/Range/Table/40/RangeDescriptor (0x016b12b0000172647363001706bbdac3b49c7f09): [/Table/40, /Table/41)
	Raw:r41:/Table/4{0-1} [(n1,s1):1, next=2, gen=0]

1659220060.993264766,2147483647 /Table/4{0-1} (0xb000-0xb100): ""
```

Resolves #83583.

Release note: None

**storage: support range keys in `Engine.MVCCIterate()`**

This patch adds support for MVCC range keys in `MVCCIterate()`, allowing
the key type to be specified and passing overlapping point and/or range
keys to the callback.

Release note: None

**cli: support MVCC range keys in `debug keys`**

This patch displays MVCC range keys in `debug keys`, interleaved with
point keys. It also adds the `--type rangekeys` parameter to only
display range keys.

For example:

```
$ ./cockroach debug keys --type rangekeys ~/local/1/data
1659382586.284196453,2147483647 /Table/{3-5}:
1659382586.284196453,2147483647 /Table/{6-12}:
1659382586.284196453,2147483647 /Table/1{4-5}:
1659382586.284196453,2147483647 /Table/{16-21}:
1659382586.284196453,2147483647 /Table/2{2-3}:
1659382586.284196453,2147483647 /Table/{24-32}:
1659382586.284196453,2147483647 /Table/3{3-7}:
1659382586.284196453,2147483647 /Table/{38-47}:
1659382586.284196453,2147483647 /{Table/50-Max}:

$ ./cockroach debug keys ~/local/1/data
[...]
1659382586.576106063,0 /Table/11/1/47/1/2022-08-01T19:41:14.829118Z/1/0:
1659382591.516425402,0 /Table/11/1/100/1/2022-08-01T19:41:38.121076Z/1/0:
1659382586.284196453,2147483647 /Table/1{4-5}:
1659382586.284196453,2147483647 /Table/{16-21}:
1659382586.284196453,2147483647 /Table/2{2-3}:
1659382586.284196453,2147483647 /Table/{24-32}:
1659382586.627810749,0 /NamespaceTable/30/1/0/0/"defaultdb"/4/1:
1659382586.641281444,0 /NamespaceTable/30/1/0/0/"postgres"/4/1:
[...]
```

Release note: None