### PR TITLE
sql: remove old stats from deleted columns or indexes

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -257,6 +257,7 @@ sql.stats.flush.enabled	boolean	true	if set, SQL execution statistics are period
 sql.stats.flush.interval	duration	10m0s	the interval at which SQL execution statistics are flushed to disk, this value must be less than or equal to sql.stats.aggregation.interval
 sql.stats.histogram_collection.enabled	boolean	true	histogram collection mode
 sql.stats.multi_column_collection.enabled	boolean	true	multi-column statistics collection mode
+sql.stats.non_default_columns.min_retention_period	duration	24h0m0s	minimum retention period for table statistics collected on non-default columns
 sql.stats.persisted_rows.max	integer	1000000	maximum number of rows of statement and transaction statistics that will be persisted in the system tables
 sql.stats.post_events.enabled	boolean	false	if set, an event is logged for every CREATE STATISTICS job
 sql.stats.response.max	integer	20000	the maximum number of statements and transaction stats returned in a CombinedStatements request

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -188,6 +188,7 @@
 <tr><td><code>sql.stats.flush.interval</code></td><td>duration</td><td><code>10m0s</code></td><td>the interval at which SQL execution statistics are flushed to disk, this value must be less than or equal to sql.stats.aggregation.interval</td></tr>
 <tr><td><code>sql.stats.histogram_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>histogram collection mode</td></tr>
 <tr><td><code>sql.stats.multi_column_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>multi-column statistics collection mode</td></tr>
+<tr><td><code>sql.stats.non_default_columns.min_retention_period</code></td><td>duration</td><td><code>24h0m0s</code></td><td>minimum retention period for table statistics collected on non-default columns</td></tr>
 <tr><td><code>sql.stats.persisted_rows.max</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of rows of statement and transaction statistics that will be persisted in the system tables</td></tr>
 <tr><td><code>sql.stats.post_events.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if set, an event is logged for every CREATE STATISTICS job</td></tr>
 <tr><td><code>sql.stats.response.max</code></td><td>integer</td><td><code>20000</code></td><td>the maximum number of statements and transaction stats returned in a CombinedStatements request</td></tr>

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -963,6 +963,9 @@ message CreateStatsDetails {
 
   // Fully qualified table name.
   string fq_table_name = 6 [(gogoproto.customname) = "FQTableName"];
+
+  // If true, delete old stats for columns not included in this message.
+  bool delete_other_stats = 8;
 }
 
 message CreateStatsProgress {

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -234,6 +234,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		TableID:          desc.GetID(),
 		JobID:            jobID,
 		RowsExpected:     rowsExpected,
+		DeleteOtherStats: details.DeleteOtherStats,
 	}
 	// Plan the SampleAggregator on the gateway, unless we have a single Sampler.
 	node := dsp.gatewaySQLInstanceID

