### PR TITLE
storage: add MVCC range tombstones in microbenchmarks

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -65,14 +65,19 @@ func BenchmarkMVCCScan_Pebble(b *testing.B) {
 				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
 					for _, valueSize := range []int{8, 64, 512} {
 						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
-								benchDataOptions: benchDataOptions{
-									numVersions: numVersions,
-									valueBytes:  valueSize,
-								},
-								numRows: numRows,
-								reverse: false,
-							})
+							for _, numRangeKeys := range []int{0, 1} { // TODO(erikgrinaker): 100
+								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
+									runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
+										benchDataOptions: benchDataOptions{
+											numVersions:  numVersions,
+											valueBytes:   valueSize,
+											numRangeKeys: numRangeKeys,
+										},
+										numRows: numRows,
+										reverse: false,
+									})
+								})
+							}
 						})
 					}
 				})
@@ -81,7 +86,7 @@ func BenchmarkMVCCScan_Pebble(b *testing.B) {
 	}
 }
 
-func BenchmarkMVCCScan_PebbleSQLRows(b *testing.B) {
+func BenchmarkMVCCScanSQLRows_Pebble(b *testing.B) {
 	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
@@ -125,14 +130,19 @@ func BenchmarkMVCCReverseScan_Pebble(b *testing.B) {
 				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
 					for _, valueSize := range []int{8, 64, 512} {
 						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
-								benchDataOptions: benchDataOptions{
-									numVersions: numVersions,
-									valueBytes:  valueSize,
-								},
-								numRows: numRows,
-								reverse: true,
-							})
+							for _, numRangeKeys := range []int{0, 1} { // TODO(erikgrinaker): 100
+								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
+									runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
+										benchDataOptions: benchDataOptions{
+											numVersions:  numVersions,
+											valueBytes:   valueSize,
+											numRangeKeys: numRangeKeys,
+										},
+										numRows: numRows,
+										reverse: true,
+									})
+								})
+							}
 						})
 					}
 				})
@@ -154,6 +164,7 @@ func BenchmarkMVCCScanTransactionalData_Pebble(b *testing.B) {
 }
 
 func BenchmarkMVCCGet_Pebble(b *testing.B) {
+	skip.UnderShort(b)
 	ctx := context.Background()
 	for _, batch := range []bool{false, true} {
 		b.Run(fmt.Sprintf("batch=%t", batch), func(b *testing.B) {
@@ -161,10 +172,15 @@ func BenchmarkMVCCGet_Pebble(b *testing.B) {
 				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
 					for _, valueSize := range []int{8} {
 						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							runMVCCGet(ctx, b, setupMVCCPebble, benchDataOptions{
-								numVersions: numVersions,
-								valueBytes:  valueSize,
-							}, batch)
+							for _, numRangeKeys := range []int{0, 1} { // TODO(erikgrinaker): 100
+								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
+									runMVCCGet(ctx, b, setupMVCCPebble, benchDataOptions{
+										numVersions:  numVersions,
+										valueBytes:   valueSize,
+										numRangeKeys: numRangeKeys,
+									}, batch)
+								})
+							}
 						})
 					}
 				})
@@ -178,7 +194,11 @@ func BenchmarkMVCCComputeStats_Pebble(b *testing.B) {
 	ctx := context.Background()
 	for _, valueSize := range []int{8, 32, 256} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-			runMVCCComputeStats(ctx, b, setupMVCCPebble, valueSize)
+			for _, numRangeKeys := range []int{0, 1} { // TODO(erikgrinaker): 100
+				b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
+					runMVCCComputeStats(ctx, b, setupMVCCPebble, valueSize, numRangeKeys)
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
This adds variants of microbenchmarks for `MVCCGet`, `MVCCScan`,
`MVCCReverseScan`, and `MVCCComputeStats` with MVCC range tombstones.
These are always written below the point keys. For `numRangeKeys=1`, we
write a single MVCC range tombstone across the entire key span. For
other values, we write random tombstones that may or may not overlap.

The results are rather brutal, with a three-orders-of-magnitude
regression for scans. This is likely to be quadratic behavior somewhere
in the iterator stack, e.g. due to point tombstone synthesis below point
keys.

```
name                                                                     time/op
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24       2.85ms ± 1%
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=1-24       6.37ms ± 1%
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=100-24      2.05s ±39%
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=0-24        5.16µs ± 1%
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=1-24        16.8µs ± 1%
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=100-24       344µs ± 2%
```

Touches #84383.

Release note: None