### PR TITLE
logictest: use deterministic ID generation in tenants

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1283,7 +1283,8 @@ func (t *logicTest) newCluster(
 				AllowSettingClusterSettings: true,
 				TestingKnobs: base.TestingKnobs{
 					SQLExecutor: &sql.ExecutorTestingKnobs{
-						DeterministicExplain: true,
+						DeterministicExplain:            true,
+						UseTransactionalDescIDGenerator: true,
 					},
 					SQLStatsKnobs: &sqlstats.TestingKnobs{
 						AOSTClause: "AS OF SYSTEM TIME '-1us'",


### PR DESCRIPTION
In #85366, we introduced a mechanism to make descriptor ID generation
transactional and, in the absence of parallelism, deterministic. That PR
failed to set the knob for secondary tenant configurations. This commit
rectifies that oversight.

This should allow us to avoid flakes like:
https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_GitHubCiOptional/5939930?showRootCauses=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true

Release note: None