### PR TITLE
externalconn: refactor ExternalConnection interface

### DIFF
--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -6,7 +6,18 @@ CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo/bar';
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
+foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
+
+# Reject invalid nodelocal URIs.
+exec-sql
+CREATE EXTERNAL CONNECTION "missing-node-id" AS 'nodelocal:///foo';
+----
+pq: failed to construct External Connection details: invalid `nodelocal` URI: host component of nodelocal URI must be a node ID (use 'self' to specify each node should access its own local filesystem): nodelocal:///foo
+
+exec-sql
+CREATE EXTERNAL CONNECTION "invalid-nodeid-nodelocal" AS 'nodelocal://a/foo';
+----
+pq: failed to construct External Connection details: invalid `nodelocal` URI: host component of nodelocal URI must be a node ID: nodelocal://a/foo
 
 # Try to create another External Connection with the same name.
 exec-sql
@@ -21,8 +32,8 @@ CREATE EXTERNAL CONNECTION bar123 AS 'nodelocal://1/baz';
 
 inspect-system-table
 ----
-bar123 STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/baz"}}, "provider": "nodelocal"}
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
+bar123 STORAGE {"nodelocal": {"uri": "nodelocal://1/baz"}}
+foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
 
 # Drop an External Connection that does not exist.
 exec-sql
@@ -35,7 +46,7 @@ DROP EXTERNAL CONNECTION bar123;
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
+foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION foo;
@@ -67,7 +78,7 @@ CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
 
 inspect-system-table
 ----
