### PR TITLE
changefeedccl: Do not swallow error.

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1266,6 +1266,7 @@ func (cf *changeFrontier) checkpointJobProgress(
 		}
 		if err := timestampManager(cf.Ctx, txn, changefeedProgress); err != nil {
 			log.Warningf(cf.Ctx, "error managing protected timestamp record: %v", err)
+			return err
 		}
 
 		if updateRunStatus {


### PR DESCRIPTION
Propagate error when attempting to manage protected
timestamp.

Release note: None