### PR TITLE
backupccl: Add ALTER BACKUP SCHEDULE command.

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -6,6 +6,7 @@ FILES = [
     "add_constraint",
     "alter_changefeed",
     "alter_backup",
+    "alter_backup_schedule",
     "alter_column",
     "alter_database_add_region_stmt",
     "alter_database_add_super_region",

--- a/docs/generated/sql/bnf/alter_backup_schedule.bnf
+++ b/docs/generated/sql/bnf/alter_backup_schedule.bnf
@@ -1,0 +1,2 @@
+alter_backup_schedule ::=
+	'ALTER' 'BACKUP' 'SCHEDULE' iconst64 alter_backup_schedule_cmds

--- a/docs/generated/sql/bnf/alter_ddl_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_ddl_stmt.bnf
@@ -12,3 +12,4 @@ alter_ddl_stmt ::=
 	| alter_changefeed_stmt
 	| alter_backup_stmt
 	| alter_func_stmt
+	| alter_backup_schedule

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -481,6 +481,7 @@ alter_ddl_stmt ::=
 	| alter_changefeed_stmt
 	| alter_backup_stmt
 	| alter_func_stmt
+	| alter_backup_schedule
 
 alter_role_stmt ::=
 	'ALTER' role_or_group_or_user role_spec opt_role_options
@@ -1113,6 +1114,7 @@ unreserved_keyword ::=
 	| 'KEYS'
 	| 'KMS'
 	| 'KV'
+	| 'LABEL'
 	| 'LANGUAGE'
 	| 'LAST'
 	| 'LATEST'
@@ -1571,6 +1573,9 @@ alter_func_stmt ::=
 	| alter_func_owner_stmt
 	| alter_func_set_schema_stmt
 	| alter_func_dep_extension_stmt
+
+alter_backup_schedule ::=
+	'ALTER' 'BACKUP' 'SCHEDULE' iconst64 alter_backup_schedule_cmds
 
 role_or_group_or_user ::=
 	'ROLE'
@@ -2170,6 +2175,9 @@ alter_func_set_schema_stmt ::=
 alter_func_dep_extension_stmt ::=
 	'ALTER' 'FUNCTION' function_with_argtypes opt_no 'DEPENDS' 'ON' 'EXTENSION' name
 
+alter_backup_schedule_cmds ::=
+	( alter_backup_schedule_cmd ) ( ( ',' alter_backup_schedule_cmd ) )*
+
 role_options ::=
 	( role_option ) ( ( role_option ) )*
 
@@ -2751,6 +2759,15 @@ opt_restrict ::=
 opt_no ::=
 	'NO'
 	| 
+
+alter_backup_schedule_cmd ::=
+	'SET' 'LABEL' string_or_placeholder
+	| 'SET' 'INTO' string_or_placeholder_opt_list
+	| 'SET' 'WITH' backup_options
+	| 'SET' cron_expr
+	| 'SET' 'FULL' 'BACKUP' 'ALWAYS'
+	| 'SET' 'FULL' 'BACKUP' sconst_or_placeholder
+	| 'SET' 'SCHEDULE' 'OPTION' kv_option
 
 role_option ::=
 	'CREATEROLE'

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     name = "backupccl",
     srcs = [
         "alter_backup_planning.go",
+        "alter_backup_schedule.go",
         "backup_job.go",
         "backup_planning.go",
         "backup_planning_tenant.go",

--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -1,0 +1,389 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+	pbtypes "github.com/gogo/protobuf/types"
+)
+
+const alterBackupScheduleOp = "ALTER BACKUP SCHEDULE"
+
+type scheduleDetails struct {
+	fullJob  *jobs.ScheduledJob
+	fullArgs *backuppb.ScheduledBackupExecutionArgs
+	incJob   *jobs.ScheduledJob
+	incArgs  *backuppb.ScheduledBackupExecutionArgs
+}
+
+func loadSchedules(
+	ctx context.Context, p sql.PlanHookState, eval *alterBackupScheduleEval,
+) (scheduleDetails, error) {
+	scheduleID := eval.scheduleID
+	s := scheduleDetails{}
+	if scheduleID == 0 {
+		return s, errors.Newf("Schedule ID expected, none found")
+	}
+
+	execCfg := p.ExecCfg()
+	env := sql.JobSchedulerEnv(execCfg)
+	schedule, err := jobs.LoadScheduledJob(ctx, env, int64(scheduleID), execCfg.InternalExecutor, p.Txn())
+	if err != nil {
+		return s, err
+	}
+
+	args := &backuppb.ScheduledBackupExecutionArgs{}
+	if err := pbtypes.UnmarshalAny(schedule.ExecutionArgs().Args, args); err != nil {
+		return s, errors.Wrap(err, "un-marshaling args")
+	}
+
+	var dependentSchedule *jobs.ScheduledJob
+	var dependentArgs *backuppb.ScheduledBackupExecutionArgs
+
+	if args.DependentScheduleID != 0 {
+		dependentSchedule, err = jobs.LoadScheduledJob(ctx, env, args.DependentScheduleID, execCfg.InternalExecutor, p.Txn())
+		if err != nil {
+			return s, err
+		}
+		dependentArgs = &backuppb.ScheduledBackupExecutionArgs{}
+		if err := pbtypes.UnmarshalAny(dependentSchedule.ExecutionArgs().Args, dependentArgs); err != nil {
+			return s, errors.Wrap(err, "un-marshaling args")
+		}
+	}
+
+	if args.BackupType == backuppb.ScheduledBackupExecutionArgs_FULL {
+		s.fullJob, s.fullArgs = schedule, args
+		s.incJob, s.incArgs = dependentSchedule, dependentArgs
+	} else {
+		s.fullJob, s.fullArgs = dependentSchedule, dependentArgs
+		s.incJob, s.incArgs = schedule, args
+	}
+	return s, nil
+}
+
+// doAlterBackupSchedule creates requested schedule (or schedules).
+// It is a plan hook implementation responsible for the creating of scheduled backup.
+func doAlterBackupSchedules(
+	ctx context.Context,
+	p sql.PlanHookState,
+	eval *alterBackupScheduleEval,
+	resultsCh chan<- tree.Datums,
+) error {
+	s, err := loadSchedules(
+		ctx, p, eval)
+	if err != nil {
+		return err
+	}
+
+	// Note that even ADMIN is subject to these restrictions. We expect to
+	// add a finer-grained permissions model soon.
+	if s.fullJob.Owner() != p.User() {
+		return pgerror.Newf(pgcode.InsufficientPrivilege, "only the OWNER of a schedule may alter it")
+	}
+
+	if s.incJob != nil && s.incJob.Owner() != p.User() {
+		return pgerror.Newf(pgcode.InsufficientPrivilege, "only the OWNER of a schedule may alter it")
+	}
+
+	s, err = processFullBackupRecurrence(
+		ctx,
+		p,
+		eval.fullBackupAlways,
+		eval.fullBackupRecurrence,
+		eval.isEnterpriseUser,
+		s,
+	)
+	if err != nil {
+		return err
+	}
+
+	s.fullJob, s.incJob, err = processRecurrence(
+		eval.recurrence,
+		s.fullJob,
+		s.incJob,
+	)
+	if err != nil {
+		return err
+	}
+
+	// TODO(benbardin): Verify backup statement. Not needed yet since we can't
+	// modify that statement yet.
+
+	fullAny, err := pbtypes.MarshalAny(s.fullArgs)
+	if err != nil {
+		return err
+	}
+	s.fullJob.SetExecutionDetails(
+		tree.ScheduledBackupExecutor.InternalName(),
+		jobspb.ExecutionArguments{Args: fullAny})
+	if err := s.fullJob.Update(ctx, p.ExecCfg().InternalExecutor, p.Txn()); err != nil {
+		return err
+	}
+
+	if s.incJob != nil {
+		incAny, err := pbtypes.MarshalAny(s.incArgs)
+		if err != nil {
+			return err
+		}
+		s.incJob.SetExecutionDetails(
+			tree.ScheduledBackupExecutor.InternalName(),
+			jobspb.ExecutionArguments{Args: incAny})
+		if err := s.incJob.Update(ctx, p.ExecCfg().InternalExecutor, p.Txn()); err != nil {
+			return err
+		}
+	}
+	// TODO(benbardin): Emit schedules.
+	return nil
+}
+
+func processRecurrence(
+	recurrence func() (string, error), fullJob *jobs.ScheduledJob, incJob *jobs.ScheduledJob,
+) (*jobs.ScheduledJob, *jobs.ScheduledJob, error) {
+	if recurrence == nil {
+		return fullJob, incJob, nil
+	}
+	recurrenceStr, err := recurrence()
+	if err != nil {
+		return nil, nil, err
+	}
+	if incJob != nil {
+		if err := incJob.SetSchedule(recurrenceStr); err != nil {
+			return nil, nil, err
+		}
+	} else {
+		if err := fullJob.SetSchedule(recurrenceStr); err != nil {
+			return nil, nil, err
+		}
+	}
+	return fullJob, incJob, nil
+}
+
+func processFullBackupRecurrence(
+	ctx context.Context,
+	p sql.PlanHookState,
+	fullBackupAlways bool,
+	fullBackupRecurrence func() (string, error),
+	isEnterpriseUser bool,
+	s scheduleDetails,
+) (scheduleDetails, error) {
+	var err error
+
+	if !fullBackupAlways && fullBackupRecurrence == nil {
+		return s, nil
+	}
+
+	env := sql.JobSchedulerEnv(p.ExecCfg())
+	ex := p.ExecCfg().InternalExecutor
+	if fullBackupAlways {
+		if s.incJob == nil {
+			// Nothing to do.
+			return s, nil
+		}
+		// Copy the cadence from the incremental to the full, and delete the
+		// incremental.
+		if err := s.fullJob.SetSchedule(s.incJob.ScheduleExpr()); err != nil {
+			return scheduleDetails{}, err
+		}
+		s.fullArgs.DependentScheduleID = 0
+		s.fullArgs.UnpauseOnSuccess = 0
+		if err := s.incJob.Delete(ctx, ex, p.Txn()); err != nil {
+			return scheduleDetails{}, err
+		}
+		s.incJob = nil
+		s.incArgs = nil
+		return s, nil
+	}
+
+	// We have FULL BACKUP <cron>.
+	if !isEnterpriseUser {
+		return scheduleDetails{}, errors.Newf("Enterprise license required to use incremental backups. " +
+			"To modify the cadence of a full backup, use the 'RECURRING <cron>' clause instead.")
+	}
+
+	if s.incJob == nil {
+		// No existing incremental job, so we need to create it, copying details
+		// from the full.
+		node, err := parser.ParseOne(s.fullArgs.BackupStatement)
+		if err != nil {
+			return scheduleDetails{}, err
+		}
+		stmt, ok := node.AST.(*tree.Backup)
+		if !ok {
+			return scheduleDetails{}, errors.Newf("unexpected node type %T", node)
+		}
+		stmt.AppendToLatest = true
+
+		scheduleExprFn := func() (string, error) {
+			return s.fullJob.ScheduleExpr(), nil
+		}
+		incRecurrence, err := computeScheduleRecurrence(env.Now(), scheduleExprFn)
+		if err != nil {
+			return scheduleDetails{}, err
+		}
+
+		s.incJob, s.incArgs, err = makeBackupSchedule(
+			env,
+			p.User(),
+			s.fullJob.ScheduleLabel(),
+			incRecurrence,
+			*s.fullJob.ScheduleDetails(),
+			jobs.InvalidScheduleID,
+			s.fullArgs.UpdatesLastBackupMetric,
+			stmt,
+			s.fullArgs.ChainProtectedTimestampRecords,
+		)
+
+		if err != nil {
+			return scheduleDetails{}, err
+		}
+
+		// We don't know if a full backup has completed yet, so pause incremental
+		// until a full backup completes.
+		s.incJob.Pause()
+		s.incJob.SetScheduleStatus("Waiting for initial backup to complete")
+		s.incArgs.DependentScheduleID = s.fullJob.ScheduleID()
+
+		incAny, err := pbtypes.MarshalAny(s.incArgs)
+		if err != nil {
+			return scheduleDetails{}, err
+		}
+		s.incJob.SetExecutionDetails(
+			tree.ScheduledBackupExecutor.InternalName(),
+			jobspb.ExecutionArguments{Args: incAny})
+
+		if err := s.incJob.Create(ctx, ex, p.Txn()); err != nil {
+			return scheduleDetails{}, err
+		}
+		s.fullArgs.UnpauseOnSuccess = s.incJob.ScheduleID()
+		s.fullArgs.DependentScheduleID = s.incJob.ScheduleID()
+	}
+	// We have an incremental backup at this point.
+	// Make no (further) changes, and just edit the cadence on the full.
+
+	fullBackupRecurrenceStr, err := fullBackupRecurrence()
+	if err != nil {
+		return scheduleDetails{}, err
+	}
+	if err := s.fullJob.SetSchedule(fullBackupRecurrenceStr); err != nil {
+		return scheduleDetails{}, err
+	}
+
+	fullAny, err := pbtypes.MarshalAny(s.fullArgs)
+	if err != nil {
+		return scheduleDetails{}, err
+	}
+	s.fullJob.SetExecutionDetails(
+		tree.ScheduledBackupExecutor.InternalName(),
+		jobspb.ExecutionArguments{Args: fullAny})
+
+	return s, nil
+}
+
+type alterBackupScheduleEval struct {
+	// Schedule specific properties that get evaluated.
+	stmt                 *tree.AlterBackupSchedule
+	scheduleID           uint64
+	recurrence           func() (string, error)
+	fullBackupRecurrence func() (string, error)
+	fullBackupAlways     bool
+	isEnterpriseUser     bool
+}
+
+// makeScheduleBackupEval prepares helper scheduledBackupEval struct to assist in evaluation
+// of various schedule and backup specific components.
+func makeAlterBackupScheduleEval(
+	ctx context.Context, p sql.PlanHookState, alterStmt *tree.AlterBackupSchedule,
+) (*alterBackupScheduleEval, error) {
+	eval := &alterBackupScheduleEval{
+		stmt: alterStmt,
+	}
+	eval.scheduleID = alterStmt.ScheduleID
+	var err error
+	observed := make(map[string]interface{})
+	empty := struct{}{}
+	observe := func(key string) error {
+		if _, alreadyObserved := observed[key]; alreadyObserved {
+			return errors.Newf("can specify %s at most once", key)
+		}
+		observed[key] = empty
+		return nil
+	}
+	for _, cmd := range alterStmt.Cmds {
+		switch typedCmd := cmd.(type) {
+		case *tree.AlterBackupScheduleSetFullBackup:
+			if err := observe("SET FULL BACKUP"); err != nil {
+				return nil, err
+			}
+			if typedCmd.FullBackup.AlwaysFull {
+				eval.fullBackupAlways = true
+			} else {
+				eval.fullBackupRecurrence, err = p.TypeAsString(ctx, typedCmd.FullBackup.Recurrence, alterBackupScheduleOp)
+			}
+		case *tree.AlterBackupScheduleSetRecurring:
+			if err := observe("SET RECURRING"); err != nil {
+				return nil, err
+			}
+			eval.recurrence, err = p.TypeAsString(ctx, typedCmd.Recurrence, alterBackupScheduleOp)
+		default:
+			return nil, errors.Newf("not yet implemented: %v", tree.AsString(typedCmd))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
+		p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), p.ExecCfg().Organization(),
+		"BACKUP INTO LATEST")
+	eval.isEnterpriseUser = enterpriseCheckErr == nil
+
+	return eval, nil
+}
+
+func alterBackupScheduleHook(
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
+) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+	alterScheduleStmt, ok := stmt.(*tree.AlterBackupSchedule)
+	if !ok {
+		return nil, nil, nil, false, nil
+	}
+
+	eval, err := makeAlterBackupScheduleEval(ctx, p, alterScheduleStmt)
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+
+	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+		err := doAlterBackupSchedules(ctx, p, eval, resultsCh)
+		if err != nil {
+			telemetry.Count("scheduled-backup.alter.failed")
+			return err
+		}
+
+		return nil
+	}
+	return fn, scheduledBackupHeader, nil, false, nil
+}
+
+func init() {
+	sql.AddPlanHook("schedule backup", alterBackupScheduleHook)
+}

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule
@@ -1,0 +1,212 @@
+new-server name=s1 allow-implicit-access
+----
+
+# Create test schedules.
+
+exec-sql
+create schedule datatest for backup into 'nodelocal://1/example-schedule' recurring '@daily' full backup '@weekly';
+----
+
+let $fullID $incID
+with schedules as (show schedules) select id from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @weekly root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Disable incremental backup.
+
+exec-sql
+alter backup schedule $fullID set full backup always;
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @daily root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}
+
+# Verify idempotency.
+
+exec-sql
+alter backup schedule $fullID set full backup always;
+alter backup schedule $fullID set full backup always;
+alter backup schedule $fullID set full backup always;
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @daily root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}
+
+# Change cadence (of full backup.)
+
+exec-sql
+alter backup schedule $fullID set recurring '@weekly';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @weekly root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}
+
+# Verify idempotency.
+
+exec-sql
+alter backup schedule $fullID set recurring '@weekly';
+alter backup schedule $fullID set recurring '@weekly';
+alter backup schedule $fullID set recurring '@weekly';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @weekly root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}
+
+# Add incremental backup.
+
+exec-sql
+alter backup schedule $fullID set full backup '0 0 1 * *';
+----
+
+let $incID
+with schedules as (show schedules) select id from schedules where label='datatest' and id != $fullID;
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> 0 0 1 * * root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @weekly root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Verify idempotency.
+
+exec-sql
+alter backup schedule $fullID set full backup '0 0 1 * *';
+alter backup schedule $fullID set full backup '0 0 1 * *';
+alter backup schedule $fullID set full backup '0 0 1 * *';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> 0 0 1 * * root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @weekly root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Change cadence (of incremental backup.)
+
+exec-sql
+-- Using full ID instead of incremental, as it should be fully interchangeable.
+alter backup schedule $fullID set recurring '@daily';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> 0 0 1 * * root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Verify idempotency
+
+exec-sql
+alter backup schedule $fullID set recurring '@daily';
+alter backup schedule $fullID set recurring '@daily';
+alter backup schedule $fullID set recurring '@daily';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> 0 0 1 * * root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Change cadence (of full backup, while incremental exists.)
+
+exec-sql
+-- Using incremental ID instead of full, as it should be fully interchangeable.
+alter backup schedule $incID set full backup '@weekly';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @weekly root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Verify idempotency.
+
+exec-sql
+alter backup schedule $incID set full backup '@weekly';
+alter backup schedule $incID set full backup '@weekly';
+alter backup schedule $incID set full backup '@weekly';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @weekly root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Alter full and incremental cadence in the same command.
+
+exec-sql
+alter backup schedule $incID set full backup '0 0 1 * *', set recurring '@weekly';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> 0 0 1 * * root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @weekly root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Verify idempotency.
+
+exec-sql
+alter backup schedule $incID set full backup '0 0 1 * *', set recurring '@weekly';
+alter backup schedule $incID set full backup '0 0 1 * *', set recurring '@weekly';
+alter backup schedule $incID set full backup '0 0 1 * *', set recurring '@weekly';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> 0 0 1 * * root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @weekly root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+# Remove incremental backup and change full cadence in the same command.
+
+exec-sql
+alter backup schedule $fullID set full backup always, set recurring '@daily';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @daily root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}
+
+# Verify idempotency.
+
+exec-sql
+alter backup schedule $fullID set full backup always, set recurring '@daily';
+alter backup schedule $fullID set full backup always, set recurring '@daily';
+alter backup schedule $fullID set full backup always, set recurring '@daily';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @daily root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}
+
+# Can't use the same command twice.
+
+exec-sql expect-error-ignore
+alter backup schedule $incID set recurring '0 0 1 * *', set recurring '@weekly';
+----
+ignoring expected error
+
+exec-sql expect-error-ignore
+alter backup schedule $incID set full backup '0 0 1 * *', set recurring '0 0 1 * *', set full backup '@weekly';
+----
+ignoring expected error

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -5,6 +5,7 @@ BNF_SRCS = [
   "//docs/generated/sql/bnf:add_column.bnf",
   "//docs/generated/sql/bnf:add_constraint.bnf",
   "//docs/generated/sql/bnf:alter_backup.bnf",
+  "//docs/generated/sql/bnf:alter_backup_schedule.bnf",
   "//docs/generated/sql/bnf:alter_changefeed.bnf",
   "//docs/generated/sql/bnf:alter_column.bnf",
   "//docs/generated/sql/bnf:alter_database_add_region_stmt.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -6,6 +6,7 @@ DIAGRAMS_SRCS = [
   "//docs/generated/sql/bnf:add_constraint.html",
   "//docs/generated/sql/bnf:alter.html",
   "//docs/generated/sql/bnf:alter_backup.html",
+  "//docs/generated/sql/bnf:alter_backup_schedule.html",
   "//docs/generated/sql/bnf:alter_changefeed.html",
   "//docs/generated/sql/bnf:alter_column.html",
   "//docs/generated/sql/bnf:alter_database.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -17,6 +17,7 @@ DOCS_SRCS = [
   "//docs/generated/sql/bnf:add_column.bnf",
   "//docs/generated/sql/bnf:add_constraint.bnf",
   "//docs/generated/sql/bnf:alter_backup.bnf",
+  "//docs/generated/sql/bnf:alter_backup_schedule.bnf",
   "//docs/generated/sql/bnf:alter_changefeed.bnf",
   "//docs/generated/sql/bnf:alter_column.bnf",
   "//docs/generated/sql/bnf:alter_database_add_region_stmt.bnf",

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -370,6 +370,7 @@ func init() {
 
 		// CCL statements (without Export which has an optimizer operator).
 		&tree.AlterBackup{},
+		&tree.AlterBackupSchedule{},
 		&tree.Backup{},
 		&tree.ShowBackup{},
 		&tree.Restore{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -495,6 +495,7 @@ func TestContextualHelp(t *testing.T) {
 		{`EXPORT INTO CSV 'a' ??`, `EXPORT`},
 		{`EXPORT INTO CSV 'a' FROM SELECT a ??`, `SELECT`},
 		{`CREATE SCHEDULE FOR BACKUP ??`, `CREATE SCHEDULE FOR BACKUP`},
+		{`ALTER BACKUP SCHEDULE ??`, `ALTER BACKUP SCHEDULE`},
 	}
 
 	// The following checks that the test definition above exercises all

--- a/pkg/sql/parser/testdata/alter_backup_schedule
+++ b/pkg/sql/parser/testdata/alter_backup_schedule
@@ -1,0 +1,47 @@
+parse
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily'
+----
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily'
+ALTER BACKUP SCHEDULE 123 SET RECURRING ('@daily') -- fully parenthesized
+ALTER BACKUP SCHEDULE 123 SET RECURRING '_' -- literals removed
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily' -- identifiers removed
+
+parse
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily', SET FULL BACKUP ALWAYS
+----
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily', SET FULL BACKUP ALWAYS
+ALTER BACKUP SCHEDULE 123 SET RECURRING ('@daily'), SET FULL BACKUP ALWAYS -- fully parenthesized
+ALTER BACKUP SCHEDULE 123 SET RECURRING '_', SET FULL BACKUP ALWAYS -- literals removed
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily', SET FULL BACKUP ALWAYS -- identifiers removed
+
+parse
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily', SET FULL BACKUP '@weekly'
+----
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily', SET FULL BACKUP '@weekly'
+ALTER BACKUP SCHEDULE 123 SET RECURRING ('@daily'), SET FULL BACKUP ('@weekly') -- fully parenthesized
+ALTER BACKUP SCHEDULE 123 SET RECURRING '_', SET FULL BACKUP '_' -- literals removed
+ALTER BACKUP SCHEDULE 123 SET RECURRING '@daily', SET FULL BACKUP '@weekly' -- identifiers removed
+
+parse
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history, SET RECURRING '@daily', SET FULL BACKUP '@weekly'
+----
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = true, SET RECURRING '@daily', SET FULL BACKUP '@weekly' -- normalized!
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = (true), SET RECURRING ('@daily'), SET FULL BACKUP ('@weekly') -- fully parenthesized
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = _, SET RECURRING '_', SET FULL BACKUP '_' -- literals removed
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = true, SET RECURRING '@daily', SET FULL BACKUP '@weekly' -- identifiers removed
+
+parse
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history, SET RECURRING '@daily', SET FULL BACKUP '@weekly', SET SCHEDULE OPTION foo = 'bar'
+----
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = true, SET RECURRING '@daily', SET FULL BACKUP '@weekly', SET SCHEDULE OPTION foo = 'bar' -- normalized!
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = (true), SET RECURRING ('@daily'), SET FULL BACKUP ('@weekly'), SET SCHEDULE OPTION foo = ('bar') -- fully parenthesized
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = _, SET RECURRING '_', SET FULL BACKUP '_', SET SCHEDULE OPTION foo = '_' -- literals removed
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = true, SET RECURRING '@daily', SET FULL BACKUP '@weekly', SET SCHEDULE OPTION _ = 'bar' -- identifiers removed
+
+parse
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history, SET RECURRING '@daily', SET FULL BACKUP '@weekly', SET SCHEDULE OPTION first_run = 'now'
+----
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = true, SET RECURRING '@daily', SET FULL BACKUP '@weekly', SET SCHEDULE OPTION first_run = 'now' -- normalized!
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = (true), SET RECURRING ('@daily'), SET FULL BACKUP ('@weekly'), SET SCHEDULE OPTION first_run = ('now') -- fully parenthesized
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = _, SET RECURRING '_', SET FULL BACKUP '_', SET SCHEDULE OPTION first_run = '_' -- literals removed
+ALTER BACKUP SCHEDULE 123 SET WITH revision_history = true, SET RECURRING '@daily', SET FULL BACKUP '@weekly', SET SCHEDULE OPTION _ = 'now' -- identifiers removed

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -662,7 +662,7 @@ func (p *planner) makeStringEvalFn(typedE tree.TypedExpr) func() (bool, string, 
 }
 
 // TypeAsBool enforces (not hints) that the given expression typechecks as a
-// string and returns a function that can be called to get the string value
+// bool and returns a function that can be called to get the bool value
 // during (planNode).Start.
 func (p *planner) TypeAsBool(
 	ctx context.Context, e tree.Expr, op string,

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     name = "tree",
     srcs = [
         "alter_backup.go",
+        "alter_backup_schedule.go",
         "alter_changefeed.go",
         "alter_database.go",
         "alter_default_privileges.go",

--- a/pkg/sql/sem/tree/alter_backup_schedule.go
+++ b/pkg/sql/sem/tree/alter_backup_schedule.go
@@ -1,0 +1,152 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+import "strconv"
+
+// AlterBackupSchedule represents an ALTER BACKUP SCHEDULE statement.
+type AlterBackupSchedule struct {
+	ScheduleID uint64
+	Cmds       AlterBackupScheduleCmds
+}
+
+var _ Statement = &AlterBackupSchedule{}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterBackupSchedule) Format(ctx *FmtCtx) {
+	ctx.WriteString(`ALTER BACKUP SCHEDULE `)
+	if ctx.HasFlags(FmtHideConstants) || ctx.HasFlags(FmtAnonymize) {
+		ctx.WriteString("123")
+	} else {
+		ctx.WriteString(strconv.FormatUint(node.ScheduleID, 10))
+	}
+	ctx.WriteByte(' ')
+	ctx.FormatNode(&node.Cmds)
+}
+
+// AlterBackupScheduleCmds represents a list of changefeed alterations
+type AlterBackupScheduleCmds []AlterBackupScheduleCmd
+
+// Format implements the NodeFormatter interface.
+func (node *AlterBackupScheduleCmds) Format(ctx *FmtCtx) {
+	for i, n := range *node {
+		if i > 0 {
+			ctx.WriteString(", ")
+		}
+		ctx.FormatNode(n)
+	}
+}
+
+// AlterBackupScheduleCmd represents a changefeed modification operation.
+type AlterBackupScheduleCmd interface {
+	NodeFormatter
+	// Placeholder function to ensure that only desired types
+	// (AlterBackupSchedule*) conform to the AlterBackupScheduleCmd interface.
+	alterBackupScheduleCmd()
+}
+
+func (*AlterBackupScheduleSetLabel) alterBackupScheduleCmd()          {}
+func (*AlterBackupScheduleSetInto) alterBackupScheduleCmd()           {}
+func (*AlterBackupScheduleSetWith) alterBackupScheduleCmd()           {}
+func (*AlterBackupScheduleSetRecurring) alterBackupScheduleCmd()      {}
+func (*AlterBackupScheduleSetFullBackup) alterBackupScheduleCmd()     {}
+func (*AlterBackupScheduleSetScheduleOption) alterBackupScheduleCmd() {}
+
+var _ AlterBackupScheduleCmd = &AlterBackupScheduleSetLabel{}
+var _ AlterBackupScheduleCmd = &AlterBackupScheduleSetInto{}
+var _ AlterBackupScheduleCmd = &AlterBackupScheduleSetWith{}
+var _ AlterBackupScheduleCmd = &AlterBackupScheduleSetRecurring{}
+var _ AlterBackupScheduleCmd = &AlterBackupScheduleSetFullBackup{}
+var _ AlterBackupScheduleCmd = &AlterBackupScheduleSetScheduleOption{}
+
+// AlterBackupScheduleSetLabel represents an ADD <label> command
+type AlterBackupScheduleSetLabel struct {
+	Label Expr
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterBackupScheduleSetLabel) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET LABEL ")
+	ctx.FormatNode(node.Label)
+}
+
+// AlterBackupScheduleSetInto represents a SET <destinations> command
+type AlterBackupScheduleSetInto struct {
+	Into StringOrPlaceholderOptList
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterBackupScheduleSetInto) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET INTO ")
+	ctx.FormatNode(&node.Into)
+}
+
+// AlterBackupScheduleSetWith represents an SET <options> command
+type AlterBackupScheduleSetWith struct {
+	With *BackupOptions
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterBackupScheduleSetWith) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET WITH ")
+	ctx.FormatNode(node.With)
+}
+
+// AlterBackupScheduleSetRecurring represents an SET RECURRING <recurrence> command
+type AlterBackupScheduleSetRecurring struct {
+	Recurrence Expr
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterBackupScheduleSetRecurring) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET RECURRING ")
+	if node.Recurrence == nil {
+		ctx.WriteString("NEVER")
+	} else {
+		ctx.FormatNode(node.Recurrence)
+	}
+}
+
+// AlterBackupScheduleSetFullBackup represents an SET FULL BACKUP <recurrence> command
+type AlterBackupScheduleSetFullBackup struct {
+	FullBackup FullBackupClause
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterBackupScheduleSetFullBackup) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET FULL BACKUP ")
+	if node.FullBackup.AlwaysFull {
+		ctx.WriteString("ALWAYS")
+	} else {
+		ctx.FormatNode(node.FullBackup.Recurrence)
+	}
+}
+
+// AlterBackupScheduleSetScheduleOption represents an SET SCHEDULE OPTION <kv_options> command
+type AlterBackupScheduleSetScheduleOption struct {
+	Option KVOption
+}
+
+// Format implements the NodeFormatter interface.
+func (node *AlterBackupScheduleSetScheduleOption) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET SCHEDULE OPTION ")
+
+	// KVOption Key values never contain PII and should be distinguished
+	// for feature tracking purposes.
+	o := node.Option
+	ctx.WithFlags(ctx.flags&^FmtMarkRedactionNode, func() {
+		ctx.FormatNode(&o.Key)
+	})
+	if o.Value != nil {
+		ctx.WriteString(` = `)
+		ctx.FormatNode(o.Value)
+	}
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -171,6 +171,7 @@ type CCLOnlyStatement interface {
 }
 
 var _ CCLOnlyStatement = &AlterBackup{}
