### PR TITLE
storage: deduplicate ingested keys in MVCC metamorphic tests

### DIFF
--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -1468,6 +1468,18 @@ var opGenerators = []opGenerator{
 			sort.Slice(keys, func(i, j int) bool {
 				return keys[i].Less(keys[j])
 			})
+			// An sstable intended for ingest cannot have the same key appear
+			// multiple times. Remove any duplicates.
+			n := len(keys)
+			for i := 1; i < n; {
+				if keys[i-1].Equal(keys[i]) {
+					copy(keys[i:], keys[i+1:])
+					n--
+				} else {
+					i++
+				}
+			}
+			keys = keys[:n]
 
 			return &ingestOp{
 				m:    m,


### PR DESCRIPTION
In the MVCC metamorphic tests, deduplicate the keys intended for ingestion.
It's illegal to add the same key twice to an sstable intended for ingestion,
because all keys in an ingested sstable adopt the same sequence number.

Release note: None

Fix #85515.