### PR TITLE
colexec: fix a "fake" memory accounting leak for intra-query period

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -69,8 +69,12 @@ type Batch interface {
 	// important for callers to call ResetInternalBatch if they own internal
 	// batches that they reuse as not doing this could result in correctness
 	// or memory blowup issues. It unsets the selection and sets the length to
-	// 0. Notably, it deeply resets the datum-backed vectors and returns the
-	// number of bytes released as a result of the reset.
+	// 0.
+	//
+	// Notably, it deeply resets the datum-backed vectors and returns the number
+	// of bytes released as a result of the reset. Callers should update the
+	// allocator (which the batch was instantiated from) accordingly unless they
+	// guarantee that the batch doesn't have any datum-backed vectors.
 	ResetInternalBatch() int64
 	// String returns a pretty representation of this batch.
 	String() string

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -367,7 +367,7 @@ func (op *hashBasedPartitioner) partitionBatch(
 	for idx, sel := range selections {
 		partitionIdx := op.partitionIdxOffset + idx
 		if len(sel) > 0 {
-			scratchBatch.ResetInternalBatch()
+			op.unlimitedAllocator.ResetBatch(scratchBatch)
 			// The partitioner expects the batches without a selection vector,
 			// so we need to copy the tuples according to the selection vector
 			// into a scratch batch.

--- a/pkg/sql/colexec/colexecutils/operator.go
+++ b/pkg/sql/colexec/colexecutils/operator.go
@@ -76,7 +76,9 @@ func (s *fixedNumTuplesNoInputOp) Next() coldata.Batch {
 	if s.numTuplesLeft == 0 {
 		return coldata.ZeroBatch
 	}
-	s.batch.ResetInternalBatch()
+	// The internal batch has no columns, so no memory is ever released on the
+	// ResetInternalBatch() call.
+	_ = s.batch.ResetInternalBatch()
 	length := s.numTuplesLeft
 	if length > coldata.BatchSize() {
 		length = coldata.BatchSize()

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -185,9 +185,12 @@ func (b *AppendOnlyBufferedBatch) Reset([]*types.T, int, coldata.ColumnFactory) 
 }
 
 // ResetInternalBatch implements the coldata.Batch interface.
+// NB: any memory released during this call is automatically released from the
+// allocator that created the batch.
 func (b *AppendOnlyBufferedBatch) ResetInternalBatch() int64 {
 	b.SetLength(0 /* n */)
-	return b.batch.ResetInternalBatch()
+	b.allocator.ReleaseMemory(b.batch.ResetInternalBatch())
+	return 0
 }
 
 // String implements the coldata.Batch interface.

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -260,7 +260,7 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 				continue
 			}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -471,7 +471,9 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								r.partitionsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -494,7 +496,9 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								r.partitionsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -522,7 +526,7 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 				r.numTuplesInPartition = 0
 			}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -749,7 +753,9 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								r.peerGroupsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -772,7 +778,9 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								r.peerGroupsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -799,7 +807,7 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 				r.numPeers = 0
 			}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -1033,7 +1041,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								r.partitionsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1056,7 +1066,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								r.partitionsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1085,7 +1097,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								r.peerGroupsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1108,7 +1122,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								r.peerGroupsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1143,7 +1159,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 				r.numPeers = 0
 			}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -155,7 +155,9 @@ func _COMPUTE_PARTITIONS_SIZES(_HAS_SEL bool) { // */}}
 				r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 				r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 				r.partitionsState.idx = 0
-				r.partitionsState.runningSizes.ResetInternalBatch()
+				// This batch has only a single INT column, so no memory is ever
+				// released on the ResetInternalBatch() call.
+				_ = r.partitionsState.runningSizes.ResetInternalBatch()
 			}
 		}
 	}
@@ -187,7 +189,9 @@ func _COMPUTE_PEER_GROUPS_SIZES(_HAS_SEL bool) { // */}}
 				r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 				r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 				r.peerGroupsState.idx = 0
-				r.peerGroupsState.runningSizes.ResetInternalBatch()
+				// This batch has only a single INT column, so no memory is ever
+				// released on the ResetInternalBatch() call.
+				_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 			}
 		}
 	}