-privileged STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo"}}, "provider": "nodelocal"}
+privileged STORAGE {"nodelocal": {"uri": "nodelocal://1/foo"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION privileged;
@@ -103,7 +114,7 @@ pq: failed to construct External Connection details: unknown query parameters: I
 
 inspect-system-table
 ----
-foo-kms KMS {"gcsKms": {"uri": "gs:///cmk?AUTH=implicit&CREDENTIALS=baz&ASSUME_ROLE=ronaldo,rashford,bruno&BEARER_TOKEN=foo"}, "provider": "gs_kms"}
+foo-kms KMS {"gcsKms": {"uri": "gs:///cmk?AUTH=implicit&CREDENTIALS=baz&ASSUME_ROLE=ronaldo,rashford,bruno&BEARER_TOKEN=foo"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION "foo-kms";

--- a/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
@@ -9,7 +9,18 @@ CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo/bar';
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
+foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
+
+# Reject invalid nodelocal URIs.
+exec-sql
+CREATE EXTERNAL CONNECTION "missing-node-id" AS 'nodelocal:///foo';
+----
+pq: failed to construct External Connection details: invalid `nodelocal` URI: host component of nodelocal URI must be a node ID (use 'self' to specify each node should access its own local filesystem): nodelocal:///foo
+
+exec-sql
+CREATE EXTERNAL CONNECTION "invalid-nodeid-nodelocal" AS 'nodelocal://a/foo';
+----
+pq: failed to construct External Connection details: invalid `nodelocal` URI: host component of nodelocal URI must be a node ID: nodelocal://a/foo
 
 # Try to create another External Connection with the same name.
 exec-sql
@@ -24,8 +35,8 @@ CREATE EXTERNAL CONNECTION bar123 AS 'nodelocal://1/baz';
 
 inspect-system-table
 ----
-bar123 STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/baz"}}, "provider": "nodelocal"}
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
+bar123 STORAGE {"nodelocal": {"uri": "nodelocal://1/baz"}}
+foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
 
 # Drop an External Connection that does not exist.
 exec-sql
@@ -38,7 +49,7 @@ DROP EXTERNAL CONNECTION bar123;
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo/bar"}}, "provider": "nodelocal"}
+foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION foo;
@@ -70,7 +81,7 @@ CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
 
 inspect-system-table
 ----
-privileged STORAGE {"nodelocal": {"cfg": {"nodeId": 1, "path": "/foo"}}, "provider": "nodelocal"}
+privileged STORAGE {"nodelocal": {"uri": "nodelocal://1/foo"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION privileged;
@@ -95,7 +106,7 @@ CREATE EXTERNAL CONNECTION "foo-kms" AS 'gs:///cmk?AUTH=implicit&CREDENTIALS=baz
 
 inspect-system-table
 ----
-foo-kms KMS {"gcsKms": {"uri": "gs:///cmk?AUTH=implicit&CREDENTIALS=baz&ASSUME_ROLE=ronaldo,rashford,bruno&BEARER_TOKEN=foo"}, "provider": "gs_kms"}
+foo-kms KMS {"gcsKms": {"uri": "gs:///cmk?AUTH=implicit&CREDENTIALS=baz&ASSUME_ROLE=ronaldo,rashford,bruno&BEARER_TOKEN=foo"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION "foo-kms";

--- a/pkg/cloud/externalconn/connection_kms.go
+++ b/pkg/cloud/externalconn/connection_kms.go
@@ -20,22 +20,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-type kmsConnectionContext struct {
-	kmsEnv cloud.KMSEnv
-}
-
-// ExternalStorageContext implements the ConnectionContext interface.
-func (k *kmsConnectionContext) ExternalStorageContext() cloud.ExternalStorageContext {
-	panic("kmsConnectionContext cannot be used for External Storage initialization")
-}
-
-// KMSEnv implements the ConnectionContext interface.
-func (k *kmsConnectionContext) KMSEnv() cloud.KMSEnv {
-	return k.kmsEnv
-}
-
-var _ ConnectionContext = &kmsConnectionContext{}
-
 func makeExternalConnectionKMS(
 	ctx context.Context, uri string, env cloud.KMSEnv,
 ) (cloud.KMS, error) {
@@ -53,7 +37,7 @@ func makeExternalConnectionKMS(
 	// the external connection object we are about to retrieve.
 
 	// Retrieve the external connection object from the system table.
-	var ec *ExternalConnection
+	var ec ExternalConnection
 	if err := env.DBHandle().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		var err error
 		ec, err = LoadExternalConnection(ctx, externalConnectionName, connectionpb.TypeKMS,
@@ -63,25 +47,14 @@ func makeExternalConnectionKMS(
 		return nil, errors.Wrap(err, "failed to load external connection object")
 	}
 
-	// Construct an ExternalStorage handle for the underlying resource represented
-	// by the external connection object.
-	details := ec.ConnectionDetails()
-	connDetails, err := MakeConnectionDetails(ctx, *details)
-	if err != nil {
-		return nil, err
+	// Construct a KMS handle for the underlying resource represented by the
+	// external connection object.
+	switch d := ec.ConnectionProto().Details.(type) {
+	case *connectionpb.ConnectionDetails_GCSKMS:
+		return cloud.KMSFromURI(ctx, d.GCSKMS.URI, env)
+	default:
+		return nil, errors.Newf("cannot connect to %T; unsupported resource for a KMS connection", d)
 	}
-	connection, err := connDetails.Dial(ctx, &kmsConnectionContext{kmsEnv: env}, "" /* subdir */)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to Dial external connection")
-	}
-
-	var kms cloud.KMS
-	var ok bool
-	if kms, ok = connection.(cloud.KMS); !ok {
-		return nil, errors.AssertionFailedf("cannot convert Connection to cloud.KMS")
-	}
-
-	return kms, nil
 }
 
 func init() {

--- a/pkg/cloud/externalconn/connectionpb/connection.proto
+++ b/pkg/cloud/externalconn/connectionpb/connection.proto
@@ -15,12 +15,7 @@ option go_package = "connectionpb";
 import "gogoproto/gogo.proto";
 import "cloud/cloudpb/external_storage.proto";
 
-enum ConnectionProvider {
-  Unknown = 0;
-  nodelocal = 1;
-  gs_kms = 2;
-}
-
+// ConnectionType is the type of the External Connection object.
 enum ConnectionType {
   option (gogoproto.goproto_enum_prefix) = false;
 
@@ -29,19 +24,23 @@ enum ConnectionType {
   KMS = 2 [(gogoproto.enumvalue_customname) = "TypeKMS"];
 }
 
+// ConnectionsDetails is the byte representation of the resource represented by
+// an External Connection object.
 message ConnectionDetails {
-  ConnectionProvider provider = 1;
-
   oneof details {
-    NodelocalConnectionDetails nodelocal = 2;
-    GCSKMSConnectionDetails gcs_kms = 3 [(gogoproto.customname) = "GCSKMS"];
+    NodelocalConnectionDetails nodelocal = 1;
+    GCSKMSConnectionDetails gcs_kms = 2 [(gogoproto.customname) = "GCSKMS"];
   }
 }
 
+// NodelocalConnectionDetails encapsulates the information required by an
+// External Connection object to represent a nodelocal connection.
 message NodelocalConnectionDetails {
-  cloudpb.LocalFileConfig cfg = 1 [(gogoproto.nullable) = false];
+  string uri = 1 [(gogoproto.customname) = "URI"];
 }
 
+// GCSKMSConnectionDetails encapsulates the information required by an External
+// Connection object to represent a GCS KMS connection.
 message GCSKMSConnectionDetails {
   string uri = 1 [(gogoproto.customname) = "URI"];
 }

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -34,10 +34,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func makeLocalFileConfig(uri *url.URL) (cloudpb.LocalFileConfig, error) {
-	localCfg := cloudpb.LocalFileConfig{}
+func validateLocalFileURI(uri *url.URL) error {
 	if uri.Host == "" {
-		return localCfg, errors.Errorf(
+		return errors.Newf(
 			"host component of nodelocal URI must be a node ID ("+
 				"use 'self' to specify each node should access its own local filesystem): %s",
 			uri.String(),
@@ -46,6 +45,20 @@ func makeLocalFileConfig(uri *url.URL) (cloudpb.LocalFileConfig, error) {
 		uri.Host = "0"
 	}
 
+	_, err := strconv.Atoi(uri.Host)
+	if err != nil {
+		return errors.Newf("host component of nodelocal URI must be a node ID: %s", uri.String())
+	}
+
+	// TODO(adityamaru): We should be restricting the URI params that nodelocal
+	// accepts but there are several tests that use `nodelocal` to test URI params
+	// for other ExternalStorage providers. Fix those and then invoke
+	// `cloud.ValidateQueryParams` with the allow-list of parameters.
+	return nil
+}
+
+func makeLocalFileConfig(uri *url.URL) (cloudpb.LocalFileConfig, error) {
+	localCfg := cloudpb.LocalFileConfig{}
 	nodeID, err := strconv.Atoi(uri.Host)
 	if err != nil {
 		return localCfg, errors.Errorf("host component of nodelocal URI must be a node ID: %s", uri.String())
@@ -56,10 +69,15 @@ func makeLocalFileConfig(uri *url.URL) (cloudpb.LocalFileConfig, error) {
 	return localCfg, nil
 }
 
-func makeLocalFileExternalStorageConf(
+func parseLocalFileURI(
 	_ cloud.ExternalStorageURIContext, uri *url.URL,
 ) (cloudpb.ExternalStorage, error) {
 	conf := cloudpb.ExternalStorage{}
+
+	if err := validateLocalFileURI(uri); err != nil {
+		return conf, errors.Wrap(err, "invalid `nodelocal` URI")
+	}
+
 	conf.Provider = cloudpb.ExternalStorageProvider_nodelocal
 	var err error
 	conf.LocalFileConfig, err = makeLocalFileConfig(uri)
@@ -215,5 +233,5 @@ func (*localFileStorage) Close() error {
 func init() {
 	const scheme = "nodelocal"
 	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_nodelocal,
-		makeLocalFileExternalStorageConf, makeLocalFileStorage, cloud.RedactedParams(), scheme)
+		parseLocalFileURI, makeLocalFileStorage, cloud.RedactedParams(), scheme)
 }

--- a/pkg/cloud/uris.go
+++ b/pkg/cloud/uris.go
@@ -113,6 +113,9 @@ func (u *consumeURL) consumeParam(p string) string {
 }
 
 func (u *consumeURL) remainingQueryParams() (res []string) {
+	if u.q == nil {
+		u.q = u.Query()
+	}
 	for p := range u.q {
 		res = append(res, p)
 	}

--- a/pkg/sql/create_external_connection.go
+++ b/pkg/sql/create_external_connection.go
@@ -77,7 +77,7 @@ func (p *planner) createExternalConnection(
 		return err
 	}
 
-	ex := externalconn.NewExternalConnection()
+	ex := externalconn.NewMutableExternalConnection()
 	name, err := eval.externalConnectionName()
 	if err != nil {
 		return errors.Wrap(err, "failed to resolve External Connection name")
@@ -95,12 +95,12 @@ func (p *planner) createExternalConnection(
 	if err != nil {
 		return errors.Wrap(err, "failed to resolve External Connection endpoint")
 	}
-	connDetails, err := externalconn.ConnectionDetailsFromURI(params.ctx, as)
+	exConn, err := externalconn.ExternalConnectionFromURI(params.ctx, as)
 	if err != nil {
 		return errors.Wrap(err, "failed to construct External Connection details")
 	}
-	ex.SetConnectionDetails(*connDetails.ConnectionProto())
-	ex.SetConnectionType(connDetails.ConnectionType())
+	ex.SetConnectionDetails(*exConn.ConnectionProto())
+	ex.SetConnectionType(exConn.ConnectionType())
 
 	// Create the External Connection and persist it in the
 	// `system.external_connections` table.


### PR DESCRIPTION
This change is a refactor of the ExternalConnection interface
to make it easier to work with. Most importantly this removes the
`Dial` method and all its related complexity, and moves the logic
to the call site. This is a good change because the call site often
has all the configuration parameters we need to make the underlying
resource, and by round-tripping this information through Dial we had
unnecessary complexity. A happy consequence of removing the `Dial`
method is the deletion of the `Provider` field from the proto.
Since this is unreleased code it is safe to delete and re-order the fields.

This change also tightens some of the interfaces to be read-write or
read-only. When interacting with external connection objects outside
their creations, callers will no longer have the ability to mutate these
objects.

Release note: None