### PR TITLE
dev: support testlogic --rewrite with a specific config

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=49
+DEV_VERSION=50
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -145,6 +145,10 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 			testsDir = "//pkg/ccl/sqlitelogictestccl/tests"
 			bigtest = true
 		}
+		// Keep track of the relative path to the root of the tests directory
+		// (i.e. not the subdirectory for the config). We'll need this path
+		// to properly build the writable path for rewrite.
+		baseTestsDir := strings.TrimPrefix(testsDir, "//")
 		if config != "" {
 			testsDir = testsDir + "/" + config
 			exists, err := d.os.IsDir(filepath.Join(workspace, strings.TrimPrefix(testsDir, "//")))
@@ -161,7 +165,7 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		targets = append(targets, testsDir+"/...")
 
 		if rewrite {
-			dir := filepath.Join(filepath.Dir(strings.TrimPrefix(testsDir, "//")), "testdata")
+			dir := filepath.Join(filepath.Dir(baseTestsDir), "testdata")
 			args = append(args, fmt.Sprintf("--sandbox_writable_path=%s", filepath.Join(workspace, dir)))
 			if choice == "ccl" {
 				// The ccl logictest target shares the testdata directory with the base


### PR DESCRIPTION
Before this change, you'd get errors:

```
$ bazel test --sandbox_writable_path=/Users/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/logictest/tests/testdata //pkg/sql/logictest/tests/local-udf/... --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -show-sql --test_env=COCKROACH_WORKSPACE=/Users/ajwerner/src/github.com/cockroachdb/cockroach --test_arg -rewrite --test_filter udf/ --test_sharding_strategy=disabled --test_output errors
INFO: Invocation ID: 231faca5-6636-421d-87d7-d2ae41b01965
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/231faca5-6636-421d-87d7-d2ae41b01965
INFO: Analyzed target //:gazelle (0 packages loaded, 148 targets configured).
INFO: Found 1 target...
Target //:gazelle up-to-date:
  _bazel/bin/gazelle-runner.bash
  _bazel/bin/gazelle
INFO: Elapsed time: 1.014s, Critical Path: 0.51s
INFO: 1 process: 1 internal.
INFO: Running command line: _bazel/bin/gazelle
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/231faca5-6636-421d-87d7-d2ae41b01965
INFO: Build completed successfully, 1 total action
done running gazelle
INFO: Invocation ID: 03cc3f16-8db8-4f71-8c7d-f5e8fce1797d
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/03cc3f16-8db8-4f71-8c7d-f5e8fce1797d
INFO: Build options --//build/toolchains:crdb_test_flag and --test_env have changed, discarding analysis cache.
INFO: Analyzed 2 targets (1 packages loaded, 23776 targets configured).
INFO: Found 1 target and 1 test target...
ERROR: /Users/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/logictest/tests/local-udf/BUILD.bazel:4:8: Testing //pkg/sql/logictest/tests/local-udf:local-udf_test failed: I/O exception during sandboxed execution: /Users/ajwerner/src/github.com/cockroachdb/cockroach/pkg/sql/logictest/tests/testdata (No such file or directory)
```

Release note: None