### PR TITLE
colmem: improve memory-limiting behavior of the accounting helpers

### DIFF
--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -145,7 +145,7 @@ func NewCaseOp(
 ) colexecop.Operator {
 	// We internally use three selection vectors, scratch.order, origSel, and
 	// prevSel.
-	allocator.AdjustMemoryUsage(3 * colmem.SizeOfBatchSizeSelVector)
+	allocator.AdjustMemoryUsage(3 * colmem.SelVectorSize(coldata.BatchSize()))
 	return &caseOp{
 		allocator: allocator,
 		buffer:    buffer.(*bufferOp),

--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -840,5 +840,5 @@ func (o *inputPartitioningOperator) close() {
 	// allocate a new windowed batch if necessary (which might be the case for
 	// the fallback strategy of the users of the hash-based partitioner).
 	o.windowedBatch = nil
-	o.allocator.ReleaseMemory(colmem.SizeOfBatchSizeSelVector)
+	o.allocator.ReleaseMemory(colmem.SelVectorSize(coldata.BatchSize()))
 }

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -40,7 +40,7 @@ func NewCrossJoiner(
 	rightTypes []*types.T,
 	diskAcc *mon.BoundAccount,
 ) colexecop.ClosableOperator {
-	return &crossJoiner{
+	c := &crossJoiner{
 		crossJoinerBase: newCrossJoinerBase(
 			unlimitedAllocator,
 			joinType,
@@ -51,21 +51,20 @@ func NewCrossJoiner(
 			fdSemaphore,
 			diskAcc,
 		),
-		joinHelper:            newJoinHelper(left, right),
-		unlimitedAllocator:    unlimitedAllocator,
-		outputTypes:           joinType.MakeOutputTypes(leftTypes, rightTypes),
-		maxOutputBatchMemSize: memoryLimit,
+		joinHelper:  newJoinHelper(left, right),
+		outputTypes: joinType.MakeOutputTypes(leftTypes, rightTypes),
 	}
+	c.helper.Init(unlimitedAllocator, memoryLimit)
+	return c
 }
 
 type crossJoiner struct {
 	*crossJoinerBase
 	*joinHelper
 
-	unlimitedAllocator    *colmem.Allocator
-	rightInputConsumed    bool
-	outputTypes           []*types.T
-	maxOutputBatchMemSize int64
+	helper             colmem.AccountingHelper
+	rightInputConsumed bool
+	outputTypes        []*types.T
 	// isLeftAllNulls and isRightAllNulls indicate whether the output vectors
 	// corresponding to the left and right inputs, respectively, should consist
 	// only of NULL values. This is the case when we have right or left,
@@ -105,10 +104,7 @@ func (c *crossJoiner) Next() coldata.Batch {
 		c.done = true
 		return coldata.ZeroBatch
 	}
-	c.output, _ = c.unlimitedAllocator.ResetMaybeReallocate(
-		c.outputTypes, c.output, willEmit, c.maxOutputBatchMemSize,
-		true, /* desiredCapacitySufficient */
-	)
+	c.output, _ = c.helper.ResetMaybeReallocate(c.outputTypes, c.output, willEmit)
 	if willEmit > c.output.Capacity() {
 		willEmit = c.output.Capacity()
 	}

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -12,7 +12,6 @@ package colexecjoin
 
 import (
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -753,10 +752,8 @@ func (hj *hashJoiner) resetOutput(nResults int) {
 	// 4. when the hashJoiner is used by the external hash joiner as the main
 	// strategy, the hash-based partitioner is responsible for making sure that
 	// partitions fit within memory limit.
-	const maxOutputBatchMemSize = math.MaxInt64
-	hj.output, _ = hj.outputUnlimitedAllocator.ResetMaybeReallocate(
-		hj.outputTypes, hj.output, nResults, maxOutputBatchMemSize,
-		true, /* desiredCapacitySufficient */
+	hj.output, _ = hj.outputUnlimitedAllocator.ResetMaybeReallocateNoMemLimit(
+		hj.outputTypes, hj.output, nResults,
 	)
 }
 

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -532,6 +532,7 @@ func newMergeJoinBase(
 		},
 		diskAcc: diskAcc,
 	}
+	base.helper.Init(unlimitedAllocator, memoryLimit)
 	base.left.distincterInput = &colexecop.FeedOperator{}
 	base.left.distincter, base.left.distinctOutput = colexecbase.OrderedDistinctColsToOperators(
 		base.left.distincterInput, lEqCols, leftTypes, false, /* nullsAreDistinct */
@@ -549,6 +550,7 @@ type mergeJoinBase struct {
 	colexecop.CloserHelper
 
 	unlimitedAllocator *colmem.Allocator
+	helper             colmem.AccountingHelper
 	memoryLimit        int64
 	diskQueueCfg       colcontainer.DiskQueueCfg
 	fdSemaphore        semaphore.Semaphore

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -14217,10 +14217,7 @@ func (o *mergeJoinExceptAllOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -15364,10 +15364,7 @@ func (o *mergeJoinFullOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -10898,10 +10898,7 @@ func (o *mergeJoinInnerOp) buildFromBufferedGroup() (bufferedGroupComplete bool)
 }
 
 func (o *mergeJoinInnerOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11608,10 +11608,7 @@ func (o *mergeJoinIntersectAllOp) buildFromBufferedGroup() (bufferedGroupComplet
 }
 
 func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -13127,10 +13127,7 @@ func (o *mergeJoinLeftAntiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 }
 
 func (o *mergeJoinLeftAntiOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -13154,10 +13154,7 @@ func (o *mergeJoinLeftOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -10851,10 +10851,7 @@ func (o *mergeJoinLeftSemiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 }
 
 func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -13058,10 +13058,7 @@ func (o *mergeJoinRightAntiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -13108,10 +13108,7 @@ func (o *mergeJoinRightOuterOp) buildFromBufferedGroup() (bufferedGroupComplete 
 }
 
 func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -10811,10 +10811,7 @@ func (o *mergeJoinRightSemiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -1353,10 +1353,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 // */}}
 
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecutils/deselector.go
+++ b/pkg/sql/colexec/colexecutils/deselector.go
@@ -11,8 +11,6 @@
 package colexecutils
 
 import (
-	"math"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -59,10 +57,8 @@ func (p *deselectorOp) Next() coldata.Batch {
 	// deselectorOp should *not* limit the capacities of the returned batches,
 	// so we don't use a memory limit here. It is up to the wrapped operator to
 	// limit the size of batches based on the memory footprint.
-	const maxBatchMemSize = math.MaxInt64
-	p.output, _ = p.unlimitedAllocator.ResetMaybeReallocate(
-		p.inputTypes, p.output, batch.Length(), maxBatchMemSize,
-		true, /* desiredCapacitySufficient */
+	p.output, _ = p.unlimitedAllocator.ResetMaybeReallocateNoMemLimit(
+		p.inputTypes, p.output, batch.Length(),
 	)
 	sel := batch.Selection()
 	p.unlimitedAllocator.PerformOperation(p.output.ColVecs(), func() {

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -12,7 +12,6 @@ package colexecwindow
 
 import (
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
@@ -248,10 +247,8 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 			sel := batch.Selection()
 			// We don't limit the batches based on the memory footprint because
 			// we assume that the input is producing reasonably sized batches.
-			const maxBatchMemSize = math.MaxInt64
-			b.currentBatch, _ = b.allocator.ResetMaybeReallocate(
-				b.outputTypes, b.currentBatch, batch.Length(), maxBatchMemSize,
-				true, /* desiredCapacitySufficient */
+			b.currentBatch, _ = b.allocator.ResetMaybeReallocateNoMemLimit(
+				b.outputTypes, b.currentBatch, batch.Length(),
 			)
 			b.allocator.PerformOperation(b.currentBatch.ColVecs(), func() {
 				for colIdx, vec := range batch.ColVecs() {

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -459,7 +459,7 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
 			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx,
 			)
 			curOutputIdx := 0
 			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {
@@ -602,7 +602,7 @@ func getNext_false(op *hashAggregator) coldata.Batch {
 			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
 			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx,
 			)
 			curOutputIdx := 0
 			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -456,26 +456,21 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 		case hashAggregatorOutputting:
 			// Note that ResetMaybeReallocate truncates the requested capacity
 			// at coldata.BatchSize(), so we can just try asking for
-			// len(op.buckets) capacity.
+			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
+			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
-				true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
-			for curOutputIdx < op.output.Capacity() &&
-				op.curOutputBucketIdx < len(op.buckets) &&
-				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {
 				bucket := op.buckets[op.curOutputBucketIdx]
 				for fnIdx, fn := range bucket.fns {
 					fn.SetOutput(op.output.ColVec(fnIdx))
 					fn.Flush(curOutputIdx)
 				}
-				op.accountingHelper.AccountForSet(curOutputIdx)
+				batchDone = op.accountingHelper.AccountForSet(curOutputIdx)
 				curOutputIdx++
 				op.curOutputBucketIdx++
-				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
-					op.maxCapacity = curOutputIdx
-				}
 			}
 			if op.curOutputBucketIdx >= len(op.buckets) {
 				if l := op.bufferingState.pendingBatch.Length(); l > 0 {
@@ -604,26 +599,21 @@ func getNext_false(op *hashAggregator) coldata.Batch {
 		case hashAggregatorOutputting:
 			// Note that ResetMaybeReallocate truncates the requested capacity
 			// at coldata.BatchSize(), so we can just try asking for
-			// len(op.buckets) capacity.
+			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
+			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
-				true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
-			for curOutputIdx < op.output.Capacity() &&
-				op.curOutputBucketIdx < len(op.buckets) &&
-				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {
 				bucket := op.buckets[op.curOutputBucketIdx]
 				for fnIdx, fn := range bucket.fns {
 					fn.SetOutput(op.output.ColVec(fnIdx))
 					fn.Flush(curOutputIdx)
 				}
-				op.accountingHelper.AccountForSet(curOutputIdx)
+				batchDone = op.accountingHelper.AccountForSet(curOutputIdx)
 				curOutputIdx++
 				op.curOutputBucketIdx++
-				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
-					op.maxCapacity = curOutputIdx
-				}
 			}
 			if op.curOutputBucketIdx >= len(op.buckets) {
 				op.state = hashAggregatorDone

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -345,7 +345,7 @@ func getNext(op *hashAggregator, partialOrder bool) coldata.Batch {
 			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
 			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx,
 			)
 			curOutputIdx := 0
 			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -342,26 +342,21 @@ func getNext(op *hashAggregator, partialOrder bool) coldata.Batch {
 		case hashAggregatorOutputting:
 			// Note that ResetMaybeReallocate truncates the requested capacity
 			// at coldata.BatchSize(), so we can just try asking for
-			// len(op.buckets) capacity.
+			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
+			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
-				true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
-			for curOutputIdx < op.output.Capacity() &&
-				op.curOutputBucketIdx < len(op.buckets) &&
-				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {
 				bucket := op.buckets[op.curOutputBucketIdx]
 				for fnIdx, fn := range bucket.fns {
 					fn.SetOutput(op.output.ColVec(fnIdx))
 					fn.Flush(curOutputIdx)
 				}
-				op.accountingHelper.AccountForSet(curOutputIdx)
+				batchDone = op.accountingHelper.AccountForSet(curOutputIdx)
 				curOutputIdx++
 				op.curOutputBucketIdx++
-				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
-					op.maxCapacity = curOutputIdx
-				}
 			}
 			if op.curOutputBucketIdx >= len(op.buckets) {
 				if partialOrder {

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
@@ -268,15 +267,15 @@ func (a *orderedAggregator) Next() coldata.Batch {
 		case orderedAggregatorReallocating:
 			// The ordered aggregator *cannot* limit the capacities of its
 			// internal batches because it works under the assumption that any
-			// input batch can be handled in a single pass, so we don't use a
-			// memory limit here. It is up to the input to limit the size of
-			// batches based on the memory footprint.
-			const maxBatchMemSize = math.MaxInt64
+			// input batch can be handled in a single pass, so we use
+			// ResetMaybeReallocateNoMemLimit. It is up to the input to limit
+			// the size of batches based on the memory footprint.
+			//
 			// Twice the batchSize is allocated to avoid having to check for
 			// overflow when outputting.
 			newMinCapacity := 2 * a.lastReadBatch.Length()
 			if newMinCapacity > coldata.BatchSize() {
-				// ResetMaybeReallocate truncates the capacity to
+				// ResetMaybeReallocateNoMemLimit truncates the capacity to
 				// coldata.BatchSize(), but we actually want a batch with larger
 				// capacity, so we choose to instantiate the batch with fixed
 				// maximal capacity that can be needed by the aggregator.
@@ -284,17 +283,15 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				newMinCapacity = 2 * coldata.BatchSize()
 				a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, newMinCapacity)
 			} else {
-				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocate(
+				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocateNoMemLimit(
 					a.outputTypes, a.scratch.Batch, newMinCapacity,
-					maxBatchMemSize, true, /* desiredCapacitySufficient */
 				)
 			}
 			// We will never copy more than coldata.BatchSize() into the
 			// temporary buffer, so a half of the scratch's capacity will always
 			// be sufficient.
-			a.scratch.tempBuffer, _ = a.allocator.ResetMaybeReallocate(
+			a.scratch.tempBuffer, _ = a.allocator.ResetMaybeReallocateNoMemLimit(
 				a.outputTypes, a.scratch.tempBuffer, newMinCapacity/2,
-				maxBatchMemSize, true, /* desiredCapacitySufficient */
 			)
 			for fnIdx, fn := range a.bucket.fns {
 				fn.SetOutput(a.scratch.ColVec(fnIdx))

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -37,7 +37,6 @@ type OrderedSynchronizer struct {
 	span *tracing.Span
 
 	accountingHelper      colmem.SetAccountingHelper
-	memoryLimit           int64
 	inputs                []colexecargs.OpWithMetaInfo
 	ordering              colinfo.ColumnOrdering
 	typs                  []*types.T
@@ -58,10 +57,6 @@ type OrderedSynchronizer struct {
 	heap []int
 	// comparators stores one comparator per ordering column.
 	comparators []vecComparator
-	// maxCapacity if non-zero indicates the target capacity of the output
-	// batch. It is set when, after setting a row, we realize that the output
-	// batch has exceeded the memory limit.
-	maxCapacity int
 	output      coldata.Batch
 	outVecs     coldata.TypedVecs
 }
@@ -91,13 +86,12 @@ func NewOrderedSynchronizer(
 	ordering colinfo.ColumnOrdering,
 ) *OrderedSynchronizer {
 	os := &OrderedSynchronizer{
-		memoryLimit:           memoryLimit,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
 		canonicalTypeFamilies: typeconv.ToCanonicalTypeFamilies(typs),
 	}
-	os.accountingHelper.Init(allocator, typs)
+	os.accountingHelper.Init(allocator, memoryLimit, typs)
 	return os
 }
 
@@ -117,7 +111,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 	}
 	o.resetOutput()
 	outputIdx := 0
-	for outputIdx < o.output.Capacity() && (o.maxCapacity == 0 || outputIdx < o.maxCapacity) {
+	for batchDone := false; !batchDone; {
 		if o.advanceMinBatch {
 			// Advance the minimum input batch, fetching a new batch if
 			// necessary.
@@ -255,11 +249,8 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 		o.advanceMinBatch = true
 
 		// Account for the memory of the row we have just set.
-		o.accountingHelper.AccountForSet(outputIdx)
+		batchDone = o.accountingHelper.AccountForSet(outputIdx)
 		outputIdx++
-		if o.maxCapacity == 0 && o.accountingHelper.Allocator.Used() >= o.memoryLimit {
-			o.maxCapacity = outputIdx
-		}
 	}
 
 	o.output.SetLength(outputIdx)
@@ -269,8 +260,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
+		o.typs, o.output, 1 /* minDesiredCapacity */, false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -260,7 +260,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minDesiredCapacity */, false, /* desiredCapacitySufficient */
+		o.typs, o.output, 0, /* tuplesToBeSet */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -210,7 +210,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minDesiredCapacity */, false, /* desiredCapacitySufficient */
+		o.typs, o.output, 0, /* tuplesToBeSet */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -60,7 +60,6 @@ type OrderedSynchronizer struct {
 	span *tracing.Span
 
 	accountingHelper      colmem.SetAccountingHelper
-	memoryLimit           int64
 	inputs                []colexecargs.OpWithMetaInfo
 	ordering              colinfo.ColumnOrdering
 	typs                  []*types.T
@@ -81,10 +80,6 @@ type OrderedSynchronizer struct {
 	heap []int
 	// comparators stores one comparator per ordering column.
 	comparators []vecComparator
-	// maxCapacity if non-zero indicates the target capacity of the output
-	// batch. It is set when, after setting a row, we realize that the output
-	// batch has exceeded the memory limit.
-	maxCapacity int
 	output      coldata.Batch
 	outVecs     coldata.TypedVecs
 }
@@ -114,13 +109,12 @@ func NewOrderedSynchronizer(
 	ordering colinfo.ColumnOrdering,
 ) *OrderedSynchronizer {
 	os := &OrderedSynchronizer{
-		memoryLimit:           memoryLimit,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
 		canonicalTypeFamilies: typeconv.ToCanonicalTypeFamilies(typs),
 	}
-	os.accountingHelper.Init(allocator, typs)
+	os.accountingHelper.Init(allocator, memoryLimit, typs)
 	return os
 }
 
@@ -140,7 +134,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 	}
 	o.resetOutput()
 	outputIdx := 0
-	for outputIdx < o.output.Capacity() && (o.maxCapacity == 0 || outputIdx < o.maxCapacity) {
+	for batchDone := false; !batchDone; {
 		if o.advanceMinBatch {
 			// Advance the minimum input batch, fetching a new batch if
 			// necessary.
@@ -205,11 +199,8 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 		o.advanceMinBatch = true
 
 		// Account for the memory of the row we have just set.
-		o.accountingHelper.AccountForSet(outputIdx)
+		batchDone = o.accountingHelper.AccountForSet(outputIdx)
 		outputIdx++
-		if o.maxCapacity == 0 && o.accountingHelper.Allocator.Used() >= o.memoryLimit {
-			o.maxCapacity = outputIdx
-		}
 	}
 
 	o.output.SetLength(outputIdx)
@@ -219,8 +210,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
+		o.typs, o.output, 1 /* minDesiredCapacity */, false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -47,15 +47,15 @@ func NewTopKSorter(
 		colexecerror.InternalError(errors.AssertionFailedf("invalid matchLen %v", matchLen))
 	}
 	base := &topKSorter{
-		allocator:             allocator,
-		OneInputNode:          colexecop.NewOneInputNode(input),
-		inputTypes:            inputTypes,
-		orderingCols:          orderingCols,
-		k:                     k,
-		hasPartialOrder:       matchLen > 0,
-		matchLen:              matchLen,
-		maxOutputBatchMemSize: maxOutputBatchMemSize,
+		allocator:       allocator,
+		OneInputNode:    colexecop.NewOneInputNode(input),
+		inputTypes:      inputTypes,
+		orderingCols:    orderingCols,
+		k:               k,
+		hasPartialOrder: matchLen > 0,
+		matchLen:        matchLen,
 	}
+	base.helper.Init(allocator, maxOutputBatchMemSize)
 	if base.hasPartialOrder {
 		base.heaper = &topKPartialOrderHeaper{base}
 		partialOrderCols := make([]uint32, matchLen)
@@ -94,6 +94,7 @@ type topKSorter struct {
 	colexecop.OneInputNode
 	colexecop.InitHelper
 	allocator       *colmem.Allocator
+	helper          colmem.AccountingHelper
 	orderingCols    []execinfrapb.Ordering_Column
 	inputTypes      []*types.T
 	k               uint64
@@ -116,9 +117,8 @@ type topKSorter struct {
 	// sel is a selection vector which specifies an ordering on topK.
 	sel []int
 	// emitted is the count of rows which have been emitted so far.
-	emitted               int
-	output                coldata.Batch
-	maxOutputBatchMemSize int64
+	emitted int
+	output  coldata.Batch
 
 	exportedFromTopK  int
 	exportedFromBatch int
@@ -200,10 +200,7 @@ func (t *topKSorter) emit() coldata.Batch {
 		// We're done.
 		return coldata.ZeroBatch
 	}
-	t.output, _ = t.allocator.ResetMaybeReallocate(
-		t.inputTypes, t.output, toEmit, t.maxOutputBatchMemSize,
-		true, /* desiredCapacitySufficient */
-	)
+	t.output, _ = t.helper.ResetMaybeReallocate(t.inputTypes, t.output, toEmit)
 	if toEmit > t.output.Capacity() {
 		toEmit = t.output.Capacity()
 	}

--- a/pkg/sql/colfetcher/vectorized_batch_size_test.go
+++ b/pkg/sql/colfetcher/vectorized_batch_size_test.go
@@ -143,36 +143,79 @@ func TestCFetcherLimitsOutputBatch(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	conn := tc.Conns[0]
 
-	// We set up a table with 50 rows that take up 16KiB each and we lower the
-	// distsql_workmem session variable to 128KiB. We also collect the stats on
-	// the table so that we had an estimated row count of 50 for the scan. With
-	// such setup the cFetcher will allocate an output batch of capacity 50, yet
-	// after setting the 7th or so row the footprint of the batch will exceed
-	// the memory limit. As a result, we will get around 7 batches.
+	// Lower the distsql_workmem session variable to 128KiB to speed up the
+	// test.
 	_, err := conn.ExecContext(ctx, `SET distsql_workmem='128KiB';`)
 	assert.NoError(t, err)
-	_, err = conn.ExecContext(ctx, `
-CREATE TABLE t (a PRIMARY KEY, b) AS
-SELECT i, repeat('a', 16 * 1024) FROM generate_series(1, 50) AS g(i);`)
-	assert.NoError(t, err)
-	_, err = conn.ExecContext(ctx, `ANALYZE t`)
-	assert.NoError(t, err)
 
-	batchCountRegex := regexp.MustCompile(`vectorized batch count: (\d+)`)
-	rows, err := conn.QueryContext(ctx, `EXPLAIN ANALYZE (VERBOSE, DISTSQL) SELECT * FROM t`)
-	assert.NoError(t, err)
-	foundBatches := -1
-	for rows.Next() {
-		var res string
-		assert.NoError(t, rows.Scan(&res))
-		if matches := batchCountRegex.FindStringSubmatch(res); len(matches) > 0 {
-			foundBatches, err = strconv.Atoi(matches[1])
+	for _, tc := range []struct {
+		// numRows and rowSize must be of the same length, with each index
+		// specifying the number of rows of the corresponding size (in bytes) to
+		// be inserted.
+		numRows []int
+		rowSize []int
+		// batchCountLowerBound is a hard lower bound on the number of
+		// vectorized batches used to return all rows inserted in the current
+		// iteration.
+		batchCountLowerBound int
+	}{
+		// Set up a table with 50 rows that take up 16KiB each. We will also
+		// collect the stats on the table so that we had an estimated row count
+		// of 50 for the scan. With such setup the cFetcher will allocate an
+		// output batch of capacity 50, yet after setting the 7th or so row the
+		// footprint of the batch will exceed the memory limit. As a result, we
+		// will get around 7 batches.
+		{
+			numRows: []int{50},
+			rowSize: []int{16 * 1024},
+			// There is a bit of non-determinism (namely, in how data in
+			// coldata.Bytes is appended), so we require that we get at least 7
+			// batches. If we get more, that's still ok since it means that the
+			// batches were even smaller.
+			batchCountLowerBound: 7,
+		},
+		// Test case when the data is of variable size. The cFetcher is happy to
+		// put first 1024 rows that are small into a single batch, so it'll
+		// attempt to do the same for the large rows; however, after setting
+		// about 128 rows, the memory limit is exceeded, so no more rows will be
+		// added.
+		{
+			numRows: []int{1024, 1024},
+			rowSize: []int{1, 1024},
+			// We expect first 1024 rows to be returned in a single batch, but
+			// second 1024 rows are split into batches of 128, so we'll at least
+			// get 9 batches, maybe more.
+			batchCountLowerBound: 9,
+		},
+	} {
+		_, err = conn.ExecContext(ctx, `DROP TABLE IF EXISTS t`)
+		assert.NoError(t, err)
+		_, err = conn.ExecContext(ctx, `CREATE TABLE t (k INT PRIMARY KEY, v STRING)`)
+		assert.NoError(t, err)
+		startIdx := 1
+		for i := range tc.numRows {
+			_, err = conn.ExecContext(ctx,
+				"INSERT INTO t SELECT i, repeat('a', $1) FROM generate_series($2, $3) AS g(i);",
+				tc.rowSize[i], startIdx, startIdx+tc.numRows[i]-1,
+			)
 			assert.NoError(t, err)
+			startIdx += tc.numRows[i]
 		}
-	}
+		_, err = conn.ExecContext(ctx, `ANALYZE t`)
+		assert.NoError(t, err)
 
-	// There is a bit of non-determinism (namely, in how data in coldata.Bytes
-	// is appended), so we require that we get at least 7 batches. If we get
-	// more, that's still ok since it means that the batches were even smaller.
-	assert.GreaterOrEqual(t, foundBatches, 7)
+		batchCountRegex := regexp.MustCompile(`vectorized batch count: (\d+)`)
+		rows, err := conn.QueryContext(ctx, `EXPLAIN ANALYZE (VERBOSE) SELECT * FROM t`)
+		assert.NoError(t, err)
+		foundBatches := -1
+		for rows.Next() {
+			var res string
+			assert.NoError(t, rows.Scan(&res))
+			if matches := batchCountRegex.FindStringSubmatch(res); len(matches) > 0 {
+				foundBatches, err = strconv.Atoi(matches[1])
+				assert.NoError(t, err)
+			}
+		}
+		assert.GreaterOrEqual(t, foundBatches, tc.batchCountLowerBound)
+	}
 }

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -13,7 +13,6 @@ package colrpc
 import (
 	"context"
 	"io"
-	"math"
 	"sync/atomic"
 	"time"
 
@@ -430,10 +429,8 @@ func (i *Inbox) Next() coldata.Batch {
 			colexecerror.InternalError(err)
 		}
 		// We rely on the outboxes to produce reasonably sized batches.
-		const maxBatchMemSize = math.MaxInt64
-		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(
-			i.typs, i.scratch.b, batchLength, maxBatchMemSize,
-			true, /* desiredCapacitySufficient */
+		i.scratch.b, _ = i.allocator.ResetMaybeReallocateNoMemLimit(
+			i.typs, i.scratch.b, batchLength,
 		)
 		i.allocator.PerformOperation(i.scratch.b.ColVecs(), func() {
 			if err := i.converter.ArrowToBatch(i.scratch.data, batchLength, i.scratch.b); err != nil {

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -22,9 +22,12 @@ go_library(
 go_test(
     name = "colmem_test",
     size = "small",
-    srcs = ["allocator_test.go"],
+    srcs = [
+        "allocator_test.go",
+        "reset_maybe_reallocate_test.go",
+    ],
+    embed = [":colmem"],
     deps = [
-        ":colmem",
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
         "//pkg/settings/cluster",

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -12,6 +12,7 @@ package colmem
 
 import (
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -221,6 +222,18 @@ func (a *Allocator) ResetMaybeReallocate(
 		}
 	}
 	return newBatch, reallocated
+}
+
+// ResetMaybeReallocateNoMemLimit is the same as ResetMaybeReallocate when
+// MaxInt64 is used as the maxBatchMemSize argument and the desired capacity is
+// sufficient. This should be used by the callers that know exactly the capacity
+// they need and have no control over that number. It is guaranteed that the
+// returned batch has the capacity of at least requiredCapacity (clamped to
+// [1, coldata.BatchSize()] range).
+func (a *Allocator) ResetMaybeReallocateNoMemLimit(
+	typs []*types.T, oldBatch coldata.Batch, requiredCapacity int,
+) (newBatch coldata.Batch, reallocated bool) {
+	return a.ResetMaybeReallocate(typs, oldBatch, requiredCapacity, math.MaxInt64, true /* desiredCapacitySufficient */)
 }
 
 // NewMemColumn returns a new coldata.Vec of the desired capacity.

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -119,13 +120,13 @@ func TestResetMaybeReallocate(t *testing.T) {
 		typs := []*types.T{types.Bytes}
 
 		// Allocate a new batch and modify it.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
 		b.SetSelection(true)
 		b.Selection()[0] = 1
 		b.ColVec(0).Bytes().Set(1, []byte("foo"))
 
 		oldBatch := b
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
 		// We should have used the same batch, and now it should be in a "reset"
 		// state.
 		require.Equal(t, oldBatch, b)
@@ -152,7 +153,7 @@ func TestResetMaybeReallocate(t *testing.T) {
 		// Allocate a new batch attempting to use the batch with too small of a
 		// capacity - new batch should **not** be allocated because the memory
 		// limit is already exceeded.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
 		require.Equal(t, smallBatch, b)
 		require.Equal(t, minDesiredCapacity/2, b.Capacity())
 
@@ -160,13 +161,13 @@ func TestResetMaybeReallocate(t *testing.T) {
 
 		// Reset the batch asking for the same small desired capacity when it is
 		// sufficient - the same batch should be returned.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
 		require.Equal(t, smallBatch, b)
 		require.Equal(t, minDesiredCapacity/2, b.Capacity())
 
 		// Reset the batch and confirm that a new batch is allocated because we
 		// have given larger memory limit.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
 		require.NotEqual(t, oldBatch, b)
 		require.Equal(t, minDesiredCapacity, b.Capacity())
 
@@ -177,7 +178,7 @@ func TestResetMaybeReallocate(t *testing.T) {
 			// ResetMaybeReallocate truncates the capacity at
 			// coldata.BatchSize(), so we run this part of the test only when
 			// doubled capacity will not be truncated.
-			b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
+			b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
 			require.NotEqual(t, oldBatch, b)
 			require.Equal(t, 2*minDesiredCapacity, b.Capacity())
 		}
@@ -266,6 +267,208 @@ func TestPerformAppend(t *testing.T) {
 	}
 }
 
+// TestAccountingHelper verifies that the colmem.AccountingHelper makes
+// reasonable decisions about when to allocate new batches.
+func TestAccountingHelper(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Set the batch size to a fixed small value to make the tests both
+	// predictable and concise.
+	oldBatchSize := coldata.BatchSize()
+	require.NoError(t, coldata.SetBatchSizeForTests(7))
+	defer func() {
+		require.NoError(t, coldata.SetBatchSizeForTests(oldBatchSize))
+	}()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	// Use increment of 1 so that no allocations are "reserved".
+	testMemMonitor := mon.NewMonitor(
+		"test-mem",
+		mon.MemoryResource,
+		nil,           /* curCount */
+		nil,           /* maxHist */
+		1,             /* increment */
+		math.MaxInt64, /* noteworthy */
+		st,
+	)
+	testMemMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
+	defer testMemMonitor.Stop(ctx)
+	memAcc := testMemMonitor.MakeBoundAccount()
+	defer memAcc.Close(ctx)
+	evalCtx := eval.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+
+	// Allocate a scratch bytes value that exceeds the target size in all
+	// scenarios.
+	v := make([]byte, 10000)
+	typs := []*types.T{types.Bytes}
+
+	// overhead returns the overhead of the batch with a single coldata.Bytes
+	// vector.
+	overhead := func(batchCapacity int) int64 {
+		return colmem.SelVectorSize(batchCapacity) +
+			coldata.FlatBytesOverhead +
+			int64(batchCapacity)*coldata.ElementSize
+	}
+
+	// iteration describes a single iteration of using the AccountingHelper.
+	type iteration struct {
+		// expectedCapacity specifies the expected capacity of the batch after
+		// ResetMaybeReallocate call of the current iteration.
+		expectedCapacity int
+		// expectedReallocated specifies whether the batch is expected to be
+		// reallocated during the ResetMaybeReallocate call of the current
+		// iteration.
+		expectedReallocated bool
+		// bytesValueSize determines the footprint of the bytes values that are
+		// set during the current iteration. Note that this only affects the
+		// call to ResetMaybeReallocate of the **next** iteration.
+		bytesValueSize int64
+	}
+	type testCase struct {
+		memoryLimit int64
+		// totalTuples, if positive, indicates the number of tuples that are
+		// expected to be set throughout this test case.
+		totalTuples int
+		iterations  []iteration
+	}
+	errorMessage := func(tc testCase, i iteration) string {
+		return fmt.Sprintf(
+			"tc: limit=%d, tuples=%d, iterations=%d i: cap=%d, realloc=%t, size=%d",
+			tc.memoryLimit, tc.totalTuples, len(tc.iterations), i.expectedCapacity,
+			i.expectedReallocated, i.bytesValueSize,
+		)
+	}
+
+	for _, tc := range []testCase{
+		// Verify the dynamic behavior of the helper. We start out without any
+		// knowledge on the number of tuples and with an unlimited budget, so
+		// we expect the capacity to grow until it reaches the maximum batch
+		// size.
+		{
+			memoryLimit: math.MaxInt64,
+			totalTuples: 0,
+			iterations: []iteration{
+				{1, true, 100},
+				{2, true, 200},
+				{4, true, 400},
+				{7, true, 700},
+				{7, false, 700},
+				{7, false, 700},
+			},
+		},
+		// A couple of tests for when the total number of tuples is known in
+		// advance.
+		{
+			memoryLimit: math.MaxInt64,
+			totalTuples: 4,
+			iterations: []iteration{
+				{4, true, 400},
+			},
+		},
+		{
+			memoryLimit: math.MaxInt64,
+			totalTuples: 13,
+			iterations: []iteration{
+				{7, true, 700},
+				{7, false, 600},
+			},
+		},
+		// A test case when the memory limit is exceeded on the third iteration
+		// at which point the batch no longer grows but is reused.
+		{
+			memoryLimit: 300 + overhead(3),
+			totalTuples: 0,
+			iterations: []iteration{
+				{1, true, 100},
+				{2, true, 200},
+				{4, true, 400},
+				{4, false, 400},
+				{4, false, 400},
+			},
+		},
+		// A test case with values of different sizes with the memory limit
+		// being exceeded even after the batch has shrunk.
+		{
+			memoryLimit: 300 + overhead(3),
+			totalTuples: 0,
+			iterations: []iteration{
+				{1, true, 100},
+				{2, true, 200},
+				{4, true, 400},
+				// The limit has just been exceeded, but not by too much, so we
+				// reuse the same batch.
+				{4, false, 1400},
+				// Now the limit has been exceeded by too much - a new batch of
+				// smaller capacity must be allocated.
+				{2, true, 200},
+				{2, false, 200},
+				{2, false, 1200},
+				// Now the limit has been exceeded by too much again - a new
+				// batch of smaller capacity must be allocated.
+				{1, true, 400},
+				// The limit has been exceeded but not by too much, so the batch
+				// is reused.
+				{1, false, 1100},
+				// Now the limit has been exceeded by too much again - a new
+				// batch is allocated, but we cannot reduce the capacity since
+				// we're at the minimum already.
+				{1, true, 100},
+			},
+		},
+		// A test case with values of different sizes with the memory limit
+		// being exceeded even after the batch has shrunk when the total number
+		// of tuples is known.
+		{
+			memoryLimit: 300 + overhead(3),
+			totalTuples: 17,
+			iterations: []iteration{
+				{7, true, 700},
+				// The limit has been exceeded by too much - a new batch of
+				// smaller capacity must be allocated.
+				{4, true, 400},
+				// The limit has just been exceeded, but not by too much, so we
+				// reuse the same batch.
+				{4, false, 1400},
+				// Now the limit has been exceeded by too much again - a new
+				// batch of smaller capacity must be allocated.
+				{2, true, 100},
+			},
+		},
+	} {
+		// Prime the allocator for reuse.
+		testAllocator.ReleaseAll()
+		var helper colmem.AccountingHelper
+		helper.Init(testAllocator, tc.memoryLimit)
+		tuplesToBeSet := tc.totalTuples
+		var batch coldata.Batch
+		var reallocated bool
+		for _, iteration := range tc.iterations {
+			batch, reallocated = helper.ResetMaybeReallocate(typs, batch, tuplesToBeSet)
+			require.Equal(t, iteration.expectedCapacity, batch.Capacity(), errorMessage(tc, iteration))
+			require.Equal(t, iteration.expectedReallocated, reallocated, errorMessage(tc, iteration))
+			testAllocator.PerformOperation(batch.ColVecs(), func() {
+				batch.ColVec(0).Bytes().Set(0, v[:iteration.bytesValueSize])
+				batch.SetLength(batch.Capacity())
+			})
+			// Since Bytes.Set appends to a byte slice, we don't know the exact
+			// capacity that is allocated for the buffer, meaning that the
+			// actual footprint can be greater than our target. That's ok since
+			// we're still properly accounting for it.
+			require.GreaterOrEqual(t, testAllocator.Used(), overhead(batch.Capacity())+iteration.bytesValueSize, errorMessage(tc, iteration))
+			if tuplesToBeSet > 0 {
+				tuplesToBeSet -= batch.Capacity()
+			}
+		}
+	}
+}
+
+// TestSetAccountingHelper verifies that the colmem.SetAccountingHelper
+// precisely tracks the memory footprint of the batch across AccountForSet()
+// calls.
 func TestSetAccountingHelper(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -307,7 +510,7 @@ func TestSetAccountingHelper(t *testing.T) {
 			maxBatchMemSize = largeMemSize
 		}
 		helper.TestingUpdateMemoryLimit(maxBatchMemSize)
-		batch, _ = helper.ResetMaybeReallocate(typs, batch, numRows, false /* desiredCapacitySufficient */)
+		batch, _ = helper.ResetMaybeReallocate(typs, batch, numRows)
 
 		for rowIdx := 0; rowIdx < batch.Capacity(); rowIdx++ {
 			for vecIdx, typ := range typs {

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -94,94 +93,6 @@ func TestMaybeAppendColumn(t *testing.T) {
 		require.Equal(t, 1, b.Width())
 		require.Equal(t, coldata.BatchSize(), b.ColVec(colIdx).Length())
 		_ = b.ColVec(colIdx).Int64()[0]
-	})
-}
-
-func TestResetMaybeReallocate(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := eval.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
-
-	t.Run("ResettingBehavior", func(t *testing.T) {
-		if coldata.BatchSize() == 1 {
-			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
-		}
-
-		var b coldata.Batch
-		typs := []*types.T{types.Bytes}
-
-		// Allocate a new batch and modify it.
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
-		b.SetSelection(true)
-		b.Selection()[0] = 1
-		b.ColVec(0).Bytes().Set(1, []byte("foo"))
-
-		oldBatch := b
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
-		// We should have used the same batch, and now it should be in a "reset"
-		// state.
-		require.Equal(t, oldBatch, b)
-		require.Nil(t, b.Selection())
-		// We should be able to set in the Bytes vector using an arbitrary
-		// position since the vector should have been reset.
-		require.NotPanics(t, func() { b.ColVec(0).Bytes().Set(0, []byte("bar")) })
-	})
-
-	t.Run("LimitingByMemSize", func(t *testing.T) {
-		if coldata.BatchSize() == 1 {
-			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
-		}
-
-		var b coldata.Batch
-		typs := []*types.T{types.Int}
-		const minDesiredCapacity = 2
-		const smallMemSize = 0
-		const largeMemSize = math.MaxInt64
-
-		// Allocate a batch with smaller capacity.
-		smallBatch := testAllocator.NewMemBatchWithFixedCapacity(typs, minDesiredCapacity/2)
-
-		// Allocate a new batch attempting to use the batch with too small of a
-		// capacity - new batch should **not** be allocated because the memory
-		// limit is already exceeded.
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
-		require.Equal(t, smallBatch, b)
-		require.Equal(t, minDesiredCapacity/2, b.Capacity())
-
-		oldBatch := b
-
-		// Reset the batch asking for the same small desired capacity when it is
-		// sufficient - the same batch should be returned.
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
-		require.Equal(t, smallBatch, b)
-		require.Equal(t, minDesiredCapacity/2, b.Capacity())
-
-		// Reset the batch and confirm that a new batch is allocated because we
-		// have given larger memory limit.
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
-		require.NotEqual(t, oldBatch, b)
-		require.Equal(t, minDesiredCapacity, b.Capacity())
-
-		if coldata.BatchSize() >= minDesiredCapacity*2 {
-			// Now reset the batch with large memory limit - we should get a new
-			// batch with the double capacity.
-			//
-			// ResetMaybeReallocate truncates the capacity at
-			// coldata.BatchSize(), so we run this part of the test only when
-			// doubled capacity will not be truncated.
-			b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
-			require.NotEqual(t, oldBatch, b)
-			require.Equal(t, 2*minDesiredCapacity, b.Capacity())
-		}
 	})
 }
 

--- a/pkg/sql/colmem/reset_maybe_reallocate_test.go
+++ b/pkg/sql/colmem/reset_maybe_reallocate_test.go
@@ -1,0 +1,116 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colmem
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetMaybeReallocate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
+	defer testMemMonitor.Stop(ctx)
+	memAcc := testMemMonitor.MakeBoundAccount()
+	defer memAcc.Close(ctx)
+	evalCtx := eval.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := NewAllocator(ctx, &memAcc, testColumnFactory)
+
+	t.Run("ResettingBehavior", func(t *testing.T) {
+		if coldata.BatchSize() == 1 {
+			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
+		}
+
+		var b coldata.Batch
+		typs := []*types.T{types.Bytes}
+
+		// Allocate a new batch and modify it.
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
+		b.SetSelection(true)
+		b.Selection()[0] = 1
+		b.ColVec(0).Bytes().Set(1, []byte("foo"))
+
+		oldBatch := b
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
+		// We should have used the same batch, and now it should be in a "reset"
+		// state.
+		require.Equal(t, oldBatch, b)
+		require.Nil(t, b.Selection())
+		// We should be able to set in the Bytes vector using an arbitrary
+		// position since the vector should have been reset.
+		require.NotPanics(t, func() { b.ColVec(0).Bytes().Set(0, []byte("bar")) })
+	})
+
+	t.Run("LimitingByMemSize", func(t *testing.T) {
+		if coldata.BatchSize() == 1 {
+			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
+		}
+
+		var b coldata.Batch
+		typs := []*types.T{types.Int}
+		const minDesiredCapacity = 2
+		const smallMemSize = 0
+		const largeMemSize = math.MaxInt64
+
+		// Allocate a batch with smaller capacity.
+		smallBatch := testAllocator.NewMemBatchWithFixedCapacity(typs, minDesiredCapacity/2)
+
+		// Allocate a new batch attempting to use the batch with too small of a
+		// capacity - new batch should **not** be allocated because the memory
+		// limit is already exceeded.
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
+		require.Equal(t, smallBatch, b)
+		require.Equal(t, minDesiredCapacity/2, b.Capacity())
+
+		oldBatch := b
+
+		// Reset the batch asking for the same small desired capacity when it is
+		// sufficient - the same batch should be returned.
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
+		require.Equal(t, smallBatch, b)
+		require.Equal(t, minDesiredCapacity/2, b.Capacity())
+
+		// Reset the batch and confirm that a new batch is allocated because we
+		// have given larger memory limit.
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
+		require.NotEqual(t, oldBatch, b)
+		require.Equal(t, minDesiredCapacity, b.Capacity())
+
+		if coldata.BatchSize() >= minDesiredCapacity*2 {
+			// Now reset the batch with large memory limit - we should get a new
+			// batch with the double capacity.
+			//
+			// resetMaybeReallocate truncates the capacity at
+			// coldata.BatchSize(), so we run this part of the test only when
+			// doubled capacity will not be truncated.
+			b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
+			require.NotEqual(t, oldBatch, b)
+			require.Equal(t, 2*minDesiredCapacity, b.Capacity())
+		}
+	})
+}

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -401,7 +401,7 @@ planning time: 10µs
 execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
-rows read from KV: 5 (40 B, 5 gRPC calls)
+rows read from KV: 4 (32 B, 4 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -426,12 +426,12 @@ regions: <hidden>
     └── • scan
           nodes: <hidden>
           regions: <hidden>
-          actual row count: 3
+          actual row count: 2
           KV time: 0µs
           KV contention time: 0µs
-          KV rows read: 3
-          KV bytes read: 24 B
-          KV gRPC calls: 3
+          KV rows read: 2
+          KV bytes read: 16 B
+          KV gRPC calls: 2
           estimated max memory allocated: 0 B
           estimated row count: 1 (100% of the table; stats collected <hidden> ago)
           table: a@a_y_idx


### PR DESCRIPTION
**colmem: introduce a helper method when no memory limit should be applied**

This commit is a pure mechanical change.

Release note: None

**colmem: move some logic of capacity-limiting into the accounting helper**

This commit moves the logic that was duplicated across each user of the
SetAccountingHelper into the helper itself. Clearly, this allows us to
de-duplicate some code, but it'll make it easier to refactor the code
which is done in the following commit.

Additionally, this commit makes a tiny change to make the resetting
behavior in the hash aggregator more precise.

Release note: None

**colmem: improve memory-limiting behavior of the accounting helpers**

This commit fixes an oversight in how we are allocating batches of the
"dynamic" capacity. We have two related ways for reallocating batches,
and both of them work by growing the capacity of the batch until the
memory limit is exceeded, and then the batch would be reused until the
end of the query execution. This is a reasonable heuristic under the
assumption that all tuples in the data stream are roughly equal in size,
but this might not be the case.

In particular, consider an example when 10k small rows of 1KiB are
followed by 10k large rows of 1MiB. According to our heuristic, we
happily grow the batch until 1024 in capacity, and then we do not shrink
the capacity of that batch, so once the large rows start appearing, we
put 1GiB worth of data into a single batch, significantly exceeding our
memory limit (usually 64MiB with the default `workmem` setting).

This commit introduces a new heuristic as follows:
- the first time a batch exceeds the memory limit, its capacity is memorized,
  and from now on that capacity will determine the upper bound on the
  capacities of the batches allocated through the helper;
- if at any point in time a batch exceeds the memory limit by at least a
  factor of two, then that batch is discarded, and the capacity will never
  exceed half of the capacity of the discarded batch;
- if the memory limit is not reached, then the behavior of the dynamic growth
  of the capacity provided by `Allocator.ResetMaybeReallocate` is still
  applicable (i.e. the capacities will grow exponentially until
  coldata.BatchSize()).

Note that this heuristic does not have an ability to grow the maximum
capacity once it's been set although it might make sense to do so (say,
if after shrinking the capacity, the next five times we see that the
batch is using less than half of the memory limit). This is an conscious
omission since I want this change to be backported, and never growing
seems like a safer choice. Thus, this improvement is left as a TODO.

Also, we still might create batches that are too large in memory
footprint in those places that don't use the SetAccountingHelper (e.g.
in the columnarizer) since we perform the memory limit check at the
batch granularity. However, this commit improves things there so that we
don't reuse that batch on the next iteration and will use half of the
capacity on the next iteration.

Fixes: #76464.

Release note (bug fix): CockroachDB now more precisely respects the
`distsql_workmem` setting which improves the stability of each node and
makes OOMs less likely.

**colmem: unexport Allocator.ResetMaybeReallocate**

This commit is a mechanical change to unexport
`Allocator.ResetMaybeReallocate` so that the users would be forced to use
the method with the same name from the helpers. This required splitting
off the tests into two files.

Release note: None