### PR TITLE
sql: Add retry reason and node ids to execution_insights

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6255,7 +6255,9 @@ CREATE TABLE crdb_internal.node_execution_insights (
 	rows_read                  INT8 NOT NULL,
 	rows_written               INT8 NOT NULL,
 	priority                   FLOAT NOT NULL,
-	retries                    INT8 NOT NULL
+	retries                    INT8 NOT NULL,
+	last_retry_reason          STRING,
+	exec_node_ids              INT[] NOT NULL
 );`,
 	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
 		p.extendedEvalCtx.statsProvider.IterateInsights(ctx, func(
@@ -6271,6 +6273,19 @@ CREATE TABLE crdb_internal.node_execution_insights (
 			if errTimestamp != nil {
 				err = errors.CombineErrors(err, errTimestamp)
 				return
+			}
+
+			execNodeIDs := tree.NewDArray(types.Int)
+			for _, nodeID := range insight.Statement.Nodes {
+				if errNodeID := execNodeIDs.Append(tree.NewDInt(tree.DInt(nodeID))); errNodeID != nil {
+					err = errors.CombineErrors(err, errNodeID)
+					return
+				}
+			}
+
+			autoRetryReason := tree.DNull
+			if insight.Statement.AutoRetryReason != "" {
+				autoRetryReason = tree.NewDString(insight.Statement.AutoRetryReason)
 			}
 
 			err = errors.CombineErrors(err, addRow(
@@ -6292,6 +6307,8 @@ CREATE TABLE crdb_internal.node_execution_insights (
 				tree.NewDInt(tree.DInt(insight.Statement.RowsWritten)),
 				tree.NewDFloat(tree.DFloat(insight.Transaction.UserPriority)),
 				tree.NewDInt(tree.DInt(insight.Statement.Retries)),
+				autoRetryReason,
+				execNodeIDs,
 			))
 		})
 		return err

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -173,6 +173,7 @@ func (ex *connExecutor) recordStatementSummary(
 		SessionID:            ex.sessionID,
 		StatementID:          planner.stmt.QueryID,
 		AutoRetryCount:       automaticRetryCount,
+		AutoRetryReason:      ex.state.mu.autoRetryReason,
 		RowsAffected:         rowsAffected,
 		ParseLatency:         parseLat,
 		PlanLatency:          planLat,

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -911,7 +911,9 @@ CREATE TABLE crdb_internal.node_execution_insights (
    rows_read INT8 NOT NULL,
    rows_written INT8 NOT NULL,
    priority FLOAT8 NOT NULL,
-   retries INT8 NOT NULL
+   retries INT8 NOT NULL,
+   last_retry_reason STRING NULL,
+   exec_node_ids INT8[] NOT NULL
 )  CREATE TABLE crdb_internal.node_execution_insights (
    session_id STRING NOT NULL,
    txn_id UUID NOT NULL,
@@ -930,7 +932,9 @@ CREATE TABLE crdb_internal.node_execution_insights (
    rows_read INT8 NOT NULL,
    rows_written INT8 NOT NULL,
    priority FLOAT8 NOT NULL,
-   retries INT8 NOT NULL
+   retries INT8 NOT NULL,
+   last_retry_reason STRING NULL,
+   exec_node_ids INT8[] NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_inflight_trace_spans (
    trace_id INT8 NOT NULL,

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -51,6 +51,9 @@ message Statement {
   int64 rows_read = 13;
   int64 rows_written = 14;
   int64 retries = 15;
+  string auto_retry_reason = 16;
+  // Nodes is the ordered list of nodes ids on which the statement was executed.
+  repeated int64 nodes = 17;
 }
 
 message Insight {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -170,6 +170,11 @@ func (s *Container) RecordStatement(
 		}
 	}
 
+	var autoRetryReason string
+	if value.AutoRetryReason != nil {
+		autoRetryReason = value.AutoRetryReason.Error()
+	}
+
 	s.outliersRegistry.ObserveStatement(value.SessionID, &insights.Statement{
 		ID:               value.StatementID,
 		FingerprintID:    stmtFingerprintID,
@@ -179,13 +184,15 @@ func (s *Container) RecordStatement(
 		StartTime:        value.StartTime,
 		EndTime:          value.EndTime,
 		FullScan:         value.FullScan,
-		User:             value.SessionData.User().SQLIdentifier(),
+		User:             value.SessionData.User().Normalized(),
 		ApplicationName:  value.SessionData.ApplicationName,
 		Database:         value.SessionData.Database,
 		PlanGist:         value.PlanGist,
 		Retries:          int64(value.AutoRetryCount),
+		AutoRetryReason:  autoRetryReason,
 		RowsRead:         value.RowsRead,
 		RowsWritten:      value.RowsWritten,
+		Nodes:            value.Nodes,
 	})
 
 	return stats.ID, nil

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -196,6 +196,7 @@ type RecordedStmtStats struct {
 	StatementID          clusterunique.ID
 	TransactionID        uuid.UUID
 	AutoRetryCount       int
+	AutoRetryReason      error
 	RowsAffected         int
 	ParseLatency         float64
 	PlanLatency          float64


### PR DESCRIPTION
Adding the retry reason and node ids to execution_insights

part of #81024

Release note (sql change): Adding last_retry_reason and 
exec_node_ids columns to
crdb_internal.node_execution_insights