### PR TITLE
cast: remove unused function call

### DIFF
--- a/pkg/sql/sem/cast/cast.go
+++ b/pkg/sql/sem/cast/cast.go
@@ -194,7 +194,6 @@ func ValidCast(src, tgt *types.T, ctx Context) bool {
 func LookupCast(src, tgt *types.T) (Cast, bool) {
 	srcFamily := src.Family()
 	tgtFamily := tgt.Family()
-	srcFamily.Name()
 
 	// Unknown is the type given to an expression that statically evaluates
 	// to NULL. NULL can be immutably cast to any type in any context.


### PR DESCRIPTION
This was introduced in 7d0f75a306d191426cca6619e4cc54c164c20980, seems
like a leftover from debugging.

Release note: None