### PR TITLE
explain: print "FULL SCAN (SOFT LIMIT)" for full scans with soft limits

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -772,7 +772,7 @@ vectorized: true
 │                   └── • scan
 │                         missing stats
 │                         table: t@t_b_key
-│                         spans: FULL SCAN
+│                         spans: FULL SCAN (SOFT LIMIT)
 │
 └── • constraint-check
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -950,7 +950,7 @@ vectorized: true
                 └── • scan
                       missing stats
                       table: xyz@xy
-                      spans: FULL SCAN
+                      spans: FULL SCAN (SOFT LIMIT)
 
 # Scalar subquery in filter is supported.
 query T
@@ -1070,7 +1070,7 @@ vectorized: true
                 └── • scan
                       missing stats
                       table: xyz@xyz_pkey
-                      spans: FULL SCAN
+                      spans: FULL SCAN (SOFT LIMIT)
 
 # VARIANCE/STDDEV
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -86,7 +86,7 @@ vectorized: true
         └── • scan
               missing stats
               table: unindexed@unindexed_pkey
-              spans: FULL SCAN
+              spans: FULL SCAN (SOFT LIMIT)
 
 # Check DELETE with LIMIT clause (MySQL extension)
 query T
@@ -108,7 +108,7 @@ vectorized: true
         └── • scan
               missing stats
               table: unindexed@unindexed_pkey
-              spans: FULL SCAN
+              spans: FULL SCAN (SOFT LIMIT)
 
 # Check fast DELETE.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
@@ -142,4 +142,4 @@ vectorized: true
         └── • scan
               missing stats
               table: abc@abc_c_b_idx
-              spans: FULL SCAN
+              spans: FULL SCAN (SOFT LIMIT)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -917,7 +917,7 @@ vectorized: true
               columns: (v)
               estimated row count: 1,000 (missing stats)
               table: t@t_pkey
-              spans: FULL SCAN
+              spans: FULL SCAN (SOFT LIMIT)
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a), FAMILY "primary" (a, b, rowid))

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -251,7 +251,7 @@ vectorized: true
               columns: (k, v, w)
               estimated row count: 1,000 (missing stats)
               table: t@t_pkey
-              spans: FULL SCAN
+              spans: FULL SCAN (SOFT LIMIT)
 
 query T
 EXPLAIN (VERBOSE) SELECT k, w FROM t WHERE v >= 1 AND v <= 100 ORDER BY v LIMIT 10
@@ -308,7 +308,7 @@ vectorized: true
                   ordering: +k
                   estimated row count: 1,000 (missing stats)
                   table: t@t_pkey
-                  spans: FULL SCAN
+                  spans: FULL SCAN (SOFT LIMIT)
 
 # Regression test for #47283: scan with both hard limit and soft limit.
 statement ok
@@ -526,7 +526,7 @@ vectorized: true
     └── • scan
           estimated row count: 100 - 1,001 (100% of the table; stats collected <hidden> ago)
           table: a@a_i_j_idx
-          spans: FULL SCAN
+          spans: FULL SCAN (SOFT LIMIT)
 
 # A limit cannot be pushed into the scan of a virtual table with ORDER BY.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -358,4 +358,4 @@ regions: <hidden>
           estimated max memory allocated: 0 B
           estimated row count: 1 (100% of the table; stats collected <hidden> ago)
           table: a@a_y_idx
-          spans: FULL SCAN
+          spans: FULL SCAN (SOFT LIMIT)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -149,7 +149,7 @@ vectorized: true
 │                 columns: (a, b, c)
 │                 estimated row count: 1,000 (missing stats)
 │                 table: abc@abc_pkey
-│                 spans: FULL SCAN
+│                 spans: FULL SCAN (SOFT LIMIT)
 │
 └── • subquery
     │ id: @S2
@@ -177,7 +177,7 @@ vectorized: true
                       ordering: -a
                       estimated row count: 1,000 (missing stats)
                       table: abc@abc_pkey
-                      spans: FULL SCAN
+                      spans: FULL SCAN (SOFT LIMIT)
 
 # IN expression transformed into semi-join.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/topk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/topk
@@ -140,4 +140,4 @@ vectorized: true
           ordering: +v
           estimated row count: 1,000 (missing stats)
           table: t@v
-          spans: FULL SCAN
+          spans: FULL SCAN (SOFT LIMIT)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -909,6 +909,9 @@ func (e *emitter) spansStr(table cat.Table, index cat.Index, scanParams exec.Sca
 		if scanParams.HardLimit > 0 {
 			return "LIMITED SCAN"
 		}
+		if scanParams.SoftLimit > 0 {
+			return "FULL SCAN (SOFT LIMIT)"
+		}
 		return "FULL SCAN"
 	}
 


### PR DESCRIPTION
Change `EXPLAIN` output of full scans with soft limits to
"FULL SCAN (SOFT LIMIT)" instead of "FULL SCAN". This will help
distinguish them from unlimited full scans.

So now we print three different messages for three kinds of full scans:
- For full scans with hard limits we print "LIMITED SCAN".
- For full scans with soft limits we print "FULL SCAN (SOFT LIMIT)".
- For unlimited full scans we print "FULL SCAN".

Release note (sql change): Change `EXPLAIN` output of full scans with
soft limits to "FULL SCAN (SOFT LIMIT)" instead of "FULL SCAN", to
distinguish them from unlimited full scans. Unlimited full scans always
scan the entire index. Full scans with soft limits could scan the entire
index, but usually halt early once enough rows have been found to
satisfy their parent operator.