### PR TITLE
streamingccl: add retry into stream ingestion job

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -256,7 +256,7 @@ func completeReplicationStream(
 	const useReadLock = false
 	return registry.UpdateJobWithTxn(evalCtx.Ctx(), jobspb.JobID(streamID), txn, useReadLock,
 		func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-			// Updates the streamingestion status, make the job resumer exit running
+			// Updates the stream ingestion status, make the job resumer exit running
 			// when picking up the new status.
 			if (md.Status == jobs.StatusRunning || md.Status == jobs.StatusPending) &&
 				md.Progress.GetStreamReplication().StreamIngestionStatus ==

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -880,6 +880,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	if backupRestoreKnobs := cfg.TestingKnobs.BackupRestore; backupRestoreKnobs != nil {
 		execCfg.BackupRestoreTestingKnobs = backupRestoreKnobs.(*sql.BackupRestoreTestingKnobs)
 	}
+	if streamTestingKnobs := cfg.TestingKnobs.Streaming; streamTestingKnobs != nil {
+		execCfg.StreamingTestingKnobs = streamTestingKnobs.(*sql.StreamingTestingKnobs)
+	}
 	if ttlKnobs := cfg.TestingKnobs.TTL; ttlKnobs != nil {
 		execCfg.TTLTestingKnobs = ttlKnobs.(*sql.TTLTestingKnobs)
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1621,6 +1621,10 @@ type StreamingTestingKnobs struct {
 	// BeforeClientSubscribe allows observation of parameters about to be passed
 	// to a streaming client
 	BeforeClientSubscribe func(addr string, token string, startTime hlc.Timestamp)
+
+	// BeforeIngestionStart allows blocking the stream ingestion job
+	// before a stream ingestion happens.
+	BeforeIngestionStart func(ctx context.Context) error
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}


### PR DESCRIPTION
This PR support ingestion job to have its own job
retry mechanism. All errors are retryable by default
unless marked as permanent job error.

Also add running status into job progress when
the job reaches various stages.

Release note: None
Release justification: Cat 4

Closes: https://github.com/cockroachdb/cockroach/issues/83450
Closes: https://github.com/cockroachdb/cockroach/issues/82509