### PR TITLE
release-22.1: sqlccl: fix TestAuthenticateWithSessionRevivalToken flake

### DIFF
--- a/pkg/ccl/testccl/sqlccl/session_revival_test.go
+++ b/pkg/ccl/testccl/sqlccl/session_revival_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -43,10 +44,7 @@ func TestAuthenticateWithSessionRevivalToken(t *testing.T) {
 
 	_, err := tenantDB.Exec("CREATE USER testuser WITH PASSWORD 'hunter2'")
 	require.NoError(t, err)
-	// TODO(rafi): use ALTER TENANT ALL when available.
-	_, err = mainDB.Exec(`INSERT INTO system.tenant_settings (tenant_id, name, value, value_type) VALUES
-		(0, 'server.user_login.session_revival_token.enabled', 'true', 'b')`)
-	require.NoError(t, err)
+	sql.AllowSessionRevival.Override(ctx, &tenant.ClusterSettings().SV, true)
 
 	var token string
 	t.Run("generate token", func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #85094.

/cc @cockroachdb/release

Release justification: test only change

---

fixes https://github.com/cockroachdb/cockroach/issues/84899

Use Override so there's no delay in propagating the setting.

Release note: None
