### PR TITLE
opt: simplify CREATE FUNCTION logic

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1036,15 +1036,7 @@ func (e *distSQLSpecExecFactory) ConstructCreateView(
 }
 
 func (e *distSQLSpecExecFactory) ConstructCreateFunction(
-	schema cat.Schema,
-	funcName *tree.FunctionName,
-	Replace bool,
-	funArgs tree.FuncArgs,
-	returnType tree.FuncReturnType,
-	options tree.FunctionOptions,
-	body tree.FunctionBodyStr,
-	deps opt.SchemaDeps,
-	typeDeps opt.SchemaTypeDeps,
+	schema cat.Schema, cf *tree.CreateFunction, deps opt.SchemaDeps, typeDeps opt.SchemaTypeDeps,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: create function")
 }

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -79,12 +79,7 @@ func (b *Builder) buildCreateFunction(cf *memo.CreateFunctionExpr) (execPlan, er
 	schema := md.Schema(cf.Schema)
 	root, err := b.factory.ConstructCreateFunction(
 		schema,
-		cf.FunctionName,
-		cf.Replace,
-		cf.Args,
-		cf.ReturnType,
-		cf.Options,
-		cf.Body,
+		cf.Syntax,
 		cf.Deps,
 		cf.TypeDeps,
 	)

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -755,12 +755,7 @@ define AlterRangeRelocate {
 # CreateFunction implements CREATE FUNCTION.
 define CreateFunction {
     Schema cat.Schema
-    FuncName *tree.FunctionName
-    Replace bool
-    FuncArgs tree.FuncArgs
-    ReturnType tree.FuncReturnType
-    Options tree.FunctionOptions
-    Body tree.FunctionBodyStr
+    Cf *tree.CreateFunction
     Deps opt.SchemaDeps
     TypeDeps opt.SchemaTypeDeps
 }

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -673,29 +673,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			n.Child(f.Buffer.String())
 		}
 	case *CreateFunctionExpr:
-		// Arguments.
-		if len(t.Args) > 0 {
-			f.Buffer.Reset()
-			f.Buffer.WriteString("arguments:")
-			for _, arg := range t.Args {
-				fmt.Fprintf(f.Buffer, " %s", arg.Type.SQLString())
-			}
-			tp.Child(f.Buffer.String())
-		}
-		// Return type.
-		f.Buffer.Reset()
-		f.Buffer.WriteString("return_type: ")
-		if t.ReturnType.IsSet {
-			f.Buffer.WriteString("setof ")
-		}
-		f.Buffer.WriteString(t.ReturnType.Type.SQLString())
-		tp.Child(f.Buffer.String())
-		// Function body.
-		tp.Child(string(t.Body))
-		// Dependencies.
-		if len(t.Deps) == 0 {
-			return
-		}
+		tp.Child(t.Syntax.String())
 		n := tp.Child("dependencies")
 		for _, dep := range t.Deps {
 			f.Buffer.Reset()

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1447,6 +1447,10 @@ func (f *ExprFmtCtx) formatLockingWithPrefix(
 
 // formatDependencies adds a new treeprinter child for schema dependencies.
 func (f *ExprFmtCtx) formatDependencies(tp treeprinter.Node, deps opt.SchemaDeps) {
+	if len(deps) == 0 {
+		tp.Child("no dependencies")
+		return
+	}
 	n := tp.Child("dependencies")
 	for _, dep := range deps {
 		f.Buffer.Reset()

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -753,46 +753,6 @@ func (h *hasher) HashPersistence(val tree.Persistence) {
 	h.hash *= prime64
 }
 
-func (h *hasher) HashFuncArgs(val tree.FuncArgs) {
-	for _, arg := range val {
-		h.HashString(string(arg.Name))
-		h.HashUint64(uint64(reflect.ValueOf(arg.Type).Pointer()))
-		h.HashInt(int(arg.Class))
-		if arg.DefaultVal != nil {
-			h.HashUint64(uint64(reflect.ValueOf(arg.DefaultVal).Pointer()))
-		}
-	}
-}
-
-func (h *hasher) HashFuncReturnType(val tree.FuncReturnType) {
-	h.HashUint64(uint64(reflect.ValueOf(val.Type).Pointer()))
-	h.HashBool(val.IsSet)
-}
-
-func (h *hasher) HashFunctionOptions(val tree.FunctionOptions) {
-	// TODO (Chengxiong): break funcOptions into separate fields so that we can
-	// hash individual option specifically .
-	for _, opt := range val {
-		h.HashString(reflect.TypeOf(opt).Name())
-		switch t := opt.(type) {
-		case tree.FunctionNullInputBehavior:
-			h.HashInt(int(t))
-		case tree.FunctionVolatility:
-			h.HashInt(int(t))
-		case tree.FunctionLeakproof:
-			h.HashBool(bool(t))
-		case tree.FunctionBodyStr:
-			h.HashString(string(t))
-		case tree.FunctionLanguage:
-			h.HashInt(int(t))
-		}
-	}
-}
-
-func (h *hasher) HashFunctionBodyStr(val tree.FunctionBodyStr) {
-	h.HashString(string(val))
-}
-
 func (h *hasher) HashVolatility(val volatility.V) {
 	h.HashInt(int(val))
 }
@@ -1251,42 +1211,6 @@ func (h *hasher) IsMaterializeClauseEqual(l, r tree.MaterializeClause) bool {
 }
 
 func (h *hasher) IsPersistenceEqual(l, r tree.Persistence) bool {
-	return l == r
-}
-
-func (h *hasher) IsFuncArgsEqual(l, r tree.FuncArgs) bool {
-	if len(l) != len(r) {
-		return false
-	}
-
-	for i := range l {
-		if l[i] != r[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (h *hasher) IsFuncReturnTypeEqual(l, r tree.FuncReturnType) bool {
-	return l == r
-}
-
-func (h *hasher) IsFunctionOptionsEqual(l, r tree.FunctionOptions) bool {
-	if len(l) != len(r) {
-		return false
-	}
-
-	for i := range l {
-		if l[i] != r[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (h *hasher) IsFunctionBodyStrEqual(l, r tree.FunctionBodyStr) bool {
 	return l == r
 }
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1486,9 +1486,9 @@ func (b *logicalPropsBuilder) buildCreateViewProps(cv *CreateViewExpr, rel *prop
 }
 
 func (b *logicalPropsBuilder) buildCreateFunctionProps(
-	cv *CreateFunctionExpr, rel *props.Relational,
+	cf *CreateFunctionExpr, rel *props.Relational,
 ) {
-	BuildSharedProps(cv, &rel.Shared, b.evalCtx)
+	BuildSharedProps(cf, &rel.Shared, b.evalCtx)
 }
 
 func (b *logicalPropsBuilder) buildFiltersItemProps(item *FiltersItem, scalar *props.Scalar) {

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -62,6 +62,7 @@ define CreateViewPrivate {
     WithData bool
 }
 
+# CreateFunction represents a CREATE FUNCTION statement.
 [Relational, DDL, Mutation]
 define CreateFunction {
     _ CreateFunctionPrivate
@@ -72,25 +73,8 @@ define CreateFunctionPrivate {
     # Schema is the ID of the catalog schema into which the new function goes.
     Schema SchemaID
 
-    # FunctionName is the name of the new function.
-    FunctionName FunctionName
-
-    # Replace indicates whether the existing function, if found, should be
-    # replaced with the new definition or not.
-    Replace bool
-
-    # Args is a slice of Arguments of the new function.
-    Args FuncArgs
-
-    # ReturnType is the return type of the new function.
-    ReturnType FuncReturnType
-
-    # TODO (Chengxiong): break Options into individual option fields.
-    # Options is a slice of attribute values of the new function.
-    Options FunctionOptions
-
-    # Body holds all statements of the new function.
-    Body FunctionBodyStr
+    # Syntax is the CREATE FUNCTION AST node.
+    Syntax CreateFunction
 
     # Deps contains the data source dependencies of the view.
     Deps SchemaDeps

--- a/pkg/sql/opt/optbuilder/testdata/create_function
+++ b/pkg/sql/opt/optbuilder/testdata/create_function
@@ -15,24 +15,21 @@ build
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
 ----
 create-function
- ├── return_type: INT8
- └── SELECT 1;
+ ├── CREATE FUNCTION f() RETURNS INT8 LANGUAGE SQL AS $$SELECT 1;$$
+ └── dependencies
 
 build
 CREATE FUNCTION f(a workday) RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
 ----
 create-function
- ├── arguments: workday
- ├── return_type: INT8
- └── SELECT 1;
+ ├── CREATE FUNCTION f(IN a workday) RETURNS INT8 LANGUAGE SQL AS $$SELECT 1;$$
+ └── dependencies
 
 build
 CREATE FUNCTION f(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM ab $$
 ----
 create-function
- ├── arguments: INT8
- ├── return_type: INT8
- ├── SELECT a FROM t.public.ab;
+ ├── CREATE FUNCTION f(IN a INT8) RETURNS INT8 LANGUAGE SQL AS $$SELECT a FROM t.public.ab;$$
  └── dependencies
       └── ab [columns: a]
 
@@ -40,8 +37,7 @@ build
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT b FROM ab@idx $$
 ----
 create-function
- ├── return_type: INT8
- ├── SELECT b FROM t.public.ab@idx;
+ ├── CREATE FUNCTION f() RETURNS INT8 LANGUAGE SQL AS $$SELECT b FROM t.public.ab@idx;$$
  └── dependencies
       └── ab@idx [columns: b]
 
@@ -52,9 +48,8 @@ CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
 $$
 ----
 create-function
- ├── return_type: INT8
- ├── SELECT a FROM t.public.ab;
- │   SELECT nextval('s');
+ ├── CREATE FUNCTION f() RETURNS INT8 LANGUAGE SQL AS $$SELECT a FROM t.public.ab;
+ │   SELECT nextval('s');$$
  └── dependencies
       ├── ab [columns: a]
       └── s

--- a/pkg/sql/opt/optbuilder/testdata/create_function
+++ b/pkg/sql/opt/optbuilder/testdata/create_function
@@ -16,14 +16,14 @@ CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
 ----
 create-function
  ├── CREATE FUNCTION f() RETURNS INT8 LANGUAGE SQL AS $$SELECT 1;$$
- └── dependencies
+ └── no dependencies
 
 build
 CREATE FUNCTION f(a workday) RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
 ----
 create-function
  ├── CREATE FUNCTION f(IN a workday) RETURNS INT8 LANGUAGE SQL AS $$SELECT 1;$$
- └── dependencies
+ └── no dependencies
 
 build
 CREATE FUNCTION f(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM ab $$

--- a/pkg/sql/opt/optbuilder/testdata/create_view
+++ b/pkg/sql/opt/optbuilder/testdata/create_view
@@ -17,7 +17,7 @@ CREATE VIEW v1 AS VALUES (1)
 create-view t.public.v1
  ├── VALUES (1)
  ├── columns: column1:1
- └── dependencies
+ └── no dependencies
 
 build
 CREATE VIEW v1 AS SELECT a FROM ab

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -222,6 +222,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"Statement":           {fullName: "tree.Statement", isInterface: true},
 		"Subquery":            {fullName: "tree.Subquery", isPointer: true, usePointerIntern: true},
 		"CreateTable":         {fullName: "tree.CreateTable", isPointer: true, usePointerIntern: true},
+		"CreateFunction":      {fullName: "tree.CreateFunction", isPointer: true, usePointerIntern: true},
 		"CreateStats":         {fullName: "tree.CreateStats", isPointer: true, usePointerIntern: true},
 		"TableName":           {fullName: "tree.TableName", isPointer: true, usePointerIntern: true},
 		"Constraint":          {fullName: "constraint.Constraint", isPointer: true, usePointerIntern: true},
@@ -249,14 +250,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"InvertedSpans":       {fullName: "inverted.Spans", passByVal: true},
 		"Persistence":         {fullName: "tree.Persistence", passByVal: true},
 		"PreFiltererState":    {fullName: "invertedexpr.PreFiltererStateForInvertedFilterer", isPointer: true, usePointerIntern: true},
-		"FunctionName":        {fullName: "tree.FunctionName", isPointer: true, usePointerIntern: true},
-		"FuncArgs":            {fullName: "tree.FuncArgs", passByVal: true},
-		// TODO (Chengxiong): break function options into separate field with
-		// primitive types, so that we don't need to these type mappings.
-		"FuncReturnType":  {fullName: "tree.FuncReturnType", passByVal: true},
-		"FunctionOptions": {fullName: "tree.FunctionOptions", passByVal: true},
-		"FunctionBodyStr": {fullName: "tree.FunctionBodyStr", passByVal: true},
-		"Volatility":      {fullName: "volatility.V", passByVal: true},
+		"Volatility":          {fullName: "volatility.V", passByVal: true},
 	}
 
 	// Add types of generated op and private structs.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1816,15 +1816,7 @@ func (ef *execFactory) ConstructCreateView(
 
 // ConstructCreateFunction is part of the exec.Factory interface.
 func (ef *execFactory) ConstructCreateFunction(
-	schema cat.Schema,
-	funcName *tree.FunctionName,
-	replace bool,
-	funArgs tree.FuncArgs,
-	returnType tree.FuncReturnType,
-	options tree.FunctionOptions,
-	body tree.FunctionBodyStr,
-	deps opt.SchemaDeps,
-	typeDeps opt.SchemaTypeDeps,
+	schema cat.Schema, cf *tree.CreateFunction, deps opt.SchemaDeps, typeDeps opt.SchemaTypeDeps,
 ) (exec.Node, error) {
 
 	if err := checkSchemaChangeEnabled(
@@ -1841,16 +1833,11 @@ func (ef *execFactory) ConstructCreateFunction(
 	}
 
 	return &createFunctionNode{
-		funcName:   funcName,
-		replace:    replace,
-		args:       funArgs,
-		returnType: returnType,
-		options:    options,
-		funcBody:   body,
-		dbDesc:     schema.(*optSchema).database,
-		scDesc:     schema.(*optSchema).schema,
-		planDeps:   planDeps,
-		typeDeps:   typeDepSet,
+		cf:       cf,
+		dbDesc:   schema.(*optSchema).database,
+		scDesc:   schema.(*optSchema).schema,
+		planDeps: planDeps,
+		typeDeps: typeDepSet,
 	}, nil
 }
 


### PR DESCRIPTION
#### opt: store entire CREATE FUNCTION AST in CreateFunctionExpr

Prior to this commit, parts of the CREATE FUNCTION AST were split into
multiple fields in the optimizer's `CreateFunctionExpr`. The entire AST
node is now stored in a single field in `CreateFunctionExpr`, matching
similar expressions like `CreateTableExpr`.

Release note: None

#### opt: de-duplicate dependency formatting logic

Release note: None

#### opt: clarify lack of dependencies in expr formatting

Release note: None
