### PR TITLE
bazel: exclude editor temporary files from `logictest` `testdata`

### DIFF
--- a/pkg/ccl/logictestccl/BUILD.bazel
+++ b/pkg/ccl/logictestccl/BUILD.bazel
@@ -3,7 +3,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 filegroup(
     name = "testdata",
-    srcs = glob(["testdata/**"]),
+    srcs = glob(
+        ["testdata/**"],
+        exclude = [
+            "**/*~",
+            "**/#*#",
+            "**/.*.swp",
+            "**/.#*",
+        ],
+    ),
     visibility = [
         "//pkg/ccl/logictestccl:__subpackages__",
         "//pkg/cmd/generate-logictest:__pkg__",

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -3,7 +3,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 filegroup(
     name = "testdata",
-    srcs = glob(["testdata/**"]),
+    srcs = glob(
+        ["testdata/**"],
+        exclude = [
+            "**/*~",
+            "**/#*#",
+            "**/.*.swp",
+            "**/.#*",
+        ],
+    ),
     visibility = [
         "//pkg/ccl/logictestccl:__subpackages__",
         "//pkg/cmd/generate-logictest:__pkg__",

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -81,7 +81,15 @@ go_test(
 
 filegroup(
     name = "testdata",
-    srcs = glob(["testdata/**"]),
+    srcs = glob(
+        ["testdata/**"],
+        exclude = [
+            "**/*~",
+            "**/#*#",
+            "**/.*.swp",
+            "**/.#*",
+        ],
+    ),
     visibility = [
         "//pkg/ccl/logictestccl:__subpackages__",
         "//pkg/cmd/generate-logictest:__pkg__",


### PR DESCRIPTION
This addresses a problem where `generate-logictest` can fail if there
are temporary/ignored files in `testdata`.

`.bazelignore` is not as feature-rich as `.gitignore` and doesn't
support stuff like wildcards. We include an `exclude` clause that
excludes common temporary editor files. This `glob` can be updated
in-place by developers if they need to exclude their own files as well.

Closes #85527.

Release note: None