### PR TITLE
sql: fix an error in an edge case of reverse scans with limits

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/hash_join_dist
+++ b/pkg/sql/logictest/testdata/logic_test/hash_join_dist
@@ -71,3 +71,20 @@ query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.exec.query.is-distributed' AND usage_count > 0
 ----
 sql.exec.query.is-distributed
+
+# Regression test for an error of seeking to /Min key for a Get request issued
+# for the reverse scan (#83618). Placement of the ranges here doesn't matter.
+statement ok
+CREATE TABLE a (id TEXT PRIMARY KEY);
+CREATE TABLE b (
+  id TEXT PRIMARY KEY,
+  a_id TEXT,
+  status INT,
+  INDEX b_a_id (a_id ASC),
+  INDEX b_status_idx (status ASC)
+);
+SELECT a.id FROM a
+LEFT JOIN b AS b2 ON (a.id = b2.a_id AND b2.status = 2)
+WHERE (a.id IN ('3f90e30a-c87a-4017-b9a0-8f964b91c4af', '3adaf3da-0368-461a-8437-ee448724b78d', 'd0c13b06-5368-4522-8126-105b0a9513cd'))
+ORDER BY id DESC
+LIMIT 2;

--- a/pkg/sql/physicalplan/span_resolver.go
+++ b/pkg/sql/physicalplan/span_resolver.go
@@ -211,6 +211,13 @@ func (it *spanResolverIterator) Seek(
 		seekKey = it.curSpan.Key
 	} else {
 		seekKey = it.curSpan.EndKey
+		if len(seekKey) == 0 {
+			// It is possible that the span doesn't have the EndKey set (when we
+			// want to use the Get request), so we need to use the start Key
+			// even if we're scanning in the reverse direction - having
+			// ReverseScans and Gets is allowed in a single BatchRequest.
+			seekKey = it.curSpan.Key
+		}
 	}
 
 	// Check if the start of the span falls within the descriptor on which we're


### PR DESCRIPTION
This commit fixes an edge case where we could run into an error of
seeking the range iterator to the `/Min` key. This would occur if
- we are performing a reverse scan (so that the scan direction is
descending)
- the BatchRequest contains a Get request (which doesn't have the
EndKey set)
- the query has a limit (so that we plan a single TableReader).

This is now fixed. The bug has been present since forever but was
exposed in 21.2.0 when we started using Get requests.

Fixes: #83618.

Release note (bug fix): Previously, CockroachDB could run into an error
when the query included a limited reverse scan and some rows needed to
be retrieved by Get requests. The bug was introduced in 21.2.0.