### PR TITLE
colflow: fix a recent flake

### DIFF
--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -230,7 +230,13 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 						},
 					)
 				}
-				synchronizer := colexec.NewParallelUnorderedSynchronizer(testAllocator, synchronizerInputs, &wg)
+				syncMemAccount := testMemMonitor.MakeBoundAccount()
+				defer syncMemAccount.Close(ctx)
+				// Note that here - for the purposes of the test - it doesn't
+				// matter which context we use since it'll only be used by the
+				// memory accounting system.
+				syncAllocator := colmem.NewAllocator(ctx, &syncMemAccount, testColumnFactory)
+				synchronizer := colexec.NewParallelUnorderedSynchronizer(syncAllocator, synchronizerInputs, &wg)
 				inputMetadataSource := colexecop.MetadataSource(synchronizer)
 				flowID := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 


### PR DESCRIPTION
In 0866ddc9dbd8b564563386f2cc95b35e8e149c11 we merged a change that
relied on the assumption that the allocator passed to the parallel
unordered synchronizer was not used by anyone else, but this assumption
was broken in a test and is now fixed.

Fixes: #85360.

Release note: None