@@ -474,7 +478,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 			}
 			// {{end}}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -211,7 +211,7 @@ func (c *Columnarizer) Next() coldata.Batch {
 			c.batch = c.allocator.NewMemBatchWithFixedCapacity(c.typs, 1 /* minCapacity */)
 			reallocated = true
 		} else {
-			c.batch.ResetInternalBatch()
+			c.allocator.ResetBatch(c.batch)
 		}
 	}
 	if reallocated {

--- a/pkg/sql/colexec/count.go
+++ b/pkg/sql/colexec/count.go
@@ -46,7 +46,9 @@ func (c *countOp) Next() coldata.Batch {
 	if c.done {
 		return coldata.ZeroBatch
 	}
-	c.internalBatch.ResetInternalBatch()
+	// The internal batch has only a single INT column, so no memory is ever
+	// released on the ResetInternalBatch() call.
+	_ = c.internalBatch.ResetInternalBatch()
 	for {
 		bat := c.Input.Next()
 		length := bat.Length()

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -188,7 +188,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 		switch a.state {
 		case orderedAggregatorAggregating:
 			if a.scratch.shouldResetInternalBatch {
-				a.scratch.ResetInternalBatch()
+				a.allocator.ResetBatch(a.scratch)
 				a.scratch.shouldResetInternalBatch = false
 			}
 			if a.scratch.resumeIdx >= coldata.BatchSize() {
@@ -314,7 +314,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				if a.unsafeBatch == nil {
 					a.unsafeBatch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, coldata.BatchSize())
 				} else {
-					a.unsafeBatch.ResetInternalBatch()
+					a.allocator.ResetBatch(a.unsafeBatch)
 				}
 				a.allocator.PerformOperation(a.unsafeBatch.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
@@ -340,7 +340,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				// the source and the destination would be the same, and
 				// resetting it would lead to the loss of data.
 				newResumeIdx := a.scratch.resumeIdx - coldata.BatchSize()
-				a.scratch.tempBuffer.ResetInternalBatch()
+				a.allocator.ResetBatch(a.scratch.tempBuffer)
 				a.allocator.PerformOperation(a.scratch.tempBuffer.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.scratch.tempBuffer.ColVec(i).Copy(
@@ -352,7 +352,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 						)
 					}
 				})
-				a.scratch.ResetInternalBatch()
+				a.allocator.ResetBatch(a.scratch)
 				a.allocator.PerformOperation(a.scratch.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.scratch.ColVec(i).Copy(

--- a/pkg/sql/colexec/values.go
+++ b/pkg/sql/colexec/values.go
@@ -92,7 +92,7 @@ func (v *valuesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 
-	v.batch.ResetInternalBatch()
+	v.allocator.ResetBatch(v.batch)
 
 	// Decode rows up to the capacity of the batch.
 	nRows := 0


### PR DESCRIPTION
This commit fixes a possible memory accounting leak that could happen
throughout the query execution (i.e. once the query finishes, the leak
would get resolved) which was introduced in
cb93c302de1bab49c8b3051ad96cf859bd91036f. The idea of that commit is to
lose references to the `tree.Datum` objects when resetting the batch
since we cannot reuse those. In the main code path we correctly update
the allocator to release the specified memory, but other less
"important" places where we call `ResetInternalBatch` explicitly were
not audited properly. Thus, it is possible that for datum vectors to
"leak" some memory because we always account for the newly-allocated
`tree.Datum` objects but we forget to shrink the accounting during those
"less important" resets. This is now fixed. The possible impact is that
a single query could exhaust the `--max-sql-memory` limit without
actually using much memory, however, it seems quite unlikely since
such a query would require too many conditions to be met (it uses types
that don't have native vectorized support, other operations within the
query are not memory intensive, etc).

Release note: None