--- a/pkg/sql/execinfrapb/processors_table_stats.proto
+++ b/pkg/sql/execinfrapb/processors_table_stats.proto
@@ -170,4 +170,7 @@ message SampleAggregatorSpec {
   // CREATE STATISTICS. Used for progress reporting. If rows expected is 0,
   // reported progress is 0 until the very end.
   optional uint64 rows_expected = 7 [(gogoproto.nullable) = false];
+
+  // If true, delete old stats for columns not included in this message.
+  optional bool delete_other_stats = 10 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -616,6 +616,152 @@ s4               {c,b}
 s4               {c,d}
 s8               {a}
 
+# Test deletion of old non-default stats.
+
+statement ok
+SET CLUSTER SETTING sql.stats.non_default_columns.min_retention_period = '0s'
+
+statement ok
+CREATE STATISTICS s9 ON e FROM data;
+ALTER TABLE data DROP COLUMN e
+
+# Collecting stats on a specific column should not cause deletion of other stats.
+statement ok
+CREATE STATISTICS s10 ON a FROM data
+
+query TT colnames
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+s10              {a}
+s4               {c,b}
+s4               {c,d}
+
+# Stats for column e still exist. (We cannot use SHOW STATISTICS to see them
+# since stats from deleted columns are filtered out.)
+query T
+SELECT name
+FROM system.table_statistics
+  WHERE NOT EXISTS (
+    SELECT * FROM crdb_internal.table_columns
+    WHERE "tableID" = descriptor_id
+    AND "columnIDs" @> array[column_id]
+    AND descriptor_name = 'data'
+  )
+  AND EXISTS (
+    SELECT * FROM crdb_internal.table_columns
+    WHERE "tableID" = descriptor_id
+    AND descriptor_name = 'data'
+  )
+  ORDER BY name
+----
+__auto__
+__auto__
+__auto__
+__auto__
+s9
+
+# Collecting stats on default columns should cause deletion of other stats.
+statement ok
+ANALYZE data
+
+# Stats for column e no longer exist.
+query T
+SELECT name
+FROM system.table_statistics
+  WHERE NOT EXISTS (
+    SELECT * FROM crdb_internal.table_columns
+    WHERE "tableID" = descriptor_id
+    AND "columnIDs" @> array[column_id]
+    AND descriptor_name = 'data'
+  )
+  AND EXISTS (
+    SELECT * FROM crdb_internal.table_columns
+    WHERE "tableID" = descriptor_id
+    AND descriptor_name = 'data'
+  )
+----
+
+# Stats on {c,b} and {c,d} are also deleted.
+query TT colnames
+SELECT statistics_name, column_names
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY statistics_name, column_names::STRING
+----
+statistics_name  column_names
+NULL             {a,b,c,d}
+NULL             {a,b,c}
+NULL             {a,b}
+NULL             {a}
+NULL             {b}
+NULL             {c}
+NULL             {d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c,d}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b,c}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a,b}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {a}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {b}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {c}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+__auto__         {d}
+
+statement ok
+RESET CLUSTER SETTING sql.stats.non_default_columns.min_retention_period
+
 # Regression test for #33195.
 statement ok
 CREATE TABLE t (x int); INSERT INTO t VALUES (1); ALTER TABLE t DROP COLUMN x

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -511,13 +511,13 @@ func TestAverageRefreshTime(t *testing.T) {
 
 	// The most recent stat is over 4 hours old, which is more than 2x the
 	// average time between refreshes, so this call must refresh the statistics
-	// on table t even though rowsAffected=0. After refresh, only 15 stats should
-	// remain (5 from column k and 10 from column v), since the old stats on k
-	// were deleted.
+	// on table t even though rowsAffected=0. After refresh, only 10 stats should
+	// remain (5 from column k and 5 from column v), since the old stats on k
+	// and v were deleted.
 	refresher.maybeRefreshStats(
 		ctx, table.GetID(), nil /* explicitSettings */, 0 /* rowsAffected */, time.Microsecond, /* asOf */
 	)
-	if err := checkStatsCount(ctx, cache, table, 15 /* expected */); err != nil {
+	if err := checkStatsCount(ctx, cache, table, 10 /* expected */); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/stats/delete_stats.go
+++ b/pkg/sql/stats/delete_stats.go
@@ -11,10 +11,14 @@
 package stats
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -28,7 +32,20 @@ const (
 	// time between refreshes. See comments in automatic_stats.go for more
 	// details.
 	keepCount = 4
+
+	// defaultKeepTime is the default time to keep around old stats for columns that are
+	// not collected by default.
+	defaultKeepTime = 24 * time.Hour
 )
+
+// TableStatisticsRetentionPeriod controls the cluster setting for the
+// retention period of statistics that are not collected by default.
+var TableStatisticsRetentionPeriod = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.stats.non_default_columns.min_retention_period",
+	"minimum retention period for table statistics collected on non-default columns",
+	defaultKeepTime,
+).WithPublic()
 
 // DeleteOldStatsForColumns deletes old statistics from the
 // system.table_statistics table. For the given tableID and columnIDs,
@@ -68,6 +85,48 @@ func DeleteOldStatsForColumns(
 		jobspb.AutoStatsName,
 		columnIDsVal,
 		keepCount,
+	)
+	return err
+}
+
+// DeleteOldStatsForOtherColumns deletes statistics from the
+// system.table_statistics table for columns *not* in the given set of column
+// IDs that are older than keepTime.
+func DeleteOldStatsForOtherColumns(
+	ctx context.Context,
+	executor sqlutil.InternalExecutor,
+	txn *kv.Txn,
+	tableID descpb.ID,
+	columnIDs [][]descpb.ColumnID,
+	keepTime time.Duration,
+) error {
+	var columnIDsPlaceholders bytes.Buffer
+	placeholderVals := make([]interface{}, 0, len(columnIDs)+2)
+	placeholderVals = append(placeholderVals, tableID, keepTime)
+	columnIDsPlaceholdersStart := len(placeholderVals) + 1
+	for i := range columnIDs {
+		columnIDsVal := tree.NewDArray(types.Int)
+		for _, c := range columnIDs[i] {
+			if err := columnIDsVal.Append(tree.NewDInt(tree.DInt(int(c)))); err != nil {
+				return err
+			}
+		}
+		if i > 0 {
+			columnIDsPlaceholders.WriteString(", ")
+		}
+		columnIDsPlaceholders.WriteString(fmt.Sprintf("$%d::string", i+columnIDsPlaceholdersStart))
+		placeholderVals = append(placeholderVals, columnIDsVal)
+	}
+
+	// This will delete all statistics for the given table that are not
+	// on the given columns and are older than keepTime.
+	_, err := executor.Exec(
+		ctx, "delete-statistics", txn,
+		fmt.Sprintf(`DELETE FROM system.table_statistics
+               WHERE "tableID" = $1
+               AND "columnIDs"::string NOT IN (%s)
+               AND "createdAt" < now() - $2`, columnIDsPlaceholders.String()),
+		placeholderVals...,
 	)
 	return err
 }


### PR DESCRIPTION
This commit updates the stats collection logic so that in addition to
deleting old stats from columns that had stats collected, it also deletes
old stats from columns that did *not* have stats collected. This is important
to avoid buildup of cruft in the `system.table_statistics` table and prevent
the optimizer from using very stale statistics.

Fixes #67407

Release note (sql change): When statistics are refreshed for a table,
CockroachDB now deletes any old statistics on that table from columns or sets
of columns that do not have their statistics refreshed by default. This ensures
that stale statistics are removed and do not impact the optmizer's ability to
create a high quality query plan. The retention time for these statistics
is controlled by a new cluster setting,
`sql.stats.non_default_columns.min_retention_period`, which defaults to 24 hours.