### PR TITLE
sql: disallow distsql_workmem of less than 2B

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -533,6 +533,12 @@ var settingWorkMemBytes = settings.RegisterByteSizeSetting(
 	"sql.distsql.temp_storage.workmem",
 	"maximum amount of memory in bytes a processor can use before falling back to temp storage",
 	execinfra.DefaultMemoryLimit, /* 64MiB */
+	func(v int64) error {
+		if v <= 1 {
+			return errors.Errorf("can only be set to a value greater than 1: %d", v)
+		}
+		return nil
+	},
 ).WithPublic()
 
 // ExperimentalDistSQLPlanningClusterSettingName is the name for the cluster

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -521,8 +521,8 @@ var varGen = map[string]sessionVar{
 			if err != nil {
 				return err
 			}
-			if limit <= 0 {
-				return errors.New("distsql_workmem can only be set to a positive value")
+			if limit <= 1 {
+				return errors.New("distsql_workmem can only be set to a value greater than 1")
 			}
 			m.SetDistSQLWorkMem(limit)
 			return nil


### PR DESCRIPTION
This commit disallows users to set `distsql_workmem` session variable
(as well as the corresponding cluster setting) to a value lower than 2B.
The rationale is that internally we treat 1B as "force disk spilling"
testing scenario and have some places where the setting is ignored if
it is 1B. Non-positive values don't make sense too. It shouldn't really
be a problem to users since nobody should be setting this value this low.

Release note: None