### PR TITLE
roachtest: extend bounds for tpch_concurrency with high refresh spans bytes

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -172,9 +172,6 @@ func registerTPCHConcurrency(r registry.Registry) {
 		// supported concurrency is always sustained and fail the test if it
 		// isn't.
 		minConcurrency, maxConcurrency := 48, 160
-		if !lowerRefreshSpansBytes {
-			minConcurrency, maxConcurrency = 4, 64
-		}
 		// Run the binary search to find the largest concurrency that doesn't
 		// crash a node in the cluster. The current range is represented by
 		// [minConcurrency, maxConcurrency).


### PR DESCRIPTION
We recently fixed several omissions around the way we track the refresh
spans memory usage, so this roachtest now hits the upper bound
consistently. This commit removes the lowered bounds for one config, and
we'll follow the behavior for a week or so - fingers crossed, we can
remove lowering of the setting.

Release note: None