### PR TITLE
kvserver: don't check ConnHealth when releasing proposal quota

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -164,11 +164,9 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		) {
 			return
 		}
-
-		// Only consider followers that that have "healthy" RPC connections.
-		if err := r.store.cfg.NodeDialer.ConnHealth(rep.NodeID, r.connectionClass.get()); err != nil {
-			return
-		}
+		// At this point, we know that either we communicated with this replica
+		// recently, or we became the leader recently. The latter case is ambiguous
+		// w.r.t. the actual state of that replica, but it is temporary.
 
 		// Note that the Match field has different semantics depending on
 		// the State.
@@ -219,7 +217,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		if progress.Match > 0 && progress.Match < minIndex {
 			minIndex = progress.Match
 		}
-		// If this is the most recently added replica and it has caught up, clear
+		// If this is the most recently added replica, and it has caught up, clear
 		// our state that was tracking it. This is unrelated to managing proposal
 		// quota, but this is a convenient place to do so.
 		if rep.ReplicaID == r.mu.lastReplicaAdded && progress.Match >= commitIndex {


### PR DESCRIPTION
The proposal quota release procedure checked node connection health for every
node that appears active after replica activity checks. This is expensive, and
previously caused issues like https://github.com/cockroachdb/cockroach/issues/84943.

This change removes the ConnHealth check, because other checks, such as
isFollowerActiveSince and paused replicas, provide sufficient protection from
various kinds of overloads.

Touches #84202

Release note: None