### PR TITLE
release-21.2: sql: don't gossip table-stats-added infos when all nodes on v21.2

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1556,7 +1556,7 @@ StatsLoop:
 
 	// Use Gossip to refresh the caches on other nodes.
 	if g, ok := params.extendedEvalCtx.ExecCfg.Gossip.Optional(47925); ok {
-		return stats.GossipTableStatAdded(g, desc.GetID())
+		return stats.GossipTableStatAdded(params.ctx, g, params.extendedEvalCtx.Settings, desc.GetID())
 	}
 	return nil
 }

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -518,7 +518,7 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 
 	if g, ok := s.FlowCtx.Cfg.Gossip.Optional(47925); ok {
 		// Gossip refresh of the stat caches for this table.
-		return stats.GossipTableStatAdded(g, s.tableID)
+		return stats.GossipTableStatAdded(ctx, g, s.FlowCtx.Cfg.Settings, s.tableID)
 	}
 	return nil
 }

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stats",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/gossip",
         "//pkg/jobs/jobspb",
         "//pkg/keys",


### PR DESCRIPTION
See https://github.com/cockroachlabs/support/issues/1709.

If no one is listening to these infos, don't gossip them. Doing so is
unnecessary (no one is listening) and also prevents a one-time migration
on v21.2 from clearing all of these out.

Release note (bug fix): v21.2 nodes no longer gossip information about
table statistics once all nodes in the cluster are upgraded to v21.2.

Release justification: low risk change for customer.