### PR TITLE
externalconn: add USAGE privilege for External Connection

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -359,6 +359,7 @@ grant_targets ::=
 	| table_pattern ',' table_pattern_list
 	| 'TABLE' table_pattern_list
 	| 'DATABASE' name_list
+	| 'EXTERNAL' 'CONNECTION' name_list
 
 role_spec_list ::=
 	( role_spec ) ( ( ',' role_spec ) )*

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -110,6 +110,7 @@ go_library(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/sqlutil",
         "//pkg/sql/stats",
+        "//pkg/sql/syntheticprivilege",
         "//pkg/sql/types",
         "//pkg/storage",
         "//pkg/upgrade/upgrades",

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupresolver"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -50,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -347,17 +350,36 @@ func checkPrivilegesForBackup(
 	if p.ExecCfg().ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound {
 		return nil
 	}
-	// Check that none of the destinations require an admin role.
+
+	// Check destination specific privileges.
 	for _, uri := range to {
 		conf, err := cloud.ExternalStorageConfFromURI(uri, p.User())
 		if err != nil {
 			return err
 		}
+
+		// Check if the destination requires the user to be an admin.
 		if !conf.AccessIsWithExplicitAuth() {
 			return pgerror.Newf(
 				pgcode.InsufficientPrivilege,
 				"only users with the admin role are allowed to BACKUP to the specified %s URI",
 				conf.Provider.String())
+		}
+
+		// If the backup is running to an External Connection, check that the user
+		// has adequate privileges.
+		if conf.Provider == cloudpb.ExternalStorageProvider_external {
+			if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.SystemExternalConnectionsTable) {
+				return pgerror.Newf(pgcode.FeatureNotSupported,
+					"version %v must be finalized to backup to an External Connection",
+					clusterversion.ByKey(clusterversion.SystemExternalConnectionsTable))
+			}
+			ecPrivilege := &syntheticprivilege.ExternalConnectionPrivilege{
+				ConnectionName: conf.ExternalConnectionConfig.Name,
+			}
+			if err := p.CheckPrivilege(ctx, ecPrivilege, privilege.USAGE); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections
@@ -214,3 +214,78 @@ schema schema full
 schema schema incremental
 
 subtest end
+
+subtest backup-restore-privileges
+
+exec-sql
+CREATE USER testuser;
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION root AS 'nodelocal://1/root'
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION fails AS 'nodelocal://1/noprivs'
+----
+pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
+
+exec-sql
+GRANT SYSTEM EXTERNALCONNECTION TO testuser;
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION fails AS 'nodelocal://1/privs'
+----
+
+exec-sql
+CREATE TABLE foo (id INT);
+----
+
+exec-sql
+GRANT SELECT ON TABLE foo TO testuser
+----
+
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://fails'
+----
+pq: user testuser does not have USAGE privilege on external_connection fails
+
+exec-sql
+GRANT USAGE ON EXTERNAL CONNECTION fails TO testuser;
+----
+
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://fails'
+----
+
+# Sanity check that the user can't write to any other external connection.
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://root'
+----
+pq: user testuser does not have USAGE privilege on external_connection root
+
+# Revoke the USAGE privilege to test that restore also requires it.
+exec-sql
+REVOKE USAGE ON EXTERNAL CONNECTION fails FROM testuser;
+----
+
+exec-sql user=testuser
+RESTORE TABLE foo FROM LATEST IN 'external://fails'
+----
+pq: user testuser does not have USAGE privilege on external_connection fails
+
+exec-sql
+GRANT USAGE ON EXTERNAL CONNECTION fails TO testuser;
+----
+
+exec-sql
+CREATE DATABASE failsdb;
+GRANT CREATE ON DATABASE failsdb TO testuser;
+----
+
+exec-sql user=testuser
+RESTORE TABLE foo FROM LATEST IN 'external://fails' WITH into_db=failsdb;
+----
+
+subtest end

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -757,6 +757,13 @@ func TestTenantLogic_expression_index(
 	runLogicTest(t, "expression_index")
 }
 
+func TestTenantLogic_external_connection_privileges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "external_connection_privileges")
+}
+
 func TestTenantLogic_family(
 	t *testing.T,
 ) {

--- a/pkg/cloud/cloudpb/external_storage.go
+++ b/pkg/cloud/cloudpb/external_storage.go
@@ -51,6 +51,10 @@ func (m *ExternalStorage) AccessIsWithExplicitAuth() bool {
 	case ExternalStorageProvider_nodelocal:
 		// The node's local filesystem is obviously accessed implicitly as the node.
 		return false
+	case ExternalStorageProvider_external:
+		// External Connections have a `USAGE` privilege that determines if a user
+		// has the appropriate privileges to use the underlying resource.
+		return true
 	default:
 		return false
 	}

--- a/pkg/cloud/externalconn/connection_kms.go
+++ b/pkg/cloud/externalconn/connection_kms.go
@@ -40,8 +40,7 @@ func makeExternalConnectionKMS(
 	var ec ExternalConnection
 	if err := env.DBHandle().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		var err error
-		ec, err = LoadExternalConnection(ctx, externalConnectionName, connectionpb.TypeKMS,
-			env.InternalExecutor(), env.User(), txn)
+		ec, err = LoadExternalConnection(ctx, externalConnectionName, env.InternalExecutor(), txn)
 		return err
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to load external connection object")

--- a/pkg/cloud/externalconn/connection_storage.go
+++ b/pkg/cloud/externalconn/connection_storage.go
@@ -68,8 +68,7 @@ func makeExternalConnectionStorage(
 	var ec ExternalConnection
 	if err := args.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		var err error
-		ec, err = LoadExternalConnection(ctx, cfg.Name, connectionpb.TypeStorage, args.InternalExecutor,
-			username.MakeSQLUsernameFromPreNormalizedString(cfg.User), txn)
+		ec, err = LoadExternalConnection(ctx, cfg.Name, args.InternalExecutor, txn)
 		return err
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to load external connection object")

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -449,6 +449,9 @@ func (p *planner) getGrantOnObject(
 	case targets.System:
 		incIAMFunc(sqltelemetry.OnSystem)
 		return privilege.Global, nil
+	case targets.ExternalConnections != nil:
+		incIAMFunc(sqltelemetry.OnExternalConnection)
+		return privilege.ExternalConnection, nil
 	default:
 		composition, err := p.getTablePatternsComposition(ctx, targets)
 		if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/external_connection_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/external_connection_privileges
@@ -1,0 +1,70 @@
+# external_connection_privileges tests the basic interaction of granting and
+# revoking privileges to an external connection. For more detailed tests around
+# usage please refer to backup, restore, import and CDC tests that use external
+# connections.
+user root
+
+query TTTT
+SELECT * FROM system.privileges
+----
+
+# Attempt to grant on an external connection that does not exist.
+statement error pq: failed to resolve External Connection: external connection with name foo does not exist
+GRANT USAGE ON EXTERNAL CONNECTION foo TO testuser
+
+statement ok
+CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo'
+
+statement ok
+GRANT USAGE ON EXTERNAL CONNECTION foo TO testuser
+
+query TTTT
+SELECT * FROM system.privileges
+----
+testuser  /externalconn/foo  {USAGE}  {}
+
+statement ok
+REVOKE USAGE ON EXTERNAL CONNECTION foo FROM testuser
+
+query TTTT
+SELECT * FROM system.privileges
+----
+
+statement ok
+GRANT USAGE ON EXTERNAL CONNECTION foo TO testuser
+
+statement ok
+CREATE USER bar
+
+# Attempt to grant usage as testuser, this should fail since we did not specify WITH GRANT OPTION
+user testuser
+
+statement error pq: user testuser missing WITH GRANT OPTION privilege on USAGE
+GRANT USAGE ON EXTERNAL CONNECTION foo TO bar
+
+user root
+
+statement ok
+GRANT USAGE ON EXTERNAL CONNECTION foo TO testuser WITH GRANT OPTION
+
+# Attempt to grant usage as testuser, this should succeed since we did specify WITH GRANT OPTION
+user testuser
+
+statement ok
+GRANT USAGE ON EXTERNAL CONNECTION foo TO bar
+
+user root
+
+query TTTT
+SELECT * FROM system.privileges ORDER BY username
+----
+bar       /externalconn/foo  {USAGE}  {}
+testuser  /externalconn/foo  {USAGE}  {USAGE}
+
+# Invalid grants on external connections.
+
+statement error pq: invalid privilege type SELECT for external_connection
+GRANT SELECT ON EXTERNAL CONNECTION foo TO testuser
+
+statement error pq: invalid privilege type INSERT for external_connection
+GRANT INSERT ON EXTERNAL CONNECTION foo TO testuser

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -723,6 +723,13 @@ func TestLogic_expression_index(
 	runLogicTest(t, "expression_index")
 }
 
+func TestLogic_external_connection_privileges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "external_connection_privileges")
+}
+
 func TestLogic_family(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -723,6 +723,13 @@ func TestLogic_expression_index(
 	runLogicTest(t, "expression_index")
 }
 
+func TestLogic_external_connection_privileges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "external_connection_privileges")
+}
+
 func TestLogic_family(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -723,6 +723,13 @@ func TestLogic_expression_index(
 	runLogicTest(t, "expression_index")
 }
 
+func TestLogic_external_connection_privileges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "external_connection_privileges")
+}
+
 func TestLogic_family(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -730,6 +730,13 @@ func TestLogic_expression_index(
 	runLogicTest(t, "expression_index")
 }
 
+func TestLogic_external_connection_privileges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "external_connection_privileges")
+}
+
 func TestLogic_family(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -744,6 +744,13 @@ func TestLogic_expression_index(
 	runLogicTest(t, "expression_index")
 }
 
+func TestLogic_external_connection_privileges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "external_connection_privileges")
+}
+
 func TestLogic_family(
 	t *testing.T,
 ) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7462,6 +7462,10 @@ grant_targets:
   {
     $$.val = tree.GrantTargetList{Databases: $2.nameList()}
   }
