### PR TITLE
colexec: fix recent bug with releasing too much memory in hash agg

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -81,7 +81,7 @@ var aggTypesWithPartial = []aggType{
 		// This is a wrapper around NewHashAggregator so its signature is
 		// compatible with NewOrderedAggregator.
 		new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
-			return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
+			return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, testAllocator, math.MaxInt64)
 		},
 		name:  "hash",
 		order: unordered,
@@ -95,7 +95,7 @@ var aggTypesWithPartial = []aggType{
 		// This is a wrapper around NewHashAggregator so its signature is
 		// compatible with NewOrderedAggregator.
 		new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
-			return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
+			return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, testAllocator, math.MaxInt64)
 		},
 		name:  "hash-partial-order",
 		order: partial,

--- a/pkg/sql/colexec/colexecdisk/external_hash_aggregator.go
+++ b/pkg/sql/colexec/colexecdisk/external_hash_aggregator.go
@@ -37,6 +37,7 @@ func NewExternalHashAggregator(
 	newAggArgs *colexecagg.NewAggregatorArgs,
 	createDiskBackedSorter DiskBackedSorterConstructor,
 	diskAcc *mon.BoundAccount,
+	hashTableAllocator *colmem.Allocator,
 	outputUnlimitedAllocator *colmem.Allocator,
 	maxOutputBatchMemSize int64,
 ) (colexecop.Operator, colexecop.Closer) {
@@ -45,7 +46,10 @@ func NewExternalHashAggregator(
 		newAggArgs.Input = partitionedInputs[0]
 		// We don't need to track the input tuples when we have already spilled.
 		// TODO(yuzefovich): it might be worth increasing the number of buckets.
-		return colexec.NewHashAggregator(&newAggArgs, nil /* newSpillingQueueArgs */, outputUnlimitedAllocator, maxOutputBatchMemSize)
+		return colexec.NewHashAggregator(
+			&newAggArgs, nil /* newSpillingQueueArgs */, hashTableAllocator,
+			outputUnlimitedAllocator, maxOutputBatchMemSize,
+		)
 	}
 	spec := newAggArgs.Spec
 	diskBackedFallbackOpConstructor := func(

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -201,6 +201,7 @@ func randomizeHashAggregatorMaxBuffered() {
 func NewHashAggregator(
 	args *colexecagg.NewAggregatorArgs,
 	newSpillingQueueArgs *colexecutils.NewSpillingQueueArgs,
+	hashTableAllocator *colmem.Allocator,
 	outputUnlimitedAllocator *colmem.Allocator,
 	maxOutputBatchMemSize int64,
 ) colexecop.ResettableOperator {
@@ -212,7 +213,7 @@ func NewHashAggregator(
 	}
 	hashAgg := &hashAggregator{
 		OneInputNode:          colexecop.NewOneInputNode(args.Input),
-		hashTableAllocator:    args.Allocator,
+		hashTableAllocator:    hashTableAllocator,
 		spec:                  args.Spec,
 		state:                 hashAggregatorBuffering,
 		inputTypes:            args.InputTypes,

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -443,6 +443,7 @@ func TestHashAggregator(t *testing.T) {
 				},
 					nil, /* newSpillingQueueArgs */
 					testAllocator,
+					testAllocator,
 					math.MaxInt64,
 				), nil
 			})
@@ -476,7 +477,7 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 			for _, agg := range []aggType{
 				{
 					new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
-						return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, math.MaxInt64)
+						return NewHashAggregator(args, nil /* newSpillingQueueArgs */, testAllocator, testAllocator, math.MaxInt64)
 					},
 					name:  "tracking=false",
 					order: unordered,
@@ -492,7 +493,7 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 							DiskQueueCfg:       queueCfg,
 							FDSemaphore:        &colexecop.TestingSemaphore{},
 							DiskAcc:            testDiskAcc,
-						}, testAllocator, math.MaxInt64)
+						}, testAllocator, testAllocator, math.MaxInt64)
 					},
 					name:  "tracking=true",
 					order: unordered,
@@ -546,7 +547,7 @@ func BenchmarkHashAggregatorPartialOrder(b *testing.B) {
 			DiskQueueCfg:       queueCfg,
 			FDSemaphore:        &colexecop.TestingSemaphore{},
 			DiskAcc:            testDiskAcc,
-		}, testAllocator, math.MaxInt64)
+		}, testAllocator, testAllocator, math.MaxInt64)
 	}
 	// We choose any_not_null aggregate function because it is the simplest
 	// possible and, thus, its Compute function call will have the least impact


### PR DESCRIPTION
This commit fixes a recent bug that was introduced in
935090df5767cd7fe314a028246e465993e9b250 which made so that the hash
table would release all of the memory from the allocator after the
operator spilled to disk. The assumption is that the allocator is solely
used by the hash table, but this is not true in the hash aggregator
where the same allocator is shared among multiple components, so if we
spill to disk, we would shrink the memory accounting by more than we
actually lose references to. This commit fixes that oversight by
explicitly creating a separate allocator for the hash table to own.
Other users of the hash table (unordered distinct and hash joiner) are
unaffected because there the allocator was already being used solely by
the hash table.

Release note: None