### PR TITLE
sql: short-circuit declarative schema changer logic if there is nothi…

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3247,6 +3247,9 @@ func (ex *connExecutor) notifyStatsRefresherOfNewTables(ctx context.Context) {
 // mutate descriptors prior to committing a SQL transaction.
 func (ex *connExecutor) runPreCommitStages(ctx context.Context) error {
 	scs := &ex.extraTxnState.schemaChangerState
+	if len(scs.state.Targets) == 0 {
+		return nil
+	}
 	deps := newSchemaChangerTxnRunDependencies(
 		ex.planner.SessionData(),
 		ex.planner.User(),

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     srcs = [
         "autocommit_extended_protocol_test.go",
         "bank_test.go",
+        "empty_query_test.go",
         "enum_test.go",
         "hash_sharded_test.go",
         "impure_builtin_test.go",
@@ -109,6 +110,7 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_btree//:btree",
+        "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//assert",

--- a/pkg/sql/tests/empty_query_test.go
+++ b/pkg/sql/tests/empty_query_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmptyQuery is a regression test to ensure that sending an empty
+// query to the database as the first query is safe.
+func TestEmptyQuery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false, UseDatabase: "defaultdb"})
+	defer s.Stopper().Stop(context.Background())
+
+	pgURL, cleanupFunc := sqlutils.PGUrl(
+		t, s.ServingSQLAddr(), "testConnClose" /* prefix */, url.User(username.RootUser),
+	)
+	defer cleanupFunc()
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, pgURL.String())
+	require.NoError(t, err)
+
+	err = conn.QueryRow(ctx, "").Scan()
+	require.Error(t, err)
+	require.Regexp(t, "no rows in result set", err)
+}


### PR DESCRIPTION
…ng to do

Not having this short-circuit logic can cause problems if the connExecutor is
in some surprising state. It'll only be in that surprising state if no
statements have been executed. Also, there's no reason to build all of these
dependencies if we're going to just return anyway. I think this should be a
bit of a performance improvement.

Fixes #85523
Fixes #85516
Fixes #85518

Release note: None