### PR TITLE
rules: more type safety

### DIFF
--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -233,7 +233,7 @@ var _ sort.Interface = nodeEntries{}
 
 func formatElementForDisplay(t *testing.T, e scpb.Element) []byte {
 	marshaled, err := sctestutils.ProtoToYAML(
-		e, false /* emitDefaults */, nil,
+		e, false /* emitDefaults */, nil, /* rewrites */
 	)
 	require.NoError(t, err)
 	dec := yaml.NewDecoder(strings.NewReader(marshaled))

--- a/pkg/sql/schemachanger/scexec/testing_knobs.go
+++ b/pkg/sql/schemachanger/scexec/testing_knobs.go
@@ -10,7 +10,10 @@
 
 package scexec
 
-import "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
+)
 
 // TestingKnobs are testing knobs which affect the running of declarative
 // schema changes.
@@ -27,8 +30,12 @@ type TestingKnobs struct {
 	// for concurrent schema changes to finish.
 	BeforeWaitingForConcurrentSchemaChanges func(stmts []string)
 
+	// OnPostCommitPlanError is called whenever the schema changer job returns an
+	// error on building the state or on planning the stages.
+	OnPostCommitPlanError func(state *scpb.CurrentState, err error) error
+
 	// OnPostCommitError is called whenever the schema changer job returns an
-	// error.
+	// error during stage execution.
 	OnPostCommitError func(p scplan.Plan, stageIdx int, err error) error
 
 	// RunBeforeBackfill is called just before starting the backfill.

--- a/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
@@ -15,15 +15,12 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules",
     visibility = ["//pkg/sql/schemachanger/scplan:__subpackages__"],
     deps = [
-        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/schemachanger/rel",
         "//pkg/sql/schemachanger/scpb",
-        "//pkg/sql/schemachanger/scplan/internal/opgen",
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/screl",
         "//pkg/sql/sem/catid",
-        "//pkg/sql/types",
         "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/timeutil",
@@ -33,14 +30,22 @@ go_library(
 
 go_test(
     name = "rules_test",
-    srcs = ["rules_test.go"],
+    srcs = [
+        "assertions_test.go",
+        "rules_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":rules"],
     deps = [
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/schemachanger/rel",
+        "//pkg/sql/schemachanger/scpb",
+        "//pkg/sql/schemachanger/scplan/internal/opgen",
         "//pkg/sql/schemachanger/screl",
+        "//pkg/sql/types",
         "//pkg/testutils",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/pkg/sql/schemachanger/scplan/internal/rules/assertions_test.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/assertions_test.go
@@ -1,0 +1,160 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rules
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/opgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+// TestRuleAssertions verifies that important helper functions verify certain
+// properties that the rule definitions rely on.
+func TestRuleAssertions(t *testing.T) {
+	for _, fn := range []func(e scpb.Element) error{
+		checkSimpleDependentsReferenceDescID,
+		checkToAbsentCategories,
+		checkIsWithTypeT,
+		checkIsWithExpression,
+		checkIsColumnDependent,
+		checkIsIndexDependent,
+	} {
+		var fni interface{} = fn
+		fullName := runtime.FuncForPC(reflect.ValueOf(fni).Pointer()).Name()
+		nameParts := strings.Split(fullName, "rules.")
+		shortName := nameParts[len(nameParts)-1]
+		t.Run(shortName, func(t *testing.T) {
+			_ = forEachElement(func(e scpb.Element) error {
+				e = nonNilElement(e)
+				if err := fn(e); err != nil {
+					t.Errorf("%T: %+v", e, err)
+				}
+				return nil
+			})
+		})
+	}
+}
+
+func nonNilElement(element scpb.Element) scpb.Element {
+	return reflect.New(reflect.ValueOf(element).Type().Elem()).Interface().(scpb.Element)
+}
+
+// Assert that only simple dependents (non-descriptor, non-index, non-column)
+// have screl.ReferencedDescID attributes.
+func checkSimpleDependentsReferenceDescID(e scpb.Element) error {
+	if isSimpleDependent(e) {
+		return nil
+	}
+	if _, err := screl.Schema.GetAttribute(screl.ReferencedDescID, e); err == nil {
+		return errors.New("unexpected screl.ReferencedDescID attr")
+	}
+	return nil
+}
+
+// Assert that elements can be grouped into three categories when transitioning
+// from PUBLIC to ABSENT:
+// - go via DROPPED iff they're descriptor elements
+// - go via a non-read status iff they're indexes or columns, which are
+//   subject to the two-version invariant.
+// - go direct to ABSENT in all other cases.
+func checkToAbsentCategories(e scpb.Element) error {
+	s0 := opgen.InitialStatus(e, scpb.Status_ABSENT)
+	s1 := opgen.NextStatus(e, scpb.Status_ABSENT, s0)
+	switch s1 {
+	case scpb.Status_OFFLINE, scpb.Status_DROPPED:
+		if IsDescriptor(e) {
+			return nil
+		}
+	case scpb.Status_VALIDATED, scpb.Status_WRITE_ONLY, scpb.Status_DELETE_ONLY:
+		if isSubjectTo2VersionInvariant(e) {
+			return nil
+		}
+	case scpb.Status_ABSENT:
+		if isSimpleDependent(e) {
+			return nil
+		}
+	}
+	return errors.Newf("unexpected transition %s -> %s in direction ABSENT", s0, s1)
+}
+
+// Assert that isWithTypeT covers all elements with embedded TypeTs.
+func checkIsWithTypeT(e scpb.Element) error {
+	return screl.WalkTypes(e, func(t *types.T) error {
+		if isWithTypeT(e) {
+			return nil
+		}
+		return errors.New("should verify isWithTypeT but doesn't")
+	})
+}
+
+// Assert that isWithExpression covers all elements with embedded
+// expressions.
+func checkIsWithExpression(e scpb.Element) error {
+	return screl.WalkExpressions(e, func(t *catpb.Expression) error {
+		switch e.(type) {
+		// Ignore elements which have catpb.Expression fields but which don't
+		// have them within an scpb.Expression for valid reasons.
+		case *scpb.RowLevelTTL:
+			return nil
+		}
+		if isWithExpression(e) {
+			return nil
+		}
+		return errors.New("should verify isWithExpression but doesn't")
+	})
+}
+
+// Assert that isColumnDependent covers all dependent elements of a column
+// element.
+func checkIsColumnDependent(e scpb.Element) error {
+	// Exclude columns themselves.
+	switch e.(type) {
+	case *scpb.Column:
+		return nil
+	}
+	// A column dependent should have a ColumnID attribute.
+	_, err := screl.Schema.GetAttribute(screl.ColumnID, e)
+	if isColumnDependent(e) {
+		if err != nil {
+			return errors.New("verifies isColumnDependent but doesn't have ColumnID attr")
+		}
+	} else if err == nil {
+		return errors.New("has ColumnID attr but doesn't verify isColumnDependent")
+	}
+	return nil
+}
+
+// Assert that isIndexDependent covers all dependent elements of an index
+// element.
+func checkIsIndexDependent(e scpb.Element) error {
+	// Exclude indexes themselves.
+	if isIndex(e) {
+		return nil
+	}
+	// An index dependent should have an IndexID attribute.
+	_, err := screl.Schema.GetAttribute(screl.IndexID, e)
+	if isIndexDependent(e) {
+		if err != nil {
+			return errors.New("verifies isIndexDependent but doesn't have IndexID attr")
+		}
+	} else if err == nil {
+		return errors.New("has IndexID attr but doesn't verify isIndexDependent")
+	}
+	return nil
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/dep_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/dep_column.go
@@ -27,12 +27,10 @@ func init() {
 		"column", "column-name",
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.el.Type((*scpb.Column)(nil)),
-				to.el.Type((*scpb.ColumnName)(nil)),
-				targetStatusEq(from.target, to.target, scpb.ToPublic),
-				currentStatus(from.node, scpb.Status_DELETE_ONLY),
-				currentStatus(to.node, scpb.Status_PUBLIC),
-				joinOnColumnID(from.el, to.el, "table-id", "col-id"),
+				from.Type((*scpb.Column)(nil)),
+				to.Type((*scpb.ColumnName)(nil)),
+				statusesToPublic(from, scpb.Status_DELETE_ONLY, to, scpb.Status_PUBLIC),
+				joinOnColumnID(from, to, "table-id", "col-id"),
 			}
 		},
 	)
@@ -42,18 +40,16 @@ func init() {
 		"column", "dependent",
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.el.Type((*scpb.Column)(nil)),
-				to.el.Type(
+				from.Type((*scpb.Column)(nil)),
+				to.Type(
 					(*scpb.ColumnName)(nil),
 					(*scpb.ColumnDefaultExpression)(nil),
 					(*scpb.ColumnOnUpdateExpression)(nil),
 					(*scpb.ColumnComment)(nil),
 					(*scpb.IndexColumn)(nil),
 				),
-				joinOnColumnID(from.el, to.el, "table-id", "col-id"),
-				targetStatusEq(from.target, to.target, scpb.ToPublic),
-				currentStatus(from.node, scpb.Status_DELETE_ONLY),
-				currentStatus(to.node, scpb.Status_PUBLIC),
+				joinOnColumnID(from, to, "table-id", "col-id"),
+				statusesToPublic(from, scpb.Status_DELETE_ONLY, to, scpb.Status_PUBLIC),
 			}
 		},
 	)
@@ -64,15 +60,13 @@ func init() {
 		"expr", "column",
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.el.Type(
+				from.Type(
 					(*scpb.ColumnDefaultExpression)(nil),
 					(*scpb.ColumnOnUpdateExpression)(nil),
 				),
-				to.el.Type((*scpb.Column)(nil)),
-				joinOnColumnID(from.el, to.el, "table-id", "col-id"),
-				targetStatusEq(from.target, to.target, scpb.ToPublic),
-				currentStatus(from.node, scpb.Status_PUBLIC),
-				currentStatus(to.node, scpb.Status_WRITE_ONLY),
+				to.Type((*scpb.Column)(nil)),
+				joinOnColumnID(from, to, "table-id", "col-id"),
+				statusesToPublic(from, scpb.Status_PUBLIC, to, scpb.Status_WRITE_ONLY),
 			}
 		},
 	)
@@ -84,11 +78,10 @@ func init() {
 		"column-name", "column-type",
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.el.Type((*scpb.ColumnName)(nil)),
-				to.el.Type((*scpb.ColumnType)(nil)),
-				joinOnColumnID(from.el, to.el, "table-id", "col-id"),
-				targetStatusEq(from.target, to.target, scpb.ToPublic),
-				currentStatusEq(from.node, to.node, scpb.Status_PUBLIC),
+				from.Type((*scpb.ColumnName)(nil)),
+				to.Type((*scpb.ColumnType)(nil)),
+				joinOnColumnID(from, to, "table-id", "col-id"),
+				statusesToPublic(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
 			}
 		},
 	)
@@ -101,11 +94,10 @@ func init() {
 		"column-comment", "column",
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.el.Type((*scpb.ColumnComment)(nil)),
-				to.el.Type((*scpb.Column)(nil)),
-				joinOnColumnID(from.el, to.el, "table-id", "col-id"),
-				targetStatusEq(from.target, to.target, scpb.ToPublic),
-				currentStatusEq(from.node, to.node, scpb.Status_PUBLIC),
+				from.Type((*scpb.ColumnComment)(nil)),
+				to.Type((*scpb.Column)(nil)),
+				joinOnColumnID(from, to, "table-id", "col-id"),
+				statusesToPublic(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
 			}
 		},
 	)
@@ -116,16 +108,14 @@ func init() {
 		"column", "dependent",
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.el.Type((*scpb.Column)(nil)),
-				to.el.Type(
+				from.Type((*scpb.Column)(nil)),
+				to.Type(
 					(*scpb.ColumnType)(nil),
 					(*scpb.ColumnName)(nil),
 					(*scpb.ColumnComment)(nil),
 				),
-				joinOnColumnID(from.el, to.el, "table-id", "col-id"),
-				targetStatusEq(from.target, to.target, scpb.ToAbsent),
-				currentStatus(from.node, scpb.Status_WRITE_ONLY),
-				currentStatus(to.node, scpb.Status_ABSENT),
+				joinOnColumnID(from, to, "table-id", "col-id"),
+				statusesToAbsent(from, scpb.Status_WRITE_ONLY, to, scpb.Status_ABSENT),
 			}
 		},
 	)