+| EXTERNAL CONNECTION name_list
+  {
+    $$.val = tree.GrantTargetList{ExternalConnections: $3.nameList()}
+  }
 
 // backup_targets is similar to grant_targets but used by backup and restore, and thus
 // supports tenants, but does not support sequences, types, or other SQL nouns

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -88,17 +88,20 @@ const (
 	Global ObjectType = "global"
 	// VirtualTable represents a virtual table object.
 	VirtualTable ObjectType = "virtual_table"
+	// ExternalConnection represents an external connection object.
+	ExternalConnection ObjectType = "external_connection"
 )
 
 var isDescriptorBacked = map[ObjectType]bool{
-	Database:     true,
-	Schema:       true,
-	Table:        true,
-	Type:         true,
-	Sequence:     true,
-	Function:     true,
-	Global:       false,
-	VirtualTable: false,
+	Database:           true,
+	Schema:             true,
+	Table:              true,
+	Type:               true,
+	Sequence:           true,
+	Function:           true,
+	Global:             false,
+	VirtualTable:       false,
+	ExternalConnection: false,
 }
 
 // Predefined sets of privileges.
@@ -115,9 +118,10 @@ var (
 	// before v22.2 we treated Sequences the same as Tables. This is to avoid making
 	// certain privileges unavailable after upgrade migration.
 	// Note that "CREATE, INSERT, DELETE, ZONECONFIG" are no-op privileges on sequences.
-	SequencePrivileges     = List{ALL, USAGE, SELECT, UPDATE, CREATE, DROP, INSERT, DELETE, ZONECONFIG}
-	SystemPrivileges       = List{ALL, MODIFYCLUSTERSETTING, EXTERNALCONNECTION, VIEWACTIVITY, VIEWACTIVITYREDACTED, VIEWCLUSTERSETTING, CANCELQUERY, NOSQLLOGIN}
-	VirtualTablePrivileges = List{ALL, SELECT}
+	SequencePrivileges           = List{ALL, USAGE, SELECT, UPDATE, CREATE, DROP, INSERT, DELETE, ZONECONFIG}
+	SystemPrivileges             = List{ALL, MODIFYCLUSTERSETTING, EXTERNALCONNECTION, VIEWACTIVITY, VIEWACTIVITYREDACTED, VIEWCLUSTERSETTING, CANCELQUERY, NOSQLLOGIN}
+	VirtualTablePrivileges       = List{ALL, SELECT}
+	ExternalConnectionPrivileges = List{ALL, USAGE}
 )
 
 // Mask returns the bitmask for a given privilege.
