### PR TITLE
sql: do not log DistSQL diagrams on the main query path

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -306,6 +306,7 @@ func runPlanInsidePlan(
 			plan.subqueryPlans,
 			recv,
 			&subqueryResultMemAcc,
+			false, /* skipDistSQLDiagramGeneration */
 		) {
 			return resultWriter.Err()
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1450,6 +1450,9 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner,
 		planner.txn, distribute)
 	planCtx.stmtType = recv.stmtType
+	// Skip the diagram generation since on this "main" query path we can get it
+	// via the statement bundle.
+	planCtx.skipDistSQLDiagramGeneration = true
 	if ex.server.cfg.TestingKnobs.TestingSaveFlows != nil {
 		planCtx.saveFlows = ex.server.cfg.TestingKnobs.TestingSaveFlows(planner.stmt.SQL)
 	} else if planner.instrumentation.ShouldSaveFlows() {
@@ -1486,6 +1489,9 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		defer subqueryResultMemAcc.Close(ctx)
 		if !ex.server.cfg.DistSQLPlanner.PlanAndRunSubqueries(
 			ctx, planner, evalCtxFactory, planner.curPlan.subqueryPlans, recv, &subqueryResultMemAcc,
+			// Skip the diagram generation since on this "main" query path we
+			// can get it via the statement bundle.
+			true, /* skipDistSQLDiagramGeneration */
 		) {
 			return *recv.stats, recv.commErr
 		}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -730,6 +730,12 @@ type PlanningCtx struct {
 	// mode.
 	planDepth int
 
+	// If set, the DistSQL diagram is **not** generated and not added to the
+	// trace (when the tracing is enabled). We generally want to include it, but
+	// on the main query path the overhead becomes too large while we also have
+	// other ways to get the diagram.
+	skipDistSQLDiagramGeneration bool
+
 	// If set, the flows for the physical plan will be passed to this function.
 	// The flows are not safe for use past the lifetime of the saveFlows function.
 	saveFlows func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains) error

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -347,6 +347,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				if !sc.distSQLPlanner.PlanAndRunSubqueries(
 					ctx, localPlanner, localPlanner.ExtendedEvalContextCopy,
 					localPlanner.curPlan.subqueryPlans, recv, &subqueryResultMemAcc,
+					false, /* skipDistSQLDiagramGeneration */
 				) {
 					if planAndRunErr = rw.Err(); planAndRunErr != nil {
 						return


### PR DESCRIPTION
We recently merged a change to add the DistSQL diagrams to the trace
(when the tracing is enabled). This was prompted by the desire to
provide more visibility into "transparent" execution flows that are
kicked off by the main query (e.g. apply joins run a new flow on each
iteration and we didn't have any visibility into the physical plan for
that). However, this introduced non-trivial performance overhead on the
main query path when the tracing is enabled. This commit goes around the
issue by skipping the diagram generation on the main query path - this
way we still get the additional visibility on the "non-main" query paths
whereas the main query path doesn't incur any overhead. We already have
tools to get the diagrams on the main path when we need it (namely, the
stmt bundles or explicit `EXPLAIN (DISTSQL)`).

Release note: None