@@ -136,15 +126,14 @@ func init() {
 		"dependent", "column-type",
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.el.Type(
+				from.Type(
 					(*scpb.SequenceOwner)(nil),
 					(*scpb.ColumnDefaultExpression)(nil),
 					(*scpb.ColumnOnUpdateExpression)(nil),
 				),
-				to.el.Type((*scpb.ColumnType)(nil)),
-				joinOnColumnID(from.el, to.el, "table-id", "col-id"),
-				targetStatusEq(from.target, to.target, scpb.ToAbsent),
-				currentStatusEq(from.node, to.node, scpb.Status_ABSENT),
+				to.Type((*scpb.ColumnType)(nil)),
+				joinOnColumnID(from, to, "table-id", "col-id"),
+				statusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_ABSENT),
 			}
 		},
 	)
@@ -155,15 +144,14 @@ func init() {
 		"dependent", "column",
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.el.Type(
+				from.Type(
 					(*scpb.ColumnName)(nil),
 					(*scpb.ColumnType)(nil),
 					(*scpb.ColumnComment)(nil),
 				),
-				to.el.Type((*scpb.Column)(nil)),
-				joinOnColumnID(from.el, to.el, "table-id", "col-id"),
-				targetStatusEq(from.target, to.target, scpb.ToAbsent),
-				currentStatusEq(from.node, to.node, scpb.Status_ABSENT),
+				to.Type((*scpb.Column)(nil)),
+				joinOnColumnID(from, to, "table-id", "col-id"),
+				statusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_ABSENT),
 			}
 		},
 	)
