### PR TITLE
dev: improve `dev {test,bench,testlogic} --timeout`

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=50
+DEV_VERSION=51
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -82,7 +82,15 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
 	if timeout > 0 {
-		args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
+		// The bazel timeout should be higher than the timeout passed to the
+		// test binary (giving it ample time to clean up, 5 seconds is probably
+		// enough).
+		args = append(args, fmt.Sprintf("--test_timeout=%d", 5+int(timeout.Seconds())))
+		args = append(args, "--test_arg", fmt.Sprintf("-test.timeout=%s", timeout.String()))
+
+		// If --test-args '-test.timeout=X' is specified as well, or
+		// -- --test_args '-test.timeout=X', that'll take precedence further
+		// below.
 	}
 
 	var testTargets []string

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -281,9 +281,17 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, "--test_arg", "-show-diff")
 	}
 	if timeout > 0 && !stress {
-		args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
+		// If stress is specified, we'll pad the timeout differently below.
 
-		// If stress is specified, we'll pad the timeout below.
+		// The bazel timeout should be higher than the timeout passed to the
+		// test binary (giving it ample time to clean up, 5 seconds is probably
+		// enough).
+		args = append(args, fmt.Sprintf("--test_timeout=%d", 5+int(timeout.Seconds())))
+		args = append(args, "--test_arg", fmt.Sprintf("-test.timeout=%s", timeout.String()))
+
+		// If --test-args '-test.timeout=X' is specified as well, or
+		// -- --test_arg '-test.timeout=X', that'll take precedence further
+		// below.
 	}
 
 	if stress {

--- a/pkg/cmd/dev/testdata/datadriven/bench
+++ b/pkg/cmd/dev/testdata/datadriven/bench
@@ -21,7 +21,7 @@ bazel test pkg/bench:all --test_arg -test.run=- --test_arg -test.bench=Benchmark
 exec
 dev bench pkg/spanconfig/spanconfigkvsubscriber -f=BenchmarkSpanConfigDecoder --cpus=10 --ignore-cache -v --timeout=50s
 ----
-bazel test --local_cpu_resources=10 --test_timeout=50 pkg/spanconfig/spanconfigkvsubscriber:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkSpanConfigDecoder --test_sharding_strategy=disabled --test_arg -test.v --test_output all
+bazel test --local_cpu_resources=10 --test_timeout=55 --test_arg -test.timeout=50s pkg/spanconfig/spanconfigkvsubscriber:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkSpanConfigDecoder --test_sharding_strategy=disabled --test_arg -test.v --test_output all
 
 exec
 dev bench pkg/bench -f='BenchmarkTracing/1node/scan/trace=off' --test-args '-test.memprofile=mem.out -test.cpuprofile=cpu.out'

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -31,7 +31,7 @@ bazel test --local_cpu_resources=12 pkg/util/tracing:all --test_env=GOTRACEBACK=
 exec
 dev test //pkg/testutils --timeout=10s
 ----
-bazel test pkg/testutils:all --test_env=GOTRACEBACK=all --test_timeout=10 --test_output errors
+bazel test pkg/testutils:all --test_env=GOTRACEBACK=all --test_timeout=15 --test_arg -test.timeout=10s --test_output errors
 
 exec
 dev test pkg/util/tracing -- -s
@@ -133,3 +133,25 @@ dev test pkg/sql/... --rewrite
 ----
 bazel info workspace --color=no
 bazel test pkg/sql/... --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql --test_sharding_strategy=disabled --test_output errors
+
+exec
+dev test pkg/spanconfig/spanconfigstore --test-args '-test.timeout=0.5s'
+----
+bazel info workspace --color=no
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.timeout=0.5s --test_output errors
+
+exec
+dev test pkg/spanconfig/spanconfigstore --timeout 30s --test-args '-test.timeout=0.5s'
+----
+bazel info workspace --color=no
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_timeout=35 --test_arg -test.timeout=30s --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.timeout=0.5s --test_output errors
+
+exec
+dev test pkg/spanconfig/spanconfigstore -- --test_arg '-test.timeout=0.5s'
+----
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_output errors --test_arg -test.timeout=0.5s
+
+exec
+dev test pkg/spanconfig/spanconfigstore --timeout=40s -- --test_arg '-test.timeout=0.5s'
+----
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_timeout=45 --test_arg -test.timeout=40s --test_output errors --test_arg -test.timeout=0.5s

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -220,9 +220,17 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, "--test_arg", "-show-diff")
 	}
 	if timeout > 0 && !stress {
-		args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
+		// If stress is specified, we'll pad the timeout differently below.
 
-		// If stress is specified, we'll pad the timeout below.
+		// The bazel timeout should be higher than the timeout passed to the
+		// test binary (giving it ample time to clean up, 5 seconds is probably
+		// enough).
+		args = append(args, fmt.Sprintf("--test_timeout=%d", 5+int(timeout.Seconds())))
+		args = append(args, "--test_arg", fmt.Sprintf("-test.timeout=%s", timeout.String()))
+
+		// If --test-args '-test.timeout=X' is specified as well, or
+		// -- --test_arg '-test.timeout=X', that'll take precedence further
+		// below.
 	}
 
 	if stress {


### PR DESCRIPTION
Pass the timeout directly to the underlying test binary in order to have
it spit out stack traces if running into such timeouts.

Release note: None