### PR TITLE
storage: remove key comparison in MVCC stats computations

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -176,13 +176,7 @@ func computeStatsDelta(
 	// If we can't use the fast stats path, or race test is enabled, compute stats
 	// across the key span to be cleared.
 	if !entireRange || util.RaceEnabled {
-		iter := readWriter.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
-			KeyTypes:   storage.IterKeyTypePointsAndRanges,
-			LowerBound: from,
-			UpperBound: to,
-		})
-		computed, err := iter.ComputeStats(from, to, delta.LastUpdateNanos)
-		iter.Close()
+		computed, err := storage.ComputeStats(readWriter, from, to, delta.LastUpdateNanos)
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -376,14 +376,7 @@ func computeStats(
 	if len(to) == 0 {
 		to = keys.MaxKey
 	}
-
-	iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
-		KeyTypes:   storage.IterKeyTypePointsAndRanges,
-		LowerBound: from,
-		UpperBound: to,
-	})
-	defer iter.Close()
-	ms, err := storage.ComputeStatsForRange(iter, from, to, nowNanos)
+	ms, err := storage.ComputeStats(reader, from, to, nowNanos)
 	require.NoError(t, err)
 	return ms
 }

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1205,14 +1205,7 @@ func mergeTrigger(
 
 	{
 		ridPrefix := keys.MakeRangeIDReplicatedPrefix(merge.RightDesc.RangeID)
-		// NB: Range-ID local keys have no versions and no intents.
-		iter := batch.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
-			KeyTypes:   storage.IterKeyTypePointsAndRanges,
-			LowerBound: ridPrefix,
-			UpperBound: ridPrefix.PrefixEnd(),
-		})
-		defer iter.Close()
-		sysMS, err := iter.ComputeStats(ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
+		sysMS, err := storage.ComputeStats(batch, ridPrefix, ridPrefix.PrefixEnd(), 0 /* nowNanos */)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
@@ -117,14 +117,8 @@ func TruncateLog(
 	// Note that any sideloaded payloads that may be removed by this truncation
 	// are not tracked in the raft log delta. The delta will be adjusted below
 	// raft.
-	iter := readWriter.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
-		KeyTypes:   storage.IterKeyTypePointsAndRanges,
-		LowerBound: start,
-		UpperBound: end,
-	})
-	defer iter.Close()
 	// We can pass zero as nowNanos because we're only interested in SysBytes.
-	ms, err := iter.ComputeStats(start, end, 0 /* nowNanos */)
+	ms, err := storage.ComputeStats(readWriter, start, end, 0 /* nowNanos */)
 	if err != nil {
 		return result.Result{}, errors.Wrap(err, "while computing stats of Raft log freed by truncation")
 	}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -453,12 +453,9 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		cpEng := storage.InMemFromFS(context.Background(), fs, cps[0], storage.CacheSize(1<<20))
 		defer cpEng.Close()
 
-		iter := cpEng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: []byte("\xff")})
-		defer iter.Close()
-
 		// The range is specified using only global keys, since the implementation
 		// may use an intentInterleavingIter.
-		ms, err := storage.ComputeStatsForRange(iter, keys.LocalMax, roachpb.KeyMax, 0 /* nowNanos */)
+		ms, err := storage.ComputeStats(cpEng, keys.LocalMax, roachpb.KeyMax, 0 /* nowNanos */)
 		assert.NoError(t, err)
 
 		assert.NotZero(t, ms.KeyBytes)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2198,13 +2198,7 @@ func ComputeRaftLogSize(
 ) (int64, error) {
 	prefix := keys.RaftLogPrefix(rangeID)
 	prefixEnd := prefix.PrefixEnd()
-	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
-		KeyTypes:   storage.IterKeyTypePointsAndRanges,
-		LowerBound: prefix,
-		UpperBound: prefixEnd,
-	})
-	defer iter.Close()
-	ms, err := iter.ComputeStats(prefix, prefixEnd, 0 /* nowNanos */)
+	ms, err := storage.ComputeStats(reader, prefix, prefixEnd, 0 /* nowNanos */)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/kv/kvserver/spanset/BUILD.bazel
+++ b/pkg/kv/kvserver/spanset/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/storage",
-        "//pkg/storage/enginepb",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -188,22 +187,6 @@ func (i *MVCCIterator) RangeBounds() roachpb.Span {
 // RangeKeys implements SimpleMVCCIterator.
 func (i *MVCCIterator) RangeKeys() storage.MVCCRangeKeyStack {
 	return i.i.RangeKeys()
-}
-
-// ComputeStats is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) ComputeStats(
-	start, end roachpb.Key, nowNanos int64,
-) (enginepb.MVCCStats, error) {
-	if i.spansOnly {
-		if err := i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
-			return enginepb.MVCCStats{}, err
-		}
-	} else {
-		if err := i.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}, i.ts); err != nil {
-			return enginepb.MVCCStats{}, err
-		}
-	}
-	return i.i.ComputeStats(start, end, nowNanos)
 }
 
 // FindSplitKey is part of the storage.MVCCIterator interface.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -252,23 +252,6 @@ type MVCCIterator interface {
 	// ValueProto unmarshals the value the iterator is currently
 	// pointing to using a protobuf decoder.
 	ValueProto(msg protoutil.Message) error
