### PR TITLE
server: fix tenant auth on statements http endpoint

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_test_utils.go
@@ -217,6 +217,10 @@ func (c *httpClient) GetJSON(path string, response protoutil.Message) {
 	require.NoError(c.t, err)
 }
 
+func (c *httpClient) GetJSONChecked(path string, response protoutil.Message) error {
+	return httputil.GetJSON(c.client, c.baseURL+path, response)
+}
+
 func (c *httpClient) PostJSON(path string, request protoutil.Message, response protoutil.Message) {
 	err := c.PostJSONChecked(path, request, response)
 	require.NoError(c.t, err)

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3420,8 +3420,14 @@ func (s *adminServer) dialNode(
 // adminPrivilegeChecker is a helper struct to check whether given usernames
 // have admin privileges.
 type adminPrivilegeChecker struct {
-	ie          *sql.InternalExecutor
-	st          *cluster.Settings
+	ie *sql.InternalExecutor
+	st *cluster.Settings
+	// makePlanner is a function that calls NewInternalPlanner
+	// to make a planner outside of the sql package. This is a hack
+	// to get around a Go package dependency cycle. See comment
+	// in pkg/scheduledjobs/env.go on planHookMaker. It should
+	// be cast to AuthorizationAccessor in order to use
+	// privilege checking functions.
 	makePlanner func(opName string) (interface{}, func())
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -716,7 +716,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	lateBoundServer := &Server{}
 	// TODO(tbg): give adminServer only what it needs (and avoid circular deps).
-	adminAuthzCheck := &adminPrivilegeChecker{ie: internalExecutor, st: st}
+	adminAuthzCheck := &adminPrivilegeChecker{ie: internalExecutor, st: st, makePlanner: nil}
 	sAdmin := newAdminServer(lateBoundServer, adminAuthzCheck, internalExecutor)
 
 	// These callbacks help us avoid a dependency on gossip in httpServer.


### PR DESCRIPTION
This patch resolves a panic due to failed authorization
by adding in the missing fields cluster.Settings and
makePlanner function to the privilegechecker in tenant.go.

Resolves #85404 

Release note (bug fix): fixes a panic when loading tenant http
endpoints for statement stats

After changes on multi-tenant:
Without system privileges:
![Screen Shot 2022-08-01 at 5 28 02 PM](https://user-images.githubusercontent.com/17861665/182249941-29cb6f7d-3e38-47e3-9349-296486239029.png)


With `VIEWACTIVITY`:
![Screen Shot 2022-08-01 at 5 28 33 PM](https://user-images.githubusercontent.com/17861665/182249905-9000b851-ac65-460a-9065-ba2f239eed39.png)