+var _ CCLOnlyStatement = &AlterBackupSchedule{}
 var _ CCLOnlyStatement = &Backup{}
 var _ CCLOnlyStatement = &ShowBackup{}
 var _ CCLOnlyStatement = &Restore{}
@@ -503,6 +504,19 @@ func (*ScheduledBackup) StatementTag() string { return "SCHEDULED BACKUP" }
 func (*ScheduledBackup) cclOnlyStatement() {}
 
 func (*ScheduledBackup) hiddenFromShowQueries() {}
+
+// StatementReturnType implements the Statement interface.
+func (*AlterBackupSchedule) StatementReturnType() StatementReturnType { return Rows }
+
+// StatementType implements the Statement interface.
+func (*AlterBackupSchedule) StatementType() StatementType { return TypeDML }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*AlterBackupSchedule) StatementTag() string { return "SCHEDULED BACKUP" }
+
+func (*AlterBackupSchedule) cclOnlyStatement() {}
+
+func (*AlterBackupSchedule) hiddenFromShowQueries() {}
 
 // StatementReturnType implements the Statement interface.
 func (*BeginTransaction) StatementReturnType() StatementReturnType { return Ack }
@@ -1923,6 +1937,8 @@ func (*AlterFunctionDepExtension) StatementTag() string { return "ALTER FUNCTION
 func (n *AlterChangefeed) String() string                     { return AsString(n) }
 func (n *AlterChangefeedCmds) String() string                 { return AsString(n) }
 func (n *AlterBackup) String() string                         { return AsString(n) }
+func (n *AlterBackupSchedule) String() string                 { return AsString(n) }
+func (n *AlterBackupScheduleCmds) String() string             { return AsString(n) }
 func (n *AlterIndex) String() string                          { return AsString(n) }
 func (n *AlterDatabaseOwner) String() string                  { return AsString(n) }
 func (n *AlterDatabaseAddRegion) String() string              { return AsString(n) }


### PR DESCRIPTION
Note that only SET RECURRING and SET FULL BACKUP are supported here. I'll add
the other commands shortly.

Release note (enterprise change): Add ALTER BACKUP SCHEDULE command to modify
existing backup schedules.

Partially addresses https://github.com/cockroachdb/cockroach/issues/84033