### PR TITLE
roachtest: re-enable costfuzz test

### DIFF
--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -33,7 +33,6 @@ func registerCostFuzz(r registry.Registry) {
 		Tags:            nil,
 		Cluster:         r.MakeClusterSpec(1),
 		Run:             runCostFuzz,
-		Skip:            "flaky test: https://github.com/cockroachdb/cockroach/issues/81717",
 	})
 }
 


### PR DESCRIPTION
We've fixed a number of issues found by costfuzz's sibling test
unoptimized-query-oracle, so it feels like the right time to cry
'Havoc!', and let slip the dogs of war.

Fixes: #81717

Release note: None