### PR TITLE
release-22.1: clusterversion: enable release-branch binaryversion check on release-22.1

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -628,9 +628,9 @@ var (
 )
 
 func init() {
-	const isReleaseBranch = false
+	const isReleaseBranch = true
 	if isReleaseBranch {
-		if binaryVersion != ByKey(V21_2) {
+		if binaryVersion != ByKey(V22_1) {
 			panic("unexpected cluster version greater than release's binary version")
 		}
 	}


### PR DESCRIPTION
Release note: none.

Release justification: bug fix.