### PR TITLE
release-22.1: colexec: fix UUID and STRING concat

### DIFF
--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sem/tree/treebin",
         "//pkg/sql/sem/tree/treecmp",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1993,16 +1993,18 @@ func planProjectionOperators(
 		}
 		leftExpr, rightExpr := t.TypedLeft(), t.TypedRight()
 		if t.Operator.Symbol == treebin.Concat {
-			// Concat requires special handling.
+			// Concat requires special handling since it has special rules when
+			// one of the arguments is an array or a string. We don't have
+			// native vectorized support for arrays yet, so we don't have to do
+			// anything extra for them, but we do need to handle the string
+			// case.
 			leftType, rightType := leftExpr.ResolvedType(), rightExpr.ResolvedType()
-			if leftType.Family() != rightType.Family() {
-				// When we have two different types, we perform the STRING
-				// concatenation.
+			if t.Fn.ReturnType == types.String && leftType.Family() != rightType.Family() {
+				// This is a special case of the STRING concatenation - we have
+				// to plan a cast of the non-string type to a STRING.
 				if leftType.Family() == types.StringFamily {
-					// Need to cast the right expr to the STRING.
 					rightExpr = tree.NewTypedCastExpr(rightExpr, types.String)
 				} else if rightType.Family() == types.StringFamily {
-					// Need to cast the left expr to the STRING.
 					leftExpr = tree.NewTypedCastExpr(leftExpr, types.String)
 				} else {
 					// This is unexpected.

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -2263,3 +2263,11 @@ SELECT indkey FROM pg_index WHERE indrelid = (SELECT oid FROM pg_class WHERE rel
 
 statement ok
 RESET distsql_workmem
+
+# Regression test for incorrect planning in the vectorized engine for
+# concatenating a string with a string array (#85295).
+query T
+SELECT ('foo'::STRING || col::STRING[])::STRING[] FROM (VALUES (ARRAY['bar':::STRING]), (ARRAY['baz':::STRING])) AS t (col);
+----
+{foo,bar}
+{foo,baz}

--- a/pkg/sql/logictest/testdata/logic_test/uuid
+++ b/pkg/sql/logictest/testdata/logic_test/uuid
@@ -116,3 +116,13 @@ query T
 SELECT ('63616665-6630-3064-6465-616462656562' COLLATE en)::uuid
 ----
 63616665-6630-3064-6465-616462656562
+
+# Regression test for incorrect concatenation of a UUID with a STRING in the
+# vectorized engine (#83093).
+statement ok
+CREATE TABLE t83093 (u) AS SELECT 'eb64afe6-ade7-40ce-8352-4bb5eec39075'::UUID
+
+query T
+SELECT u || 'foo' FROM t83093
+----
+eb64afe6-ade7-40ce-8352-4bb5eec39075foo

--- a/pkg/sql/sem/tree/testdata/eval/concat
+++ b/pkg/sql/sem/tree/testdata/eval/concat
@@ -52,6 +52,11 @@ true || 'a' || false
 'trueafalse'
 
 eval
+'eb64afe6-ade7-40ce-8352-4bb5eec39075'::UUID || 'a'
+----
+'eb64afe6-ade7-40ce-8352-4bb5eec39075a'
+
+eval
 (1,2) || 'a' || (3,4)
 ----
 '(1,2)a(3,4)'


### PR DESCRIPTION
Backport:
  * 1/1 commits from "colexec: fix UUID and STRING concat" (#85150)
  * 1/1 commits from "colexec: fix recent concat fix" (#85329)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: bug fix.