### PR TITLE
release-22.1: colexec: fix a "fake" memory accounting leak for intra-query period

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -69,8 +69,12 @@ type Batch interface {
 	// important for callers to call ResetInternalBatch if they own internal
 	// batches that they reuse as not doing this could result in correctness
 	// or memory blowup issues. It unsets the selection and sets the length to
-	// 0. Notably, it deeply resets the datum-backed vectors and returns the
-	// number of bytes released as a result of the reset.
+	// 0.
+	//
+	// Notably, it deeply resets the datum-backed vectors and returns the number
+	// of bytes released as a result of the reset. Callers should update the
+	// allocator (which the batch was instantiated from) accordingly unless they
+	// guarantee that the batch doesn't have any datum-backed vectors.
 	ResetInternalBatch() int64
 	// String returns a pretty representation of this batch.
 	String() string

--- a/pkg/sql/colexec/colexecutils/operator.go
+++ b/pkg/sql/colexec/colexecutils/operator.go
@@ -76,7 +76,9 @@ func (s *fixedNumTuplesNoInputOp) Next() coldata.Batch {
 	if s.numTuplesLeft == 0 {
 		return coldata.ZeroBatch
 	}
-	s.batch.ResetInternalBatch()
+	// The internal batch has no columns, so no memory is ever released on the
+	// ResetInternalBatch() call.
+	_ = s.batch.ResetInternalBatch()
 	length := s.numTuplesLeft
 	if length > coldata.BatchSize() {
 		length = coldata.BatchSize()

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -183,9 +183,12 @@ func (b *AppendOnlyBufferedBatch) Reset([]*types.T, int, coldata.ColumnFactory) 
 }
 
 // ResetInternalBatch implements the coldata.Batch interface.
+// NB: any memory released during this call is automatically released from the
+// allocator that created the batch.
 func (b *AppendOnlyBufferedBatch) ResetInternalBatch() int64 {
 	b.SetLength(0 /* n */)
-	return b.batch.ResetInternalBatch()
+	b.allocator.ReleaseMemory(b.batch.ResetInternalBatch())
+	return 0
 }
 
 // String implements the coldata.Batch interface.

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -260,7 +260,7 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 				continue
 			}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -473,7 +473,9 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								r.partitionsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -496,7 +498,9 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								r.partitionsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -524,7 +528,7 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 				r.numTuplesInPartition = 0
 			}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -753,7 +757,9 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								r.peerGroupsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -776,7 +782,9 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								r.peerGroupsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -803,7 +811,7 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 				r.numPeers = 0
 			}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -1039,7 +1047,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								r.partitionsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1062,7 +1072,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								r.partitionsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1091,7 +1103,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								r.peerGroupsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1114,7 +1128,9 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								r.peerGroupsState.runningSizes.ResetInternalBatch()
+								// This batch has only a single INT column, so no memory is ever
+								// released on the ResetInternalBatch() call.
+								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1149,7 +1165,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 				r.numPeers = 0
 			}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -155,7 +155,9 @@ func _COMPUTE_PARTITIONS_SIZES(_HAS_SEL bool) { // */}}
 				r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 				r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 				r.partitionsState.idx = 0
-				r.partitionsState.runningSizes.ResetInternalBatch()
+				// This batch has only a single INT column, so no memory is ever
+				// released on the ResetInternalBatch() call.
+				_ = r.partitionsState.runningSizes.ResetInternalBatch()
 			}
 		}
 	}
@@ -187,7 +189,9 @@ func _COMPUTE_PEER_GROUPS_SIZES(_HAS_SEL bool) { // */}}
 				r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 				r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 				r.peerGroupsState.idx = 0
-				r.peerGroupsState.runningSizes.ResetInternalBatch()
+				// This batch has only a single INT column, so no memory is ever
+				// released on the ResetInternalBatch() call.
+				_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
 			}
 		}
 	}
@@ -474,7 +478,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 			}
 			// {{end}}
 