@@ -323,6 +327,8 @@ func GetValidPrivilegesForObject(objectType ObjectType) List {
 		return SystemPrivileges
 	case VirtualTable:
 		return VirtualTablePrivileges
+	case ExternalConnection:
+		return ExternalConnectionPrivileges
 	default:
 		panic(errors.AssertionFailedf("unknown object type %s", objectType))
 	}

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -42,6 +42,8 @@ type GrantTargetList struct {
 	AllTablesInSchema bool
 	// If the target is system.
 	System bool
+	// If the target is External Connection.
+	ExternalConnections NameList
 
 	// ForRoles and Roles are used internally in the parser and not used
 	// in the AST. Therefore they do not participate in pretty-printing,
@@ -72,6 +74,9 @@ func (tl *GrantTargetList) Format(ctx *FmtCtx) {
 			}
 			ctx.FormatNode(typ)
 		}
+	} else if tl.ExternalConnections != nil {
+		ctx.WriteString("EXTERNAL CONNECTION ")
+		ctx.FormatNode(&tl.ExternalConnections)
 	} else {
 		if tl.Tables.SequenceOnly {
 			ctx.WriteString("SEQUENCE ")

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2181,6 +2181,9 @@ func (node *GrantTargetList) docRow(p *PrettyCfg) pretty.TableRow {
 	if node.Tables.SequenceOnly {
 		return p.row("SEQUENCE", p.Doc(&node.Tables.TablePatterns))
 	}
+	if node.ExternalConnections != nil {
+		return p.row("EXTERNAL CONNECTION", p.Doc(&node.ExternalConnections))
+	}
 	return p.row("TABLE", p.Doc(&node.Tables.TablePatterns))
 }
 

--- a/pkg/sql/sqltelemetry/iam.go
+++ b/pkg/sql/sqltelemetry/iam.go
@@ -44,6 +44,9 @@ const (
 	OnAllSequencesInSchema = "on_all_sequences_in_schemas"
 	// OnSystem is used when a GRANT/REVOKE is happening on system.
 	OnSystem = "on_system"
+	// OnExternalConnection is used when a GRANT/REVOKE is happening on an
+	// external connection object.
+	OnExternalConnection = "on_external_connection"
 
 	iamRoles = "iam.roles"
 )

--- a/pkg/sql/syntheticprivilege/BUILD.bazel
+++ b/pkg/sql/syntheticprivilege/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "syntheticprivilege",
     srcs = [
         "constants.go",
+        "external_connection_privilege.go",
         "global_privilege.go",
         "synthetic_privilege_registry.go",
         "vtable_privilege.go",

--- a/pkg/sql/syntheticprivilege/external_connection_privilege.go
+++ b/pkg/sql/syntheticprivilege/external_connection_privilege.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syntheticprivilege
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+)
+
+// ExternalConnectionPrivilege represents privileges on external connection
+// objects stored in `system.external_connections`.
+type ExternalConnectionPrivilege struct {
+	ConnectionName string `priv:"ConnectionName"`
+}
+
+var _ catalog.PrivilegeObject = &ExternalConnectionPrivilege{}
+
+// GetPath implements the Object interface.
+func (e *ExternalConnectionPrivilege) GetPath() string {
+	return fmt.Sprintf("/externalconn/%s", e.ConnectionName)
+}
+
+// GetPrivilegeDescriptor implements the PrivilegeObject interface.
+func (e *ExternalConnectionPrivilege) GetPrivilegeDescriptor(
+	ctx context.Context, planner eval.Planner,
+) (*catpb.PrivilegeDescriptor, error) {
+	if planner.IsActive(ctx, clusterversion.SystemPrivilegesTable) {
+		return planner.SynthesizePrivilegeDescriptor(ctx, e.GetName(), e.GetPath(),
+			e.GetObjectType())
+	}
+	return catpb.NewPrivilegeDescriptor(
+		username.PublicRoleName(), privilege.List{privilege.USAGE}, privilege.List{}, username.NodeUserName(),
+	), nil
+}
+
+// GetObjectType implements the PrivilegeObject interface.
+func (e *ExternalConnectionPrivilege) GetObjectType() privilege.ObjectType {
+	return privilege.ExternalConnection
+}
+
+// GetName implements the PrivilegeObject interface.
+func (e *ExternalConnectionPrivilege) GetName() string {
+	return e.ConnectionName
+}

--- a/pkg/sql/syntheticprivilege/synthetic_privilege_registry.go
+++ b/pkg/sql/syntheticprivilege/synthetic_privilege_registry.go
@@ -46,6 +46,11 @@ var registry = []*Metadata{
 		regex:  regexp.MustCompile(`(/vtable/((?P<SchemaName>.*))/((?P<TableName>.*)))$`),
 		val:    reflect.TypeOf((*VirtualTablePrivilege)(nil)),
 	},
+	{
+		prefix: "/externalconn",
+		regex:  regexp.MustCompile(`(/externalconn/((?P<ConnectionName>.*)))$`),
+		val:    reflect.TypeOf((*ExternalConnectionPrivilege)(nil)),
+	},
 }
 
 func findMetadata(val string) *Metadata {
@@ -100,6 +105,8 @@ func unmarshal(val reflect.Value, f reflect.StructField) (reflect.Value, error) 
 	case "TableName":
 		return val, nil
 	case "SchemaName":
+		return val, nil
+	case "ConnectionName":
 		return val, nil
 	default:
 		panic(errors.AssertionFailedf("unhandled type %v", f.Type))


### PR DESCRIPTION
This diff introduces the `USAGE` privilege that can be granted
to a role/user on a particular External Connection object. External
Connection privileges are non-descriptor backed synthetic privileges
that are uniquely identified by the object's name.

This change requires a user to have the `USAGE` privilege on External
Connection for backup and restore. In the future we will also add
this privilege check to export, import and cdc once we have support
for more sinks.

Informs: https://github.com/cockroachdb/cockroach/issues/85554

Release note (sql change): Users can now
`GRANT USAGE ON EXTERNAL CONNECTION` and
`REVOKE USAGE ON EXTERNAL CONNECTION` to grant and revoke the
`USAGE` privilege. This privilege is required by all operations that
interact with external connections.