### PR TITLE
dev: support `dev gen bazel --short`

### DIFF
--- a/pkg/cmd/dev/testdata/datadriven/generate
+++ b/pkg/cmd/dev/testdata/datadriven/generate
@@ -16,6 +16,11 @@ bazel info workspace --color=no
 crdb-checkout/build/bazelutil/check.sh
 
 exec
+dev gen bazel --short
+----
+bazel run //:gazelle
+
+exec
 dev generate bazel --mirror --force
 ----
 bazel info workspace --color=no


### PR DESCRIPTION
Running just gazelle (updating BUILD.bazel files) is a lot faster than
auto-genning all bazel related files. It's also more frequent
(dependencies changing, files added/removed).

Release note: None