### PR TITLE
kv: retry AdminSplit on LeaseTransferRejectedBecauseTargetMayNeedSnapshot

### DIFF
--- a/pkg/kv/kvserver/markers.go
+++ b/pkg/kv/kvserver/markers.go
@@ -32,7 +32,9 @@ var errMarkCanRetryReplicationChangeWithUpdatedDesc = errors.New("should retry w
 // assumed to have been emitted by the KV layer during a replication change
 // operation) is likely to succeed when retried with an updated descriptor.
 func IsRetriableReplicationChangeError(err error) bool {
-	return errors.Is(err, errMarkCanRetryReplicationChangeWithUpdatedDesc) || isSnapshotError(err)
+	return errors.Is(err, errMarkCanRetryReplicationChangeWithUpdatedDesc) ||
+		IsLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(err) ||
+		isSnapshotError(err)
 }
 
 const (

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -546,9 +546,9 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 		}
 
 		lastErr = updateDesc(r.Desc())
-		// On seeing a ConditionFailedError or an AmbiguousResultError, retry the
-		// command with the updated descriptor.
-		if !errors.HasType(lastErr, (*roachpb.ConditionFailedError)(nil)) &&
+		// On seeing a retryable replication change or an AmbiguousResultError,
+		// retry the command with the updated descriptor.
+		if !IsRetriableReplicationChangeError(lastErr) &&
 			!errors.HasType(lastErr, (*roachpb.AmbiguousResultError)(nil)) {
 			break
 		}

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1251,7 +1251,7 @@ func (rp *replicaProposer) rejectProposalWithLeaseTransferRejectedLocked(
 	rp.store.metrics.LeaseTransferErrorCount.Inc(1)
 	log.VEventf(ctx, 2, "not proposing lease transfer because the target %s may "+
 		"need a snapshot: %s", lease.Replica, reason)
-	err := newLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(lease.Replica, reason)
+	err := NewLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(lease.Replica, reason)
 	rp.rejectProposalWithErrLocked(ctx, prop, roachpb.NewError(err))
 }
 

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -914,7 +914,7 @@ func (r *Replica) AdminTransferLease(ctx context.Context, target roachpb.StoreID
 			r.store.metrics.LeaseTransferErrorCount.Inc(1)
 			log.VEventf(ctx, 2, "not initiating lease transfer because the target %s may "+
 				"need a snapshot: %s", nextLeaseHolder, snapStatus)
-			err := newLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(nextLeaseHolder, snapStatus)
+			err := NewLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(nextLeaseHolder, snapStatus)
 			return nil, nil, err
 		}
 
@@ -1060,10 +1060,10 @@ func newNotLeaseHolderErrorWithSpeculativeLease(
 	return newNotLeaseHolderError(speculativeLease, proposerStoreID, rangeDesc, msg)
 }
 
-// newLeaseTransferRejectedBecauseTargetMayNeedSnapshotError return an error
+// NewLeaseTransferRejectedBecauseTargetMayNeedSnapshotError return an error
 // indicating that a lease transfer failed because the current leaseholder could
 // not prove that the lease transfer target did not need a Raft snapshot.
-func newLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(
+func NewLeaseTransferRejectedBecauseTargetMayNeedSnapshotError(
 	target roachpb.ReplicaDescriptor, snapStatus raftutil.ReplicaNeedsSnapshotStatus,
 ) error {
 	err := errors.Errorf("refusing to transfer lease to %d because target may need a Raft snapshot: %s",


### PR DESCRIPTION
Informs #84635.
Informs #84162.
Fixes #85449.
Fixes #83174.

This commit considers the `LeaseTransferRejectedBecauseTargetMayNeedSnapshot`
status to be a form of a retriable replication change error. It then hooks
`Replica.executeAdminCommandWithDescriptor` up to consult this status in its
retry loop.

This avoids spurious errors when a split gets blocked behind a lateral replica
move like we see in the following situation:
1. issue AdminSplit
2. range in joint config, first needs to leave (maybeLeaveAtomicChangeReplicas)
3. to leave, needs to transfer lease from voter_outgoing to voter_incoming
4. can’t transfer lease because doing so is deemed to be potentially unsafe

Release note: None

Release justification: Low risk, resolves flaky test.