### PR TITLE
gcjob: introduce DeleteAllTableData()

### DIFF
--- a/pkg/sql/gcjob/BUILD.bazel
+++ b/pkg/sql/gcjob/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/timeutil",
@@ -51,6 +52,7 @@ go_test(
         "gc_job_test.go",
         "gc_protected_timestamp_test.go",
         "main_test.go",
+        "table_garbage_collection_test.go",
     ],
     embed = [":gcjob"],
     deps = [
@@ -59,6 +61,7 @@ go_test(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",

--- a/pkg/sql/gcjob/table_garbage_collection_test.go
+++ b/pkg/sql/gcjob/table_garbage_collection_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package gcjob
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteAllSpanData checks that deleteAllSpanData properly deletes data
+// from the provided span.
+func TestDeleteAllSpanData(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	b := &kv.Batch{}
+	b.Put("aa", "1")
+	b.Put("ab", "2")
+	b.Put("bb", "3")
+	require.NoError(t, kvDB.Run(context.Background(), b))
+
+	deleteSpan := roachpb.RSpan{Key: roachpb.RKey("aa"), EndKey: roachpb.RKey("bb")}
+	distSender := s.DistSenderI().(*kvcoord.DistSender)
+	require.NoError(t, deleteAllSpanData(ctx, kvDB, distSender, deleteSpan))
+
+	kvs, err := kvDB.Scan(ctx, "aa", "bb", 0)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(kvs))
+}


### PR DESCRIPTION
This patch introduces the DeleteAllTableData and deleteAllSpanData funcions,
which allow the sql layer to issue DeleteRange requests over an arbitralily
large span. Future prs will replace the ClearTableData calls in import
rollbacks (https://github.com/cockroachdb/cockroach/pull/84923) and in gc jobs.

Note that deleteAllSpanData looks identical to clearSpanData, except:
- it uses DeleteRangeRequest instead ClearRangeRequest
- each request is sent with admission control
- the waitTime was removed  because a single MVCC rangeTombstone is unlikely to
  overwhelm the kv layer. Whether pebble tombstones created during
  a gc job overwhelm the system should be tested later.

Note that deleteAllSpanData still partitions the provided span into
subspans, to prevent reaching the distSender concurrency limit. Once https://github.com/cockroachdb/cockroach/issues/85470
closes, this partitioning may no longer be necessary.