### PR TITLE
ccl/streamingccl/streamingest: skip TestTenantStreamingDeleteRange

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -846,6 +846,7 @@ func TestTenantStreamingCutoverOnSourceFailure(t *testing.T) {
 
 func TestTenantStreamingDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 85630, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// TODO(casper): disabled due to error when setting a cluster setting


### PR DESCRIPTION
Refs: #85630

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None