-	// ComputeStats scans the underlying engine from start to end keys and
-	// computes stats counters based on the values. This method is used after a
-	// range is split to recompute stats for each subrange. The nowNanos arg
-	// specifies the wall time in nanoseconds since the epoch and is used to
-	// compute the total age of intents and garbage.
-	//
-	// To properly account for intents and range keys, the iterator must be
-	// created with MVCCKeyAndIntentsIterKind and IterKeyTypePointsAndRanges,
-	// and the LowerBound and UpperBound must be set equal to start and end
-	// in order for range keys to be truncated to the bounds.
-	//
-	// TODO(erikgrinaker): This should be replaced by ComputeStatsForRange
-	// instead, which should set up its own iterator with appropriate options.
-	// This isn't currently done in order to do spanset assertions on it, but this
-	// could be better solved by checking the iterator bounds in NewMVCCIterator
-	// and requiring callers to set them appropriately.
-	ComputeStats(start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error)
 	// FindSplitKey finds a key from the given span such that the left side of
 	// the split is roughly targetSize bytes. The returned key will never be
 	// chosen from the key ranges listed in keys.NoSplitSpans and will always

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -1165,12 +1164,6 @@ func (i *intentInterleavingIter) UnsafeRawMVCCKey() []byte {
 func (i *intentInterleavingIter) ValueProto(msg protoutil.Message) error {
 	value := i.UnsafeValue()
 	return protoutil.Unmarshal(value, msg)
-}
-
-func (i *intentInterleavingIter) ComputeStats(
-	start, end roachpb.Key, nowNanos int64,
-) (enginepb.MVCCStats, error) {
-	return ComputeStatsForRange(i, start, end, nowNanos)
 }
 
 func (i *intentInterleavingIter) FindSplitKey(

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5250,41 +5250,65 @@ func willOverflow(a, b int64) bool {
 	return math.MinInt64-b > a
 }
 
-// ComputeStatsForRange scans the iterator from start to end keys and computes
-// stats counters based on the values. This method is used after a range is
-// split to recompute stats for each subrange. The nowNanos arg specifies the
-// wall time in nanoseconds since the epoch and is used to compute the total age
-// of all intents.
-//
-// To account for intents and range keys, the iterator must be created with
-// MVCCKeyAndIntentsIterKind and IterKeyTypePointsAndRanges. To correctly
-// account for range key truncation bounds, the iterator must have an
-// appropriate UpperBound and LowerBound.
-//
-// TODO(erikgrinaker): Consider removing the start,end parameters, forcing the
-// caller to set appropriate bounds on the iterator instead.
-func ComputeStatsForRange(
-	iter SimpleMVCCIterator, start, end roachpb.Key, nowNanos int64,
-) (enginepb.MVCCStats, error) {
-	return ComputeStatsForRangeWithVisitors(iter, start, end, nowNanos, nil, nil)
+// ComputeStats scans the given key span and computes MVCC stats. nowNanos
+// specifies the wall time in nanoseconds since the epoch and is used to compute
+// age-related stats quantities.
+func ComputeStats(r Reader, start, end roachpb.Key, nowNanos int64) (enginepb.MVCCStats, error) {
+	return ComputeStatsWithVisitors(r, start, end, nowNanos, nil, nil)
 }
 
-// ComputeStatsForRangeWithVisitors is like ComputeStatsForRange, but also
-// takes a point and/or range key callback that is invoked for each physical
-// key-value pair (i.e. not for implicit meta records), and iteration is aborted
-// on the first error returned from either of them.
-//
-// Callbacks must copy any data they intend to hold on to.
-func ComputeStatsForRangeWithVisitors(
-	iter SimpleMVCCIterator,
+// ComputeStatsWithVisitors is like ComputeStats, but also takes a point and/or
+// range key callback that is invoked for each key.
+func ComputeStatsWithVisitors(
+	r Reader,
 	start, end roachpb.Key,
 	nowNanos int64,
 	pointKeyVisitor func(MVCCKey, []byte) error,
 	rangeKeyVisitor func(MVCCRangeKeyValue) error,
 ) (enginepb.MVCCStats, error) {
+	iter := r.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		KeyTypes:   IterKeyTypePointsAndRanges,
+		LowerBound: start,
+		UpperBound: end,
+	})
+	defer iter.Close()
+	iter.SeekGE(MVCCKey{Key: start})
+	return computeStatsForIterWithVisitors(iter, nowNanos, pointKeyVisitor, rangeKeyVisitor)
+}
+
+// ComputeStatsForIter is like ComputeStats, but scans across the given iterator
+// until exhausted. The iterator must have appropriate bounds, key types, and
+// intent options set, and it must have been seeked to the appropriate starting
+// point.
+//
+// We don't take start/end here, because that would require expensive key
+// comparisons. We also don't seek to e.g. MinKey, because that might violate
+// spanset assertions.
+//
+// Most callers should use ComputeStats() instead. This exists primarily for use
+// with SST iterators.
+func ComputeStatsForIter(iter SimpleMVCCIterator, nowNanos int64) (enginepb.MVCCStats, error) {
+	return computeStatsForIterWithVisitors(iter, nowNanos, nil, nil)
+}
+
+// computeStatsForIterWithVisitors performs the actual stats computation for the
+// other ComputeStats methods.
+//
+// The iterator must already have been seeked. This requirement is to comply
+// with spanset assertions, such that ComputeStats can seek to the given start
+// key (satisfying the spanset asserter), while ComputeStatsForIter can seek to
+// MinKey (in effect the iterator's lower bound) as it's geared towards SST
+// iterators which are not subject to spanset assertions.
+//
+// Notably, we do not want to take the start/end key here, and instead rely on
+// the iterator's bounds, to avoid expensive key comparisons.
+func computeStatsForIterWithVisitors(
+	iter SimpleMVCCIterator,
+	nowNanos int64,
+	pointKeyVisitor func(MVCCKey, []byte) error,
+	rangeKeyVisitor func(MVCCRangeKeyValue) error,
+) (enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
-	// Only some callers are providing an MVCCIterator. The others don't have
-	// any intents.
 	var meta enginepb.MVCCMetadata
 	var prevKey, prevRangeStart []byte
 	first := false
@@ -5296,12 +5320,11 @@ func ComputeStatsForRangeWithVisitors(
 	// of the point in time at which the current key begins to age.
 	var accrueGCAgeNanos int64
 	var rangeKeys MVCCRangeKeyStack
-	mvccEndKey := MakeMVCCMetadataKey(end)
 
-	for iter.SeekGE(MakeMVCCMetadataKey(start)); ; iter.Next() {
+	for ; ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
 			return ms, err
-		} else if !ok || !iter.UnsafeKey().Less(mvccEndKey) {
+		} else if !ok {
 			break
 		}
 

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -516,7 +516,8 @@ func TestMVCCHistories(t *testing.T) {
 					// that we can compare the deltas.
 					var msEngineBefore enginepb.MVCCStats
 					if stats {
-						msEngineBefore = computeStats(e.t, e.engine, span.Key, span.EndKey, statsTS)
+						msEngineBefore, err = ComputeStats(e.engine, span.Key, span.EndKey, statsTS)
+						require.NoError(t, err)
 					}
 					msEvalBefore := *e.ms
 
@@ -533,7 +534,8 @@ func TestMVCCHistories(t *testing.T) {
 					if stats && cmd.typ == typDataUpdate {
 						// If stats are enabled, emit evaluated stats returned by the
 						// command, and compare them with the real computed stats diff.
-						msEngineDiff := computeStats(e.t, e.engine, span.Key, span.EndKey, statsTS)
+						msEngineDiff, err := ComputeStats(e.engine, span.Key, span.EndKey, statsTS)
+						require.NoError(t, err)
 						msEngineDiff.Subtract(msEngineBefore)
 
 						msEvalDiff := *e.ms
@@ -576,7 +578,8 @@ func TestMVCCHistories(t *testing.T) {
 
 				// Calculate and output final stats if requested and the data changed.
 				if stats && dataChange {
-					ms := computeStats(t, e.engine, span.Key, span.EndKey, statsTS)
+					ms, err := ComputeStats(e.engine, span.Key, span.EndKey, statsTS)
+					require.NoError(t, err)
 					buf.Printf("stats: %s\n", formatStats(ms, false))
 				}
 
@@ -1056,13 +1059,7 @@ func cmdDeleteRangeTombstone(e *evalCtx) error {
 		// Some tests will submit invalid MVCC range keys, where e.g. the end key is
 		// before the start key -- ignore them to avoid iterator panics.
 		if key.Compare(endKey) < 0 {
-			iter := e.engine.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
-				KeyTypes:   IterKeyTypePointsAndRanges,
-				LowerBound: key,
-				UpperBound: endKey,
-			})
-			ms, err := ComputeStatsForRange(iter, key, endKey, ts.WallTime)
-			iter.Close()
+			ms, err := ComputeStats(e.engine, key, endKey, ts.WallTime)
 			if err != nil {
 				return err
 			}

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1502,13 +1502,10 @@ func runIncrementalBenchmark(
 		// Pull all of the sstables into the cache.  This
 		// probably defeats a lot of the benefits of the
 		// time-based optimization.
-		iter := eng.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
-			KeyTypes:   IterKeyTypePointsAndRanges,
-			LowerBound: roachpb.LocalMax,
-			UpperBound: roachpb.KeyMax,
-		})
-		_, _ = iter.ComputeStats(keys.LocalMax, roachpb.KeyMax, 0)
-		iter.Close()
+		_, err := ComputeStats(eng, keys.LocalMax, roachpb.KeyMax, 0)
+		if err != nil {
+			b.Fatalf("stats failed: %s", err)
+		}
 	}
 	defer eng.Close()
 

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -872,7 +872,7 @@ func TestMVCCGetProtoInconsistent(t *testing.T) {
 }
 
 // Regression test for #28205: MVCCGet and MVCCScan, FindSplitKey, and
-// ComputeStats need to invalidate the cached iterator data.
+// ComputeStatsForIter need to invalidate the cached iterator data.
 func TestMVCCInvalidateIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -923,9 +923,10 @@ func TestMVCCInvalidateIterator(t *testing.T) {
 						_, err = MVCCScan(ctx, batch, key, roachpb.KeyMax, ts2, MVCCScanOptions{})
 					case "findSplitKey":
 						_, err = MVCCFindSplitKey(ctx, batch, roachpb.RKeyMin, roachpb.RKeyMax, 64<<20)
-					case "computeStats":
+					case "computeStatsForIter":
 						iter := batch.NewMVCCIterator(MVCCKeyAndIntentsIterKind, iterOptions)
-						_, err = iter.ComputeStats(keys.LocalMax, roachpb.KeyMax, 0)
+						iter.SeekGE(MVCCKey{Key: iterOptions.LowerBound})
+						_, err = ComputeStatsForIter(iter, 0)
 						iter.Close()
 					}
 					if err != nil {
@@ -2179,29 +2180,6 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	})
 }
 
-func computeStats(
-	t *testing.T, reader Reader, from, to roachpb.Key, nowNanos int64,
-) enginepb.MVCCStats {
-	t.Helper()
-
-	if len(from) == 0 {
-		from = keys.LocalMax
-	}
-	if len(to) == 0 {
-		to = keys.MaxKey
-	}
-
-	iter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
-		KeyTypes:   IterKeyTypePointsAndRanges,
-		LowerBound: from,
-		UpperBound: to,
-	})
-	defer iter.Close()
-	ms, err := ComputeStatsForRange(iter, from, to, nowNanos)
-	require.NoError(t, err)
-	return ms
-}
-
 // TestMVCCClearTimeRangeOnRandomData sets up mostly random KVs and then picks
 // some random times to which to revert, ensuring that a MVCC-Scan at each of
 // those times before reverting matches the result of an MVCC-Scan done at a
@@ -2268,7 +2246,9 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 	ms.AgeTo(2000)
 
 	// Sanity check starting stats.
-	require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
+	msComputed, err := ComputeStats(e, localMax, keyMax, 2000)
+	require.NoError(t, err)
+	require.Equal(t, msComputed, ms)
 
 	// Pick timestamps to which we'll revert, and sort them so we can go back
 	// though them in order. The largest will still be less than randTimeRange so
@@ -2304,7 +2284,9 @@ func TestMVCCClearTimeRangeOnRandomData(t *testing.T) {
 				batch.Close()
 			}
 
-			require.Equal(t, computeStats(t, e, localMax, keyMax, 2000), ms)
+			msComputed, err := ComputeStats(e, localMax, keyMax, 2000)
+			require.NoError(t, err)
+			require.Equal(t, msComputed, ms)
 			// Scanning at "now" post-revert should yield the same result as scanning
 			// at revert-time pre-revert.
 			resAfter, err := MVCCScan(ctx, e, localMax, keyMax, now, MVCCScanOptions{MaxKeys: numKVs})
@@ -4897,12 +4879,9 @@ func TestMVCCGarbageCollect(t *testing.T) {
 			}
 
 			// Verify aggregated stats match computed stats after GC.
-			iter := engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind,
-				IterOptions{UpperBound: roachpb.KeyMax, KeyTypes: IterKeyTypePointsAndRanges})
-			defer iter.Close()
 			for _, mvccStatsTest := range mvccStatsTests {
 				t.Run(mvccStatsTest.name, func(t *testing.T) {
-					expMS, err := mvccStatsTest.fn(iter, localMax, roachpb.KeyMax, gcTime.WallTime)
+					expMS, err := mvccStatsTest.fn(engine, localMax, roachpb.KeyMax, gcTime.WallTime)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -5761,12 +5740,7 @@ func TestMVCCGarbageCollectRanges(t *testing.T) {
 						"not all range tombstone expectations were consumed")
 
 					ms.AgeTo(tsMax.WallTime)
-					it = engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
-						KeyTypes:   IterKeyTypePointsAndRanges,
-						LowerBound: d.rangeStart,
-						UpperBound: d.rangeEnd,
-					})
-					expMs, err := ComputeStatsForRange(it, rangeStart, rangeEnd, tsMax.WallTime)
+					expMs, err := ComputeStats(engine, d.rangeStart, d.rangeEnd, tsMax.WallTime)
 					require.NoError(t, err, "failed to compute stats for range")
 					require.EqualValues(t, expMs, ms, "computed range stats vs gc'd")
 				})

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -697,13 +696,6 @@ func (p *pebbleIterator) EngineRangeKeys() []EngineRangeKeyValue {
 		rkvs = append(rkvs, EngineRangeKeyValue{Version: rk.Suffix, Value: rk.Value})
 	}
 	return rkvs
