### PR TITLE
bazel: bump size of `streamingest_test`

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -64,7 +64,7 @@ go_library(
 
 go_test(
     name = "streamingest_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "main_test.go",
         "stream_ingestion_frontier_processor_test.go",


### PR DESCRIPTION
This has timed out in CI.

Release note: None