### PR TITLE
kv: don't heap allocate transaction deadline timestamp

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -446,9 +446,9 @@ func (tc *TxnCoordSender) finalizeNonLockingTxnLocked(
 	et := ba.Requests[0].GetEndTxn()
 	if et.Commit {
 		deadline := et.Deadline
-		if deadline != nil && !deadline.IsEmpty() && deadline.LessEq(tc.mu.txn.WriteTimestamp) {
+		if !deadline.IsEmpty() && deadline.LessEq(tc.mu.txn.WriteTimestamp) {
 			txn := tc.mu.txn.Clone()
-			pErr := generateTxnDeadlineExceededErr(txn, *deadline)
+			pErr := generateTxnDeadlineExceededErr(txn, deadline)
 			// We need to bump the epoch and transform this retriable error.
 			ba.Txn = txn
 			return tc.updateStateLocked(ctx, ba, nil /* br */, pErr)

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -314,8 +314,8 @@ func (tc *txnCommitter) sendLockedWithElidedEndTxn(
 	// transaction is trying to commit.
 	if et.Commit {
 		deadline := et.Deadline
-		if deadline != nil && !deadline.IsEmpty() && deadline.LessEq(br.Txn.WriteTimestamp) {
-			return nil, generateTxnDeadlineExceededErr(ba.Txn, *deadline)
+		if !deadline.IsEmpty() && deadline.LessEq(br.Txn.WriteTimestamp) {
+			return nil, generateTxnDeadlineExceededErr(ba.Txn, deadline)
 		}
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -445,8 +445,8 @@ func EndTxn(
 // IsEndTxnExceedingDeadline returns true if the transaction's provisional
 // commit timestamp exceeded its deadline. If so, the transaction should not be
 // allowed to commit.
-func IsEndTxnExceedingDeadline(commitTS hlc.Timestamp, deadline *hlc.Timestamp) bool {
-	return deadline != nil && !deadline.IsEmpty() && deadline.LessEq(commitTS)
+func IsEndTxnExceedingDeadline(commitTS hlc.Timestamp, deadline hlc.Timestamp) bool {
+	return !deadline.IsEmpty() && deadline.LessEq(commitTS)
 }
 
 // IsEndTxnTriggeringRetryError returns true if the EndTxnRequest cannot be

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -100,7 +100,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 		commit         bool
 		noLockSpans    bool
 		inFlightWrites []roachpb.SequencedWrite
-		deadline       *hlc.Timestamp
+		deadline       hlc.Timestamp
 		// Expected result.
 		expError string
 		expTxn   *roachpb.TransactionRecord
@@ -917,7 +917,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			// Sanity check request args.
 			if !c.commit {
 				require.Nil(t, c.inFlightWrites)
-				require.Nil(t, c.deadline)
+				require.Zero(t, c.deadline)
 			}
 
 			// Issue an EndTxn request.

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -557,13 +557,13 @@ func canDoServersideRetry(
 	ba *roachpb.BatchRequest,
 	br *roachpb.BatchResponse,
 	g *concurrency.Guard,
-	deadline *hlc.Timestamp,
+	deadline hlc.Timestamp,
 ) bool {
 	if ba.Txn != nil {
 		if !ba.CanForwardReadTimestamp {
 			return false
 		}
-		if deadline != nil {
+		if !deadline.IsEmpty() {
 			log.Fatal(ctx, "deadline passed for transactional request")
 		}
 		if etArg, ok := ba.GetArg(roachpb.EndTxn); ok {

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -311,7 +312,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 			break
 		}
 		// If we can retry, set a higher batch timestamp and continue.
-		if !canDoServersideRetry(ctx, pErr, ba, br, g, nil /* deadline */) {
+		if !canDoServersideRetry(ctx, pErr, ba, br, g, hlc.Timestamp{} /* deadline */) {
 			r.store.Metrics().ReadEvaluationServerSideRetryFailure.Inc(1)
 			break
 		} else {

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/circuit"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -794,7 +795,7 @@ func (r *Replica) handleReadWithinUncertaintyIntervalError(
 	// Attempt a server-side retry of the request. Note that we pass nil for
 	// latchSpans, because we have already released our latches and plan to
 	// re-acquire them if the retry is allowed.
-	if !canDoServersideRetry(ctx, pErr, ba, nil /* br */, nil /* g */, nil /* deadline */) {
+	if !canDoServersideRetry(ctx, pErr, ba, nil /* br */, nil /* g */, hlc.Timestamp{} /* deadline */) {
 		r.store.Metrics().ReadWithinUncertaintyIntervalErrorServerSideRetryFailure.Inc(1)
 		return nil, pErr
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -3946,15 +3946,13 @@ func TestEndTxnDeadline(t *testing.T) {
 			// No deadline.
 		case 1:
 			// Past deadline.
-			ts := txn.WriteTimestamp.Prev()
-			etArgs.Deadline = &ts
+			etArgs.Deadline = txn.WriteTimestamp.Prev()
 		case 2:
 			// Equal deadline.
-			etArgs.Deadline = &txn.WriteTimestamp
+			etArgs.Deadline = txn.WriteTimestamp
 		case 3:
 			// Future deadline.
-			ts := txn.WriteTimestamp.Next()
-			etArgs.Deadline = &ts
+			etArgs.Deadline = txn.WriteTimestamp.Next()
 		}
 
 		{
@@ -4016,9 +4014,8 @@ func TestSerializableDeadline(t *testing.T) {
 	// Send an EndTxn with a deadline below the point where the txn has been
 	// pushed.
 	etArgs, etHeader := endTxnArgs(txn, true /* commit */)
-	deadline := updatedPushee.WriteTimestamp
-	deadline.Logical--
-	etArgs.Deadline = &deadline
+	etArgs.Deadline = updatedPushee.WriteTimestamp
+	etArgs.Deadline.Logical--
 	_, pErr = tc.SendWrappedWith(etHeader, &etArgs)
 	const expectedErrMsg = "TransactionRetryError: retry txn \\(RETRY_SERIALIZABLE\\)"
 	if pErr == nil {
@@ -4152,8 +4149,7 @@ func TestEndTxnDeadline_1PC(t *testing.T) {
 	put := putArgs(key, []byte("value"))
 	et, etH := endTxnArgs(txn, true)
 	// Past deadline.
-	ts := txn.WriteTimestamp.Prev()
-	et.Deadline = &ts
+	et.Deadline = txn.WriteTimestamp.Prev()
 
 	var ba roachpb.BatchRequest
 	ba.Header = etH

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -430,7 +430,7 @@ func (r *Replica) evaluateWriteBatch(
 	rec := NewReplicaEvalContext(ctx, r, g.LatchSpans(), ba.RequiresClosedTSOlderThanStorageSnapshot())
 	defer rec.Release()
 	batch, br, res, pErr := r.evaluateWriteBatchWithServersideRefreshes(
-		ctx, idKey, rec, ms, ba, g, st, ui, nil /* deadline */)
+		ctx, idKey, rec, ms, ba, g, st, ui, hlc.Timestamp{} /* deadline */)
 	return batch, *ms, br, res, pErr
 }
 
@@ -606,7 +606,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
-	deadline *hlc.Timestamp,
+	deadline hlc.Timestamp,
 ) (batch storage.Batch, br *roachpb.BatchResponse, res result.Result, pErr *roachpb.Error) {
 	goldenMS := *ms
 	for retries := 0; ; retries++ {

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -511,14 +511,14 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 		}), clock, stopper)
 	txn := NewTxn(ctx, db, 0 /* gatewayNodeID */)
 
-	if txn.deadline() != nil {
+	if !txn.deadline().IsEmpty() {
 		t.Errorf("unexpected initial deadline: %s", txn.deadline())
 	}
 
 	deadline := hlc.Timestamp{WallTime: 10, Logical: 1}
 	err := txn.UpdateDeadline(ctx, deadline)
 	require.NoError(t, err, "Deadline update failed")
-	if d := *txn.deadline(); d != deadline {
+	if d := txn.deadline(); d != deadline {
 		t.Errorf("unexpected deadline: %s", d)
 	}
 
@@ -527,14 +527,14 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 	futureDeadline := hlc.Timestamp{WallTime: 11, Logical: 1}
 	err = txn.UpdateDeadline(ctx, futureDeadline)
 	require.NoError(t, err, "Future deadline update failed")
-	if d := *txn.deadline(); d != futureDeadline {
+	if d := txn.deadline(); d != futureDeadline {
 		t.Errorf("unexpected deadline: %s", d)
 	}
 
 	pastDeadline := hlc.Timestamp{WallTime: 9, Logical: 1}
 	err = txn.UpdateDeadline(ctx, pastDeadline)
 	require.NoError(t, err, "Past deadline update failed")
-	if d := *txn.deadline(); d != pastDeadline {
+	if d := txn.deadline(); d != pastDeadline {
 		t.Errorf("unexpected deadline: %s", d)
 	}
 }

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -707,7 +707,7 @@ message EndTxnRequest {
   // If EndTxn(Commit=true) finds that the txn's timestamp has been pushed above
   // this deadline, an error will be returned and the client is supposed to
   // rollback the txn.
-  util.hlc.Timestamp deadline = 3;
+  util.hlc.Timestamp deadline = 3 [(gogoproto.nullable) = false];
   // commit triggers. Note that commit triggers are for
   // internal use only and will cause an error if requested through the
   // external-facing KV API.

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1143,10 +1143,10 @@ func TestTransactionDeadline(t *testing.T) {
 
 		if args, ok := ba.GetArg(roachpb.EndTxn); ok {
 			et := args.(*roachpb.EndTxnRequest)
-			if et.Deadline == nil || et.Deadline.IsEmpty() {
+			if et.Deadline.IsEmpty() {
 				return nil
 			}
-			mu.txnDeadline = *et.Deadline
+			mu.txnDeadline = et.Deadline
 		}
 		return nil
 	}


### PR DESCRIPTION
Fixes #74224.
Second half of #74225.

This commit changes `EndTxnRequest.Deadline` from a nullable `*hlc.Timestamp` to
a non-nullable `hlc.Timestamp`. This avoids the need to heap allocate the
transaction deadline.

In #74224, we saw that in a run of sysbench's `oltp_point_select` workload, this
was the 9th most frequent source of heap allocations, accounting for over **1%**
of total allocations.

```
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
...
----------------------------------------------------------+-------------
                                          63603658   100% |   github.com/cockroachdb/cockroach/pkg/sql/catalog/descs.(*leasedDescriptors).maybeUpdateDeadline /go/src/github.com/cockroachdb/cockroach/pkg/sql/catalog/descs/leased_descriptors.go:217
  63603658  1.06% 13.90%   63603658  1.06%                | github.com/cockroachdb/cockroach/pkg/kv.(*Txn).UpdateDeadline /go/src/github.com/cockroachdb/cockroach/pkg/kv/txn.go:784
----------------------------------------------------------+-------------
```

Release note: None