### PR TITLE
release-22.1: roachtest: skip kv0/enc=false/nodes=1/size=64kb/conc=4096

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -160,7 +160,10 @@ func registerKV(r registry.Registry) {
 		// CPU overload test, to stress admission control.
 		{nodes: 1, cpus: 8, readPercent: 50, concMultiplier: 8192},
 		// IO write overload test, to stress admission control.
-		{nodes: 1, cpus: 8, readPercent: 0, concMultiplier: 4096, blockSize: 1 << 16 /* 64 KB */},
+		// NOTE: this test is skipped on 22.1 due to many deficiencies w.r.t. write
+		// handling. The high concurrency tests are fragile, and thus noisy.
+		// See: https://github.com/cockroachdb/cockroach/issues/77891
+		//{nodes: 1, cpus: 8, readPercent: 0, concMultiplier: 4096, blockSize: 1 << 16 /* 64 KB */},
 		{nodes: 1, cpus: 8, readPercent: 95},
 		{nodes: 1, cpus: 32, readPercent: 0},
 		{nodes: 1, cpus: 32, readPercent: 95},


### PR DESCRIPTION
There are a number of deficiencies with respect to write handling that
make the `kv0/enc=false/nodes=1/size=64kb/conc=4096` roachtest fail
consistently in 22.1.

Skip the test on 22.1 to reduce noise.

Closes #77891.

Release note: None.

Release justification: Test only.