-}
-
-// ComputeStats implements the MVCCIterator interface.
-func (p *pebbleIterator) ComputeStats(
-	start, end roachpb.Key, nowNanos int64,
-) (enginepb.MVCCStats, error) {
-	return ComputeStatsForRange(p, start, end, nowNanos)
 }
 
 // Go-only version of IsValidSplitKey. Checks if the specified key is in

--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -634,13 +633,6 @@ func (i *pointSynthesizingIter) RangeBounds() roachpb.Span {
 // RangeKeys implements MVCCIterator.
 func (i *pointSynthesizingIter) RangeKeys() MVCCRangeKeyStack {
 	return MVCCRangeKeyStack{}
-}
-
-// ComputeStats implements MVCCIterator.
-func (i *pointSynthesizingIter) ComputeStats(
-	start, end roachpb.Key, nowNanos int64,
-) (enginepb.MVCCStats, error) {
-	return i.iter.ComputeStats(start, end, nowNanos)
 }
 
 // FindSplitKey implements MVCCIterator.


### PR DESCRIPTION
This patch restructures MVCC stats computations to use an MVCC iterator
with appropriate bounds. This allows omitting a key comparison in the
hot path, yielding a ~10% performance improvement. The new stats
functions are:

* `ComputeStats`: calculates stats for a `Reader` key span.

* `ComputeStatsWithVisitors`: calculates stats for a `Reader` key span,
  calling the given visitor callbacks for every point/range key.

* `ComputeStatsForIter`: calculates stats for a given `MVCCIterator`, by
  scanning it until exhausted.

It also removes the `MVCCIterator.ComputeStats` method, which had no
business being part of the interface.

```
name                                     old time/op   new time/op   delta
MVCCComputeStats_Pebble/valueSize=64-24    130ms ± 1%    119ms ± 1%  -8.77%  (p=0.000 n=10+10)

name                                     old speed     new speed     delta
MVCCComputeStats_Pebble/valueSize=64-24  516MB/s ± 1%  565MB/s ± 1%  +9.61%  (p=0.000 n=10+10)
```

Resolves #41899.
Touches #84544.

Release note: None