### PR TITLE
opt: allow auto-commit and bounded staleness with distribute operator

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -455,3 +455,15 @@ vectorized: true
           table: t85043@t85043_pkey
           spans: [/'ab020c49-ba5e-4800-8000-00000000014e' - /'ab020c49-ba5e-4800-8000-00000000014e']
           locking strength: for update
+
+# Regression test for #85288. Distribute enforcer should not prevent the
+# optimizer from using bounded staleness.
+statement ok
+CREATE TABLE t85288 (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ts TIMESTAMP
+);
+
+statement ok
+select ts FROM t85288 AS OF SYSTEM TIME with_max_staleness('1h') WHERE
+ id = '00000000-0000-4000-8000-000000000000';

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -426,3 +426,32 @@ USE multi_region_test_db; SELECT g FROM t74890 ORDER BY g
 3
 4
 5
+
+# Regression test for #85043. Distribute enforcer should not prevent the
+# optimizer from planning auto-commit.
+statement ok
+CREATE DATABASE one_region_test_db PRIMARY REGION "ca-central-1";
+USE one_region_test_db;
+CREATE TABLE t85043 (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ts TIMESTAMP
+);
+
+query T
+EXPLAIN UPDATE t85043 SET ts = '2022-08-01 18:07:07' WHERE id = 'ab020c49-ba5e-4800-8000-00000000014e'
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: t85043
+│ set: ts
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: t85043@t85043_pkey
+          spans: [/'ab020c49-ba5e-4800-8000-00000000014e' - /'ab020c49-ba5e-4800-8000-00000000014e']
+          locking strength: for update

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -926,6 +926,11 @@ func (b *Builder) canAutoCommit(rel memo.RelExpr) bool {
 		}
 		return b.canAutoCommit(proj.Input)
 
+	case opt.DistributeOp:
+		// Distribute is currently a no-op, so check whether the input can
+		// auto-commit.
+		return b.canAutoCommit(rel.(*memo.DistributeExpr).Input)
+
 	default:
 		return false
 	}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2673,6 +2673,7 @@ var boundedStalenessAllowList = map[opt.Operator]struct{}{
 	opt.GroupByOp:          {},
 	opt.ScalarGroupByOp:    {},
 	opt.DistinctOnOp:       {},
+	opt.DistributeOp:       {},
 	opt.EnsureDistinctOnOp: {},
 	opt.LimitOp:            {},
 	opt.OffsetOp:           {},


### PR DESCRIPTION
**opt: allow auto-commit with distribute operator**

Prior to this commit, we disallowed auto-commit when a plan had a
distribute enforcer. However, this was an oversight, as the distribute
operator in the the optimizer is currently a no-op, and should not
impact the ability to perform auto-commit.

Fixes https://github.com/cockroachdb/cockroach/issues/85043

Release note (bug fix): Fixed a bug that was introduced in 22.1.0 that
could cause the optimizer to not use auto-commit for some mutations in
multi-region clusters when it should have done so. This could cause
poor query performance.

**opt: allow bounded staleness with distribute operator**

Prior to this commit, we disallowed bounded staleness when a plan had a
distribute enforcer. However, this was an oversight, as the distribute
operator in the the optimizer is currently a no-op, and should not
impact the ability to perform reads with bounded staleness.

Fixes https://github.com/cockroachdb/cockroach/issues/85288

Release note (bug fix): Fixed a bug that was introduced in 22.1.0 that
could cause the optimizer to reject valid bounded staleness queries with
the error "unimplemented: cannot use bounded staleness for DISTRIBUTE".
This has now been fixed.