### PR TITLE
dev: don't `stress` anything but `go_test`s

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=50
+DEV_VERSION=51
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -24,11 +24,6 @@ dev test pkg/util/tracing -f TestStartChild* --ignore-cache
 bazel test pkg/util/tracing:all --nocache_test_results --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output errors
 
 exec
-dev test --stress pkg/util/tracing --filter TestStartChild* --cpus=12 --timeout=25s
-----
-bazel test --local_cpu_resources=12 pkg/util/tracing:all --test_env=GOTRACEBACK=all --test_timeout=85 --test_env=COCKROACH_STRESS=true --run_under '@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts '"'"'XML_OUTPUT_FILE=dev merge-test-xmls'"'"' -maxtime=25s -p=12' '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output streamed
-
-exec
 dev test //pkg/testutils --timeout=10s
 ----
 bazel test pkg/testutils:all --test_env=GOTRACEBACK=all --test_timeout=10 --test_output errors


### PR DESCRIPTION
Other types of tests (e.g. `sh_test`s like `disallowed_imports_test`)
don't have the sharding logic that `dev` expects in this case. So when
`--stress` is passed, we filter out everything but `go_test`s.

Closes #85422.

Release note: None