### PR TITLE
sql: CREATE TABLE AS could hit into command size limits

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -579,9 +579,10 @@ func (n *createTableNode) startExec(params runParams) error {
 					break
 				}
 
-				// Periodically flush out the batches, so that we don't issue gigantic,
+				// Periodically flush out the batches, so that we don't issue gigantic
 				// raft commands.
-				if ti.currentBatchSize >= ti.maxBatchSize {
+				if ti.currentBatchSize >= ti.maxBatchSize ||
+					ti.b.ApproximateMutationBytes() >= ti.maxBatchByteSize {
 					if err := tw.flushAndStartNewBatch(params.ctx); err != nil {
 						return err
 					}


### PR DESCRIPTION
Fixes: #85207

Previously, when we attempted to address CREATE TABLE AS
running into command size limits, we only took the row count
into account for flushing transaction batches. This was
inadequate because of wide rows its possible for a smaller
number of rows to run into the command size limit. To address,
this these changes go a step further and check the command
sizes and force a flush if they get too big.

Release note: None