@@ -178,15 +166,13 @@ func init() {
 		func(from, to nodeVars) rel.Clauses {
 			status := rel.Var("status")
 			return rel.Clauses{
-				from.el.Type((*scpb.Column)(nil)),
-				to.el.Type((*scpb.Column)(nil)),
-				join(from.el, to.el, screl.DescID, "table-id"),
-				targetStatusEq(from.target, to.target, scpb.ToPublic),
+				from.Type((*scpb.Column)(nil)),
+				to.Type((*scpb.Column)(nil)),
+				joinOnDescID(from, to, "table-id"),
+				toPublic(from, to),
 				status.In(scpb.Status_WRITE_ONLY, scpb.Status_PUBLIC),
 				status.Entities(screl.CurrentStatus, from.node, to.node),
-				rel.Filter("columnHasSmallerID", from.el, to.el)(func(
-					from *scpb.Column, to *scpb.Column,
-				) bool {
+				filterElements("SmallerColumnIDFirst", from, to, func(from, to *scpb.Column) bool {
 					return from.ColumnID < to.ColumnID
 				}),
 			}

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -11,18 +11,13 @@
 package rules
 
 import (
-	"fmt"
 	"reflect"
-	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/opgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 )
@@ -36,59 +31,105 @@ func idInIDs(objects []descpb.ID, id descpb.ID) bool {
 	return false
 }
 
-func currentStatus(node rel.Var, status scpb.Status) rel.Clause {
-	return node.AttrEq(screl.CurrentStatus, status)
-}
-
-func targetStatus(target rel.Var, status scpb.TargetStatus) rel.Clause {
-	return target.AttrEq(screl.TargetStatus, status.Status())
-}
-
-func targetStatusEq(aTarget, bTarget rel.Var, status scpb.TargetStatus) rel.Clause {
-	return rel.And(targetStatus(aTarget, status), targetStatus(bTarget, status))
-}
-
-func currentStatusEq(aNode, bNode rel.Var, status scpb.Status) rel.Clause {
-	return rel.And(currentStatus(aNode, status), currentStatus(bNode, status))
-}
-
-func join(a, b rel.Var, attr rel.Attr, eqVarName rel.Var) rel.Clause {
+func join(a, b nodeVars, attr rel.Attr, eqVarName rel.Var) rel.Clause {
 	return joinOn(a, attr, b, attr, eqVarName)
 }
 
-func joinOn(a rel.Var, aAttr rel.Attr, b rel.Var, bAttr rel.Attr, eqVarName rel.Var) rel.Clause {
+var _ = join
+
+func joinOn(a nodeVars, aAttr rel.Attr, b nodeVars, bAttr rel.Attr, eqVarName rel.Var) rel.Clause {
 	return rel.And(
-		a.AttrEqVar(aAttr, eqVarName),
-		b.AttrEqVar(bAttr, eqVarName),
+		a.el.AttrEqVar(aAttr, eqVarName),
+		b.el.AttrEqVar(bAttr, eqVarName),
 	)
 }
 
+func filterElements(name string, a, b nodeVars, fn interface{}) rel.Clause {
+	return rel.Filter(name, a.el, b.el)(fn)
+}
+
+func toPublic(from, to nodeVars) rel.Clause {
+	return toPublicUntyped(from.target, to.target)
+}
+
+func statusesToPublic(
+	from nodeVars, fromStatus scpb.Status, to nodeVars, toStatus scpb.Status,
+) rel.Clause {
+	return rel.And(
+		toPublic(from, to),
+		from.currentStatus(fromStatus),
+		to.currentStatus(toStatus),
+	)
+}
+
+func toAbsent(from, to nodeVars) rel.Clause {
+	return toAbsentUntyped(from.target, to.target)
+}
+
+func statusesToAbsent(
+	from nodeVars, fromStatus scpb.Status, to nodeVars, toStatus scpb.Status,
+) rel.Clause {
+	return rel.And(
+		toAbsent(from, to),
+		from.currentStatus(fromStatus),
+		to.currentStatus(toStatus),
+	)
+}
+
+func joinOnDescID(a, b nodeVars, descriptorIDVar rel.Var) rel.Clause {
+	return joinOnDescIDUntyped(a.el, b.el, descriptorIDVar)
+}
+
+func joinReferencedDescID(a, b nodeVars, descriptorIDVar rel.Var) rel.Clause {
+	return joinReferencedDescIDUntyped(a.el, b.el, descriptorIDVar)
+}
+
+func joinOnColumnID(a, b nodeVars, relationIDVar, columnIDVar rel.Var) rel.Clause {
+	return joinOnColumnIDUntyped(a.el, b.el, relationIDVar, columnIDVar)
+}
+
+func joinOnIndexID(a, b nodeVars, relationIDVar, indexIDVar rel.Var) rel.Clause {
+	return joinOnIndexIDUntyped(a.el, b.el, relationIDVar, indexIDVar)
+}
+
+func joinOnConstraintID(a, b nodeVars, relationIDVar, constraintID rel.Var) rel.Clause {
+	return joinOnConstraintIDUntyped(a.el, b.el, relationIDVar, constraintID)
+}
+
+func columnInIndex(
+	indexColumn, index nodeVars, relationIDVar, columnIDVar, indexIDVar rel.Var,
+) rel.Clause {
+	return columnInIndexUntyped(indexColumn.el, index.el, relationIDVar, columnIDVar, indexIDVar)
+}
+
+func columnInPrimaryIndexSwap(
+	indexColumn, index nodeVars, relationIDVar, columnIDVar, indexIDVar rel.Var,
+) rel.Clause {
+	return columnInPrimaryIndexSwapUntyped(indexColumn.el, index.el, relationIDVar, columnIDVar, indexIDVar)
+}
+
 var (
-	toAbsent = screl.Schema.Def2(
+	toPublicUntyped = screl.Schema.Def2(
+		"toPublic",
+		"target1", "target2",
+		func(target1 rel.Var, target2 rel.Var) rel.Clauses {
+			return rel.Clauses{
+				target1.AttrEq(screl.TargetStatus, scpb.Status_PUBLIC),
+				target2.AttrEq(screl.TargetStatus, scpb.Status_PUBLIC),
+			}
+		})
+
+	toAbsentUntyped = screl.Schema.Def2(
 		"toAbsent",
 		"target1", "target2",
 		func(target1 rel.Var, target2 rel.Var) rel.Clauses {
 			return rel.Clauses{
-				targetStatusEq(target1, target2, scpb.ToAbsent),
+				target1.AttrEq(screl.TargetStatus, scpb.Status_ABSENT),
+				target2.AttrEq(screl.TargetStatus, scpb.Status_ABSENT),
 			}
 		})
 
-	toAbsentIn = func(status scpb.Status) rel.Rule4 {
-		ss := status.String()
-		return screl.Schema.Def4(
-			fmt.Sprintf("toAbsentIn%s%s", ss[0:1], strings.ToLower(ss[1:])),
-			"target1", "node1", "target2", "node2",
-			func(
-				target1 rel.Var, node1 rel.Var, target2 rel.Var, node2 rel.Var,
-			) rel.Clauses {
-				return rel.Clauses{
-					toAbsent(target1, target2),
-					currentStatusEq(node1, node2, status),
-				}
-			})
-	}
-	toAbsentInAbsent     = toAbsentIn(scpb.Status_ABSENT)
-	joinReferencedDescID = screl.Schema.Def3(
+	joinReferencedDescIDUntyped = screl.Schema.Def3(
 		"joinReferencedDescID", "referrer", "referenced", "id", func(
 			referrer, referenced, id rel.Var,
 		) rel.Clauses {
@@ -97,7 +138,7 @@ var (
 				referenced.AttrEqVar(screl.DescID, id),
 			}
 		})
-	joinOnDescID = screl.Schema.Def3(
+	joinOnDescIDUntyped = screl.Schema.Def3(
 		"joinOnDescID", "a", "b", "id", func(
 			a, b, id rel.Var,
 		) rel.Clauses {
@@ -105,73 +146,52 @@ var (
 				id.Entities(screl.DescID, a, b),
 			}
 		})
-	joinOnIndexID = screl.Schema.Def4(
+	joinOnIndexIDUntyped = screl.Schema.Def4(
 		"joinOnIndexID", "a", "b", "desc-id", "index-id", func(
 			a, b, descID, indexID rel.Var,
 		) rel.Clauses {
 			return rel.Clauses{
-				joinOnDescID(a, b, descID),
+				joinOnDescIDUntyped(a, b, descID),
 				indexID.Entities(screl.IndexID, a, b),
 			}
 		},
 	)
-	joinOnColumnID = screl.Schema.Def4(
+	joinOnColumnIDUntyped = screl.Schema.Def4(
 		"joinOnColumnID", "a", "b", "desc-id", "col-id", func(
 			a, b, descID, colID rel.Var,
 		) rel.Clauses {
 			return rel.Clauses{
-				joinOnDescID(a, b, descID),
+				joinOnDescIDUntyped(a, b, descID),
 				colID.Entities(screl.ColumnID, a, b),
 			}
 		},
 	)
-	joinOnConstraintID = screl.Schema.Def4(
+	joinOnConstraintIDUntyped = screl.Schema.Def4(
 		"joinOnConstraintID", "a", "b", "desc-id", "constraint-id", func(
 			a, b, descID, constraintID rel.Var,
 		) rel.Clauses {
 			return rel.Clauses{
-				joinOnDescID(a, b, descID),
+				joinOnDescIDUntyped(a, b, descID),
 				constraintID.Entities(screl.ConstraintID, a, b),
 			}
 		},
 	)
-	indexDependents = screl.Schema.Def4("index-dependents",
-		"index", "dep",
-		"table-id", "index-id", func(
-			index, dep, tableID, indexID rel.Var,
-		) rel.Clauses {
-			return rel.Clauses{
-				dep.Type(
-					(*scpb.IndexName)(nil),
-					(*scpb.IndexPartitioning)(nil),
-					(*scpb.SecondaryIndexPartial)(nil),
-					(*scpb.IndexComment)(nil),
-					(*scpb.IndexColumn)(nil),
-				),
-				index.Type(
-					(*scpb.PrimaryIndex)(nil),
-					(*scpb.TemporaryIndex)(nil),
-					(*scpb.SecondaryIndex)(nil),
-				),
-				joinOnIndexID(dep, index, "table-id", "index-id"),
-			}
-		})
 
-	indexContainsColumn = screl.Schema.Def6(
-		"indexContainsColumn",
-		"index", "column", "index-column", "table-id", "column-id", "index-id", func(
-			index, column, indexColumn, tableID, columnID, indexID rel.Var,
+	columnInIndexUntyped = screl.Schema.Def5(
+		"columnInIndex",
+		"index-column", "index", "table-id", "column-id", "index-id", func(
+			indexColumn, index, tableID, columnID, indexID rel.Var,
 		) rel.Clauses {
 			return rel.Clauses{
-				index.AttrEqVar(screl.IndexID, indexID),
 				indexColumn.Type((*scpb.IndexColumn)(nil)),
 				indexColumn.AttrEqVar(screl.DescID, rel.Blank),
-				joinOnColumnID(column, indexColumn, tableID, columnID),
-				joinOnIndexID(index, indexColumn, tableID, indexID),
+				indexColumn.AttrEqVar(screl.ColumnID, columnID),
+				index.AttrEqVar(screl.IndexID, indexID),
+				joinOnIndexIDUntyped(index, indexColumn, tableID, indexID),
 			}
 		})
 
-	sourceIndexNotSet = screl.Schema.Def1("sourceIndexNotSet", "index", func(
+	sourceIndexNotSetUntyped = screl.Schema.Def1("sourceIndexNotSet", "index", func(
 		index rel.Var,
 	) rel.Clauses {
 		return rel.Clauses{
@@ -179,16 +199,16 @@ var (
 		}
 	})
 
-	columnInPrimaryIndexSwap = screl.Schema.Def6(
+	columnInPrimaryIndexSwapUntyped = screl.Schema.Def5(
 		"columnInPrimaryIndexSwap",
-		"index", "column", "index-column", "table-id", "column-id", "index-id", func(
-			index, column, indexColumn, tableID, columnID, indexID rel.Var,
+		"index-column", "index", "table-id", "column-id", "index-id", func(
+			indexColumn, index, tableID, columnID, indexID rel.Var,
 		) rel.Clauses {
 			return rel.Clauses{
-				indexContainsColumn(
-					index, column, indexColumn, tableID, columnID, indexID,
+				columnInIndexUntyped(
+					indexColumn, index, tableID, columnID, indexID,
 				),
-				sourceIndexNotSet(index),
+				sourceIndexNotSetUntyped(index),
 			}
 		})
 )
@@ -205,32 +225,6 @@ func forEachElement(fn func(element scpb.Element) error) error {
 	return nil
 }
 
-// elementTypes returns a Type clause which binds the element var to elements of
-// a specific type, filtered by the conjunction of all provided predicates.
-func elementTypes(nv nodeVars, filters ...func(element scpb.Element) bool) rel.Clause {
-	if len(filters) == 0 {
-		panic(errors.AssertionFailedf("empty filter predicate list for var %q", nv))
-	}
-	var types []interface{}
-	_ = forEachElement(func(e scpb.Element) error {
-		for _, filter := range filters {
-			if !filter(e) {
-				return nil
-			}
-		}
-		types = append(types, e)
-		return nil
-	})
-	if len(types) == 0 {
-		panic(errors.AssertionFailedf("empty type list for var %q", nv))
-	}
-	return nv.el.Type(types[0], types[1:]...)
-}
-
-func nonNilElement(element scpb.Element) scpb.Element {
-	return reflect.New(reflect.ValueOf(element).Type().Elem()).Interface().(scpb.Element)
-}
-
 // IsDescriptor returns true for a descriptor-element, i.e. an element which
 // owns its corresponding descriptor.
 func IsDescriptor(e scpb.Element) bool {
@@ -242,8 +236,20 @@ func IsDescriptor(e scpb.Element) bool {
 }
 
 func isSubjectTo2VersionInvariant(e scpb.Element) bool {
+	return isIndex(e) || isColumn(e)
+}
+
+func isIndex(e scpb.Element) bool {
 	switch e.(type) {
-	case *scpb.Column, *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
+	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
+		return true
+	}
+	return false
+}
+
+func isColumn(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.Column:
 		return true
 	}
 	return false
@@ -251,52 +257,6 @@ func isSubjectTo2VersionInvariant(e scpb.Element) bool {
 
 func isSimpleDependent(e scpb.Element) bool {
 	return !IsDescriptor(e) && !isSubjectTo2VersionInvariant(e)
-}
-
-// Assert that only simple dependents (non-descriptor, non-index, non-column)
-// have screl.ReferencedDescID attributes.
-func init() {
-	_ = forEachElement(func(e scpb.Element) error {
-		if isSimpleDependent(e) {
-			return nil
-		}
-		e = nonNilElement(e)
-		if _, err := screl.Schema.GetAttribute(screl.ReferencedDescID, e); err == nil {
-			panic(errors.AssertionFailedf("%T not expected to have screl.ReferencedDescID attr", e))
-		}
-		return nil
-	})
-}
-
-// Assert that elements can be grouped into three categories when transitioning
-// from PUBLIC to ABSENT:
-// - go via DROPPED iff they're descriptor elements
-// - go via a non-read status iff they're indexes or columns, which are
-//   subject to the two-version invariant.
-// - go direct to ABSENT in all other cases.
-func init() {
-	_ = forEachElement(func(e scpb.Element) error {
-		s0 := opgen.InitialStatus(e, scpb.Status_ABSENT)
-		s1 := opgen.NextStatus(e, scpb.Status_ABSENT, s0)
-		switch s1 {
-		case scpb.Status_OFFLINE, scpb.Status_DROPPED:
-			if IsDescriptor(e) {
-				return nil
-			}
-		case scpb.Status_VALIDATED, scpb.Status_WRITE_ONLY, scpb.Status_DELETE_ONLY:
-			if isSubjectTo2VersionInvariant(e) {
-				return nil
-			}
-		case scpb.Status_ABSENT:
-			if isSimpleDependent(e) {
-				return nil
-			}
-		}
-		panic(errors.AssertionFailedf(
-			"unexpected transition %s -> %s in direction ABSENT for %T (descriptor=%v, 2VI=%v)",
-			s0, s1, e, IsDescriptor(e), isSubjectTo2VersionInvariant(e),
-		))
-	})
 }
 
 func getTypeT(element scpb.Element) (*scpb.TypeT, error) {
@@ -326,19 +286,6 @@ func getTypeTOrPanic(element scpb.Element) *scpb.TypeT {
 		panic(err)
 	}
 	return ret
-}
-
-// Assert that isWithTypeT covers all elements with embedded TypeTs.
-func init() {
-	_ = forEachElement(func(e scpb.Element) error {
-		e = nonNilElement(e)
-		return screl.WalkTypes(e, func(t *types.T) error {
-			if isWithTypeT(e) {
-				return nil
-			}
-			panic(errors.AssertionFailedf("getTypeT should support %T but doesn't", e))
-		})
-	})
 }
 
 func getExpression(element scpb.Element) (*scpb.Expression, error) {
@@ -385,15 +332,30 @@ func getExpressionOrPanic(element scpb.Element) *scpb.Expression {
 	return ret
 }
 
-// Assert that isWithExpression covers all elements with embedded
-// expressions.
-func init() {
-	_ = forEachElement(func(e scpb.Element) error {
-		return screl.WalkExpressions(e, func(t *catpb.Expression) error {
-			if isWithExpression(e) {
-				return nil
-			}
-			panic(errors.AssertionFailedf("getExpression should support %T but doesn't", e))
-		})
-	})
+func isColumnDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.ColumnType:
+		return true
+	case *scpb.ColumnName, *scpb.ColumnComment, *scpb.IndexColumn:
+		return true
+	}
+	return isColumnTypeDependent(e)
+}
+
+func isColumnTypeDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.SequenceOwner, *scpb.ColumnDefaultExpression, *scpb.ColumnOnUpdateExpression:
+		return true
+	}
+	return false
+}
+
+func isIndexDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.IndexName, *scpb.IndexComment, *scpb.IndexColumn:
+		return true
+	case *scpb.IndexPartitioning, *scpb.SecondaryIndexPartial:
+		return true
+	}
+	return false
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/op_drop.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/op_drop.go
@@ -39,18 +39,21 @@ func init() {
 		"skip column removal ops on relation drop",
 		column.node,
 		screl.MustQuery(
-			relation.el.Type(
+			relation.Type(
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 			),
-			column.el.Type(
+			column.Type(
 				(*scpb.Column)(nil),
 			),
-			joinOnDescID(relation.el, column.el, relationID),
+
+			joinOnDescID(relation, column, relationID),
+
 			relation.joinTarget(),
-			toAbsent(relation.target, column.target),
+			relation.targetStatus(scpb.ToAbsent),
 			column.joinTargetNode(),
-			column.node.AttrIn(screl.CurrentStatus,
+			column.targetStatus(scpb.ToAbsent),
+			column.currentStatus(
 				// All but DELETE_ONLY which is the status leading to ABSENT.
 				scpb.Status_PUBLIC,
 				scpb.Status_WRITE_ONLY,
@@ -62,24 +65,26 @@ func init() {
 		"skip column dependents removal ops on relation drop",
 		dep.node,
 		screl.MustQuery(
-			relation.el.Type(
+			relation.Type(
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 			),
-			column.el.Type(
+			column.Type(
 				(*scpb.Column)(nil),
 			),
-			dep.el.Type(
+			dep.Type(
 				(*scpb.ColumnName)(nil),
 			),
 
-			joinOnDescID(relation.el, column.el, relationID),
-			joinOnColumnID(column.el, dep.el, relationID, columnID),
+			joinOnDescID(relation, column, relationID),
+			joinOnColumnID(column, dep, relationID, columnID),
+
 			relation.joinTarget(),
-			toAbsent(relation.target, column.target),
+			relation.targetStatus(scpb.ToAbsent),
 			column.joinTarget(),
+			column.targetStatus(scpb.ToAbsent),
 			dep.joinTargetNode(),
-			dep.target.AttrEq(screl.TargetStatus, scpb.Status_ABSENT),
+			dep.targetStatus(scpb.ToAbsent),
 		),
 	)
 }
@@ -97,20 +102,22 @@ func init() {
 		"skip index removal ops on relation drop",
 		index.node,
 		screl.MustQuery(
-			relation.el.Type(
+			relation.Type(
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 			),
-			index.el.Type(
+			index.Type(
 				(*scpb.PrimaryIndex)(nil),
 				(*scpb.SecondaryIndex)(nil),
 				(*scpb.TemporaryIndex)(nil),
 			),
 
-			joinOnDescID(relation.el, index.el, relationID),
+			joinOnDescID(relation, index, relationID),
+
 			relation.joinTarget(),
+			relation.targetStatus(scpb.ToAbsent),
 			index.joinTargetNode(),
-			toAbsent(relation.target, index.target),
+			index.targetStatus(scpb.ToAbsent),
 		),
 	)
 
@@ -118,29 +125,26 @@ func init() {
 		"skip index dependents removal ops on relation drop",
 		dep.node,
 		screl.MustQuery(
-			relation.el.Type(
+			relation.Type(
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 			),
-			index.el.Type(
-				(*scpb.PrimaryIndex)(nil),
-				(*scpb.SecondaryIndex)(nil),
-				(*scpb.TemporaryIndex)(nil),
-			),
-			dep.el.Type(
+			index.typeFilter(isIndex),
+			dep.Type(
 				(*scpb.IndexName)(nil),
 				(*scpb.IndexPartitioning)(nil),
 				(*scpb.IndexColumn)(nil),
 			),
 
-			joinOnDescID(relation.el, index.el, relationID),
-			joinOnIndexID(index.el, dep.el, relationID, indexID),
+			joinOnDescID(relation, index, relationID),
+			joinOnIndexID(index, dep, relationID, indexID),
 
 			relation.joinTarget(),
-			toAbsent(relation.target, index.target),
+			relation.targetStatus(scpb.ToAbsent),
 			index.joinTarget(),
+			index.targetStatus(scpb.ToAbsent),
 			dep.joinTargetNode(),
-			dep.target.AttrEq(screl.TargetStatus, scpb.Status_ABSENT),
+			dep.targetStatus(scpb.ToAbsent),
 		),
 	)
 }
@@ -159,18 +163,20 @@ func init() {
 		"skip constraint removal ops on relation drop",
 		constraint.node,
 		screl.MustQuery(
-			relation.el.Type(
+			relation.Type(
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 			),
-			constraint.el.Type(
+			constraint.Type(
 				(*scpb.UniqueWithoutIndexConstraint)(nil),
 			),
 
-			joinOnDescID(relation.el, constraint.el, relationID),
+			joinOnDescID(relation, constraint, relationID),
+
 			relation.joinTarget(),
-			toAbsent(relation.target, constraint.target),
+			relation.targetStatus(scpb.ToAbsent),
 			constraint.joinTargetNode(),
+			constraint.targetStatus(scpb.ToAbsent),
 		),
 	)
 
@@ -178,26 +184,28 @@ func init() {
 		"skip constraint dependents removal ops on relation drop",
 		dep.node,
 		screl.MustQuery(
-			relation.el.Type(
+			relation.Type(
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 			),
-			constraint.el.Type(
+			constraint.Type(
 				(*scpb.UniqueWithoutIndexConstraint)(nil),
 				(*scpb.CheckConstraint)(nil),
 				(*scpb.ForeignKeyConstraint)(nil),
 			),
-			dep.el.Type(
+			dep.Type(
 				(*scpb.ConstraintName)(nil),
 			),
 
-			joinOnDescID(relation.el, constraint.el, relationID),
-			joinOnConstraintID(constraint.el, dep.el, relationID, constraintID),
+			joinOnDescID(relation, constraint, relationID),
+			joinOnConstraintID(constraint, dep, relationID, constraintID),
+
 			relation.joinTarget(),
+			relation.targetStatus(scpb.ToAbsent),
 			constraint.joinTarget(),
-			toAbsent(relation.target, constraint.target),
+			constraint.targetStatus(scpb.ToAbsent),
 			dep.joinTargetNode(),
-			dep.target.AttrEq(screl.TargetStatus, scpb.Status_ABSENT),
+			dep.targetStatus(scpb.ToAbsent),
 		),
 	)
 }
@@ -219,25 +227,20 @@ func init() {
 		"skip element removal ops on descriptor drop",
 		dep.node,
 		screl.MustQuery(
-			desc.el.Type(
-				(*scpb.Database)(nil),
-				(*scpb.Schema)(nil),
-				(*scpb.Table)(nil),
-				(*scpb.View)(nil),
-				(*scpb.Sequence)(nil),
-				(*scpb.AliasType)(nil),
-				(*scpb.EnumType)(nil),
-			),
-			dep.el.Type(
+			desc.typeFilter(IsDescriptor),
+			dep.Type(
 				(*scpb.ColumnFamily)(nil),
 				(*scpb.Owner)(nil),
 				(*scpb.UserPrivileges)(nil),
 				(*scpb.EnumTypeValue)(nil),
 			),
-			joinOnDescID(desc.el, dep.el, descID),
+
+			joinOnDescID(desc, dep, descID),
+
 			desc.joinTarget(),
-			toAbsent(desc.target, dep.target),
+			desc.targetStatus(scpb.ToAbsent),
 			dep.joinTargetNode(),
+			dep.targetStatus(scpb.ToAbsent),
 		),
 	)
 }
@@ -253,22 +256,24 @@ func init() {
 		"skip table comment removal ops on descriptor drop",
 		dep.node,
 		screl.MustQuery(
-			desc.el.Type(
+			desc.Type(
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 				(*scpb.Sequence)(nil),
 			),
-			dep.el.Type(
+			dep.Type(
 				(*scpb.ColumnComment)(nil),
 				(*scpb.IndexComment)(nil),
 				(*scpb.ConstraintComment)(nil),
 				(*scpb.TableComment)(nil),
 			),
 
-			joinOnDescID(desc.el, dep.el, descID),
+			joinOnDescID(desc, dep, descID),
+
 			desc.joinTarget(),
-			toAbsent(desc.target, dep.target),
+			desc.targetStatus(scpb.ToAbsent),
 			dep.joinTargetNode(),
+			dep.targetStatus(scpb.ToAbsent),
 		),
 	)
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/registry.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/registry.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -145,8 +146,53 @@ func (v nodeVars) joinTargetNode() rel.Clause {
 	return screl.JoinTargetNode(v.el, v.target, v.node)
 }
 
+func (v nodeVars) currentStatus(status ...scpb.Status) rel.Clause {
+	if len(status) == 0 {
+		panic(errors.AssertionFailedf("empty current status values"))
+	}
+	if len(status) == 1 {
+		return v.node.AttrEq(screl.CurrentStatus, status[0])
+	}
+	in := make([]interface{}, len(status))
+	for i, s := range status {
+		in[i] = s
+	}
+	return v.node.AttrIn(screl.CurrentStatus, in...)
+}
+
 func (v nodeVars) joinTarget() rel.Clause {
 	return screl.JoinTarget(v.el, v.target)
+}
+
+func (v nodeVars) targetStatus(status scpb.TargetStatus) rel.Clause {
+	return v.target.AttrEq(screl.TargetStatus, status.Status())
+}
+
+// Type delegates to the element var Type method.
+func (v nodeVars) Type(valuesForTypeOf ...interface{}) rel.Clause {
+	if len(valuesForTypeOf) == 0 {
+		panic(errors.AssertionFailedf("empty type list for %q", v.el))
+	}
+	return v.el.Type(valuesForTypeOf[0], valuesForTypeOf[1:]...)
+}
+
+// typeFilter returns a Type clause which binds the element var to elements of
+// a specific type, filtered by the conjunction of all provided predicates.
+func (v nodeVars) typeFilter(predicatesForTypeOf ...func(element scpb.Element) bool) rel.Clause {
+	if len(predicatesForTypeOf) == 0 {
+		panic(errors.AssertionFailedf("empty type predicate for %q", v.el))
+	}
+	var valuesForTypeOf []interface{}
+	_ = forEachElement(func(e scpb.Element) error {
+		for _, p := range predicatesForTypeOf {
+			if !p(e) {
+				return nil
+			}
+		}
+		valuesForTypeOf = append(valuesForTypeOf, e)
+		return nil
+	})
+	return v.Type(valuesForTypeOf...)
 }
 
 func mkNodeVars(elStr string) nodeVars {

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -1,18 +1,14 @@
 rules
 ----
-columnInPrimaryIndexSwap(index, column, index-column, table-id, column-id, index-id):
-    - indexContainsColumn($index, $column, $index-column, $table-id, $column-id, $index-id)
-    - sourceIndexNotSet($index)
-index-dependents(index, dep, table-id, index-id):
-    - $dep[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
-    - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.TemporaryIndex', '*scpb.SecondaryIndex']
-    - joinOnIndexID($dep, $index, $table-id, $index-id)
-indexContainsColumn(index, column, index-column, table-id, column-id, index-id):
-    - $index[IndexID] = $index-id
+columnInIndex(index-column, index, table-id, column-id, index-id):
     - $index-column[Type] = '*scpb.IndexColumn'
     - $index-column[DescID] = $_
-    - joinOnColumnID($column, $index-column, $table-id, $column-id)
+    - $index-column[ColumnID] = $column-id
+    - $index[IndexID] = $index-id
     - joinOnIndexID($index, $index-column, $table-id, $index-id)
+columnInPrimaryIndexSwap(index-column, index, table-id, column-id, index-id):
+    - columnInIndex($index-column, $index, $table-id, $column-id, $index-id)
+    - sourceIndexNotSet($index)
 joinOnColumnID(a, b, desc-id, col-id):
     - joinOnDescID($a, $b, $desc-id)
     - $a[ColumnID] = $col-id
@@ -44,10 +40,9 @@ sourceIndexNotSet(index):
 toAbsent(target1, target2):
     - $target1[TargetStatus] = ABSENT
     - $target2[TargetStatus] = ABSENT
-toAbsentInAbsent(target1, node1, target2, node2):
-    - toAbsent($target1, $target2)
-    - $node1[CurrentStatus] = ABSENT
-    - $node2[CurrentStatus] = ABSENT
+toPublic(target1, target2):
+    - $target1[TargetStatus] = PUBLIC
+    - $target2[TargetStatus] = PUBLIC
 
 deprules
 ----
@@ -59,8 +54,7 @@ deprules
     - $expr[Type] IN ['*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($expr, $column, $table-id, $col-id)
-    - $expr-target[TargetStatus] = PUBLIC
-    - $column-target[TargetStatus] = PUBLIC
+    - toPublic($expr-target, $column-target)
     - $expr-node[CurrentStatus] = PUBLIC
     - $column-node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($expr, $expr-target, $expr-node)
@@ -72,12 +66,11 @@ deprules
   query:
     - $index[Type] = '*scpb.PrimaryIndex'
     - $column[Type] = '*scpb.Column'
-    - columnInPrimaryIndexSwap($index, $column, $index-column, $table-id, $column-id, $index-id)
-    - $index-target[TargetStatus] = PUBLIC
-    - $column-target[TargetStatus] = PUBLIC
-    - $status IN [PUBLIC]
-    - $index-node[CurrentStatus] = $status
-    - $column-node[CurrentStatus] = $status
+    - columnInPrimaryIndexSwap($index-column, $index, $table-id, $column-id, $index-id)
+    - joinOnColumnID($index-column, $column, $table-id, $column-id)
+    - toPublic($index-target, $column-target)
+    - $index-node[CurrentStatus] = PUBLIC
+    - $column-node[CurrentStatus] = PUBLIC
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($column, $column-target, $column-node)
 - name: column comment exists before column becomes public
@@ -88,8 +81,7 @@ deprules
     - $column-comment[Type] = '*scpb.ColumnComment'
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-comment, $column, $table-id, $col-id)
-    - $column-comment-target[TargetStatus] = PUBLIC
-    - $column-target[TargetStatus] = PUBLIC
+    - toPublic($column-comment-target, $column-target)
     - $column-comment-node[CurrentStatus] = PUBLIC
     - $column-node[CurrentStatus] = PUBLIC
     - joinTargetNode($column-comment, $column-comment-target, $column-comment-node)
@@ -102,8 +94,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnType', '*scpb.ColumnName', '*scpb.ColumnComment']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
-    - $column-target[TargetStatus] = ABSENT
-    - $dependent-target[TargetStatus] = ABSENT
+    - toAbsent($column-target, $dependent-target)
     - $column-node[CurrentStatus] = WRITE_ONLY
     - $dependent-node[CurrentStatus] = ABSENT
     - joinTargetNode($column, $column-target, $column-node)
@@ -116,8 +107,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
-    - $column-target[TargetStatus] = PUBLIC
-    - $dependent-target[TargetStatus] = PUBLIC
+    - toPublic($column-target, $dependent-target)
     - $column-node[CurrentStatus] = DELETE_ONLY
     - $dependent-node[CurrentStatus] = PUBLIC
     - joinTargetNode($column, $column-target, $column-node)
@@ -129,9 +119,9 @@ deprules
   query:
     - $column[Type] = '*scpb.Column'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - indexContainsColumn($index, $column, $index-column, $table-id, $column-id, $index-id)
-    - $column-target[TargetStatus] = PUBLIC
-    - $index-target[TargetStatus] = PUBLIC
+    - joinOnColumnID($column, $index-column, $table-id, $column-id)
+    - columnInIndex($index-column, $index, $table-id, $column-id, $index-id)
+    - toPublic($column-target, $index-target)
     - $column-node[CurrentStatus] = DELETE_ONLY
     - $index-node[CurrentStatus] = BACKFILL_ONLY
     - joinTargetNode($column, $column-target, $column-node)
@@ -143,7 +133,8 @@ deprules
   query:
     - $column[Type] = '*scpb.Column'
     - $temp-index[Type] = '*scpb.TemporaryIndex'
-    - indexContainsColumn($temp-index, $column, $index-column, $table-id, $column-id, $index-id)
+    - columnInIndex($index-column, $temp-index, $table-id, $column-id, $temp-index-id)
+    - joinOnColumnID($index-column, $column, $table-id, $column-id)
     - $column-target[TargetStatus] = PUBLIC
     - $temp-index-target[TargetStatus] = TRANSIENT_ABSENT
     - $column-node[CurrentStatus] = DELETE_ONLY
@@ -157,7 +148,8 @@ deprules
   query:
     - $column[Type] = '*scpb.Column'
     - $index[Type] = '*scpb.TemporaryIndex'
-    - indexContainsColumn($index, $column, $index-column, $table-id, $column-id, $index-id)
+    - joinOnColumnID($index-column, $column, $table-id, $column-id)
+    - columnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - $column-target[TargetStatus] = PUBLIC
     - $index-target[TargetStatus] = TRANSIENT_ABSENT
     - $column-node[CurrentStatus] = WRITE_ONLY
@@ -172,8 +164,7 @@ deprules
     - $column-name-or-type[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType']
     - $index-column[Type] = '*scpb.IndexColumn'
     - joinOnColumnID($column-name-or-type, $index-column, $table-id, $column-id)
-    - $column-name-or-type-target[TargetStatus] = PUBLIC
-    - $index-column-target[TargetStatus] = PUBLIC
+    - toPublic($column-name-or-type-target, $index-column-target)
     - $column-name-or-type-node[CurrentStatus] = PUBLIC
     - $index-column-node[CurrentStatus] = PUBLIC
     - joinTargetNode($column-name-or-type, $column-name-or-type-target, $column-name-or-type-node)
@@ -185,8 +176,7 @@ deprules
   query:
     - $column[Type] = '*scpb.Column'
     - $column-name[Type] = '*scpb.ColumnName'
-    - $column-target[TargetStatus] = PUBLIC
-    - $column-name-target[TargetStatus] = PUBLIC
+    - toPublic($column-target, $column-name-target)
     - $column-node[CurrentStatus] = DELETE_ONLY
     - $column-name-node[CurrentStatus] = PUBLIC
     - joinOnColumnID($column, $column-name, $table-id, $col-id)
@@ -200,8 +190,7 @@ deprules
     - $column-name[Type] = '*scpb.ColumnName'
     - $column-type[Type] = '*scpb.ColumnType'
     - joinOnColumnID($column-name, $column-type, $table-id, $col-id)
-    - $column-name-target[TargetStatus] = PUBLIC
-    - $column-type-target[TargetStatus] = PUBLIC
+    - toPublic($column-name-target, $column-type-target)
     - $column-name-node[CurrentStatus] = PUBLIC
     - $column-type-node[CurrentStatus] = PUBLIC
     - joinTargetNode($column-name, $column-name-target, $column-name-node)
@@ -214,8 +203,7 @@ deprules
     - $dependent[Type] IN ['*scpb.SequenceOwner', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression']
     - $column-type[Type] = '*scpb.ColumnType'
     - joinOnColumnID($dependent, $column-type, $table-id, $col-id)
-    - $dependent-target[TargetStatus] = ABSENT
-    - $column-type-target[TargetStatus] = ABSENT
+    - toAbsent($dependent-target, $column-type-target)
     - $dependent-node[CurrentStatus] = ABSENT
     - $column-type-node[CurrentStatus] = ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
@@ -228,11 +216,10 @@ deprules
     - $column-type[Type] = '*scpb.ColumnType'
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-type, $column, $table-id, $col-id)
-    - $column-type-target[TargetStatus] = ABSENT
-    - $column-target[TargetStatus] = ABSENT
+    - toAbsent($column-type-target, $column-target)
     - $column-type-node[CurrentStatus] = ABSENT
     - $column-node[CurrentStatus] = ABSENT
-    - columnTypeIsNotBeingDropped(*scpb.ColumnType)($column-type)
+    - RelationIsNotBeingDropped(*scpb.ColumnType)($column-type)
     - joinTargetNode($column-type, $column-type-target, $column-type-node)
     - joinTargetNode($column, $column-target, $column-node)
 - name: comment existence precedes index becoming public
@@ -243,8 +230,7 @@ deprules
     - $child[Type] = '*scpb.IndexComment'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - joinOnIndexID($child, $index, $table-id, $index-id)
-    - $child-target[TargetStatus] = PUBLIC
-    - $index-target[TargetStatus] = PUBLIC
+    - toPublic($child-target, $index-target)
     - $child-node[CurrentStatus] = PUBLIC
     - $index-node[CurrentStatus] = PUBLIC
     - joinTargetNode($child, $child-target, $child-node)
@@ -257,8 +243,7 @@ deprules
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnComment']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
-    - $dependent-target[TargetStatus] = ABSENT
-    - $column-target[TargetStatus] = ABSENT
+    - toAbsent($dependent-target, $column-target)
     - $dependent-node[CurrentStatus] = ABSENT
     - $column-node[CurrentStatus] = ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
@@ -268,9 +253,10 @@ deprules
   kind: Precedence
   to: index-node
   query:
-    - index-dependents($index, $dependent, $table-id, $index-id)
-    - $dependent-target[TargetStatus] = ABSENT
-    - $index-target[TargetStatus] = ABSENT
+    - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
+    - joinOnIndexID($dependent, $index, $table-id, $index-id)
+    - toAbsent($dependent-target, $index-target)
     - $dependent-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
@@ -282,10 +268,10 @@ deprules
   query:
     - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
     - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue']
+    - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-target, $dependent-target)
     - $descriptor-node[CurrentStatus] = DROPPED
     - $dependent-node[CurrentStatus] = ABSENT
-    - joinOnDescID($descriptor, $dependent, $desc-id)
     - joinTargetNode($descriptor, $descriptor-target, $descriptor-node)
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: descriptor drop right before removing dependent with attr ref
@@ -295,10 +281,10 @@ deprules
   query:
     - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
     - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue']
+    - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-target, $referencing-via-attr-target)
     - $referenced-descriptor-node[CurrentStatus] = DROPPED
     - $referencing-via-attr-node[CurrentStatus] = ABSENT
-    - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-target, $referenced-descriptor-node)
     - joinTargetNode($referencing-via-attr, $referencing-via-attr-target, $referencing-via-attr-node)
 - name: descriptor drop right before removing dependent with expr ref
@@ -311,7 +297,7 @@ deprules
     - toAbsent($referenced-descriptor-target, $referencing-via-expr-target)
     - $referenced-descriptor-node[CurrentStatus] = DROPPED
     - $referencing-via-expr-node[CurrentStatus] = ABSENT
-    - RefByTypeT(scpb.Element, scpb.Element)($referenced-descriptor, $referencing-via-expr)
+    - RefByExpression(scpb.Element, scpb.Element)($referenced-descriptor, $referencing-via-expr)
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-target, $referenced-descriptor-node)
     - joinTargetNode($referencing-via-expr, $referencing-via-expr-target, $referencing-via-expr-node)
 - name: descriptor drop right before removing dependent with type ref
@@ -334,8 +320,10 @@ deprules
   query:
     - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
     - $idx-or-col[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - toAbsentInAbsent($descriptor-target, $descriptor-node, $idx-or-col-target, $idx-or-col-node)
     - joinOnDescID($descriptor, $idx-or-col, $desc-id)
+    - toAbsent($descriptor-target, $idx-or-col-target)
+    - $descriptor-node[CurrentStatus] = ABSENT
+    - $idx-or-col-node[CurrentStatus] = ABSENT
     - joinTargetNode($descriptor, $descriptor-target, $descriptor-node)
     - joinTargetNode($idx-or-col, $idx-or-col-target, $idx-or-col-node)
 - name: ensure columns are in increasing order
@@ -345,14 +333,12 @@ deprules
   query:
     - $later-column[Type] = '*scpb.Column'
     - $earlier-column[Type] = '*scpb.Column'
-    - $later-column[DescID] = $table-id
-    - $earlier-column[DescID] = $table-id
-    - $later-column-target[TargetStatus] = PUBLIC
-    - $earlier-column-target[TargetStatus] = PUBLIC
+    - joinOnDescID($later-column, $earlier-column, $table-id)
+    - toPublic($later-column-target, $earlier-column-target)
     - $status IN [WRITE_ONLY, PUBLIC]
     - $later-column-node[CurrentStatus] = $status
     - $earlier-column-node[CurrentStatus] = $status
-    - columnHasSmallerID(*scpb.Column, *scpb.Column)($later-column, $earlier-column)
+    - SmallerColumnIDFirst(*scpb.Column, *scpb.Column)($later-column, $earlier-column)
     - joinTargetNode($later-column, $later-column-target, $later-column-node)
     - joinTargetNode($earlier-column, $earlier-column-target, $earlier-column-node)
 - name: index existence precedes index name and comment
@@ -363,8 +349,7 @@ deprules
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $index-dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexComment']
     - joinOnIndexID($index, $index-dependent, $table-id, $index-id)
-    - $index-target[TargetStatus] = PUBLIC
-    - $index-dependent-target[TargetStatus] = PUBLIC
+    - toPublic($index-target, $index-dependent-target)
     - $index-node[CurrentStatus] = BACKFILL_ONLY
     - $index-dependent-node[CurrentStatus] = PUBLIC
     - joinTargetNode($index, $index-target, $index-node)
@@ -376,8 +361,7 @@ deprules
   query:
     - $index-name[Type] = '*scpb.IndexName'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $index-name-target[TargetStatus] = PUBLIC
-    - $index-target[TargetStatus] = PUBLIC
+    - toPublic($index-name-target, $index-target)
     - $index-name-node[CurrentStatus] = PUBLIC
     - $index-node[CurrentStatus] = PUBLIC
     - joinOnIndexID($index-name, $index, $table-id, $index-id)
@@ -388,7 +372,9 @@ deprules
   kind: Precedence
   to: child-node
   query:
-    - index-dependents($index, $child, $table-id, $index-id)
+    - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
+    - $child[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
+    - joinOnIndexID($index, $child, $table-id, $index-id)
     - toAbsent($index-target, $child-target)
     - $index-node[CurrentStatus] = VALIDATED
     - $child-node[CurrentStatus] = ABSENT
@@ -402,8 +388,7 @@ deprules
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $index-column[Type] = '*scpb.IndexColumn'
     - joinOnIndexID($index, $index-column, $table-id, $index-id)
-    - $index-target[TargetStatus] = PUBLIC
-    - $index-column-target[TargetStatus] = PUBLIC
+    - toPublic($index-target, $index-column-target)
     - $index-node[CurrentStatus] = BACKFILL_ONLY
     - $index-column-node[CurrentStatus] = PUBLIC
     - joinTargetNode($index, $index-target, $index-node)
@@ -430,8 +415,7 @@ deprules
     - $index-column[Type] = '*scpb.IndexColumn'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - joinOnIndexID($index-column, $index, $table-id, $index-id)
-    - $index-column-target[TargetStatus] = PUBLIC
-    - $index-target[TargetStatus] = PUBLIC
+    - toPublic($index-column-target, $index-target)
     - $index-column-node[CurrentStatus] = PUBLIC
     - $index-node[CurrentStatus] = BACKFILLED
     - joinTargetNode($index-column, $index-column-target, $index-column-node)
@@ -457,31 +441,16 @@ deprules
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
     - $column[Type] = '*scpb.Column'
-    - indexContainsColumn($index, $column, $index-column, $table-id, $column-id, $index-id)
     - $column-type[Type] = '*scpb.ColumnType'
-    - joinOnColumnID($column, $column-type, $table-id, $column-id)
-    - $index-target[TargetStatus] = ABSENT
-    - $column-target[TargetStatus] = ABSENT
+    - columnInIndex($index-column, $index, $table-id, $column-id, $index-id)
+    - joinOnColumnID($index-column, $column, $table-id, $column-id)
+    - joinOnColumnID($index-column, $column-type, $table-id, $column-id)
+    - toAbsent($index-target, $column-target)
     - $index-node[CurrentStatus] = ABSENT
     - $column-node[CurrentStatus] = ABSENT
-    - columnTypeIsNotBeingDropped(*scpb.ColumnType)($column-type)
+    - RelationIsNotBeingDropped(*scpb.ColumnType)($column-type)
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($column, $column-target, $column-node)
-- name: indexes reach absent at the same time as other indexes
-  from: index-a-node
-  kind: SameStagePrecedence
-  to: index-b-node
-  query:
-    - $index-a[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $index-b[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - joinOnDescID($index-a, $index-b, $descID)
-    - $index-a-target[TargetStatus] = ABSENT
-    - $index-b-target[TargetStatus] = ABSENT
-    - $index-a-node[CurrentStatus] = ABSENT
-    - $index-b-node[CurrentStatus] = ABSENT
-    - indexes-id-less(scpb.Element, scpb.Element)($a, $b)
-    - joinTargetNode($index-a, $index-a-target, $index-a-node)
-    - joinTargetNode($index-b, $index-b-target, $index-b-node)
 - name: partial predicate removed right before secondary index when not dropping relation
   from: partial-predicate-node
   kind: SameStagePrecedence
@@ -490,11 +459,10 @@ deprules
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
-    - $partial-predicate-target[TargetStatus] = ABSENT
-    - $index-target[TargetStatus] = ABSENT
+    - toAbsent($partial-predicate-target, $index-target)
     - $partial-predicate-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = ABSENT
-    - secondaryIndexPartialIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
+    - RelationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
     - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: primary index should be cleaned up before newly added column when reverting
@@ -504,11 +472,11 @@ deprules
   query:
     - $index[Type] = '*scpb.PrimaryIndex'
     - $column[Type] = '*scpb.Column'
+    - columnInPrimaryIndexSwap($index-column, $index, $table-id, $column-id, $index-id)
+    - joinOnColumnID($index-column, $column, $table-id, $column-id)
     - toAbsent($index-target, $column-target)
-    - columnInPrimaryIndexSwap($index, $column, $indexColumn, $table-id, $column-id, $index-id)
-    - $status = WRITE_ONLY
-    - $index-node[CurrentStatus] = $status
-    - $column-node[CurrentStatus] = $status
+    - $index-node[CurrentStatus] = WRITE_ONLY
+    - $column-node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($column, $column-target, $column-node)
 - name: primary index swap
@@ -523,7 +491,7 @@ deprules
     - $new-index-target[TargetStatus] = PUBLIC
     - $old-index-node[CurrentStatus] = VALIDATED
     - $new-index-node[CurrentStatus] = PUBLIC
-    - primary-indexes-depend-on-each-other(*scpb.PrimaryIndex, *scpb.PrimaryIndex)($old-index, $new-index)
+    - primaryIndexesDependency(*scpb.PrimaryIndex, *scpb.PrimaryIndex)($old-index, $new-index)
     - joinTargetNode($old-index, $old-index-target, $old-index-node)
     - joinTargetNode($new-index, $new-index-target, $new-index-node)
 - name: primary index with new columns should exist before secondary indexes
@@ -536,8 +504,7 @@ deprules
     - joinOnDescID($primary-index, $second-index, $table-id)
     - $primary-index[IndexID] = $primary-index-id
     - $second-index[SourceIndexID] = $primary-index-id
-    - $primary-index-target[TargetStatus] = PUBLIC
-    - $second-index-target[TargetStatus] = PUBLIC
+    - toPublic($primary-index-target, $second-index-target)
     - $primary-index-node[CurrentStatus] = PUBLIC
     - $second-index-node[CurrentStatus] = BACKFILL_ONLY
     - joinTargetNode($primary-index, $primary-index-target, $primary-index-node)
@@ -631,7 +598,7 @@ deprules
   query:
     - $temp[Type] = '*scpb.TemporaryIndex'
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - joinOnDescID($temp, $index, $desc-id)
+    - joinOnDescID($temp, $index, $table-id)
     - $temp[IndexID] = $temp-index-id
     - $index[TemporaryIndexID] = $temp-index-id
     - $temp-target[TargetStatus] = TRANSIENT_ABSENT
@@ -647,7 +614,7 @@ deprules
   query:
     - $index-a[Type] = '*scpb.TemporaryIndex'
     - $index-b[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - joinOnDescID($index-a, $index-b, $descID)
+    - joinOnDescID($index-a, $index-b, $desc-id)
     - $index-a-target[TargetStatus] = TRANSIENT_ABSENT
     - $index-b-target[TargetStatus] = ABSENT
     - $index-a-node[CurrentStatus] = TRANSIENT_ABSENT

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/oprules
@@ -1,18 +1,14 @@
 rules
 ----
-columnInPrimaryIndexSwap(index, column, index-column, table-id, column-id, index-id):
-    - indexContainsColumn($index, $column, $index-column, $table-id, $column-id, $index-id)
-    - sourceIndexNotSet($index)
-index-dependents(index, dep, table-id, index-id):
-    - $dep[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
-    - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.TemporaryIndex', '*scpb.SecondaryIndex']
-    - joinOnIndexID($dep, $index, $table-id, $index-id)
-indexContainsColumn(index, column, index-column, table-id, column-id, index-id):
-    - $index[IndexID] = $index-id
+columnInIndex(index-column, index, table-id, column-id, index-id):
     - $index-column[Type] = '*scpb.IndexColumn'
     - $index-column[DescID] = $_
-    - joinOnColumnID($column, $index-column, $table-id, $column-id)
+    - $index-column[ColumnID] = $column-id
+    - $index[IndexID] = $index-id
     - joinOnIndexID($index, $index-column, $table-id, $index-id)
+columnInPrimaryIndexSwap(index-column, index, table-id, column-id, index-id):
+    - columnInIndex($index-column, $index, $table-id, $column-id, $index-id)
+    - sourceIndexNotSet($index)
 joinOnColumnID(a, b, desc-id, col-id):
     - joinOnDescID($a, $b, $desc-id)
     - $a[ColumnID] = $col-id
@@ -44,10 +40,9 @@ sourceIndexNotSet(index):
 toAbsent(target1, target2):
     - $target1[TargetStatus] = ABSENT
     - $target2[TargetStatus] = ABSENT
-toAbsentInAbsent(target1, node1, target2, node2):
-    - toAbsent($target1, $target2)
-    - $node1[CurrentStatus] = ABSENT
-    - $node2[CurrentStatus] = ABSENT
+toPublic(target1, target2):
+    - $target1[TargetStatus] = PUBLIC
+    - $target2[TargetStatus] = PUBLIC
 
 oprules
 ----
@@ -60,8 +55,9 @@ oprules
     - joinOnDescID($relation, $column, $relation-id)
     - joinOnColumnID($column, $column-dep, $relation-id, $column-id)
     - joinTarget($relation, $relation-target)
-    - toAbsent($relation-target, $column-target)
+    - $relation-target[TargetStatus] = ABSENT
     - joinTarget($column, $column-target)
+    - $column-target[TargetStatus] = ABSENT
     - joinTargetNode($column-dep, $column-dep-target, $column-dep-node)
     - $column-dep-target[TargetStatus] = ABSENT
 - name: skip column removal ops on relation drop
@@ -71,8 +67,9 @@ oprules
     - $column[Type] = '*scpb.Column'
     - joinOnDescID($relation, $column, $relation-id)
     - joinTarget($relation, $relation-target)
-    - toAbsent($relation-target, $column-target)
+    - $relation-target[TargetStatus] = ABSENT
     - joinTargetNode($column, $column-target, $column-node)
+    - $column-target[TargetStatus] = ABSENT
     - $column-node[CurrentStatus] IN [PUBLIC, WRITE_ONLY]
 - name: skip constraint dependents removal ops on relation drop
   from: constraint-dep-node
@@ -83,8 +80,9 @@ oprules
     - joinOnDescID($relation, $constraint, $relation-id)
     - joinOnConstraintID($constraint, $constraint-dep, $relation-id, $constraint-id)
     - joinTarget($relation, $relation-target)
+    - $relation-target[TargetStatus] = ABSENT
     - joinTarget($constraint, $constraint-target)
-    - toAbsent($relation-target, $constraint-target)
+    - $constraint-target[TargetStatus] = ABSENT
     - joinTargetNode($constraint-dep, $constraint-dep-target, $constraint-dep-node)
     - $constraint-dep-target[TargetStatus] = ABSENT
 - name: skip constraint removal ops on relation drop
@@ -94,17 +92,19 @@ oprules
     - $constraint[Type] = '*scpb.UniqueWithoutIndexConstraint'
     - joinOnDescID($relation, $constraint, $relation-id)
     - joinTarget($relation, $relation-target)
-    - toAbsent($relation-target, $constraint-target)
+    - $relation-target[TargetStatus] = ABSENT
     - joinTargetNode($constraint, $constraint-target, $constraint-node)
+    - $constraint-target[TargetStatus] = ABSENT
 - name: skip element removal ops on descriptor drop
   from: dep-node
   query:
-    - $desc[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.Table', '*scpb.View', '*scpb.Sequence', '*scpb.AliasType', '*scpb.EnumType']
+    - $desc[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
     - $dep[Type] IN ['*scpb.ColumnFamily', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.EnumTypeValue']
     - joinOnDescID($desc, $dep, $desc-id)
     - joinTarget($desc, $desc-target)
-    - toAbsent($desc-target, $dep-target)
+    - $desc-target[TargetStatus] = ABSENT
     - joinTargetNode($dep, $dep-target, $dep-node)
+    - $dep-target[TargetStatus] = ABSENT
 - name: skip index dependents removal ops on relation drop
   from: index-dep-node
   query:
@@ -114,8 +114,9 @@ oprules
     - joinOnDescID($relation, $index, $relation-id)
     - joinOnIndexID($index, $index-dep, $relation-id, $index-id)
     - joinTarget($relation, $relation-target)
-    - toAbsent($relation-target, $index-target)
+    - $relation-target[TargetStatus] = ABSENT
     - joinTarget($index, $index-target)
+    - $index-target[TargetStatus] = ABSENT
     - joinTargetNode($index-dep, $index-dep-target, $index-dep-node)
     - $index-dep-target[TargetStatus] = ABSENT
 - name: skip index removal ops on relation drop
@@ -125,8 +126,9 @@ oprules
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnDescID($relation, $index, $relation-id)
     - joinTarget($relation, $relation-target)
+    - $relation-target[TargetStatus] = ABSENT
     - joinTargetNode($index, $index-target, $index-node)
-    - toAbsent($relation-target, $index-target)
+    - $index-target[TargetStatus] = ABSENT
 - name: skip table comment removal ops on descriptor drop
   from: dep-node
   query:
@@ -134,5 +136,6 @@ oprules
     - $dep[Type] IN ['*scpb.ColumnComment', '*scpb.IndexComment', '*scpb.ConstraintComment', '*scpb.TableComment']
     - joinOnDescID($desc, $dep, $desc-id)
     - joinTarget($desc, $desc-target)
-    - toAbsent($desc-target, $dep-target)
+    - $desc-target[TargetStatus] = ABSENT
     - joinTargetNode($dep, $dep-target, $dep-node)
+    - $dep-target[TargetStatus] = ABSENT

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -107,6 +107,9 @@ func RunSchemaChangesInJob(
 		})
 	})
 	if err != nil {
+		if knobs != nil && knobs.OnPostCommitPlanError != nil {
+			return knobs.OnPostCommitPlanError(nil, err)
+		}
 		return errors.Wrapf(err, "failed to construct state for job %d", jobID)
 	}
 	sc, err := scplan.MakePlan(state, scplan.Params{
@@ -114,6 +117,9 @@ func RunSchemaChangesInJob(
 		SchemaChangerJobIDSupplier: func() jobspb.JobID { return jobID },
 	})
 	if err != nil {
+		if knobs != nil && knobs.OnPostCommitPlanError != nil {
+			return knobs.OnPostCommitPlanError(&state, err)
+		}
 		return err
 	}
 

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -145,6 +146,9 @@ func Rollback(t *testing.T, dir string, newCluster NewClusterFunc) {
 
 		db, cleanup := newCluster(t, &scexec.TestingKnobs{
 			BeforeStage: beforeStage,
+			OnPostCommitPlanError: func(state *scpb.CurrentState, err error) error {
+				panic(fmt.Sprintf("%+v", err))
+			},
 			OnPostCommitError: func(p scplan.Plan, stageIdx int, err error) error {
 				if strings.Contains(err.Error(), "boom") {
 					return err


### PR DESCRIPTION
This PR refactors the declarative schema changer rule definitions to be more type-safe. Functionally, nothing changes much.  This is a prelude to redefining the index and column rules in a more principled way, like we already did in `dep_drop.go`.