### PR TITLE
changefeedccl: add retries to sinkless changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1038,7 +1038,7 @@ func (cf *changeFrontier) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetad
 				// Detect whether this boundary should be used to kill or restart the
 				// changefeed.
 				if cf.frontier.boundaryType == jobspb.ResolvedSpan_RESTART {
-					err = changefeedbase.MarkRetryableError(err)
+					err = changefeedbase.MarkRetryableErrorWithTimestamp(err, cf.frontier.boundaryTime)
 				}
 			}
 

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/flowinfra",
+        "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 )
 
@@ -77,13 +78,26 @@ func (e *taggedError) Unwrap() error { return e.wrapped }
 const retryableErrorString = "retryable changefeed error"
 
 type retryableError struct {
-	wrapped error
+	// A schema change may result in a changefeed returning retryableError,
+	// which can signal the changefeed to restart.
+	// boundaryTimestamp can be returned inside this error so
+	// the changefeed knows where to restart from. Note this is
+	// only useful for sinkless/core changefeeds because they do not have
+	// the ability to read/write their state to jobs tables during restarts.
+	boundaryTimestamp hlc.Timestamp
+	wrapped           error
 }
 
 // MarkRetryableError wraps the given error, marking it as retryable to
 // changefeeds.
 func MarkRetryableError(e error) error {
 	return &retryableError{wrapped: e}
+}
+
+// MarkRetryableErrorWithTimestamp wraps the given error, marks it as
+// retryable, and attaches a timestamp to the error.
+func MarkRetryableErrorWithTimestamp(e error, ts hlc.Timestamp) error {
+	return &retryableError{boundaryTimestamp: ts, wrapped: e}
 }
 
 // Error implements the error interface.
@@ -123,6 +137,17 @@ func IsRetryableError(err error) bool {
 		flowinfra.IsNoInboundStreamConnectionError(err) ||
 		errors.HasType(err, (*roachpb.NodeUnavailableError)(nil)) ||
 		errors.Is(err, sql.ErrPlanChanged))
+}
+
+// MaybeGetRetryableErrorTimestamp will get the timestamp of an error if
+// the error is a retryableError and the timestamp field is populated.
+func MaybeGetRetryableErrorTimestamp(err error) (timestamp hlc.Timestamp, ok bool) {
+	if retryableErr := (*retryableError)(nil); errors.As(err, &retryableErr) {
+		if !retryableErr.boundaryTimestamp.IsEmpty() {
+			return retryableErr.boundaryTimestamp, true
+		}
+	}
+	return hlc.Timestamp{}, false
 }
 
 // MaybeStripRetryableErrorMarker performs some minimal attempt to clean the


### PR DESCRIPTION
This change updates core/sinkless changefeeds to run in a retry loop, allowing for changefeed restarts in case of transient errors or declarative schema changes. 

See commit notes for more details.

Fixes https://github.com/cockroachdb/cockroach/issues/85008