### PR TITLE
bazel: move `bazel run :gazelle` before `generate-logictest`

### DIFF
--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -55,13 +55,13 @@ else
   bazel run pkg/cmd/generate-staticcheck --run_under="cd $PWD && "
 fi
 
+bazel run //:gazelle
+
 if files_unchanged_from_upstream WORKSPACE $(find_relevant ./pkg/sql/logictest/logictestbase -name BUILD.bazel -or -name '*.go') $(find_relevant ./pkg/sql/logictest/testdata -name '*') $(find_relevant ./pkg/sql/sqlitelogictest -name BUILD.bazel -or -name '*.go') $(find_relevant ./pkg/ccl/logictestccl/testdata -name '*') $(find_relevant pkg/sql/opt/exec/execbuilder/testdata -name '*'); then
   echo "Skipping //pkg/cmd/generate-logictest (relevant files are unchanged from upstream)"
 else
   bazel run pkg/cmd/generate-logictest -- -out-dir="$PWD"
 fi
-
-bazel run //:gazelle
 
 if files_unchanged_from_upstream c-deps/archived.bzl c-deps/REPOSITORIES.bzl DEPS.bzl WORKSPACE $(find_relevant ./pkg/cmd/generate-distdir -name BUILD.bazel -or -name '*.go') $(find_relevant ./pkg/build/bazel -name BUILD.bazel -or -name '*.go') $(find_relevant pkg/build/starlarkutil -name BUILD.bazel -or -name '*.go'); then
     echo "Skipping //pkg/cmd/generate-distdir (relevant files are unchanged from upstream)."


### PR DESCRIPTION
`gazelle` populates the `BUILD.bazel` files for the `staticcheck`
analyzers, so we want those populated before `generate-logictest`.

Release note: None