### PR TITLE
gc: add delete range parameters to gc request

### DIFF
--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -151,7 +151,7 @@ func runGCOld(
 						if batchGCKeysBytes >= KeyVersionChunkBytes {
 							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
 
-							err := gcer.GC(ctx, batchGCKeys, nil)
+							err := gcer.GC(ctx, batchGCKeys, nil, nil)
 
 							batchGCKeys = nil
 							batchGCKeysBytes = 0
@@ -210,7 +210,7 @@ func runGCOld(
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
 			return Info{}, err
 		}
 	}

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -725,6 +725,7 @@ type fakeGCer struct {
 	// feed them into MVCCGarbageCollectRangeKeys and ranges argument should be
 	// non-overlapping.
 	gcRangeKeyBatches [][]roachpb.GCRequest_GCRangeKey
+	gcRangeDeleteKeys []roachpb.GCRequest_GCClearRangeKey
 	threshold         Threshold
 	intents           []roachpb.Intent
 	batches           [][]roachpb.Intent
@@ -745,12 +746,16 @@ func (f *fakeGCer) SetGCThreshold(ctx context.Context, t Threshold) error {
 }
 
 func (f *fakeGCer) GC(
-	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+	ctx context.Context,
+	keys []roachpb.GCRequest_GCKey,
+	rangeKeys []roachpb.GCRequest_GCRangeKey,
+	deletionKeys []roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	for _, k := range keys {
 		f.gcKeys[k.Key.String()] = k
 	}
 	f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
+	f.gcRangeDeleteKeys = append(f.gcRangeDeleteKeys, deletionKeys...)
 	return nil
 }
 

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -56,7 +56,10 @@ type collectingGCer struct {
 }
 
 func (c *collectingGCer) GC(
-	_ context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+	_ context.Context,
+	keys []roachpb.GCRequest_GCKey,
+	_ []roachpb.GCRequest_GCRangeKey,
+	_ []roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	c.keys = append(c.keys, keys)
 	return nil

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -484,7 +484,10 @@ func (r *replicaGCer) SetGCThreshold(ctx context.Context, thresh gc.Threshold) e
 }
 
 func (r *replicaGCer) GC(
-	ctx context.Context, keys []roachpb.GCRequest_GCKey, rangeKeys []roachpb.GCRequest_GCRangeKey,
+	ctx context.Context,
+	keys []roachpb.GCRequest_GCKey,
+	rangeKeys []roachpb.GCRequest_GCRangeKey,
+	clearRangeKeys []roachpb.GCRequest_GCClearRangeKey,
 ) error {
 	if len(keys) == 0 && len(rangeKeys) == 0 {
 		return nil
@@ -492,6 +495,7 @@ func (r *replicaGCer) GC(
 	req := r.template()
 	req.Keys = keys
 	req.RangeKeys = rangeKeys
+	req.ClearRangeKeys = clearRangeKeys
 	return r.send(ctx, req)
 }
 

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -979,6 +979,17 @@ message GCRequest {
   // Threshold is the expiration timestamp.
   util.hlc.Timestamp threshold = 4 [(gogoproto.nullable) = false];
 
+  // Range deletion request.
+  message GCClearRangeKey {
+    bytes start_key = 1 [(gogoproto.casttype) = "Key"];
+    bytes end_key = 2 [(gogoproto.casttype) = "Key"];
+  }
+  // range_deletion_keys contains zero or more (typically a single) ranges
+  // that would be deleted using storage range delete operation. Note that
+  // those ranges must not have any data newer than GC threshold or the
+  // request will fail.
+  repeated GCClearRangeKey clear_range_keys = 7 [(gogoproto.nullable) = false];
+
   reserved 5;
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4852,22 +4852,15 @@ func MVCCGarbageCollectRangeKeys(
 			// erroneous GC request and mvcc stats should be updated correctly.
 			// In those cases gcKey boundaries will not match underlying range
 			// tombstone boundaries and need to be adjusted.
-			trimLeft, trimRight := false, false
-			gcedRangeStartKey := bounds.Key
-			if gcKey.StartKey.Compare(gcedRangeStartKey) > 0 {
-				gcedRangeStartKey = gcKey.StartKey
-				trimLeft = true
-			}
-			gcedRangeEndKey := bounds.EndKey
-			if gcKey.EndKey.Compare(gcedRangeEndKey) < 0 {
-				gcedRangeEndKey = gcKey.EndKey
-				trimRight = true
-			}
+			gcdSpan, trimLeft, trimRight := trimSpanToBounds(roachpb.Span{
+				Key:    gcKey.MVCCRangeKey.StartKey,
+				EndKey: gcKey.MVCCRangeKey.EndKey,
+			}, bounds)
 
 			gcedRange := MVCCRangeKeyValue{
 				RangeKey: MVCCRangeKey{
-					StartKey: gcedRangeStartKey,
-					EndKey:   gcedRangeEndKey,
+					StartKey: gcdSpan.Key,
+					EndKey:   gcdSpan.EndKey,
 				},
 			}
 			remaining := len(unsafeRangeKeys)
@@ -4896,7 +4889,7 @@ func MVCCGarbageCollectRangeKeys(
 				}
 			}
 
-			mergeTracker.update(gcedRangeStartKey, gcedRangeEndKey, unsafeRangeKeys[0:remaining])
+			mergeTracker.update(gcdSpan.Key, gcdSpan.EndKey, unsafeRangeKeys[0:remaining])
 
 			// If we didn't find any removable fragments, shortcut without checking
 			// underlying keys.
@@ -4908,12 +4901,12 @@ func MVCCGarbageCollectRangeKeys(
 			// time bound iterator.
 			ptIter = NewMVCCIncrementalIterator(rw, MVCCIncrementalIterOptions{
 				KeyTypes:     IterKeyTypePointsOnly,
-				StartKey:     gcedRangeStartKey,
-				EndKey:       gcedRangeEndKey,
+				StartKey:     gcdSpan.Key,
+				EndKey:       gcdSpan.EndKey,
 				EndTime:      gcKey.Timestamp,
 				IntentPolicy: MVCCIncrementalIterIntentPolicyEmit,
 			})
-			ptIter.SeekGE(MVCCKey{Key: gcedRangeStartKey})
+			ptIter.SeekGE(MVCCKey{Key: gcdSpan.Key})
 			for ; ; ptIter.Next() {
 				if ok, err := ptIter.Valid(); err != nil {
 					return err
@@ -4936,6 +4929,19 @@ func MVCCGarbageCollectRangeKeys(
 	}
 
 	return nil
+}
+
+func trimSpanToBounds(span, bounds roachpb.Span) (result roachpb.Span, trimLeft, trimRight bool) {
+	result = bounds
+	if span.Key.Compare(result.Key) > 0 {
+		result.Key = span.Key
+		trimLeft = true
+	}
+	if span.EndKey.Compare(result.EndKey) < 0 {
+		result.EndKey = span.EndKey
+		trimRight = true
+	}
+	return result, trimLeft, trimRight
 }
 
 // updateStatsOnRangeTombstoneGC updates stats for removed range keys.
@@ -5005,6 +5011,215 @@ func updateStatsOnRangeTombstoneMerge(rangeKeys []MVCCRangeKeyValue) (ms enginep
 		ms.RangeValBytes -= int64(len(rk.Value))
 	}
 	return ms
+}
+
+// CollectableGCClearRangeKey is range together with allowed boundaries that
+// should be evaluated by MVCCGarbageCollectWithClearRange. LatchSpan declares
+// extension to range that could be evaluated when checking for neighbouring
+// ranges for the sake of merging or splitting.
+type CollectableGCClearRangeKey struct {
+	roachpb.Span
+	LatchSpan roachpb.Span
+}
+
+var emptyMetaToken enginepb.MVCCMetadata
+
+// MVCCGarbageCollectWithClearRange removes garbage collected data falling under
+// ranges covered by rks. This function performs a check to ensure that no
+// non-deleted data (most recent or history with timestamp greater that
+// threshold) is being deleted.
+func MVCCGarbageCollectWithClearRange(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	threshold hlc.Timestamp,
+	rks []CollectableGCClearRangeKey,
+) error {
+	var count int64
+	defer func(begin time.Time) {
+		// TODO(oleg): this could be misleading if GC fails, but this function still
+		// reports how many keys were GC'd. The approach is identical to what point
+		// key GC does for consistency, but both places could be improved.
+		log.Eventf(ctx,
+			"done with GC evaluation for %d clear range keys at %.2f keys/sec. Deleted %d entries",
+			len(rks), float64(len(rks))*1e9/float64(timeutil.Since(begin)), count)
+	}(timeutil.Now())
+
+	if len(rks) == 0 {
+		return nil
+	}
+
+	var iter MVCCIterator
+	defer func() {
+		if iter != nil {
+			iter.Close()
+		}
+	}()
+
+	for _, gcKey := range rks {
+		// Bound the iterator appropriately for the set of keys we'll be garbage
+		// collecting. We are using latch bounds to collect info about adjacent
+		// range fragments for correct MVCCStats updates.
+		iter = rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+			LowerBound: gcKey.LatchSpan.Key,
+			UpperBound: gcKey.LatchSpan.EndKey,
+			KeyTypes:   IterKeyTypePointsAndRanges,
+		})
+
+		iter.SeekGE(MVCCKey{Key: gcKey.LatchSpan.Key})
+
+		var prevPointKey MVCCKey
+		var rangeTombstoneStartKey roachpb.Key
+		var rangeTombstoneTs []hlc.Timestamp
+
+		for ; ; iter.Next() {
+			if ok, err := iter.Valid(); err != nil {
+				return err
+			} else if !ok {
+				break
+			}
+
+			hasPoint, hasRange := iter.HasPointAndRange()
+			if hasRange {
+				rangeBounds := iter.RangeBounds()
+				if !rangeBounds.Key.Equal(rangeTombstoneStartKey) {
+					rangeTombstoneStartKey = rangeBounds.Key.Clone()
+
+					// Ignore ranges fully before required range.
+					if rangeBounds.EndKey.Compare(gcKey.Key) <= 0 {
+						continue
+					}
+					// Ignore ranges fully after required range.
+					if rangeBounds.Key.Compare(gcKey.EndKey) >= 0 {
+						continue
+					}
+
+					rangeTombstones := iter.RangeKeys()
+					rangeTombstoneTs = make([]hlc.Timestamp, len(rangeTombstones))
+					for i, rkv := range rangeTombstones {
+						rangeTombstoneTs[i] = rkv.RangeKey.Timestamp
+					}
+					if threshold.Less(rangeTombstoneTs[0]) {
+						return errors.Errorf("attempt to clear range with data %s",
+							rangeTombstones[0].RangeKey.String())
+					}
+
+					if ms != nil {
+						gcdSpan, trimLeft, trimRight := trimSpanToBounds(gcKey.Span, rangeBounds)
+						gcedRange := MVCCRangeKeyValue{
+							RangeKey: MVCCRangeKey{
+								StartKey: gcdSpan.Key,
+								EndKey:   gcdSpan.EndKey,
+							},
+						}
+
+						// Update stats for range deletion.
+						for i, rkv := range rangeTombstones {
+							gcedRange.RangeKey.Timestamp = rkv.RangeKey.Timestamp
+							gcedRange.Value = rkv.Value
+							topRangeKey := i == 0
+							ms.Add(updateStatsOnRangeTombstoneGC(gcedRange, topRangeKey))
+							if trimLeft {
+								ms.Add(updateStatsOnRangeTombstoneSplit(gcedRange, gcedRange.RangeKey.StartKey, topRangeKey))
+							}
+							if trimRight {
+								ms.Add(updateStatsOnRangeTombstoneSplit(gcedRange, gcedRange.RangeKey.EndKey, topRangeKey))
+							}
+							count++
+						}
+					}
+				}
+			} else {
+				rangeTombstoneTs = nil
+			}
+
+			if hasPoint {
+				unsafeKey := iter.UnsafeKey()
+				newKey := !prevPointKey.Key.Equal(unsafeKey.Key)
+				if newKey {
+					// Skip keys that fall outside of range.
+					// TODO(oleg): This is suboptimal and we can just jump over next key,
+					// but good enough for now as we expect clearing full ranges anyway.
+					if unsafeKey.Key.Compare(gcKey.Key) < 0 {
+						continue
+					}
+					if unsafeKey.Key.Compare(gcKey.EndKey) >= 0 {
+						continue
+					}
+
+					if unsafeKey.Timestamp.IsEmpty() {
+						return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+					}
+					if threshold.Less(unsafeKey.Timestamp) {
+						return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+					}
+					prevPointKey = unsafeKey.Clone()
+				}
+
+				// Unmarshal value to check MVCC tombstone with timestamp.
+				unsafeValRaw := iter.UnsafeValue()
+				unsafeVal, unsafeValOK, err := tryDecodeSimpleMVCCValue(unsafeValRaw)
+				if !unsafeValOK && err == nil {
+					unsafeVal, err = decodeExtendedMVCCValue(unsafeValRaw)
+				}
+				if err != nil {
+					return err
+				}
+
+				if newKey {
+					// Don't allow deletion of values directly on threshold.
+					if !unsafeVal.IsTombstone() && unsafeKey.Timestamp.Equal(threshold) {
+						return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+					}
+					// Don't allow deletion of values not covered by range key.
+					if len(rangeTombstoneTs) == 0 && !unsafeVal.IsTombstone() || len(rangeTombstoneTs) > 0 && rangeTombstoneTs[0].Less(unsafeKey.Timestamp) {
+						return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+					}
+				}
+
+				if ms != nil {
+					// Update stats for value.
+					var validTill hlc.Timestamp
+					if unsafeVal.IsTombstone() {
+						// Tombstones are garbage till its own ts.
+						validTill = unsafeKey.Timestamp
+					} else {
+						// Top level keys are not garbage.
+						if !newKey {
+							// Non top level value keys are valid till next version.
+							validTill = prevPointKey.Timestamp
+						}
+						// Unless next value is range tombstone.
+						if i := sort.Search(len(rangeTombstoneTs), func(i int) bool {
+							return rangeTombstoneTs[i].Less(unsafeKey.Timestamp)
+						}); i > 0 {
+							// If there's a range between current value and value above
+							// use that timestamp.
+							if validTill.IsEmpty() || rangeTombstoneTs[i-1].Less(validTill) {
+								validTill = rangeTombstoneTs[i-1]
+							}
+						}
+					}
+					if newKey {
+						ms.Add(updateStatsOnGC(gcKey.Key, int64(EncodedMVCCKeyPrefixLength(unsafeKey.Key)), 0,
+							&emptyMetaToken, validTill.WallTime))
+					}
+					ms.Add(updateStatsOnGC(gcKey.Key, MVCCVersionTimestampSize, int64(len(unsafeValRaw)), nil,
+						validTill.WallTime))
+					count++
+				}
+				prevPointKey.Timestamp = unsafeKey.Timestamp
+			}
+		}
+		iter.Close()
+		iter = nil
+
+		if err := rw.ClearMVCCRange(gcKey.Key, gcKey.EndKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // MVCCFindSplitKey finds a key from the given span such that the left side of

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5277,6 +5277,11 @@ func pt(key roachpb.Key, ts hlc.Timestamp) rangeTestDataItem {
 	return rangeTestDataItem{point: MVCCKeyValue{Key: mvccVersionKey(key, ts), Value: val}}
 }
 
+// tb creates a point tombstone.
+func tb(key roachpb.Key, ts hlc.Timestamp) rangeTestDataItem {
+	return rangeTestDataItem{point: MVCCKeyValue{Key: mvccVersionKey(key, ts)}}
+}
+
 // txn wraps point update and adds transaction to it for intent creation.
 func txn(d rangeTestDataItem) rangeTestDataItem {
 	ts := d.point.Key.Timestamp
@@ -5812,6 +5817,30 @@ func rangesFromRequests(
 	return collectableKeys
 }
 
+func clearRangesFromRequests(
+	rangeStart, rangeEnd roachpb.Key, rangeKeys []roachpb.GCRequest_GCClearRangeKey,
+) []CollectableGCClearRangeKey {
+	collectableKeys := make([]CollectableGCClearRangeKey, len(rangeKeys))
+	for i, rk := range rangeKeys {
+		leftPeekBound := rk.StartKey.Prevish(roachpb.PrevishKeyLength)
+		if leftPeekBound.Compare(rangeStart) <= 0 {
+			leftPeekBound = rangeStart
+		}
+		rightPeekBound := rk.EndKey.Next()
+		if rightPeekBound.Compare(rangeEnd) >= 0 {
+			rightPeekBound = rangeEnd
+		}
+		collectableKeys[i] = CollectableGCClearRangeKey{
+			Span: roachpb.Span{
+				Key:    rk.StartKey,
+				EndKey: rk.EndKey,
+			},
+			LatchSpan: roachpb.Span{Key: leftPeekBound, EndKey: rightPeekBound},
+		}
+	}
+	return collectableKeys
+}
+
 func TestMVCCGarbageCollectRangesFailures(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -5913,6 +5942,316 @@ func TestMVCCGarbageCollectRangesFailures(t *testing.T) {
 					d.before.populateEngine(t, engine, nil)
 					rangeKeys := rangesFromRequests(rangeStart, rangeEnd, d.request)
 					err := MVCCGarbageCollectRangeKeys(ctx, engine, nil, rangeKeys)
+					require.Errorf(t, err, "expected error '%s' but found none", d.error)
+					require.True(t, testutils.IsError(err, d.error),
+						"expected error '%s' found '%s'", d.error, err)
+				})
+			}
+		})
+	}
+}
+
+func TestMVCCGarbageCollectClearRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	mkKey := func(k string) roachpb.Key {
+		return append(keys.SystemSQLCodec.TablePrefix(42), k...)
+	}
+	rangeStart := mkKey("")
+	rangeEnd := rangeStart.PrefixEnd()
+
+	// Note we use keys of different lengths so that stats accounting errors
+	// would not obviously cancel out if right and left bounds are used
+	// incorrectly.
+	keyA := mkKey("a")
+	keyB := mkKey("bb")
+	keyC := mkKey("ccc")
+	keyD := mkKey("dddd")
+	keyE := mkKey("eeeee")
+
+	mkTs := func(wallTimeSec int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: time.Second.Nanoseconds() * wallTimeSec}
+	}
+
+	ts1 := mkTs(1)
+	ts2 := mkTs(2)
+	ts3 := mkTs(3)
+	ts4 := mkTs(4)
+	tsMax := mkTs(9)
+
+	testData := []struct {
+		name string
+		// Note that range test data should be in ascending order (valid writes).
+		before  rangeTestData
+		request []roachpb.GCRequest_GCClearRangeKey
+		after   rangeTestData
+		// Optional start and end range for tests that want to restrict default
+		// key range.
+		rangeStart roachpb.Key
+		rangeEnd   roachpb.Key
+	}{
+		{
+			name: "single point",
+			before: rangeTestData{
+				rng(keyA, keyD, ts3),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			},
+		},
+		{
+			name: "single range",
+			before: rangeTestData{
+				rng(keyA, keyD, ts4),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			},
+		},
+		{
+			name: "clear over deleted points",
+			before: rangeTestData{
+				pt(keyB, ts2),
+				tb(keyB, ts4),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			},
+		},
+		{
+			name: "clear over range tombstone deleted points",
+			before: rangeTestData{
+				pt(keyB, ts2),
+				rng(keyA, keyD, ts4),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			},
+		},
+		{
+			name: "clear over multiple versions",
+			before: rangeTestData{
+				pt(keyB, ts1),
+				pt(keyB, ts2),
+				tb(keyB, ts3),
+				tb(keyB, ts4),
+				pt(keyC, ts1),
+				tb(keyC, ts2),
+				pt(keyC, ts3),
+				tb(keyC, ts4),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyB, EndKey: keyD},
+			},
+			after: rangeTestData{},
+		},
+		{
+			name: "clear over interleaved points and ranges",
+			before: rangeTestData{
+				pt(keyB, ts1),
+				rng(keyB, keyC, ts2),
+				pt(keyB, ts3),
+				rng(keyB, keyC, ts4),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyB, EndKey: keyD},
+			},
+			after: rangeTestData{},
+		},
+		{
+			name: "clear over partial range (start)",
+			before: rangeTestData{
+				rng(keyA, keyC, ts2),
+				rng(keyA, keyC, ts4),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyB, EndKey: keyD},
+			},
+			after: rangeTestData{
+				rng(keyA, keyB, ts2),
+				rng(keyA, keyB, ts4),
+			},
+		},
+		{
+			name: "clear over partial range (end)",
+			before: rangeTestData{
+				rng(keyB, keyD, ts2),
+				rng(keyB, keyD, ts4),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyB, EndKey: keyC},
+			},
+			after: rangeTestData{
+				rng(keyC, keyD, ts2),
+				rng(keyC, keyD, ts4),
+			},
+		},
+		{
+			name: "clear over data outside range",
+			before: rangeTestData{
+				pt(keyA, ts2),
+				pt(keyA, tsMax),
+				pt(keyE, ts3),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyB, EndKey: keyD},
+			},
+			after: rangeTestData{
+				pt(keyA, ts2),
+				pt(keyA, tsMax),
+				pt(keyE, ts3),
+			},
+		},
+	}
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			for _, d := range testData {
+				t.Run(d.name, func(t *testing.T) {
+					engine := engineImpl.create()
+					defer engine.Close()
+
+					// Populate range descriptor defaults.
+					if len(d.rangeStart) == 0 {
+						d.rangeStart = rangeStart
+					}
+					if len(d.rangeEnd) == 0 {
+						d.rangeEnd = rangeEnd
+					}
+
+					var ms enginepb.MVCCStats
+					d.before.populateEngine(t, engine, &ms)
+
+					rangeKeys := clearRangesFromRequests(rangeStart, rangeEnd, d.request)
+					require.NoError(t, MVCCGarbageCollectWithClearRange(ctx, engine, &ms, tsMax, rangeKeys),
+						"failed to run mvcc range tombstone garbage collect")
+
+					expected := engineImpl.create()
+					defer expected.Close()
+					var expMs enginepb.MVCCStats
+					d.after.populateEngine(t, expected, &expMs)
+
+					rks := scanRangeKeys(t, engine)
+					expRks := scanRangeKeys(t, expected)
+					require.EqualValues(t, rks, expRks)
+
+					ks := scanPointKeys(t, engine)
+					expKs := scanPointKeys(t, expected)
+					require.EqualValues(t, ks, expKs)
+
+					ms.AgeTo(tsMax.WallTime)
+					it := engine.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+						KeyTypes:   IterKeyTypePointsAndRanges,
+						LowerBound: d.rangeStart,
+						UpperBound: d.rangeEnd,
+					})
+					expMs, err := ComputeStatsForRange(it, rangeStart, rangeEnd, tsMax.WallTime)
+					require.NoError(t, err, "failed to compute stats for range")
+					require.EqualValues(t, expMs, ms, "computed range stats vs gc'd")
+				})
+			}
+		})
+	}
+}
+
+func TestMVCCGarbageCollectClearRangeFailure(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	mkKey := func(k string) roachpb.Key {
+		return append(keys.SystemSQLCodec.TablePrefix(42), k...)
+	}
+	rangeStart := mkKey("")
+	rangeEnd := rangeStart.PrefixEnd()
+
+	// Note we use keys of different lengths so that stats accounting errors
+	// would not obviously cancel out if right and left bounds are used
+	// incorrectly.
+	keyA := mkKey("a")
+	keyD := mkKey("dddd")
+
+	mkTs := func(wallTimeSec int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: time.Second.Nanoseconds() * wallTimeSec}
+	}
+
+	ts1 := mkTs(1)
+	tsGC := mkTs(5)
+	tsMax := mkTs(9)
+
+	testData := []struct {
+		name string
+		// Note that range test data should be in ascending order (valid writes).
+		before  rangeTestData
+		request []roachpb.GCRequest_GCClearRangeKey
+		error   string
+		// Optional start and end range for tests that want to restrict default
+		// key range.
+		rangeStart roachpb.Key
+		rangeEnd   roachpb.Key
+	}{
+		{
+			name: "clear over intent",
+			before: rangeTestData{
+				txn(pt(keyA, ts1)),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			},
+			error: `attempt to clear range with data /Table/42/"a"`,
+		},
+		{
+			name: "clear over non-deleted data",
+			before: rangeTestData{
+				pt(keyA, ts1),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			},
+			error: `attempt to clear range with data /Table/42/"a"/1.000000000,0`,
+		},
+		{
+			name: "clear over recent range tombstone",
+			before: rangeTestData{
+				rng(keyA, keyD, tsMax),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			},
+			error: `attempt to clear range with data /Table/42/"{a"-dddd"}/9.000000000,0`,
+		},
+		{
+			name: "clear over range tombstone above gc threshold",
+			before: rangeTestData{
+				rng(keyA, keyD, tsMax),
+			},
+			request: []roachpb.GCRequest_GCClearRangeKey{
+				{StartKey: keyA, EndKey: keyD},
+			},
+			error: `attempt to clear range with data /Table/42/"{a"-dddd"}/9.000000000,0`,
+		},
+	}
+	for _, engineImpl := range mvccEngineImpls {
+		t.Run(engineImpl.name, func(t *testing.T) {
+			for _, d := range testData {
+				t.Run(d.name, func(t *testing.T) {
+					engine := engineImpl.create()
+					defer engine.Close()
+
+					// Populate range descriptor defaults.
+					if len(d.rangeStart) == 0 {
+						d.rangeStart = rangeStart
+					}
+					if len(d.rangeEnd) == 0 {
+						d.rangeEnd = rangeEnd
+					}
+
+					var ms enginepb.MVCCStats
+					d.before.populateEngine(t, engine, &ms)
+
+					rangeKeys := clearRangesFromRequests(rangeStart, rangeEnd, d.request)
+					err := MVCCGarbageCollectWithClearRange(ctx, engine, &ms, tsGC, rangeKeys)
 					require.Errorf(t, err, "expected error '%s' but found none", d.error)
 					require.True(t, testutils.IsError(err, d.error),
 						"expected error '%s' found '%s'", d.error, err)


### PR DESCRIPTION
This commit adds range_deletion_keys parameters to GC request.
range_deletion_keys is used by GC queue to remove chunks of
consecutive keys where no new data was written above the GC
threshold and storage can optimize deletions with range
tombstones.
To support new types of keys, GCer interface is also updated
to pass provided keys down to request.

Release note: None