### PR TITLE
tracing: fix lazytag export for Jaegar/otel

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -923,34 +923,19 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 			// We encode the tag values as strings.
 			addTag(string(kv.Key), kv.Value.Emit())
 		}
-		for _, kv := range s.mu.lazyTags {
-			switch v := kv.Value.(type) {
-			case LazyTag:
-				var tagGroup *tracingpb.TagGroup
-				for _, tag := range v.Render() {
-					if tagGroup == nil {
-						// Only create the tag group if we have at least one child tag.
-						tagGroup = addTagGroup(kv.Key)
-					}
-					childKey := string(tag.Key)
-					childValue := tag.Value.Emit()
-
-					if rs.Tags == nil {
-						rs.Tags = make(map[string]string)
-					}
-					rs.Tags[childKey] = childValue
-
-					tagGroup.Tags = append(tagGroup.Tags,
-						tracingpb.Tag{
-							Key:   childKey,
-							Value: childValue,
-						},
-					)
+		for _, tg := range s.getLazyTagGroupsLocked() {
+			if tg.Name == tracingpb.AnonymousTagGroupName {
+				for _, tag := range tg.Tags {
+					addTag(tag.Key, tag.Value)
 				}
-			case fmt.Stringer:
-				addTag(kv.Key, v.String())
-			default:
-				addTag(kv.Key, fmt.Sprintf("<can't render %T>", kv.Value))
+			} else {
+				rs.TagGroups = append(rs.TagGroups, *tg)
+				if rs.Tags == nil {
+					rs.Tags = make(map[string]string)
+				}
+				for _, tag := range tg.Tags {
+					rs.Tags[tag.Key] = tag.Value
+				}
 			}
 		}
 
@@ -971,6 +956,59 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 	}
 
 	return rs
+}
+
+// getLazyTagGroupsLocked returns a list of lazy tags as a slice of
+// *tracingpb.TagGroup
+func (s *crdbSpan) getLazyTagGroupsLocked() []*tracingpb.TagGroup {
+	var lazyTags []*tracingpb.TagGroup
+	addTagGroup := func(name string) *tracingpb.TagGroup {
+		lazyTags = append(lazyTags,
+			&tracingpb.TagGroup{
+				Name: name,
+			})
+		return lazyTags[len(lazyTags)-1]
+	}
+
+	addTag := func(k, v string) {
+		var tagGroup *tracingpb.TagGroup
+		for _, tg := range lazyTags {
+			if tg.Name == tracingpb.AnonymousTagGroupName {
+				tagGroup = tg
+				break
+			}
+		}
+		if tagGroup == nil {
+			tagGroup = addTagGroup(tracingpb.AnonymousTagGroupName)
+		}
+		tagGroup.Tags = append(tagGroup.Tags, tracingpb.Tag{
+			Key:   k,
+			Value: v,
+		})
+	}
+	for _, kv := range s.mu.lazyTags {
+		switch v := kv.Value.(type) {
+		case LazyTag:
+			var tagGroup *tracingpb.TagGroup
+			for _, tag := range v.Render() {
+				if tagGroup == nil {
+					// Only create the tag group if we have at least one child tag.
+					tagGroup = addTagGroup(kv.Key)
+				}
+				tagGroup.Tags = append(tagGroup.Tags,
+					tracingpb.Tag{
+						Key:   string(tag.Key),
+						Value: tag.Value.Emit(),
+					},
+				)
+			}
+		case fmt.Stringer:
+			addTag(kv.Key, v.String())
+		default:
+			addTag(kv.Key, fmt.Sprintf("<can't render %T>", kv.Value))
+		}
+	}
+	return lazyTags
 }
 
 // addChildLocked adds a child to the receiver.


### PR DESCRIPTION
Previously, lazytags would not render in the otel export to
Jaeger. This was because otel doesn't support an on-demand
nature of the lazytags in its interface.

This change manually adds lazytags as otel tags before an otel
span is finished, allowing them to render in Jaeger after they
are exported.

Resolves: #85166

Release note: None

Release justification: bug fixes