-			r.output.ResetInternalBatch()
+			r.allocator.ResetBatch(r.output)
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -206,7 +206,7 @@ func (c *Columnarizer) Next() coldata.Batch {
 			c.batch = c.allocator.NewMemBatchWithFixedCapacity(c.typs, 1 /* minCapacity */)
 			reallocated = true
 		} else {
-			c.batch.ResetInternalBatch()
+			c.allocator.ResetBatch(c.batch)
 		}
 	}
 	if reallocated {

--- a/pkg/sql/colexec/count.go
+++ b/pkg/sql/colexec/count.go
@@ -46,7 +46,9 @@ func (c *countOp) Next() coldata.Batch {
 	if c.done {
 		return coldata.ZeroBatch
 	}
-	c.internalBatch.ResetInternalBatch()
+	// The internal batch has only a single INT column, so no memory is ever
+	// released on the ResetInternalBatch() call.
+	_ = c.internalBatch.ResetInternalBatch()
 	for {
 		bat := c.Input.Next()
 		length := bat.Length()

--- a/pkg/sql/colexec/hash_based_partitioner.go
+++ b/pkg/sql/colexec/hash_based_partitioner.go
@@ -366,7 +366,7 @@ func (op *hashBasedPartitioner) partitionBatch(
 	for idx, sel := range selections {
 		partitionIdx := op.partitionIdxOffset + idx
 		if len(sel) > 0 {
-			scratchBatch.ResetInternalBatch()
+			op.unlimitedAllocator.ResetBatch(scratchBatch)
 			// The partitioner expects the batches without a selection vector,
 			// so we need to copy the tuples according to the selection vector
 			// into a scratch batch.

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -188,7 +188,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 		switch a.state {
 		case orderedAggregatorAggregating:
 			if a.scratch.shouldResetInternalBatch {
-				a.scratch.ResetInternalBatch()
+				a.allocator.ResetBatch(a.scratch)
 				a.scratch.shouldResetInternalBatch = false
 			}
 			if a.scratch.resumeIdx >= coldata.BatchSize() {
@@ -312,7 +312,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				if a.unsafeBatch == nil {
 					a.unsafeBatch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, coldata.BatchSize())
 				} else {
-					a.unsafeBatch.ResetInternalBatch()
+					a.allocator.ResetBatch(a.unsafeBatch)
 				}
 				a.allocator.PerformOperation(a.unsafeBatch.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
@@ -338,7 +338,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				// the source and the destination would be the same, and
 				// resetting it would lead to the loss of data.
 				newResumeIdx := a.scratch.resumeIdx - coldata.BatchSize()
-				a.scratch.tempBuffer.ResetInternalBatch()
+				a.allocator.ResetBatch(a.scratch.tempBuffer)
 				a.allocator.PerformOperation(a.scratch.tempBuffer.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.scratch.tempBuffer.ColVec(i).Copy(
@@ -350,7 +350,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 						)
 					}
 				})
-				a.scratch.ResetInternalBatch()
+				a.allocator.ResetBatch(a.scratch)
 				a.allocator.PerformOperation(a.scratch.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.scratch.ColVec(i).Copy(

--- a/pkg/sql/colexec/values.go
+++ b/pkg/sql/colexec/values.go
@@ -92,7 +92,7 @@ func (v *valuesOp) Next() coldata.Batch {
 		return coldata.ZeroBatch
 	}
 
-	v.batch.ResetInternalBatch()
+	v.allocator.ResetBatch(v.batch)
 
 	// Decode rows up to the capacity of the batch.
 	nRows := 0

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -149,6 +149,11 @@ func (a *Allocator) NewMemBatchNoCols(typs []*types.T, capacity int) coldata.Bat
 	return coldata.NewMemBatchNoCols(typs, capacity)
 }
 
+// ResetBatch resets the batch while keeping the memory accounting updated.
+func (a *Allocator) ResetBatch(batch coldata.Batch) {
+	a.ReleaseMemory(batch.ResetInternalBatch())
+}
+
 // ResetMaybeReallocate returns a batch that is guaranteed to be in a "reset"
 // state (meaning it is ready to be used) and to have the capacity of at least
 // 1. minDesiredCapacity is a hint about the capacity of the returned batch
@@ -189,7 +194,7 @@ func (a *Allocator) ResetMaybeReallocate(
 		}
 		if useOldBatch {
 			reallocated = false
-			a.ReleaseMemory(oldBatch.ResetInternalBatch())
+			a.ResetBatch(oldBatch)
 			newBatch = oldBatch
 		} else {
 			a.ReleaseMemory(oldBatchMemSize)
@@ -360,6 +365,8 @@ func (a *Allocator) AdjustMemoryUsage(delta int64) {
 func (a *Allocator) ReleaseMemory(size int64) {
 	if size < 0 {
 		colexecerror.InternalError(errors.AssertionFailedf("unexpectedly negative size in ReleaseMemory: %d", size))
+	} else if size == 0 {
+		return
 	}
 	if size > a.acc.Used() {
 		size = a.acc.Used()


### PR DESCRIPTION
Backport 1/1 commits from #85437.

/cc @cockroachdb/release

---

This commit fixes a possible memory accounting leak that could happen
throughout the query execution (i.e. once the query finishes, the leak
would get resolved) which was introduced in
cb93c302de1bab49c8b3051ad96cf859bd91036f. The idea of that commit is to
lose references to the `tree.Datum` objects when resetting the batch
since we cannot reuse those. In the main code path we correctly update
the allocator to release the specified memory, but other less
"important" places where we call `ResetInternalBatch` explicitly were
not audited properly. Thus, it is possible that for datum vectors to
"leak" some memory because we always account for the newly-allocated
`tree.Datum` objects but we forget to shrink the accounting during those
"less important" resets. This is now fixed. The possible impact is that
a single query could exhaust the `--max-sql-memory` limit without
actually using much memory, however, it seems quite unlikely since
such a query would require too many conditions to be met (it uses types
that don't have native vectorized support, other operations within the
query are not memory intensive, etc).

Release note: None

Release justification: bug fix.