### PR TITLE
roachtest: skip on AWS when using multiple stores

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -291,10 +291,16 @@ func registerKV(r registry.Registry) {
 		if opts.encryption {
 			encryption = registry.EncryptionAlwaysEnabled
 		}
+		cSpec := r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds), spec.RAID0(opts.raid0))
+		var skip string
+		if opts.ssds != 0 && cSpec.Cloud != spec.GCE {
+			skip = fmt.Sprintf("multi-store tests are not supported on cloud %s", cSpec.Cloud)
+		}
 		r.Add(registry.TestSpec{
+			Skip:    skip,
 			Name:    strings.Join(nameParts, "/"),
 			Owner:   owner,
-			Cluster: r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds), spec.RAID0(opts.raid0)),
+			Cluster: cSpec,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runKV(ctx, t, c, opts)
 			},

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -210,11 +210,17 @@ func registerRebalanceLoad(r registry.Registry) {
 			},
 		},
 	)
+	cSpec := r.MakeClusterSpec(7, spec.SSD(2)) // the last node is just used to generate load
+	var skip string
+	if cSpec.Cloud != spec.GCE {
+		skip = fmt.Sprintf("multi-store tests are not supported on cloud %s", cSpec.Cloud)
+	}
 	r.Add(
 		registry.TestSpec{
+			Skip:    skip,
 			Name:    `rebalance/by-load/replicas/ssds=2`,
 			Owner:   registry.OwnerKV,
-			Cluster: r.MakeClusterSpec(7, spec.SSD(2)), // the last node is just used to generate load
+			Cluster: cSpec,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					t.Fatal("cannot run multi-store in local mode")


### PR DESCRIPTION
In roachtests we cannot set the number of stores when running on AWS.
This patch skips a few (recently added) roachtests that fail when
trying to do that.

Tested by running these roachtests with --cloud=aws and --cloud=gce.

Release note: None