### PR TITLE
logictest: temporarily disable workmem randomization in SQLLite tests

### DIFF
--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
@@ -72,6 +72,8 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
+		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -91,6 +91,8 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
+		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
@@ -71,6 +71,8 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
+		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
@@ -71,6 +71,8 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
+		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
@@ -71,6 +71,8 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
+		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
@@ -71,6 +71,8 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
+		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local/generated_test.go
@@ -71,6 +71,8 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
+		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }


### PR DESCRIPTION
This commit restores 2bdcab7e6941ec96ca2be2ea5fb25331022c06c0 that was
lost during the mega logic test refactor.

Fixes: #85377.

Release note: None