### PR TITLE
opt: skip cycle tests when the race detector is enabled

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/cycle
+++ b/pkg/sql/opt/norm/testdata/rules/cycle
@@ -1,6 +1,6 @@
 # This test ensures that a rule cycle does not cause a stack overflow. In test
 # builds, a deep constructor call stack is detected and the Factory panics.
-exprnorm
+exprnorm skip-race
 (NormCycleTestRel (True))
 ----
 error: optimizer factory constructor call stack exceeded max depth of 10000

--- a/pkg/sql/opt/xform/testdata/rules/cycle
+++ b/pkg/sql/opt/xform/testdata/rules/cycle
@@ -25,7 +25,7 @@ CREATE TABLE xy (
 # This test ensures that a memo cycle does not cause a stack overflow. Instead,
 # the cycle is detected and the optimizer throws an internal error. The cycle is
 # created by the test-only exploration rule MemoCycleTestRelRule.
-expropt disable=MemoCycleTestRelRuleFilter
+expropt disable=MemoCycleTestRelRuleFilter skip-race
 (MemoCycleTestRel
     (Scan [ (Table "ab") (Cols "a,b") ])
     [ (Eq (Var "b") (Const 1 "int")) ]
@@ -44,7 +44,7 @@ memo (not optimized, ~3KB, required=[], cycle=[G1->G1])
  ├── G5: (variable b)
  └── G6: (const 1)
 
-expropt disable=MemoCycleTestRelRuleFilter
+expropt disable=MemoCycleTestRelRuleFilter skip-race
 (LeftJoin
     (Scan [ (Table "ab") (Cols "a,b") ])
     (LeftJoin
@@ -82,7 +82,7 @@ memo (not optimized, ~15KB, required=[], cycle=[G1->G3->G5->G5])
  └── G11: (const 1)
 
 # Ensure that a cycle through a filter can be detected.
-expropt disable=MemoCycleTestRelRule
+expropt disable=MemoCycleTestRelRule skip-race
 (MemoCycleTestRel
     (Scan [ (Table "uv") (Cols "u,v") ])
     [ (Eq (Var "v") (Const 1 "int")) ]


### PR DESCRIPTION
Optimizer tests that create normalization and memo cycles are now
skipped if the race detector is enabled. These tests are sporadically
failing in CI with the error:

    runtime: goroutine stack exceeds 1000000000-byte limit

We suspect this is due to memory overhead of the race detector. From
https://go.dev/doc/articles/race_detector:

    The race detector currently allocates an extra 8 bytes per defer and
    recover statement. Those extra allocations are not recovered until
    the goroutine exits. This means that if you have a long-running
    goroutine that is periodically issuing defer and recover calls, the
    program memory usage may grow without bound.

There is no need to run these tests with the race detector. Their
purpose is to prove that our cycle detection works as intended and they
trigger normalization and exploration rules that cannot be triggered
outside of these tests. It is sufficient to run them only in non-race
builds.

Release note: None