### PR TITLE
externalconn: refactor proto to reduce duplication

### DIFF
--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -6,7 +6,7 @@ CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo/bar';
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
+foo STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo/bar"}}
 
 # Reject invalid nodelocal URIs.
 exec-sql
@@ -32,8 +32,8 @@ CREATE EXTERNAL CONNECTION bar123 AS 'nodelocal://1/baz';
 
 inspect-system-table
 ----
-bar123 STORAGE {"nodelocal": {"uri": "nodelocal://1/baz"}}
-foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
+bar123 STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/baz"}}
+foo STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo/bar"}}
 
 # Drop an External Connection that does not exist.
 exec-sql
@@ -46,7 +46,7 @@ DROP EXTERNAL CONNECTION bar123;
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
+foo STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo/bar"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION foo;
@@ -78,7 +78,7 @@ CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
 
 inspect-system-table
 ----
-privileged STORAGE {"nodelocal": {"uri": "nodelocal://1/foo"}}
+privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION privileged;
@@ -114,7 +114,7 @@ pq: failed to construct External Connection details: unknown query parameters: I
 
 inspect-system-table
 ----
-foo-kms KMS {"gcsKms": {"uri": "gs:///cmk?AUTH=implicit&CREDENTIALS=baz&ASSUME_ROLE=ronaldo,rashford,bruno&BEARER_TOKEN=foo"}}
+foo-kms KMS {"provider": "gs_kms", "simpleUri": {"uri": "gs:///cmk?AUTH=implicit&CREDENTIALS=baz&ASSUME_ROLE=ronaldo,rashford,bruno&BEARER_TOKEN=foo"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION "foo-kms";

--- a/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
@@ -9,7 +9,7 @@ CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo/bar';
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
+foo STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo/bar"}}
 
 # Reject invalid nodelocal URIs.
 exec-sql
@@ -35,8 +35,8 @@ CREATE EXTERNAL CONNECTION bar123 AS 'nodelocal://1/baz';
 
 inspect-system-table
 ----
-bar123 STORAGE {"nodelocal": {"uri": "nodelocal://1/baz"}}
-foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
+bar123 STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/baz"}}
+foo STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo/bar"}}
 
 # Drop an External Connection that does not exist.
 exec-sql
@@ -49,7 +49,7 @@ DROP EXTERNAL CONNECTION bar123;
 
 inspect-system-table
 ----
-foo STORAGE {"nodelocal": {"uri": "nodelocal://1/foo/bar"}}
+foo STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo/bar"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION foo;
@@ -81,7 +81,7 @@ CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
 
 inspect-system-table
 ----
-privileged STORAGE {"nodelocal": {"uri": "nodelocal://1/foo"}}
+privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION privileged;
@@ -106,7 +106,7 @@ CREATE EXTERNAL CONNECTION "foo-kms" AS 'gs:///cmk?AUTH=implicit&CREDENTIALS=baz
 
 inspect-system-table
 ----
-foo-kms KMS {"gcsKms": {"uri": "gs:///cmk?AUTH=implicit&CREDENTIALS=baz&ASSUME_ROLE=ronaldo,rashford,bruno&BEARER_TOKEN=foo"}}
+foo-kms KMS {"provider": "gs_kms", "simpleUri": {"uri": "gs:///cmk?AUTH=implicit&CREDENTIALS=baz&ASSUME_ROLE=ronaldo,rashford,bruno&BEARER_TOKEN=foo"}}
 
 exec-sql
 DROP EXTERNAL CONNECTION "foo-kms";

--- a/pkg/cloud/externalconn/connection_kms.go
+++ b/pkg/cloud/externalconn/connection_kms.go
@@ -50,8 +50,8 @@ func makeExternalConnectionKMS(
 	// Construct a KMS handle for the underlying resource represented by the
 	// external connection object.
 	switch d := ec.ConnectionProto().Details.(type) {
-	case *connectionpb.ConnectionDetails_GCSKMS:
-		return cloud.KMSFromURI(ctx, d.GCSKMS.URI, env)
+	case *connectionpb.ConnectionDetails_SimpleURI:
+		return cloud.KMSFromURI(ctx, d.SimpleURI.URI, env)
 	default:
 		return nil, errors.Newf("cannot connect to %T; unsupported resource for a KMS connection", d)
 	}

--- a/pkg/cloud/externalconn/connection_storage.go
+++ b/pkg/cloud/externalconn/connection_storage.go
@@ -78,10 +78,10 @@ func makeExternalConnectionStorage(
 	// Construct an ExternalStorage handle for the underlying resource represented
 	// by the external connection object.
 	switch d := ec.ConnectionProto().Details.(type) {
-	case *connectionpb.ConnectionDetails_Nodelocal:
+	case *connectionpb.ConnectionDetails_SimpleURI:
 		// Append the subdirectory that was passed in with the `external` URI to the
 		// underlying `nodelocal` URI.
-		uri, err := url.Parse(d.Nodelocal.URI)
+		uri, err := url.Parse(d.SimpleURI.URI)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse `nodelocal` URI")
 		}

--- a/pkg/cloud/externalconn/connectionpb/connection.go
+++ b/pkg/cloud/externalconn/connectionpb/connection.go
@@ -14,12 +14,12 @@ import "github.com/cockroachdb/errors"
 
 // Type returns the ConnectionType of the receiver.
 func (d *ConnectionDetails) Type() ConnectionType {
-	switch t := d.Details.(type) {
-	case *ConnectionDetails_Nodelocal:
+	switch d.Provider {
+	case ConnectionProvider_TypeNodelocal:
 		return TypeStorage
-	case *ConnectionDetails_GCSKMS:
+	case ConnectionProvider_TypeGSKMS:
 		return TypeKMS
 	default:
-		panic(errors.AssertionFailedf("ConnectionDetails.Type called on a details with an unknown type: %T", t))
+		panic(errors.AssertionFailedf("ConnectionDetails.Type called on a details with an unknown type: %T", d.Provider.String()))
 	}
 }

--- a/pkg/cloud/externalconn/connectionpb/connection.proto
+++ b/pkg/cloud/externalconn/connectionpb/connection.proto
@@ -14,6 +14,16 @@ option go_package = "connectionpb";
 
 import "gogoproto/gogo.proto";
 
+enum ConnectionProvider {
+  Unknown = 0 [(gogoproto.enumvalue_customname) = "TypeUnspecified"];;
+
+  // External Storage providers.
+  nodelocal = 1 [(gogoproto.enumvalue_customname) = "TypeNodelocal"];;
+
+  // KMS providers.
+  gs_kms = 2 [(gogoproto.enumvalue_customname) = "TypeGSKMS"];;
+}
+
 // ConnectionType is the type of the External Connection object.
 enum ConnectionType {
   option (gogoproto.goproto_enum_prefix) = false;
@@ -23,23 +33,18 @@ enum ConnectionType {
   KMS = 2 [(gogoproto.enumvalue_customname) = "TypeKMS"];
 }
 
+// SimpleURI encapsulates the information that represents an External Connection
+// object that only relies on a URI to connect.
+message SimpleURI {
+  string uri = 1 [(gogoproto.customname) = "URI"];
+}
+
 // ConnectionsDetails is the byte representation of the resource represented by
 // an External Connection object.
 message ConnectionDetails {
+  ConnectionProvider provider = 1;
+
   oneof details {
-    NodelocalConnectionDetails nodelocal = 1;
-    GCSKMSConnectionDetails gcs_kms = 2 [(gogoproto.customname) = "GCSKMS"];
+    SimpleURI simple_uri = 2 [(gogoproto.customname) = "SimpleURI"];
   }
-}
-
-// NodelocalConnectionDetails encapsulates the information required by an
-// External Connection object to represent a nodelocal connection.
-message NodelocalConnectionDetails {
-  string uri = 1 [(gogoproto.customname) = "URI"];
-}
-
-// GCSKMSConnectionDetails encapsulates the information required by an External
-// Connection object to represent a GCS KMS connection.
-message GCSKMSConnectionDetails {
-  string uri = 1 [(gogoproto.customname) = "URI"];
 }

--- a/pkg/cloud/gcp/gcs_kms_connection.go
+++ b/pkg/cloud/gcp/gcs_kms_connection.go
@@ -26,8 +26,11 @@ func parseAndValidateGCSKMSConnectionURI(
 	}
 
 	connDetails := connectionpb.ConnectionDetails{
-		Details: &connectionpb.ConnectionDetails_GCSKMS{
-			GCSKMS: &connectionpb.GCSKMSConnectionDetails{URI: uri.String()},
+		Provider: connectionpb.ConnectionProvider_TypeGSKMS,
+		Details: &connectionpb.ConnectionDetails_SimpleURI{
+			SimpleURI: &connectionpb.SimpleURI{
+				URI: uri.String(),
+			},
 		},
 	}
 

--- a/pkg/cloud/nodelocal/nodelocal_connection.go
+++ b/pkg/cloud/nodelocal/nodelocal_connection.go
@@ -27,8 +27,9 @@ func parseAndValidateLocalFileConnectionURI(
 	}
 
 	connDetails := connectionpb.ConnectionDetails{
-		Details: &connectionpb.ConnectionDetails_Nodelocal{
-			Nodelocal: &connectionpb.NodelocalConnectionDetails{
+		Provider: connectionpb.ConnectionProvider_TypeNodelocal,
+		Details: &connectionpb.ConnectionDetails_SimpleURI{
+			SimpleURI: &connectionpb.SimpleURI{
 				URI: uri.String(),
 			},
 		},


### PR DESCRIPTION
Adding more provider support to External Connections surfaced
a pattern where most providers are only going to depend on
a URI to configure and connect. Having n details all just storing
a URI field is verbose and unnecessary. This change adds
a shared `SimpleURI` detail type that can be used by all such
providers. If a provider has more configuration than a simple URI
they can add their specific details to the `oneof`.

Release note: None