### PR TITLE
bazel: bump sizes of `kvtenantccl_test`, `jobs_test`

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
@@ -40,7 +40,7 @@ go_library(
 
 go_test(
     name = "kvtenantccl_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "connector_test.go",
         "main_test.go",

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -78,7 +78,7 @@ go_library(
 
 go_test(
     name = "jobs_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "delegate_control_test.go",
         "executor_impl_test.go",


### PR DESCRIPTION
These have [timed out](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_BazelEssentialCi/5968787?showRootCauses=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true)
on a `bors` run.

Release note: None