### PR TITLE
explain: fix annotating nodes with execution stats and estimates

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -48,10 +48,8 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 2
 │           │
 │           └── • render
-│               │ estimated row count: 2
 │               │
 │               └── • values
 │                     size: 2 columns, 2 rows
@@ -66,9 +64,9 @@ vectorized: true
             │ equality cols are key
             │
             └── • render
-                │ estimated row count: 2
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 
@@ -296,6 +294,7 @@ vectorized: true
 │               │ lookup condition: (((crdb_region = 'ap-southeast-2') AND (column3 = c_w_id)) AND (column2 = c_d_id)) AND (column1 = c_id)
 │               │
 │               └── • scan buffer
+│                     estimated row count: 1
 │                     label: buffer 1
 │
 └── • constraint-check
@@ -315,6 +314,7 @@ vectorized: true
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (column5 = d_w_id)) AND (column4 = d_id)
                 │
                 └── • scan buffer
+                      estimated row count: 1
                       label: buffer 1
 
 # Regression test for #62269. Ensure that locality optimized search results in

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -65,26 +65,25 @@ vectorized: true
         │
         └── • project
             │ columns: (pid)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
-                    │ estimated row count: 1
                     │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                     │ render pid: column2
                     │
                     └── • project
                         │ columns: (column2)
-                        │ estimated row count: 1
                         │
                         └── • scan buffer
                               columns: (column1, column2)
+                              estimated row count: 1
                               label: buffer 1
 
 query T
@@ -120,7 +119,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (id)
-│           │ estimated row count: 1 (missing stats)
 │           │
 │           └── • cross join (inner)
 │               │ columns: (id, id, part)
@@ -145,26 +143,25 @@ vectorized: true
         │
         └── • project
             │ columns: (pid)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
-                    │ estimated row count: 1
                     │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                     │ render pid: column2
                     │
                     └── • project
                         │ columns: (column2)
-                        │ estimated row count: 1
                         │
                         └── • scan buffer
                               columns: (column1, column2, column3, check1)
+                              estimated row count: 1
                               label: buffer 1
 
 subtest test_uniqueness_check_uuid
@@ -195,7 +192,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_user_id_shard_16_comp, user_id_default, val_cast, column2, check1, check2)
-    │ estimated row count: 1
     │ render check1: column2 IN ('new york', 'seattle')
     │ render check2: crdb_internal_user_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column2: column2
@@ -205,7 +201,6 @@ vectorized: true
     │
     └── • render
         │ columns: (crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-        │ estimated row count: 1
         │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
         │ render column2: column2
         │ render val_cast: val_cast
@@ -233,7 +228,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_user_id_shard_16_comp, user_id_default, val_cast, column2, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column2 IN ('new york', 'seattle')
     │ render check2: crdb_internal_user_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column2: column2
@@ -249,17 +243,16 @@ vectorized: true
         │
         └── • project
             │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                 │
                 └── • render
                     │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-                    │ estimated row count: 1
                     │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                     │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                     │ render column2: column2
@@ -288,7 +281,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_user_id_shard_16_comp, user_id_default, val_cast, column2, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column2 IN ('new york', 'seattle')
     │ render check2: crdb_internal_user_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column2: column2
@@ -304,17 +296,16 @@ vectorized: true
         │
         └── • project
             │ columns: (column2, val_cast, user_id_default, crdb_internal_user_id_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
                 │
                 └── • render
                     │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
-                    │ estimated row count: 2
                     │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                     │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                     │ render column2: column2
@@ -323,7 +314,6 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (user_id_default, column2, val_cast)
-                        │ estimated row count: 2
                         │ render user_id_default: gen_random_uuid()
                         │ render column2: column2
                         │ render val_cast: val_cast
@@ -378,7 +368,6 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 1 (missing stats)
             │
             └── • cross join (inner)
                 │ columns: (id, crdb_internal_id_shard_16, id, part)
@@ -391,7 +380,6 @@ vectorized: true
                 │
                 └── • limit
                     │ columns: (crdb_internal_id_shard_16, id, part)
-                    │ estimated row count: 1 (missing stats)
                     │ count: 1
                     │
                     └── • distinct
@@ -430,7 +418,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column2 IN ('new york', 'seattle')
     │ render check2: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column1: column1
@@ -470,7 +457,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column2 IN ('new york', 'seattle')
     │ render check2: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column1: column1
@@ -479,17 +465,16 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, column2, crdb_internal_id_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
+            │ estimated row count: 0 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
             │
             └── • render
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
-                │ estimated row count: 2
                 │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                 │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                 │ render column1: column1
@@ -518,7 +503,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column2 IN ('new york', 'seattle')
     │ render check2: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column1: column1
@@ -558,7 +542,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, column2, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column2 IN ('new york', 'seattle')
     │ render check2: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column1: column1
@@ -567,17 +550,16 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, column2, crdb_internal_id_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
+            │ estimated row count: 0 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
             │
             └── • render
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
-                │ estimated row count: 2
                 │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                 │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                 │ render column1: column1
@@ -615,7 +597,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part, upsert_part)
-│               │ estimated row count: 1 (missing stats)
 │               │ render check1: upsert_part IN ('new york', 'seattle')
 │               │ render check2: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render column1: column1
@@ -628,7 +609,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_part, column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part)
-│                   │ estimated row count: 1 (missing stats)
 │                   │ render upsert_part: CASE WHEN part IS NULL THEN column2 ELSE part END
 │                   │ render column1: column1
 │                   │ render column2: column2
@@ -663,21 +643,19 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (crdb_internal_id_shard_16, id, part)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                     │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
                     │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (part != part)
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                         │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
                         │ render id: column1
@@ -685,10 +663,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_part)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, column1, part, check1, check2, upsert_part)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1
 
 query T
@@ -715,7 +693,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part, upsert_part)
-│               │ estimated row count: 2 (missing stats)
 │               │ render check1: upsert_part IN ('new york', 'seattle')
 │               │ render check2: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render column1: column1
@@ -728,7 +705,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_part, column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part)
-│                   │ estimated row count: 2 (missing stats)
 │                   │ render upsert_part: CASE WHEN part IS NULL THEN column2 ELSE part END
 │                   │ render column1: column1
 │                   │ render column2: column2
@@ -739,10 +715,10 @@ vectorized: true
 │                   │
 │                   └── • project
 │                       │ columns: (column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part)
-│                       │ estimated row count: 2 (missing stats)
 │                       │
 │                       └── • lookup join (left outer)
 │                           │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part)
+│                           │ estimated row count: 2 (missing stats)
 │                           │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
 │                           │ equality cols are key
 │                           │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -750,7 +726,6 @@ vectorized: true
 │                           │
 │                           └── • render
 │                               │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
-│                               │ estimated row count: 2
 │                               │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
 │                               │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
 │                               │ render column1: column1
@@ -771,21 +746,19 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 1 (missing stats)
             │
             └── • project
                 │ columns: (crdb_internal_id_shard_16, id, part)
-                │ estimated row count: 1 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                     │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
                     │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (part != part)
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
-                        │ estimated row count: 2 (missing stats)
                         │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                         │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
                         │ render id: column1
@@ -793,10 +766,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_part)
-                            │ estimated row count: 2 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, column1, part, check1, check2, upsert_part)
+                                  estimated row count: 2 (missing stats)
                                   label: buffer 1
 
 query T
@@ -817,7 +790,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, check2, column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part)
-        │ estimated row count: 1 (missing stats)
         │ render check1: column2 IN ('new york', 'seattle')
         │ render check2: CASE WHEN part IS NULL THEN crdb_internal_id_shard_16_comp ELSE crdb_internal_id_shard_16 END IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
         │ render column1: column1
@@ -864,7 +836,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, check2, column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part)
-        │ estimated row count: 2 (missing stats)
         │ render check1: column2 IN ('new york', 'seattle')
         │ render check2: CASE WHEN part IS NULL THEN crdb_internal_id_shard_16_comp ELSE crdb_internal_id_shard_16 END IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
         │ render column1: column1
@@ -876,10 +847,10 @@ vectorized: true
         │
         └── • project
             │ columns: (column1, column2, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, part)
-            │ estimated row count: 2 (missing stats)
             │
             └── • lookup join (left outer)
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2, crdb_internal_id_shard_16, id, part)
+                │ estimated row count: 2 (missing stats)
                 │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -887,7 +858,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
-                    │ estimated row count: 2
                     │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                     │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                     │ render column1: column1
@@ -922,7 +892,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, id_new, check2)
-│           │ estimated row count: 1 (missing stats)
 │           │ render check2: true
 │           │ render crdb_internal_id_shard_16_comp: 6
 │           │ render id_new: 1234
@@ -945,21 +914,19 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (crdb_internal_id_shard_16, id, part)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                     │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
                     │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (part != part)
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, part)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(id_new)), 16)
                         │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
                         │ render id: id_new
@@ -967,10 +934,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (crdb_internal_id_shard_16_comp, id_new, part)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (crdb_internal_id_shard_16, id, part, crdb_internal_id_shard_16_comp, id_new, check2)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1
 
 subtest test_uniqueness_check_sec_key
@@ -1020,7 +987,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (id)
-│           │ estimated row count: 1 (missing stats)
 │           │
 │           └── • cross join (inner)
 │               │ columns: (id, id, part)
@@ -1045,7 +1011,6 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 1 (missing stats)
             │
             └── • cross join (inner)
                 │ columns: (email, id, email, part)
@@ -1058,7 +1023,6 @@ vectorized: true
                 │
                 └── • limit
                     │ columns: (id, email, part)
-                    │ estimated row count: 1 (missing stats)
                     │ count: 1
                     │
                     └── • distinct
@@ -1103,7 +1067,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column3 IN ('new york', 'seattle')
     │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column1: column1
@@ -1113,17 +1076,16 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_email_shard_16_eq, column1, column2, column3, crdb_internal_email_shard_16_comp)
+            │ estimated row count: 0 (missing stats)
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
             │
             └── • render
                 │ columns: (crdb_internal_email_shard_16_eq, column1, column2, column3, crdb_internal_email_shard_16_comp)
-                │ estimated row count: 0 (missing stats)
                 │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                 │ render column1: column1
                 │ render column2: column2
@@ -1144,7 +1106,6 @@ vectorized: true
                     │
                     └── • project
                         │ columns: ()
-                        │ estimated row count: 1 (missing stats)
                         │
                         └── • scan
                               columns: (id)
@@ -1168,7 +1129,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column3 IN ('new york', 'seattle')
     │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render column1: column1
@@ -1185,17 +1145,16 @@ vectorized: true
         │
         └── • project
             │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
                 │
                 └── • render
                     │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
-                    │ estimated row count: 2
                     │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                     │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                     │ render column1: column1
@@ -1229,7 +1188,6 @@ vectorized: true
 │   │
 │   └── • render
 │       │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ estimated row count: 0 (missing stats)
 │       │ render check1: column3 IN ('new york', 'seattle')
 │       │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │       │ render column1: column1
@@ -1251,7 +1209,6 @@ vectorized: true
 │           │
 │           └── • project
 │               │ columns: ()
-│               │ estimated row count: 1 (missing stats)
 │               │
 │               └── • scan
 │                     columns: (email)
@@ -1267,7 +1224,6 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 1 (missing stats)
             │
             └── • cross join (inner)
                 │ columns: (id, id, part)
@@ -1306,7 +1262,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
-│           │ estimated row count: 0 (missing stats)
 │           │ render check1: column3 IN ('new york', 'seattle')
 │           │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │           │ render column1: column1
@@ -1316,17 +1271,16 @@ vectorized: true
 │           │
 │           └── • project
 │               │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp)
-│               │ estimated row count: 0 (missing stats)
 │               │
 │               └── • lookup join (anti)
 │                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
+│                   │ estimated row count: 0 (missing stats)
 │                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                   │ equality cols are key
 │                   │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
 │                   │
 │                   └── • render
 │                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
-│                       │ estimated row count: 2
 │                       │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                       │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                       │ render column1: column1
@@ -1350,7 +1304,6 @@ vectorized: true
         │
         └── • project
             │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (semi)
                 │ columns: (column1, column3)
@@ -1361,10 +1314,10 @@ vectorized: true
                 │
                 └── • project
                     │ columns: (column1, column3)
-                    │ estimated row count: 0 (missing stats)
                     │
                     └── • scan buffer
                           columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, check1, check2)
+                          estimated row count: 0 (missing stats)
                           label: buffer 1
 
 query T
@@ -1391,7 +1344,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_id, upsert_email, upsert_part, upsert_crdb_internal_email_shard_16)
-│               │ estimated row count: 1 (missing stats)
 │               │ render check1: upsert_part IN ('new york', 'seattle')
 │               │ render check2: upsert_crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render column1: column1
@@ -1409,7 +1361,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_id, upsert_email, upsert_part, upsert_crdb_internal_email_shard_16, column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16)
-│                   │ estimated row count: 1 (missing stats)
 │                   │ render upsert_id: CASE WHEN part IS NULL THEN column1 ELSE id END
 │                   │ render upsert_email: CASE WHEN part IS NULL THEN column2 ELSE 'bad_email' END
 │                   │ render upsert_part: CASE WHEN part IS NULL THEN column3 ELSE part END
@@ -1437,7 +1388,6 @@ vectorized: true
 │                       │
 │                       └── • render
 │                           │ columns: (crdb_internal_email_shard_16, id, email, part)
-│                           │ estimated row count: 1 (missing stats)
 │                           │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
 │                           │ render id: id
 │                           │ render email: email
@@ -1457,7 +1407,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (upsert_id)
-│           │ estimated row count: 0 (missing stats)
 │           │
 │           └── • lookup join (semi)
 │               │ columns: (upsert_id, upsert_part)
@@ -1468,10 +1417,10 @@ vectorized: true
 │               │
 │               └── • project
 │                   │ columns: (upsert_id, upsert_part)
-│                   │ estimated row count: 1 (missing stats)
 │                   │
 │                   └── • scan buffer
 │                         columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+│                         estimated row count: 1 (missing stats)
 │                         label: buffer 1
 │
 └── • constraint-check
@@ -1481,21 +1430,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (id, email, part)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (part != part)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(upsert_email)), 16)
                         │ render id: upsert_id
                         │ render email: upsert_email
@@ -1503,10 +1450,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (upsert_id, upsert_email, upsert_part)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1
 
 query T
@@ -1533,7 +1480,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_id, upsert_email, upsert_part, upsert_crdb_internal_email_shard_16)
-│               │ estimated row count: 2 (missing stats)
 │               │ render check1: upsert_part IN ('new york', 'seattle')
 │               │ render check2: upsert_crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render column1: column1
@@ -1551,7 +1497,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_id, upsert_email, upsert_part, upsert_crdb_internal_email_shard_16, column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16)
-│                   │ estimated row count: 2 (missing stats)
 │                   │ render upsert_id: CASE WHEN part IS NULL THEN column1 ELSE id END
 │                   │ render upsert_email: CASE WHEN part IS NULL THEN column2 ELSE 'bad_email' END
 │                   │ render upsert_part: CASE WHEN part IS NULL THEN column3 ELSE part END
@@ -1567,7 +1512,6 @@ vectorized: true
 │                   │
 │                   └── • render
 │                       │ columns: (crdb_internal_email_shard_16, column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part)
-│                       │ estimated row count: 2 (missing stats)
 │                       │ render crdb_internal_email_shard_16: CASE id IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(email)), 16) END
 │                       │ render column1: column1
 │                       │ render column2: column2
@@ -1579,14 +1523,13 @@ vectorized: true
 │                       │
 │                       └── • project
 │                           │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part)
-│                           │ estimated row count: 2 (missing stats)
 │                           │
 │                           └── • project
 │                               │ columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16)
-│                               │ estimated row count: 2 (missing stats)
 │                               │
 │                               └── • lookup join (left outer)
 │                                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3, id, email, part, crdb_internal_email_shard_16)
+│                                   │ estimated row count: 2 (missing stats)
 │                                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                                   │ equality cols are key
 │                                   │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
@@ -1594,7 +1537,6 @@ vectorized: true
 │                                   │
 │                                   └── • render
 │                                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
-│                                       │ estimated row count: 2
 │                                       │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                                       │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                                       │ render column1: column1
@@ -1618,7 +1560,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (upsert_id)
-│           │ estimated row count: 1 (missing stats)
 │           │
 │           └── • lookup join (semi)
 │               │ columns: (upsert_id, upsert_part)
@@ -1629,10 +1570,10 @@ vectorized: true
 │               │
 │               └── • project
 │                   │ columns: (upsert_id, upsert_part)
-│                   │ estimated row count: 2 (missing stats)
 │                   │
 │                   └── • scan buffer
 │                         columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+│                         estimated row count: 2 (missing stats)
 │                         label: buffer 1
 │
 └── • constraint-check
@@ -1642,21 +1583,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 1 (missing stats)
             │
             └── • project
                 │ columns: (id, email, part)
-                │ estimated row count: 1 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (part != part)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
-                        │ estimated row count: 2 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(upsert_email)), 16)
                         │ render id: upsert_id
                         │ render email: upsert_email
@@ -1664,10 +1603,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (upsert_id, upsert_email, upsert_part)
-                            │ estimated row count: 2 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, part, check1, check2, upsert_id, upsert_part)
+                                  estimated row count: 2 (missing stats)
                                   label: buffer 1
 
 query T
@@ -1694,7 +1633,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, upsert_id, column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16)
-│               │ estimated row count: 1 (missing stats)
 │               │ render check1: column3 IN ('new york', 'seattle')
 │               │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render upsert_id: CASE WHEN part IS NULL THEN column1 ELSE id END
@@ -1721,7 +1659,6 @@ vectorized: true
 │                   │
 │                   └── • render
 │                       │ columns: (crdb_internal_email_shard_16, id, email, part)
-│                       │ estimated row count: 1 (missing stats)
 │                       │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
 │                       │ render id: id
 │                       │ render email: email
@@ -1741,21 +1678,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (id, email, part)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (part != part)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                         │ render id: upsert_id
                         │ render email: column2
@@ -1763,10 +1698,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (upsert_id, column2, column3)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_comp, part, check1, check2, upsert_id)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1
 
 query T
@@ -1793,7 +1728,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, upsert_id, column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16)
-│               │ estimated row count: 2 (missing stats)
 │               │ render check1: column3 IN ('new york', 'seattle')
 │               │ render check2: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render upsert_id: CASE WHEN part IS NULL THEN column1 ELSE id END
@@ -1808,7 +1742,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (crdb_internal_email_shard_16, column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part)
-│                   │ estimated row count: 2 (missing stats)
 │                   │ render crdb_internal_email_shard_16: CASE id IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(email)), 16) END
 │                   │ render column1: column1
 │                   │ render column2: column2
@@ -1828,7 +1761,6 @@ vectorized: true
 │                       │
 │                       └── • render
 │                           │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
-│                           │ estimated row count: 2
 │                           │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                           │ render column1: column1
 │                           │ render column2: column2
@@ -1851,21 +1783,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 1 (missing stats)
             │
             └── • project
                 │ columns: (id, email, part)
-                │ estimated row count: 1 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (part != part)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
-                        │ estimated row count: 2 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                         │ render id: upsert_id
                         │ render email: column2
@@ -1873,10 +1803,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (upsert_id, column2, column3)
-                            │ estimated row count: 2 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, column3, crdb_internal_email_shard_16_comp, id, email, part, crdb_internal_email_shard_16, column2, column3, crdb_internal_email_shard_16_comp, part, check1, check2, upsert_id)
+                                  estimated row count: 2 (missing stats)
                                   label: buffer 1
 
 query T
@@ -1900,7 +1830,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (id, email, part, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_comp, check2)
-│           │ estimated row count: 1 (missing stats)
 │           │ render check2: true
 │           │ render crdb_internal_email_shard_16_comp: 5
 │           │ render email_new: 'email1'
@@ -1924,21 +1853,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (id, email, part)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (part != part)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, part)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(email_new)), 16)
                         │ render id: id
                         │ render email: email_new
@@ -1946,8 +1873,8 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (id, email_new, part)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (id, email, part, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_comp, check2)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -281,6 +281,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 1
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -297,6 +298,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 1
                   label: buffer 1
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -67,10 +67,10 @@ vectorized: true
         │
         └── • project
             │ columns: (pid)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
@@ -84,16 +84,15 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, pid)
-                        │ estimated row count: 1
                         │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                         │ render pid: column2
                         │
                         └── • project
                             │ columns: (column2)
-                            │ estimated row count: 1
                             │
                             └── • scan buffer
                                   columns: (column1, column2)
+                                  estimated row count: 1
                                   label: buffer 1
 
 query T
@@ -129,7 +128,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (id)
-│           │ estimated row count: 1 (missing stats)
 │           │
 │           └── • cross join (inner)
 │               │ columns: (id, id, crdb_region)
@@ -154,10 +152,10 @@ vectorized: true
         │
         └── • project
             │ columns: (pid)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
@@ -171,16 +169,15 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, pid)
-                        │ estimated row count: 1
                         │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                         │ render pid: column2
                         │
                         └── • project
                             │ columns: (column2)
-                            │ estimated row count: 1
                             │
                             └── • scan buffer
                                   columns: (column1, column2, crdb_region_default, check1)
+                                  estimated row count: 1
                                   label: buffer 1
 
 subtest test_uniqueness_check_uuid
@@ -207,7 +204,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_user_id_shard_16_comp, user_id_default, val_cast, crdb_region_default, check1, check2)
-    │ estimated row count: 1
     │ render check1: crdb_internal_user_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render val_cast: val_cast
@@ -217,7 +213,6 @@ vectorized: true
     │
     └── • render
         │ columns: (crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-        │ estimated row count: 1
         │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
         │ render val_cast: val_cast
         │ render user_id_default: user_id_default
@@ -245,7 +240,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_user_id_shard_16_comp, user_id_default, val_cast, crdb_region_default, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_user_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render val_cast: val_cast
@@ -261,10 +255,10 @@ vectorized: true
         │
         └── • project
             │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
@@ -278,7 +272,6 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                        │ estimated row count: 1
                         │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                         │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                         │ render val_cast: val_cast
@@ -307,7 +300,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_user_id_shard_16_comp, user_id_default, val_cast, crdb_region_default, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_user_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render val_cast: val_cast
@@ -323,10 +315,10 @@ vectorized: true
         │
         └── • project
             │ columns: (val_cast, user_id_default, crdb_region_default, crdb_internal_user_id_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
@@ -340,7 +332,6 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
-                        │ estimated row count: 2
                         │ render crdb_internal_user_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                         │ render crdb_internal_user_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(user_id_default)), 16)
                         │ render val_cast: val_cast
@@ -349,7 +340,6 @@ vectorized: true
                         │
                         └── • render
                             │ columns: (user_id_default, crdb_region_default, val_cast)
-                            │ estimated row count: 2
                             │ render user_id_default: gen_random_uuid()
                             │ render crdb_region_default: 'ap-southeast-2'
                             │ render val_cast: val_cast
@@ -397,7 +387,6 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 1 (missing stats)
             │
             └── • cross join (inner)
                 │ columns: (id, crdb_internal_id_shard_16, id, crdb_region)
@@ -410,7 +399,6 @@ vectorized: true
                 │
                 └── • limit
                     │ columns: (crdb_internal_id_shard_16, id, crdb_region)
-                    │ estimated row count: 1 (missing stats)
                     │ count: 1
                     │
                     └── • filter
@@ -450,7 +438,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render column1: column1
@@ -501,7 +488,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render column1: column1
@@ -510,10 +496,10 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+            │ estimated row count: 0 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -527,7 +513,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-                    │ estimated row count: 2
                     │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                     │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                     │ render crdb_region_default: 'ap-southeast-2'
@@ -554,7 +539,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render column1: column1
@@ -605,7 +589,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render column1: column1
@@ -614,10 +597,10 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
+            │ estimated row count: 0 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -631,7 +614,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-                    │ estimated row count: 2
                     │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                     │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                     │ render crdb_region_default: 'ap-southeast-2'
@@ -667,7 +649,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, column1, crdb_region_default, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, crdb_region, upsert_crdb_region)
-│               │ estimated row count: 1 (missing stats)
 │               │ render check1: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render check2: upsert_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
 │               │ render column1: column1
@@ -680,7 +661,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_crdb_region, column1, crdb_region_default, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, crdb_region)
-│                   │ estimated row count: 1 (missing stats)
 │                   │ render upsert_crdb_region: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END
 │                   │ render column1: column1
 │                   │ render crdb_region_default: crdb_region_default
@@ -725,21 +705,19 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (crdb_internal_id_shard_16, id, crdb_region)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                     │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
                     │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (crdb_region != crdb_region)
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                         │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
                         │ render id: column1
@@ -747,10 +725,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_crdb_region)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, column1, crdb_region, check1, check2, upsert_crdb_region)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1
 
 query T
@@ -777,7 +755,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, column1, crdb_region_default, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, crdb_region, upsert_crdb_region)
-│               │ estimated row count: 2 (missing stats)
 │               │ render check1: crdb_internal_id_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render check2: upsert_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
 │               │ render column1: column1
@@ -790,7 +767,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_crdb_region, column1, crdb_region_default, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, crdb_region)
-│                   │ estimated row count: 2 (missing stats)
 │                   │ render upsert_crdb_region: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END
 │                   │ render column1: column1
 │                   │ render crdb_region_default: crdb_region_default
@@ -801,10 +777,10 @@ vectorized: true
 │                   │
 │                   └── • project
 │                       │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, crdb_region)
-│                       │ estimated row count: 2 (missing stats)
 │                       │
 │                       └── • lookup join (left outer)
 │                           │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1, crdb_internal_id_shard_16, id, crdb_region)
+│                           │ estimated row count: 2 (missing stats)
 │                           │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
 │                           │ equality cols are key
 │                           │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -813,7 +789,6 @@ vectorized: true
 │                           │
 │                           └── • render
 │                               │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-│                               │ estimated row count: 2
 │                               │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
 │                               │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
 │                               │ render crdb_region_default: 'ap-southeast-2'
@@ -832,21 +807,19 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 1 (missing stats)
             │
             └── • project
                 │ columns: (crdb_internal_id_shard_16, id, crdb_region)
-                │ estimated row count: 1 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                     │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
                     │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (crdb_region != crdb_region)
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
-                        │ estimated row count: 2 (missing stats)
                         │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                         │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
                         │ render id: column1
@@ -854,10 +827,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (crdb_internal_id_shard_16_comp, column1, upsert_crdb_region)
-                            │ estimated row count: 2 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, column1, crdb_region, check1, check2, upsert_crdb_region)
+                                  estimated row count: 2 (missing stats)
                                   label: buffer 1
 
 query T
@@ -875,7 +848,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_region, check1, check2)
-    │ estimated row count: 1 (missing stats)
     │ render check1: CASE WHEN crdb_region IS NULL THEN crdb_internal_id_shard_16_comp ELSE crdb_internal_id_shard_16 END IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render column1: column1
@@ -927,7 +899,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_id_shard_16_comp, column1, crdb_region_default, crdb_region, check1, check2)
-    │ estimated row count: 2 (missing stats)
     │ render check1: CASE WHEN crdb_region IS NULL THEN crdb_internal_id_shard_16_comp ELSE crdb_internal_id_shard_16 END IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render column1: column1
@@ -937,10 +908,10 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, crdb_region_default, crdb_internal_id_shard_16_comp, crdb_internal_id_shard_16, id, crdb_region)
-        │ estimated row count: 2 (missing stats)
         │
         └── • lookup join (left outer)
             │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1, crdb_internal_id_shard_16, id, crdb_region)
+            │ estimated row count: 2 (missing stats)
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
@@ -949,7 +920,6 @@ vectorized: true
             │
             └── • render
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
-                │ estimated row count: 2
                 │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                 │ render crdb_internal_id_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 16)
                 │ render crdb_region_default: 'ap-southeast-2'
@@ -982,7 +952,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, id_new, check1)
-│           │ estimated row count: 1 (missing stats)
 │           │ render check1: true
 │           │ render crdb_internal_id_shard_16_comp: 6
 │           │ render id_new: 1234
@@ -1015,21 +984,19 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (crdb_internal_id_shard_16, id, crdb_region)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                     │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (id = id)
                     │ pred: (crdb_internal_id_shard_16 != crdb_internal_id_shard_16) OR (crdb_region != crdb_region)
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16, id, crdb_region)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(id_new)), 16)
                         │ render crdb_internal_id_shard_16: crdb_internal_id_shard_16_comp
                         │ render id: id_new
@@ -1037,10 +1004,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (crdb_internal_id_shard_16_comp, id_new, crdb_region)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (crdb_internal_id_shard_16, id, crdb_region, crdb_internal_id_shard_16_comp, id_new, check1)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1
 
 subtest test_uniqueness_check_sec_key
@@ -1086,7 +1053,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (id)
-│           │ estimated row count: 1 (missing stats)
 │           │
 │           └── • cross join (inner)
 │               │ columns: (id, id, crdb_region)
@@ -1111,7 +1077,6 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 1 (missing stats)
             │
             └── • cross join (inner)
                 │ columns: (email, id, email, crdb_region)
@@ -1124,7 +1089,6 @@ vectorized: true
                 │
                 └── • limit
                     │ columns: (id, email, crdb_region)
-                    │ estimated row count: 1 (missing stats)
                     │ count: 1
                     │
                     └── • distinct
@@ -1180,7 +1144,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render column1: column1
@@ -1190,17 +1153,16 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-        │ estimated row count: 0 (missing stats)
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
+            │ estimated row count: 0 (missing stats)
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
             │
             └── • render
                 │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-                │ estimated row count: 0 (missing stats)
                 │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                 │ render column1: column1
                 │ render column2: column2
@@ -1221,7 +1183,6 @@ vectorized: true
                     │
                     └── • project
                         │ columns: ()
-                        │ estimated row count: 1 (missing stats)
                         │
                         └── • union all
                             │ columns: (id)
@@ -1256,7 +1217,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
     │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
     │ render column1: column1
@@ -1273,10 +1233,10 @@ vectorized: true
         │
         └── • project
             │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
@@ -1290,7 +1250,6 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-                        │ estimated row count: 2
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                         │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                         │ render crdb_region_default: 'ap-southeast-2'
@@ -1322,7 +1281,6 @@ vectorized: true
 │   │
 │   └── • render
 │       │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│       │ estimated row count: 0 (missing stats)
 │       │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │       │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
 │       │ render column1: column1
@@ -1344,7 +1302,6 @@ vectorized: true
 │           │
 │           └── • project
 │               │ columns: ()
-│               │ estimated row count: 1 (missing stats)
 │               │
 │               └── • union all
 │                   │ columns: (email)
@@ -1371,7 +1328,6 @@ vectorized: true
         │
         └── • project
             │ columns: (id)
-            │ estimated row count: 1 (missing stats)
             │
             └── • cross join (inner)
                 │ columns: (id, id, crdb_region)
@@ -1410,7 +1366,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
-│           │ estimated row count: 0 (missing stats)
 │           │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │           │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
 │           │ render column1: column1
@@ -1420,10 +1375,10 @@ vectorized: true
 │           │
 │           └── • project
 │               │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
-│               │ estimated row count: 0 (missing stats)
 │               │
 │               └── • lookup join (anti)
 │                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
+│                   │ estimated row count: 0 (missing stats)
 │                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                   │ equality cols are key
 │                   │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
@@ -1437,7 +1392,6 @@ vectorized: true
 │                       │
 │                       └── • render
 │                           │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-│                           │ estimated row count: 2
 │                           │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                           │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                           │ render crdb_region_default: 'ap-southeast-2'
@@ -1459,7 +1413,6 @@ vectorized: true
         │
         └── • project
             │ columns: (column1)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (semi)
                 │ columns: (column1, crdb_region_default)
@@ -1470,10 +1423,10 @@ vectorized: true
                 │
                 └── • project
                     │ columns: (column1, crdb_region_default)
-                    │ estimated row count: 0 (missing stats)
                     │
                     └── • scan buffer
                           columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, check1, check2)
+                          estimated row count: 0 (missing stats)
                           label: buffer 1
 
 query T
@@ -1500,7 +1453,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_id, upsert_email, upsert_crdb_region, upsert_crdb_internal_email_shard_16)
-│               │ estimated row count: 1 (missing stats)
 │               │ render check1: upsert_crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render check2: upsert_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
 │               │ render column1: column1
@@ -1518,7 +1470,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_id, upsert_email, upsert_crdb_region, upsert_crdb_internal_email_shard_16, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16)
-│                   │ estimated row count: 1 (missing stats)
 │                   │ render upsert_id: CASE WHEN crdb_region IS NULL THEN column1 ELSE id END
 │                   │ render upsert_email: CASE WHEN crdb_region IS NULL THEN column2 ELSE 'bad_email' END
 │                   │ render upsert_crdb_region: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END
@@ -1546,7 +1497,6 @@ vectorized: true
 │                       │
 │                       └── • render
 │                           │ columns: (crdb_internal_email_shard_16, id, email, crdb_region)
-│                           │ estimated row count: 1 (missing stats)
 │                           │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
 │                           │ render id: id
 │                           │ render email: email
@@ -1577,7 +1527,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (upsert_id)
-│           │ estimated row count: 0 (missing stats)
 │           │
 │           └── • lookup join (semi)
 │               │ columns: (upsert_id, upsert_crdb_region)
@@ -1588,10 +1537,10 @@ vectorized: true
 │               │
 │               └── • project
 │                   │ columns: (upsert_id, upsert_crdb_region)
-│                   │ estimated row count: 1 (missing stats)
 │                   │
 │                   └── • scan buffer
 │                         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+│                         estimated row count: 1 (missing stats)
 │                         label: buffer 1
 │
 └── • constraint-check
@@ -1601,21 +1550,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (id, email, crdb_region)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(upsert_email)), 16)
                         │ render id: upsert_id
                         │ render email: upsert_email
@@ -1623,10 +1570,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (upsert_id, upsert_email, upsert_crdb_region)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1
 
 query T
@@ -1653,7 +1600,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_id, upsert_email, upsert_crdb_region, upsert_crdb_internal_email_shard_16)
-│               │ estimated row count: 2 (missing stats)
 │               │ render check1: upsert_crdb_internal_email_shard_16 IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render check2: upsert_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
 │               │ render column1: column1
@@ -1671,7 +1617,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_id, upsert_email, upsert_crdb_region, upsert_crdb_internal_email_shard_16, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16)
-│                   │ estimated row count: 2 (missing stats)
 │                   │ render upsert_id: CASE WHEN crdb_region IS NULL THEN column1 ELSE id END
 │                   │ render upsert_email: CASE WHEN crdb_region IS NULL THEN column2 ELSE 'bad_email' END
 │                   │ render upsert_crdb_region: CASE WHEN crdb_region IS NULL THEN crdb_region_default ELSE crdb_region END
@@ -1687,7 +1632,6 @@ vectorized: true
 │                   │
 │                   └── • render
 │                       │ columns: (crdb_internal_email_shard_16, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region)
-│                       │ estimated row count: 2 (missing stats)
 │                       │ render crdb_internal_email_shard_16: CASE id IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(email)), 16) END
 │                       │ render column1: column1
 │                       │ render column2: column2
@@ -1699,14 +1643,13 @@ vectorized: true
 │                       │
 │                       └── • project
 │                           │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region)
-│                           │ estimated row count: 2 (missing stats)
 │                           │
 │                           └── • project
 │                               │ columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16)
-│                               │ estimated row count: 2 (missing stats)
 │                               │
 │                               └── • lookup join (left outer)
 │                                   │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2, id, email, crdb_region, crdb_internal_email_shard_16)
+│                                   │ estimated row count: 2 (missing stats)
 │                                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                                   │ equality cols are key
 │                                   │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
@@ -1715,7 +1658,6 @@ vectorized: true
 │                                   │
 │                                   └── • render
 │                                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-│                                       │ estimated row count: 2
 │                                       │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                                       │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                                       │ render crdb_region_default: 'ap-southeast-2'
@@ -1737,7 +1679,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (upsert_id)
-│           │ estimated row count: 1 (missing stats)
 │           │
 │           └── • lookup join (semi)
 │               │ columns: (upsert_id, upsert_crdb_region)
@@ -1748,10 +1689,10 @@ vectorized: true
 │               │
 │               └── • project
 │                   │ columns: (upsert_id, upsert_crdb_region)
-│                   │ estimated row count: 2 (missing stats)
 │                   │
 │                   └── • scan buffer
 │                         columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+│                         estimated row count: 2 (missing stats)
 │                         label: buffer 1
 │
 └── • constraint-check
@@ -1761,21 +1702,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 1 (missing stats)
             │
             └── • project
                 │ columns: (id, email, crdb_region)
-                │ estimated row count: 1 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
-                        │ estimated row count: 2 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(upsert_email)), 16)
                         │ render id: upsert_id
                         │ render email: upsert_email
@@ -1783,10 +1722,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (upsert_id, upsert_email, upsert_crdb_region)
-                            │ estimated row count: 2 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, upsert_email, upsert_crdb_internal_email_shard_16, crdb_region, check1, check2, upsert_id, upsert_crdb_region)
+                                  estimated row count: 2 (missing stats)
                                   label: buffer 1
 
 query T
@@ -1813,7 +1752,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, upsert_id, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16)
-│               │ estimated row count: 1 (missing stats)
 │               │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
 │               │ render upsert_id: CASE WHEN crdb_region IS NULL THEN column1 ELSE id END
@@ -1840,7 +1778,6 @@ vectorized: true
 │                   │
 │                   └── • render
 │                       │ columns: (crdb_internal_email_shard_16, id, email, crdb_region)
-│                       │ estimated row count: 1 (missing stats)
 │                       │ render crdb_internal_email_shard_16: mod(fnv32(crdb_internal.datums_to_bytes(email)), 16)
 │                       │ render id: id
 │                       │ render email: email
@@ -1871,21 +1808,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (id, email, crdb_region)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                         │ render id: upsert_id
                         │ render email: column2
@@ -1893,10 +1828,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (upsert_id, column2, crdb_region_default)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_comp, crdb_region, check1, check2, upsert_id)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1
 
 query T
@@ -1923,7 +1858,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, check2, upsert_id, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16)
-│               │ estimated row count: 2 (missing stats)
 │               │ render check1: crdb_internal_email_shard_16_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 │               │ render check2: crdb_region_default IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
 │               │ render upsert_id: CASE WHEN crdb_region IS NULL THEN column1 ELSE id END
@@ -1938,7 +1872,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (crdb_internal_email_shard_16, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region)
-│                   │ estimated row count: 2 (missing stats)
 │                   │ render crdb_internal_email_shard_16: CASE id IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(email)), 16) END
 │                   │ render column1: column1
 │                   │ render column2: column2
@@ -1959,7 +1892,6 @@ vectorized: true
 │                       │
 │                       └── • render
 │                           │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
-│                           │ estimated row count: 2
 │                           │ render crdb_internal_email_shard_16_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
 │                           │ render crdb_region_default: 'ap-southeast-2'
 │                           │ render column1: column1
@@ -1980,21 +1912,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 1 (missing stats)
             │
             └── • project
                 │ columns: (id, email, crdb_region)
-                │ estimated row count: 1 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ estimated row count: 1 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
-                        │ estimated row count: 2 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                         │ render id: upsert_id
                         │ render email: column2
@@ -2002,10 +1932,10 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (upsert_id, column2, crdb_region_default)
-                            │ estimated row count: 2 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp, id, email, crdb_region, crdb_internal_email_shard_16, column2, crdb_region_default, crdb_internal_email_shard_16_comp, crdb_region, check1, check2, upsert_id)
+                                  estimated row count: 2 (missing stats)
                                   label: buffer 1
 
 query T
@@ -2029,7 +1959,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (id, email, crdb_region, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_comp, check1)
-│           │ estimated row count: 1 (missing stats)
 │           │ render check1: true
 │           │ render crdb_internal_email_shard_16_comp: 5
 │           │ render email_new: 'email1'
@@ -2063,21 +1992,19 @@ vectorized: true
         │
         └── • project
             │ columns: (email)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (id, email, crdb_region)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (semi)
                     │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
+                    │ estimated row count: 0 (missing stats)
                     │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                     │ lookup condition: ((crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (email = email)
                     │ pred: (id != id) OR (crdb_region != crdb_region)
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_eq, id, email, crdb_region)
-                        │ estimated row count: 1 (missing stats)
                         │ render crdb_internal_email_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(email_new)), 16)
                         │ render id: id
                         │ render email: email_new
@@ -2085,8 +2012,8 @@ vectorized: true
                         │
                         └── • project
                             │ columns: (id, email_new, crdb_region)
-                            │ estimated row count: 1 (missing stats)
                             │
                             └── • scan buffer
                                   columns: (id, email, crdb_region, crdb_internal_email_shard_16, email_new, crdb_internal_email_shard_16_comp, check1)
+                                  estimated row count: 1 (missing stats)
                                   label: buffer 1

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -297,7 +297,6 @@ ORDER BY pk LIMIT 5] OFFSET 2
 ·
 • limit
 │ columns: (pk, pk2, a, b, j)
-│ estimated row count: 5 (missing stats)
 │ count: 5
 │
 └── • union all
@@ -1137,6 +1136,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1)] OFFSET 2
                 │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column2 = p_id)
                 │
                 └── • scan buffer
+                      estimated row count: 1
                       label: buffer 1
 
 # Non-constant insert values cannot be inlined in uniqueness check, and all
@@ -1154,7 +1154,6 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 2
 │           │
 │           └── • values
 │                 size: 2 columns, 2 rows
@@ -1169,6 +1168,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
 │           │ pred: crdb_region_default != crdb_region
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -1186,6 +1186,7 @@ SELECT * FROM [EXPLAIN INSERT INTO child VALUES (1, 1), (2, 2)] OFFSET 2
                 │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column2 = p_id)
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 query T
@@ -1321,11 +1322,9 @@ LIMIT 1] OFFSET 2
 ·
 • project
 │ columns: (a, b)
-│ estimated row count: 1
 │
 └── • limit
     │ columns: (a, b, count_rows)
-    │ estimated row count: 1
     │ count: 1
     │
     └── • filter
@@ -1403,11 +1402,9 @@ LIMIT 1] OFFSET 2
 ·
 • project
 │ columns: (b)
-│ estimated row count: 1
 │
 └── • limit
     │ columns: (b, count_rows)
-    │ estimated row count: 1
     │ count: 1
     │
     └── • filter
@@ -1471,11 +1468,9 @@ LIMIT 1] OFFSET 2
 ·
 • project
 │ columns: (c)
-│ estimated row count: 1
 │
 └── • limit
     │ columns: (c, count_rows)
-    │ estimated row count: 1
     │ count: 1
     │
     └── • filter
@@ -1743,7 +1738,6 @@ VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
 │               │ locking strength: for update
 │               │
 │               └── • render
-│                   │ estimated row count: 2
 │                   │
 │                   └── • values
 │                         size: 5 columns, 2 rows
@@ -2946,6 +2940,7 @@ vectorized: true
             │ pred: (id_default != id) OR (crdb_region_default != crdb_region)
             │
             └── • scan buffer
+                  estimated row count: 1
                   label: buffer 1
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -57,7 +57,7 @@ func (b *Builder) buildMutationInput(
 		}
 	}
 
-	input, err = b.ensureColumns(input, colList, inputExpr.ProvidedPhysical().Ordering)
+	input, err = b.ensureColumns(input, inputExpr, colList, inputExpr.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -363,8 +363,25 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 		}
 	}
 
-	// If we are building against an ExplainFactory, annotate the nodes with more
-	// information.
+	b.maybeAnnotateWithEstimates(ep.root, e)
+
+	if saveTableName != "" {
+		ep, err = b.applySaveTable(ep, e, saveTableName)
+		if err != nil {
+			return execPlan{}, err
+		}
+	}
+
+	// Wrap the expression in a render expression if presentation requires it.
+	if p := e.RequiredPhysical(); !p.Presentation.Any() {
+		ep, err = b.applyPresentation(ep, p.Presentation)
+	}
+	return ep, err
+}
+
+// maybeAnnotateWithEstimates checks if we are building against an
+// ExplainFactory and annotates the node with more information if so.
+func (b *Builder) maybeAnnotateWithEstimates(node exec.Node, e memo.RelExpr) {
 	if ef, ok := b.factory.(exec.ExplainFactory); ok {
 		stats := &e.Relational().Stats
 		val := exec.EstimatedStats{
@@ -385,21 +402,8 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 				val.LimitHint = scan.RequiredPhysical().LimitHint
 			}
 		}
-		ef.AnnotateNode(ep.root, exec.EstimatedStatsID, &val)
+		ef.AnnotateNode(node, exec.EstimatedStatsID, &val)
 	}
-
-	if saveTableName != "" {
-		ep, err = b.applySaveTable(ep, e, saveTableName)
-		if err != nil {
-			return execPlan{}, err
-		}
-	}
-
-	// Wrap the expression in a render expression if presentation requires it.
-	if p := e.RequiredPhysical(); !p.Presentation.Any() {
-		ep, err = b.applyPresentation(ep, p.Presentation)
-	}
-	return ep, err
 }
 
 func (b *Builder) buildValues(values *memo.ValuesExpr) (execPlan, error) {
@@ -841,15 +845,17 @@ func (b *Builder) buildInvertedFilter(invFilter *memo.InvertedFilterExpr) (execP
 	// TODO(rytaft): the invertedFilter used to do this post-projection, but we
 	// had difficulty integrating that behavior. Investigate and restore that
 	// original behavior.
-	return b.applySimpleProject(
-		res, invFilter.Relational().OutputCols, invFilter.ProvidedPhysical().Ordering,
-	)
+	return b.applySimpleProject(res, invFilter, invFilter.Relational().OutputCols, invFilter.ProvidedPhysical().Ordering)
 }
 
 // applySimpleProject adds a simple projection on top of an existing plan.
 func (b *Builder) applySimpleProject(
-	input execPlan, cols opt.ColSet, providedOrd opt.Ordering,
+	input execPlan, inputExpr memo.RelExpr, cols opt.ColSet, providedOrd opt.Ordering,
 ) (execPlan, error) {
+	// Since we are constructing a simple project on top of the main operator,
+	// we need to explicitly annotate the latter with estimates since the code
+	// in buildRelational() will attach them to the project.
+	b.maybeAnnotateWithEstimates(input.root, inputExpr)
 	// We have only pass-through columns.
 	colList := make([]exec.NodeColumnOrdinal, 0, cols.Len())
 	var res execPlan
@@ -877,7 +883,7 @@ func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
 	projections := prj.Projections
 	if len(projections) == 0 {
 		// We have only pass-through columns.
-		return b.applySimpleProject(input, prj.Passthrough, prj.ProvidedPhysical().Ordering)
+		return b.applySimpleProject(input, prj.Input, prj.Passthrough, prj.ProvidedPhysical().Ordering)
 	}
 
 	var res execPlan
@@ -1422,7 +1428,7 @@ func (b *Builder) buildDistinct(distinct memo.RelExpr) (execPlan, error) {
 	if input.outputCols.Len() == outCols.Len() {
 		return ep, nil
 	}
-	return b.ensureColumns(ep, outCols.ToList(), distinct.ProvidedPhysical().Ordering)
+	return b.ensureColumns(ep, distinct, outCols.ToList(), distinct.ProvidedPhysical().Ordering)
 }
 
 func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
@@ -1514,11 +1520,11 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	// Note that (unless this is part of a larger query) the presentation property
 	// will ensure that the columns are presented correctly in the output (i.e. in
 	// the order `b, c, a`).
-	left, err = b.ensureColumns(left, private.LeftCols, leftExpr.ProvidedPhysical().Ordering)
+	left, err = b.ensureColumns(left, leftExpr, private.LeftCols, leftExpr.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
 	}
-	right, err = b.ensureColumns(right, private.RightCols, rightExpr.ProvidedPhysical().Ordering)
+	right, err = b.ensureColumns(right, rightExpr, private.RightCols, rightExpr.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -1858,7 +1864,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		if join.JoinType == opt.SemiJoinOp || join.JoinType == opt.AntiJoinOp {
 			outCols = join.Cols.Intersection(inputCols)
 		}
-		return b.applySimpleProject(res, outCols, join.ProvidedPhysical().Ordering)
+		return b.applySimpleProject(res, join, outCols, join.ProvidedPhysical().Ordering)
 	}
 	return res, nil
 }
@@ -1960,7 +1966,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 	}
 
 	// Apply a post-projection to remove the inverted column.
-	return b.applySimpleProject(res, join.Cols, join.ProvidedPhysical().Ordering)
+	return b.applySimpleProject(res, join, join.Cols, join.ProvidedPhysical().Ordering)
 }
 
 func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
@@ -2064,7 +2070,7 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	}
 
 	// Apply a post-projection to retain only the columns we need.
-	return b.applySimpleProject(res, join.Cols, join.ProvidedPhysical().Ordering)
+	return b.applySimpleProject(res, join, join.Cols, join.ProvidedPhysical().Ordering)
 }
 
 func (b *Builder) buildMax1Row(max1Row *memo.Max1RowExpr) (execPlan, error) {
@@ -2127,7 +2133,7 @@ func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error
 	}
 
 	// Make sure we have the columns in the correct order.
-	initial, err = b.ensureColumns(initial, rec.InitialCols, nil /* ordering */)
+	initial, err = b.ensureColumns(initial, rec.Initial, rec.InitialCols, nil /* ordering */)
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -2162,7 +2168,7 @@ func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error
 			return nil, err
 		}
 		// Ensure columns are output in the same order.
-		plan, err = innerBld.ensureColumns(plan, rec.RecursiveCols, opt.Ordering{})
+		plan, err = innerBld.ensureColumns(plan, rec.Recursive, rec.RecursiveCols, opt.Ordering{})
 		if err != nil {
 			return nil, err
 		}
@@ -2203,7 +2209,7 @@ func (b *Builder) buildWithScan(withScan *memo.WithScanExpr) (execPlan, error) {
 	res := execPlan{root: node, outputCols: e.outputCols}
 
 	// Apply any necessary projection to produce the InCols in the given order.
-	res, err = b.ensureColumns(res, withScan.InCols, withScan.ProvidedPhysical().Ordering)
+	res, err = b.ensureColumns(res, withScan, withScan.InCols, withScan.ProvidedPhysical().Ordering)
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -2381,7 +2387,7 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 	// TODO(justin): this call to ensureColumns is kind of unfortunate because it
 	// can result in an extra render beneath each window function. Figure out a
 	// way to alleviate this.
-	input, err = b.ensureColumns(input, desiredCols, opt.Ordering{})
+	input, err = b.ensureColumns(input, w, desiredCols, opt.Ordering{})
 	if err != nil {
 		return execPlan{}, err
 	}
@@ -2601,12 +2607,16 @@ func (b *Builder) needProjection(
 // ensureColumns applies a projection as necessary to make the output match the
 // given list of columns; colNames is optional.
 func (b *Builder) ensureColumns(
-	input execPlan, colList opt.ColList, provided opt.Ordering,
+	input execPlan, inputExpr memo.RelExpr, colList opt.ColList, provided opt.Ordering,
 ) (execPlan, error) {
 	cols, needProj := b.needProjection(input, colList)
 	if !needProj {
 		return input, nil
 	}
+	// Since we are constructing a simple project on top of the main operator,
+	// we need to explicitly annotate the latter with estimates since the code
+	// in buildRelational() will attach them to the project.
+	b.maybeAnnotateWithEstimates(input.root, inputExpr)
 	var res execPlan
 	for i, col := range colList {
 		res.outputCols.Set(int(col), i)

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -48,7 +48,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column7 int, column10 unknown, column17 bool, column19 bool, column21 bytes)
-    │ estimated row count: 1,000 (missing stats)
     │ render column7: (1)[int]
     │ render column10: (NULL)[unknown]
     │ render column17: (true)[bool]
@@ -101,7 +100,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column10 int, column16 bool, column19 bytes, k int, v int)
-    │ estimated row count: 1,000 (missing stats)
     │ render column10: (1)[int]
     │ render column16: ((v)[int] = (1)[int])[bool]
     │ render column19: ((s)[string]::BYTES)[bytes]
@@ -126,7 +124,6 @@ vectorized: true
 ·
 • render
 │ columns: (min int, count int, max int, sum_int int, avg float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string, corr float, covar_pop float, covar_samp float, sqrdiff decimal, regr_intercept float, regr_r2 float, regr_slope float, regr_sxx float, regr_sxy float, regr_syy float, regr_count int, regr_avgx float, regr_avgy float)
-│ estimated row count: 1
 │ render avg: ((avg)[decimal]::FLOAT8)[float]
 │ render to_hex: (to_hex((xor_agg)[bytes]))[string]
 │ render min: (min)[int]
@@ -223,7 +220,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column8 int)
-    │ estimated row count: 1,000 (missing stats)
     │ render column8: ((k)[int] + (v)[int])[int]
     │
     └── • scan
@@ -241,7 +237,6 @@ vectorized: true
 ·
 • render
 │ columns: (count int, r int)
-│ estimated row count: 1,000 (missing stats)
 │ render r: ((k)[int] + (any_not_null)[int])[int]
 │ render count_rows: (count_rows)[int]
 │
@@ -336,7 +331,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column13)
-        │ estimated row count: 1,000,000 (missing stats)
         │ render column13: ((k, v, w, s) AS k, v, w, s)
         │
         └── • cross join (inner)
@@ -363,7 +357,6 @@ vectorized: true
 ·
 • project
 │ columns: (min)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • group (hash)
     │ columns: (k, min)
@@ -395,7 +388,6 @@ vectorized: true
 ·
 • project
 │ columns: (min)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • group (hash)
     │ columns: (k, min)
@@ -428,7 +420,6 @@ vectorized: true
 ·
 • project
 │ columns: (min)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • group (hash)
     │ columns: (k, min)
@@ -461,7 +452,6 @@ vectorized: true
 ·
 • project
 │ columns: (v)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • distinct
     │ columns: (v, w, s)
@@ -1240,7 +1230,6 @@ vectorized: true
         │
         └── • render
             │ columns: (column7 unknown, v int)
-            │ estimated row count: 1,000 (missing stats)
             │ render column7: (NULL)[unknown]
             │ render v: (v)[int]
             │
@@ -1265,7 +1254,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column7, v)
-    │ estimated row count: 333 (missing stats)
     │ render column7: NULL
     │ render v: v
     │
@@ -1298,7 +1286,6 @@ vectorized: true
 ·
 • project
 │ columns: (count, max)
-│ estimated row count: 100 (missing stats)
 │
 └── • group (hash)
     │ columns: (v, count, max)
@@ -1309,7 +1296,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column7, column8, v)
-        │ estimated row count: 1,000 (missing stats)
         │ render column7: true
         │ render column8: k > 5
         │ render v: v
@@ -1328,7 +1314,6 @@ vectorized: true
 ·
 • project
 │ columns: (count)
-│ estimated row count: 100 (missing stats)
 │
 └── • group (hash)
     │ columns: (v, count)
@@ -1338,7 +1323,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column7, column8, v)
-        │ estimated row count: 1,000 (missing stats)
         │ render column7: true
         │ render column8: k > 5
         │ render v: v
@@ -1358,7 +1342,6 @@ vectorized: true
 ·
 • render
 │ columns: (a int)
-│ estimated row count: 1,000 (missing stats)
 │ render a: (1)[int]
 │
 └── • scan
@@ -1375,7 +1358,6 @@ vectorized: true
 ·
 • project
 │ columns: (sum decimal)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • group (hash)
     │ columns: (k int, sum decimal)
@@ -1442,7 +1424,6 @@ vectorized: true
     │
     └── • limit
         │ columns: (k int, v int)
-        │ estimated row count: 1 (missing stats)
         │ count: (1)[int]
         │
         └── • filter
@@ -1480,7 +1461,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column5 int)
-        │ estimated row count: 333 (missing stats)
         │ render column5: ((v)[int] + (1)[int])[int]
         │
         └── • filter
@@ -1503,7 +1483,6 @@ vectorized: true
 ·
 • project
 │ columns: (min int)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • group (streaming)
     │ columns: (k int, min int)
@@ -1530,7 +1509,6 @@ vectorized: true
 ·
 • render
 │ columns: (r tuple{int, int})
-│ estimated row count: 1,000 (missing stats)
 │ render r: (((b)[int], (a)[int]))[tuple{int, int}]
 │
 └── • scan
@@ -1547,7 +1525,6 @@ vectorized: true
 ·
 • render
 │ columns: (min string, r tuple{int, int})
-│ estimated row count: 100,000 (missing stats)
 │ render r: (((any_not_null)[int], (a)[int]))[tuple{int, int}]
 │ render min: (min)[string]
 │
@@ -1697,7 +1674,6 @@ vectorized: true
 ·
 • render
 │ columns: (a int)
-│ estimated row count: 333 (missing stats)
 │ render a: (1)[int]
 │
 └── • distinct
@@ -1712,7 +1688,6 @@ vectorized: true
         │
         └── • render
             │ columns: (column7 decimal, v int)
-            │ estimated row count: 1,000 (missing stats)
             │ render column7: ((w)[int]::DECIMAL)[decimal]
             │ render v: (v)[int]
             │
@@ -1734,7 +1709,6 @@ vectorized: true
 ·
 • project
 │ columns: (m)
-│ estimated row count: 100 (missing stats)
 │
 └── • group (hash)
     │ columns: (column7, min)
@@ -1744,7 +1718,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column7, a)
-        │ estimated row count: 1,000 (missing stats)
         │ render column7: a
         │ render a: a
         │
@@ -1762,7 +1735,6 @@ vectorized: true
 ·
 • project
 │ columns: (m)
-│ estimated row count: 100 (missing stats)
 │
 └── • group (hash)
     │ columns: (column7, min)
@@ -1772,7 +1744,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column7, a)
-        │ estimated row count: 1,000 (missing stats)
         │ render column7: b
         │ render a: a
         │
@@ -1881,7 +1852,6 @@ vectorized: true
 └── • render
     │ columns: (column7, k, s)
     │ ordering: +k
-    │ estimated row count: 1,000 (missing stats)
     │ render column7: ','
     │ render k: k
     │ render s: s
@@ -1964,7 +1934,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column7, s)
-    │ estimated row count: 1,000 (missing stats)
     │ render column7: ', '
     │ render s: s
     │
@@ -2009,7 +1978,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column6, company_id, employee)
-        │ estimated row count: 1,000 (missing stats)
         │ render column6: ','
         │ render company_id: company_id
         │ render employee: employee
@@ -2048,7 +2016,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column6, column7, company_id)
-        │ estimated row count: 1,000 (missing stats)
         │ render column6: employee::BYTES
         │ render column7: '\x2c'
         │ render company_id: company_id
@@ -2087,7 +2054,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column6, company_id, employee)
-        │ estimated row count: 1,000 (missing stats)
         │ render column6: NULL
         │ render company_id: company_id
         │ render employee: employee
@@ -2126,7 +2092,6 @@ vectorized: true
     │
     └── • render
         │ columns: (column6, column7, company_id)
-        │ estimated row count: 1,000 (missing stats)
         │ render column6: employee::BYTES
         │ render column7: NULL
         │ render company_id: company_id

--- a/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/check_constraints
@@ -33,7 +33,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, b_new, check1)
-    │ estimated row count: 1 (missing stats)
     │ render check1: a > b_new
     │ render a: a
     │ render b: b
@@ -41,7 +40,6 @@ vectorized: true
     │
     └── • render
         │ columns: (b_new, a, b)
-        │ estimated row count: 1 (missing stats)
         │ render b_new: b + 1
         │ render a: a
         │ render b: b
@@ -68,7 +66,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, c, d, e, a_new, check1)
-    │ estimated row count: 1 (missing stats)
     │ render check1: b < 2
     │ render a_new: 2
     │ render a: a

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -273,7 +273,6 @@ vectorized: true
 ·
 • project
 │ columns: (z)
-│ estimated row count: 990 (missing stats)
 │
 └── • delete
     │ columns: (x, z)
@@ -301,7 +300,6 @@ vectorized: true
 ·
 • project
 │ columns: (z)
-│ estimated row count: 990 (missing stats)
 │
 └── • delete
     │ columns: (x, z)

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -103,7 +103,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 1
 │
 └── • except all
     │ columns: (a, a)
@@ -134,7 +133,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?", "?column?", "?column?")
-│ estimated row count: 1
 │ render ?column?: column1
 │ render ?column?: column2
 │ render ?column?: column3

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -199,7 +199,6 @@ vectorized: true
 • render
 │ columns: (z, d, b)
 │ ordering: +d,+b
-│ estimated row count: 1,000 (missing stats)
 │ render z: 1
 │ render b: b
 │ render d: d

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -254,11 +254,11 @@ vectorized: true
 • project
 │ columns: (a, c)
 │ ordering: +a
-│ estimated row count: 100 (missing stats)
 │
 └── • distinct
     │ columns: (a, b, c)
     │ ordering: +a
+    │ estimated row count: 100 (missing stats)
     │ distinct on: a
     │ order key: a
     │
@@ -424,11 +424,9 @@ vectorized: true
 ·
 • project
 │ columns: (min)
-│ estimated row count: 1 (missing stats)
 │
 └── • limit
     │ columns: (y, min)
-    │ estimated row count: 1 (missing stats)
     │ count: 1
     │
     └── • filter

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -222,11 +222,11 @@ vectorized: true
 • project
 │ columns: (a, b)
 │ ordering: +a,+b
-│ estimated row count: 1,000 (missing stats)
 │
 └── • distinct
     │ columns: (a, b, c)
     │ ordering: +a,+b
+    │ estimated row count: 1,000 (missing stats)
     │ distinct on: a, b
     │ order key: a, b
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -37,7 +37,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b)
-│ estimated row count: 100 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
@@ -162,7 +162,6 @@ vectorized: true
 ·
 • project
 │ columns: (pid1, pa1, cid1, ca1)
-│ estimated row count: 30 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (pid1, cid1, ca1, pid1, pa1)
@@ -217,7 +216,6 @@ vectorized: true
 ·
 • project
 │ columns: (pid1, cid1, ca1, pa1)
-│ estimated row count: 30 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (pid1, cid1, ca1, pid1, pa1)
@@ -333,7 +331,6 @@ vectorized: true
 • project
 │ columns: (pid1, pa1, cid2, cid3, ca2)
 │ ordering: +pid1
-│ estimated row count: 333 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (pid1, pa1, pid1, cid2, cid3, ca2)
@@ -389,7 +386,6 @@ vectorized: true
 • project
 │ columns: (pid1, pa1, cid2, cid3, ca2)
 │ ordering: +pid1
-│ estimated row count: 40 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (pid1, cid2, cid3, ca2, pid1, pa1)
@@ -451,7 +447,6 @@ vectorized: true
 ·
 • project
 │ columns: (pid1, pa1, cid2, cid3, gcid2, gca2)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)
@@ -523,7 +518,6 @@ vectorized: true
 ·
 • project
 │ columns: (pid1, cid2, cid3, gcid2, gca2, pa1)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (pid1, cid2, cid3, gcid2, gca2, pid1, pa1)
@@ -780,7 +774,6 @@ vectorized: true
 ·
 • render
 │ columns: (pid1, pa1, cid1, cid2, ca1)
-│ estimated row count: 1,000 (missing stats)
 │ render pid1: COALESCE(pid1, pid1)
 │ render pa1: pa1
 │ render cid1: cid1
@@ -840,7 +833,6 @@ vectorized: true
 ·
 • render
 │ columns: (pid1, cid1, cid2, gcid1, gca1, ca1)
-│ estimated row count: 1,999 (missing stats)
 │ render pid1: COALESCE(pid1, pid1)
 │ render cid1: COALESCE(cid1, cid1)
 │ render cid2: COALESCE(cid2, cid2)
@@ -901,7 +893,6 @@ vectorized: true
 ·
 • project
 │ columns: (pid1, cid1, cid2, ca1, pa1)
-│ estimated row count: 400 (missing stats)
 │
 └── • merge join (left outer)
     │ columns: (pid1, cid1, cid2, ca1, pid1, pa1)
@@ -955,7 +946,6 @@ vectorized: true
 ·
 • project
 │ columns: (pid1, pa1, cid1, cid2, gcid1, gca1)
-│ estimated row count: 200 (missing stats)
 │
 └── • merge join (left outer)
     │ columns: (pid1, cid1, cid2, gcid1, gca1, pid1, pa1)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -153,7 +153,6 @@ vectorized: true
 ·
 • project
 │ columns: (x, str)
-│ estimated row count: 333 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (x, y, str)
@@ -361,7 +360,6 @@ vectorized: true
 │
 └── • render
     │ columns: (res, y, str)
-    │ estimated row count: 1,000 (missing stats)
     │ render res: repeat('test', y)
     │ render y: y
     │ render str: str
@@ -387,7 +385,6 @@ vectorized: true
 │
 └── • render
     │ columns: (res, y, str)
-    │ estimated row count: 1,000 (missing stats)
     │ render res: repeat('test', y)
     │ render y: y
     │ render str: str

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -649,7 +649,6 @@ vectorized: true
 │ order: +username
 │
 └── • render
-    │ estimated row count: 3
     │
     └── • group (hash)
         │ estimated row count: 3
@@ -672,7 +671,6 @@ vectorized: true
                 │       │ estimated row count: 3
                 │       │
                 │       └── • render
-                │           │ estimated row count: 3
                 │           │
                 │           └── • hash join (left outer)
                 │               │ estimated row count: 3
@@ -716,7 +714,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1
 │ render ?column?: last_value
 │
 └── • sequence select
@@ -840,7 +837,6 @@ vectorized: true
 ·
 • limit
 │ columns: (k, v, "ordinality")
-│ estimated row count: 1 (missing stats)
 │ offset: 1
 │
 └── • ordinality
@@ -876,12 +872,10 @@ vectorized: true
 ·
 • limit
 │ columns: (v)
-│ estimated row count: 1 (missing stats)
 │ offset: 1
 │
 └── • limit
     │ columns: (v)
-    │ estimated row count: 2 (missing stats)
     │ count: 2
     │
     └── • distinct
@@ -1066,7 +1060,6 @@ vectorized: true
 ·
 • render
 │ columns: (z int, v int)
-│ estimated row count: 0
 │ render z: ((count)[int] * (2)[int])[int]
 │ render v: (v)[int]
 │
@@ -1118,7 +1111,6 @@ vectorized: true
 │
 └── • render
     │ columns: (k int, v int, v_new int)
-    │ estimated row count: 333 (missing stats)
     │ render v_new: ((k)[int] + (1)[int])[int]
     │ render k: (k)[int]
     │ render v: (v)[int]
@@ -1651,7 +1643,6 @@ vectorized: true
 ·
 • project
 │ columns: (attnum)
-│ estimated row count: 1 (missing stats)
 │
 └── • filter
     │ columns: (attrelid, attname, attnum)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -419,6 +419,7 @@ regions: <hidden>
                       nodes: <hidden>
                       regions: <hidden>
                       actual row count: 1
+                      estimated row count: 1
                       label: buffer 1
 ·
 Diagram 1 (subquery): https://cockroachdb.github.io/distsqlplan/decode.html#eJysU9Fq2zAUfd9XXO5TAiqxUwbDT-1CBqGpU5I0MEYoqnxxRW3Jk67XZCWftR_Ylw1b9VZTmm1sT7bOvUe65-joEf3nAhOcpavpcg2zdL0AdaeLDDbn8-vpCgaxgMFqOp9O1lBqM6iG8GG5uIRKOjI8HKJAYzNKZUkek08Yo8C3uBVYOavIe-sa-LFtmmU7TCKB2lQ1N_BWoLKOMHlE1lwQJpjaE1uNxigwI5a6aDelHamatTXAuqQEou_fPAq8lazuyIOtuao5gQgFOvvwC4hxexAYVk_neZY5YXJ6EM9mio_PtJa3BS1JZuRGUX-yYMNZ-NxU97RHgRNb1KXxCVQocFXJ5vcEBc51qRkahy42fSUXG1DWMJmXIi820GpyJLOkI9_umTroHbwPYL68moCSReFD3-VmMgHPVIGytWEY0I5H2vAwgajVERqI7l9rKOUOSiqt24MsCqskU5ZA1B74D-bHf2P-eZ47yiVbN4r73p-nH2_SxfomvZ7PB2dxE8X_H5Rxb9bfhHdJvrLGU2_O13aODluBlOUUHoi3tVN05axqjwnLRctrgYw8h-ppWMxMKDUDPifHR8nj4-TxUXLUJ7dSWlVoiB-su4dCMhm1_-l8hz9Izf07yciT07LQX-XLC-toT8lXpL_QU_q7UvcEulp4Bl21JO9l3muI_jQI28ObHwEAAP__GAys-A==

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -39,6 +39,7 @@ vectorized: true
             │ equality cols are key
             │
             └── • scan buffer
+                  estimated row count: 2
                   label: buffer 1
 
 # Use data from a different table as input.
@@ -116,6 +117,7 @@ vectorized: true
                 │ filter: column2 IS NOT NULL
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 # Tests with multicolumn FKs.
@@ -161,6 +163,7 @@ vectorized: true
                 │ filter: (column2 IS NOT NULL) AND (column3 IS NOT NULL)
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 statement ok
@@ -210,6 +213,7 @@ vectorized: true
 │               │ filter: column2 IS NOT NULL
 │               │
 │               └── • scan buffer
+│                     estimated row count: 2
 │                     label: buffer 1
 │
 └── • constraint-check
@@ -226,6 +230,7 @@ vectorized: true
                 │ filter: (column3 IS NOT NULL) AND (column4 IS NOT NULL)
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 # FK check can be omitted when we are inserting only NULLs.
@@ -1232,6 +1237,7 @@ vectorized: true
             │ right cols are key
             │
             ├── • scan buffer
+            │     estimated row count: 10
             │     label: buffer 1
             │
             └── • scan
@@ -1255,7 +1261,6 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 33
 │           │
 │           └── • scan
 │                 estimated row count: 33 (33% of the table; stats collected <hidden> ago)
@@ -1277,6 +1282,7 @@ vectorized: true
             │   │ filter: p_new IS NOT NULL
             │   │
             │   └── • scan buffer
+            │         estimated row count: 33
             │         label: buffer 1
             │
             └── • scan
@@ -1349,7 +1355,6 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 33
 │           │
 │           └── • scan
 │                 estimated row count: 33 (33% of the table; stats collected <hidden> ago)
@@ -1372,6 +1377,7 @@ vectorized: true
                 │ filter: p_new IS NOT NULL
                 │
                 └── • scan buffer
+                      estimated row count: 33
                       label: buffer 1
 
 query T
@@ -1443,7 +1449,6 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 10
 │           │
 │           └── • project set
 │               │ estimated row count: 10
@@ -1460,6 +1465,7 @@ vectorized: true
             │ right cols are key
             │
             ├── • scan buffer
+            │     estimated row count: 10
             │     label: buffer 1
             │
             └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -28,14 +28,12 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_a_shard_11_comp, column1, check1)
-    │ estimated row count: 2
     │ render check1: crdb_internal_a_shard_11_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
     │ render column1: column1
     │ render crdb_internal_a_shard_11_comp: crdb_internal_a_shard_11_comp
     │
     └── • render
         │ columns: (crdb_internal_a_shard_11_comp, column1)
-        │ estimated row count: 2
         │ render crdb_internal_a_shard_11_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 11)
         │ render column1: column1
         │
@@ -53,7 +51,6 @@ vectorized: true
 ·
 • limit
 │ columns: (a)
-│ estimated row count: 10
 │ count: 10
 │
 └── • union all
@@ -78,7 +75,6 @@ vectorized: true
     │   │   │   │
     │   │   │   ├── • limit
     │   │   │   │   │ columns: (a)
-    │   │   │   │   │ estimated row count: 10
     │   │   │   │   │ count: 10
     │   │   │   │   │
     │   │   │   │   └── • filter
@@ -96,7 +92,6 @@ vectorized: true
     │   │   │   │
     │   │   │   └── • limit
     │   │   │       │ columns: (a)
-    │   │   │       │ estimated row count: 10
     │   │   │       │ count: 10
     │   │   │       │
     │   │   │       └── • filter
@@ -119,7 +114,6 @@ vectorized: true
     │   │       │
     │   │       ├── • limit
     │   │       │   │ columns: (a)
-    │   │       │   │ estimated row count: 10
     │   │       │   │ count: 10
     │   │       │   │
     │   │       │   └── • filter
@@ -137,7 +131,6 @@ vectorized: true
     │   │       │
     │   │       └── • limit
     │   │           │ columns: (a)
-    │   │           │ estimated row count: 10
     │   │           │ count: 10
     │   │           │
     │   │           └── • filter
@@ -165,7 +158,6 @@ vectorized: true
     │       │   │
     │       │   ├── • limit
     │       │   │   │ columns: (a)
-    │       │   │   │ estimated row count: 10
     │       │   │   │ count: 10
     │       │   │   │
     │       │   │   └── • filter
@@ -183,7 +175,6 @@ vectorized: true
     │       │   │
     │       │   └── • limit
     │       │       │ columns: (a)
-    │       │       │ estimated row count: 10
     │       │       │ count: 10
     │       │       │
     │       │       └── • filter
@@ -201,7 +192,6 @@ vectorized: true
     │       │
     │       └── • limit
     │           │ columns: (a)
-    │           │ estimated row count: 10
     │           │ count: 10
     │           │
     │           └── • filter
@@ -229,7 +219,6 @@ vectorized: true
         │   │
         │   ├── • limit
         │   │   │ columns: (a)
-        │   │   │ estimated row count: 10
         │   │   │ count: 10
         │   │   │
         │   │   └── • filter
@@ -247,7 +236,6 @@ vectorized: true
         │   │
         │   └── • limit
         │       │ columns: (a)
-        │       │ estimated row count: 10
         │       │ count: 10
         │       │
         │       └── • filter
@@ -270,7 +258,6 @@ vectorized: true
             │
             ├── • limit
             │   │ columns: (a)
-            │   │ estimated row count: 10
             │   │ count: 10
             │   │
             │   └── • filter
@@ -288,7 +275,6 @@ vectorized: true
             │
             └── • limit
                 │ columns: (a)
-                │ estimated row count: 10
                 │ count: 10
                 │
                 └── • filter
@@ -321,7 +307,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, crdb_internal_a_shard_12_comp, rowid_default, check1)
-    │ estimated row count: 2
     │ render check1: crdb_internal_a_shard_12_comp IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
     │ render column1: column1
     │ render rowid_default: rowid_default
@@ -329,7 +314,6 @@ vectorized: true
     │
     └── • render
         │ columns: (crdb_internal_a_shard_12_comp, rowid_default, column1)
-        │ estimated row count: 2
         │ render crdb_internal_a_shard_12_comp: mod(fnv32(crdb_internal.datums_to_bytes(column1)), 12)
         │ render rowid_default: unique_rowid()
         │ render column1: column1
@@ -348,7 +332,6 @@ vectorized: true
 ·
 • limit
 │ columns: (a)
-│ estimated row count: 10 (missing stats)
 │ count: 10
 │
 └── • union all
@@ -662,7 +645,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_a_shard_8, a, b, crdb_internal_a_shard_8_comp, a_new, check1)
-    │ estimated row count: 1 (missing stats)
     │ render check1: true
     │ render crdb_internal_a_shard_8_comp: 1
     │ render a_new: 4321
@@ -718,7 +700,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, column1, column2, crdb_internal_a_shard_8_comp, crdb_internal_a_shard_8, a, b, upsert_crdb_internal_a_shard_8, upsert_a)
-        │ estimated row count: 1 (missing stats)
         │ render check1: upsert_crdb_internal_a_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7)
         │ render column1: column1
         │ render column2: column2
@@ -731,7 +712,6 @@ vectorized: true
         │
         └── • render
             │ columns: (upsert_crdb_internal_a_shard_8, upsert_a, column1, column2, crdb_internal_a_shard_8_comp, crdb_internal_a_shard_8, a, b)
-            │ estimated row count: 1 (missing stats)
             │ render upsert_crdb_internal_a_shard_8: CASE WHEN crdb_internal_a_shard_8 IS NULL THEN crdb_internal_a_shard_8_comp ELSE 1 END
             │ render upsert_a: CASE WHEN crdb_internal_a_shard_8 IS NULL THEN column1 ELSE 4321 END
             │ render column1: column1
@@ -774,7 +754,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_a_shard_8_comp, column1, column2, check1)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_a_shard_8_comp IN (0, 1, 2, 3, 4, 5, 6, 7)
     │ render column1: column1
     │ render column2: column2
@@ -812,7 +791,6 @@ vectorized: true
 │
 └── • render
     │ columns: (crdb_internal_a_shard_8_comp, column1, column2, check1)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_a_shard_8_comp IN (0, 1, 2, 3, 4, 5, 6, 7)
     │ render column1: column1
     │ render column2: column2
@@ -884,7 +862,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, crdb_internal_b_shard_8, b_new, crdb_internal_b_shard_8_comp, check1)
-    │ estimated row count: 1 (missing stats)
     │ render check1: true
     │ render crdb_internal_b_shard_8_comp: 3
     │ render b_new: 8765
@@ -917,7 +894,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, column1, column2, crdb_internal_b_shard_8_comp, a, b, crdb_internal_b_shard_8)
-        │ estimated row count: 1 (missing stats)
         │ render check1: crdb_internal_b_shard_8_comp IN (0, 1, 2, 3, 4, 5, 6, 7)
         │ render column1: column1
         │ render column2: column2
@@ -939,7 +915,6 @@ vectorized: true
             │
             └── • render
                 │ columns: (crdb_internal_b_shard_8, a, b)
-                │ estimated row count: 1 (missing stats)
                 │ render crdb_internal_b_shard_8: mod(fnv32(crdb_internal.datums_to_bytes(b)), 8)
                 │ render a: a
                 │ render b: b
@@ -968,7 +943,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, column1, column2, crdb_internal_b_shard_8_comp, a, b, crdb_internal_b_shard_8, upsert_b, upsert_crdb_internal_b_shard_8)
-        │ estimated row count: 1 (missing stats)
         │ render check1: upsert_crdb_internal_b_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7)
         │ render column1: column1
         │ render column2: column2
@@ -981,7 +955,6 @@ vectorized: true
         │
         └── • render
             │ columns: (upsert_b, upsert_crdb_internal_b_shard_8, column1, column2, crdb_internal_b_shard_8_comp, a, b, crdb_internal_b_shard_8)
-            │ estimated row count: 1 (missing stats)
             │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE 8765 END
             │ render upsert_crdb_internal_b_shard_8: CASE WHEN a IS NULL THEN crdb_internal_b_shard_8_comp ELSE 3 END
             │ render column1: column1
@@ -1004,7 +977,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (crdb_internal_b_shard_8, a, b)
-                    │ estimated row count: 1 (missing stats)
                     │ render crdb_internal_b_shard_8: mod(fnv32(crdb_internal.datums_to_bytes(b)), 8)
                     │ render a: a
                     │ render b: b
@@ -1033,7 +1005,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, column1, column2, crdb_internal_b_shard_8_comp, a, b, crdb_internal_b_shard_8, upsert_b, upsert_crdb_internal_b_shard_8)
-        │ estimated row count: 1 (missing stats)
         │ render check1: upsert_crdb_internal_b_shard_8 IN (0, 1, 2, 3, 4, 5, 6, 7)
         │ render column1: column1
         │ render column2: column2
@@ -1046,7 +1017,6 @@ vectorized: true
         │
         └── • render
             │ columns: (upsert_b, upsert_crdb_internal_b_shard_8, column1, column2, crdb_internal_b_shard_8_comp, a, b, crdb_internal_b_shard_8)
-            │ estimated row count: 1 (missing stats)
             │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE 8765 END
             │ render upsert_crdb_internal_b_shard_8: CASE WHEN a IS NULL THEN crdb_internal_b_shard_8_comp ELSE 3 END
             │ render column1: column1
@@ -1069,7 +1039,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (crdb_internal_b_shard_8, a, b)
-                    │ estimated row count: 1 (missing stats)
                     │ render crdb_internal_b_shard_8: mod(fnv32(crdb_internal.datums_to_bytes(b)), 8)
                     │ render a: a
                     │ render b: b
@@ -1098,7 +1067,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, column1, column2, crdb_internal_b_shard_8_comp, a, b, crdb_internal_b_shard_8)
-        │ estimated row count: 2 (missing stats)
         │ render check1: crdb_internal_b_shard_8_comp IN (0, 1, 2, 3, 4, 5, 6, 7)
         │ render column1: column1
         │ render column2: column2
@@ -1109,7 +1077,6 @@ vectorized: true
         │
         └── • render
             │ columns: (crdb_internal_b_shard_8, column1, column2, crdb_internal_b_shard_8_comp, a, b)
-            │ estimated row count: 2 (missing stats)
             │ render crdb_internal_b_shard_8: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(crdb_internal.datums_to_bytes(b)), 8) END
             │ render column1: column1
             │ render column2: column2
@@ -1119,10 +1086,10 @@ vectorized: true
             │
             └── • project
                 │ columns: (column1, column2, crdb_internal_b_shard_8_comp, a, b)
-                │ estimated row count: 2 (missing stats)
                 │
                 └── • lookup join (left outer)
                     │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2, a, b)
+                    │ estimated row count: 2 (missing stats)
                     │ table: t_hash_indexed@idx_t_hash_indexed
                     │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
                     │ equality cols are key
@@ -1130,7 +1097,6 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
-                        │ estimated row count: 2
                         │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
                         │ render crdb_internal_b_shard_8_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
                         │ render column1: column1
@@ -1160,7 +1126,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, crdb_internal_b_shard_8_comp, check1)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_b_shard_8_comp IN (0, 1, 2, 3, 4, 5, 6, 7)
     │ render column1: column1
     │ render column2: column2
@@ -1168,17 +1133,16 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, column2, crdb_internal_b_shard_8_comp)
-        │ estimated row count: 0 (missing stats)
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_comp)
+            │ estimated row count: 0 (missing stats)
             │ table: t_hash_indexed@idx_t_hash_indexed
             │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
             │ equality cols are key
             │
             └── • render
                 │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_comp)
-                │ estimated row count: 0 (missing stats)
                 │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
                 │ render column1: column1
                 │ render column2: column2
@@ -1197,7 +1161,6 @@ vectorized: true
                     │
                     └── • project
                         │ columns: ()
-                        │ estimated row count: 1 (missing stats)
                         │
                         └── • scan
                               columns: (a)
@@ -1221,7 +1184,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, crdb_internal_b_shard_8_comp, check1)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_b_shard_8_comp IN (0, 1, 2, 3, 4, 5, 6, 7)
     │ render column1: column1
     │ render column2: column2
@@ -1236,17 +1198,16 @@ vectorized: true
         │
         └── • project
             │ columns: (column1, column2, crdb_internal_b_shard_8_comp)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_hash_indexed@idx_t_hash_indexed
                 │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
                 │ equality cols are key
                 │
                 └── • render
                     │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
-                    │ estimated row count: 2
                     │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
                     │ render crdb_internal_b_shard_8_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
                     │ render column1: column1
@@ -1275,7 +1236,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, crdb_internal_b_shard_8_comp, check1)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_b_shard_8_comp IN (0, 1, 2, 3, 4, 5, 6, 7)
     │ render column1: column1
     │ render column2: column2
@@ -1294,7 +1254,6 @@ vectorized: true
         │
         └── • project
             │ columns: ()
-            │ estimated row count: 1 (missing stats)
             │
             └── • scan
                   columns: (b)
@@ -1317,7 +1276,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, crdb_internal_b_shard_8_comp, check1)
-    │ estimated row count: 0 (missing stats)
     │ render check1: crdb_internal_b_shard_8_comp IN (0, 1, 2, 3, 4, 5, 6, 7)
     │ render column1: column1
     │ render column2: column2
@@ -1325,17 +1283,16 @@ vectorized: true
     │
     └── • project
         │ columns: (column1, column2, crdb_internal_b_shard_8_comp)
-        │ estimated row count: 0 (missing stats)
         │
         └── • lookup join (anti)
             │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
+            │ estimated row count: 0 (missing stats)
             │ table: t_hash_indexed@idx_t_hash_indexed
             │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
             │ equality cols are key
             │
             └── • render
                 │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
-                │ estimated row count: 2
                 │ render crdb_internal_b_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
                 │ render crdb_internal_b_shard_8_comp: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 8)
                 │ render column1: column1
@@ -1394,26 +1351,25 @@ vectorized: true
         │
         └── • project
             │ columns: (pid)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_parent_pk@t_parent_pk_pkey
                 │ equality: (crdb_internal_id_shard_16_eq, pid) = (crdb_internal_id_shard_16,id)
                 │ equality cols are key
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
-                    │ estimated row count: 1
                     │ render crdb_internal_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                     │ render pid: column2
                     │
                     └── • project
                         │ columns: (column2)
-                        │ estimated row count: 1
                         │
                         └── • scan buffer
                               columns: (column1, column2)
+                              estimated row count: 1
                               label: buffer 1
 
 statement ok
@@ -1464,24 +1420,23 @@ vectorized: true
         │
         └── • project
             │ columns: (pid)
-            │ estimated row count: 0 (missing stats)
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_real_id_shard_16_eq, pid)
+                │ estimated row count: 0 (missing stats)
                 │ table: t_parent_sec@idx_t_parent_sec_real_id
                 │ equality: (crdb_internal_real_id_shard_16_eq, pid) = (crdb_internal_real_id_shard_16,real_id)
                 │ equality cols are key
                 │
                 └── • render
                     │ columns: (crdb_internal_real_id_shard_16_eq, pid)
-                    │ estimated row count: 1
                     │ render crdb_internal_real_id_shard_16_eq: mod(fnv32(crdb_internal.datums_to_bytes(column2)), 16)
                     │ render pid: column2
                     │
                     └── • project
                         │ columns: (column2)
-                        │ estimated row count: 1
                         │
                         └── • scan buffer
                               columns: (column1, column2)
+                              estimated row count: 1
                               label: buffer 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -316,7 +316,6 @@ vectorized: true
 │
 └── • render
     │ columns: (x, v, rowid_default)
-    │ estimated row count: 10 (missing stats)
     │ render rowid_default: unique_rowid()
     │ render x: x
     │ render v: v
@@ -349,7 +348,6 @@ vectorized: true
 │
 └── • render
     │ columns: (x, v, rowid_default)
-    │ estimated row count: 1 (missing stats)
     │ render rowid_default: unique_rowid()
     │ render x: x
     │ render v: v
@@ -373,10 +371,8 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ estimated row count: 1
     │
     └── • limit
-        │ estimated row count: 1
         │ count: 1
         │
         └── • values
@@ -393,7 +389,6 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ estimated row count: 1
     │
     └── • top-k
         │ estimated row count: 1
@@ -414,7 +409,6 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ estimated row count: 1
     │
     └── • top-k
         │ estimated row count: 1
@@ -435,7 +429,6 @@ vectorized: true
 │ auto commit
 │
 └── • render
-    │ estimated row count: 1
     │
     └── • top-k
         │ estimated row count: 1
@@ -455,7 +448,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 10 (missing stats)
 │ render ?column?: x + v
 │
 └── • insert
@@ -465,7 +457,6 @@ vectorized: true
     │
     └── • render
         │ columns: (length, "?column?", rowid_default)
-        │ estimated row count: 10 (missing stats)
         │ render rowid_default: unique_rowid()
         │ render length: length
         │ render ?column?: "?column?"
@@ -479,7 +470,6 @@ vectorized: true
             │
             └── • render
                 │ columns: (length, "?column?", column12)
-                │ estimated row count: 1,000 (missing stats)
                 │ render length: length(k)
                 │ render ?column?: 2
                 │ render column12: k || v
@@ -509,7 +499,6 @@ vectorized: true
 ·
 • project
 │ columns: (x)
-│ estimated row count: 1
 │
 └── • insert fast path
       columns: (x, rowid)
@@ -585,7 +574,6 @@ vectorized: true
         │
         └── • project
             │ columns: (z)
-            │ estimated row count: 1,000 (missing stats)
             │
             └── • insert
                 │ columns: (z, rowid)
@@ -594,7 +582,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (a, b, c, rowid_default)
-                    │ estimated row count: 1,000 (missing stats)
                     │ render rowid_default: unique_rowid()
                     │ render a: a
                     │ render b: b

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -289,10 +289,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 2
         │
@@ -319,10 +319,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 2
         │
@@ -391,10 +391,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 2
         │
@@ -418,10 +418,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 2
         │
@@ -452,10 +452,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 2
             │
@@ -484,10 +484,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 3
             │
@@ -513,10 +513,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: d@foo_inv
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -543,10 +543,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 6
             │
@@ -593,10 +593,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 3
             │
@@ -642,10 +642,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 6
             │
@@ -749,10 +749,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 3
         │
@@ -778,10 +778,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 4
         │
@@ -805,10 +805,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 4
         │
@@ -832,10 +832,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 6
         │
@@ -859,10 +859,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 6
         │
@@ -890,10 +890,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: d@foo_inv
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -917,10 +917,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: d@foo_inv
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -944,10 +944,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: d@foo_inv
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -974,10 +974,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: d@foo_inv
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -1001,10 +1001,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: d@foo_inv
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -1028,10 +1028,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: d@foo_inv
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -1056,10 +1056,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 3
         │
@@ -1083,10 +1083,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 4
         │
@@ -1269,10 +1269,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: e@bidx
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -1296,10 +1296,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: e@bidx
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -1350,10 +1350,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 2
             │
@@ -1405,10 +1405,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 2
             │
@@ -1461,10 +1461,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 5
             │
@@ -1516,10 +1516,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 2
             │
@@ -1548,10 +1548,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 8
             │
@@ -1596,10 +1596,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 1
         │
@@ -1642,10 +1642,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 111 (missing stats)
     │
     └── • inverted filter
         │ columns: (a, b_inverted_key)
+        │ estimated row count: 111 (missing stats)
         │ inverted column: b_inverted_key
         │ num spans: 1
         │
@@ -1684,7 +1684,6 @@ vectorized: true
 ·
 • project
 │ columns: (k)
-│ estimated row count: 110 (missing stats)
 │
 └── • filter
     │ columns: (k, geom)
@@ -1699,10 +1698,10 @@ vectorized: true
         │
         └── • project
             │ columns: (k)
-            │ estimated row count: 111 (missing stats)
             │
             └── • inverted filter
                 │ columns: (k, geom_inverted_key)
+                │ estimated row count: 111 (missing stats)
                 │ inverted column: geom_inverted_key
                 │ num spans: 31
                 │
@@ -1764,10 +1763,10 @@ vectorized: true
 ·
 • project
 │ columns: (k, geom, k, geom)
-│ estimated row count: 9,801 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (k, geom, k, k, geom)
+    │ estimated row count: 9,801 (missing stats)
     │ table: geo_table@geo_table_pkey
     │ equality: (k) = (k)
     │ equality cols are key
@@ -1775,10 +1774,10 @@ vectorized: true
     │
     └── • project
         │ columns: (k, geom, k)
-        │ estimated row count: 10,000 (missing stats)
         │
         └── • inverted join (inner)
             │ columns: (k, geom, k, geom_inverted_key)
+            │ estimated row count: 10,000 (missing stats)
             │ table: geo_table@geom_index
             │ inverted expr: st_intersects(geom, geom_inverted_key)
             │
@@ -1797,7 +1796,6 @@ vectorized: true
 ·
 • project
 │ columns: (k)
-│ estimated row count: 330 (missing stats)
 │
 └── • filter
     │ columns: (k, geom)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -101,16 +101,15 @@ vectorized: true
 └── • project
     │ columns: (lk, rk1)
     │ ordering: +lk
-    │ estimated row count: 326,700 (missing stats)
     │
     └── • project
         │ columns: (lk, geom1, rk1, geom)
         │ ordering: +lk
-        │ estimated row count: 326,700 (missing stats)
         │
         └── • lookup join (inner)
             │ columns: (lk, geom1, rk1, rk2, rk1, geom)
             │ ordering: +lk
+            │ estimated row count: 326,700 (missing stats)
             │ table: rtable@rtable_pkey
             │ equality: (rk1, rk2) = (rk1,rk2)
             │ equality cols are key
@@ -119,11 +118,11 @@ vectorized: true
             └── • project
                 │ columns: (lk, geom1, rk1, rk2)
                 │ ordering: +lk
-                │ estimated row count: 10,000 (missing stats)
                 │
                 └── • inverted join (inner)
                     │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
                     │ ordering: +lk
+                    │ estimated row count: 10,000 (missing stats)
                     │ table: rtable@geom_index
                     │ inverted expr: st_intersects(geom1, geom_inverted_key) OR st_dwithin(geom1, geom_inverted_key, 2.0)
                     │
@@ -152,16 +151,15 @@ vectorized: true
 └── • project
     │ columns: (lk, rk1)
     │ ordering: +lk
-    │ estimated row count: 9,801 (missing stats)
     │
     └── • project
         │ columns: (lk, geom1, rk1, geom)
         │ ordering: +lk
-        │ estimated row count: 9,801 (missing stats)
         │
         └── • lookup join (inner)
             │ columns: (lk, geom1, rk1, rk2, rk1, geom)
             │ ordering: +lk
+            │ estimated row count: 9,801 (missing stats)
             │ table: rtable@rtable_pkey
             │ equality: (rk1, rk2) = (rk1,rk2)
             │ equality cols are key
@@ -170,11 +168,11 @@ vectorized: true
             └── • project
                 │ columns: (lk, geom1, rk1, rk2)
                 │ ordering: +lk
-                │ estimated row count: 10,000 (missing stats)
                 │
                 └── • inverted join (inner)
                     │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
                     │ ordering: +lk
+                    │ estimated row count: 10,000 (missing stats)
                     │ table: rtable@geom_index
                     │ inverted expr: st_intersects(geom1, geom_inverted_key) AND st_dwithin(geom1, geom_inverted_key, 2.0)
                     │
@@ -196,14 +194,13 @@ vectorized: true
 ·
 • project
 │ columns: (lk, rk1)
-│ estimated row count: 3,267 (missing stats)
 │
 └── • project
     │ columns: (lk, geom1, geom2, rk1, geom)
-    │ estimated row count: 3,267 (missing stats)
     │
     └── • lookup join (inner)
         │ columns: (lk, geom1, geom2, rk1, rk2, rk1, geom)
+        │ estimated row count: 3,267 (missing stats)
         │ table: rtable@rtable_pkey
         │ equality: (rk1, rk2) = (rk1,rk2)
         │ equality cols are key
@@ -211,10 +208,10 @@ vectorized: true
         │
         └── • project
             │ columns: (lk, geom1, geom2, rk1, rk2)
-            │ estimated row count: 10,000 (missing stats)
             │
             └── • inverted join (inner)
                 │ columns: (lk, geom1, geom2, rk1, rk2, geom_inverted_key)
+                │ estimated row count: 10,000 (missing stats)
                 │ table: rtable@geom_index
                 │ inverted expr: (st_intersects(geom1, geom_inverted_key) AND st_covers(geom2, geom_inverted_key)) AND (st_dfullywithin(geom1, geom_inverted_key, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom_inverted_key))
                 │
@@ -235,14 +232,13 @@ vectorized: true
 ·
 • project
 │ columns: (lk)
-│ estimated row count: 10 (missing stats)
 │
 └── • project
     │ columns: (lk, geom2)
-    │ estimated row count: 10 (missing stats)
     │
     └── • lookup join (semi)
         │ columns: (lk, geom2, rk1, rk2, cont)
+        │ estimated row count: 10 (missing stats)
         │ table: rtable@rtable_pkey
         │ equality: (rk1, rk2) = (rk1,rk2)
         │ equality cols are key
@@ -250,10 +246,10 @@ vectorized: true
         │
         └── • project
             │ columns: (lk, geom2, rk1, rk2, cont)
-            │ estimated row count: 10,000 (missing stats)
             │
             └── • inverted join (inner)
                 │ columns: (lk, geom2, rk1, rk2, geom_inverted_key, cont)
+                │ estimated row count: 10,000 (missing stats)
                 │ table: rtable@geom_index
                 │ inverted expr: st_intersects(geom2, geom_inverted_key)
                 │
@@ -273,14 +269,13 @@ vectorized: true
 ·
 • project
 │ columns: (lk, rk1)
-│ estimated row count: 10,000 (missing stats)
 │
 └── • project
     │ columns: (lk, geom1, rk1, geom)
-    │ estimated row count: 10,000 (missing stats)
     │
     └── • lookup join (left outer)
         │ columns: (lk, geom1, rk1, rk2, cont, rk1, geom)
+        │ estimated row count: 10,000 (missing stats)
         │ table: rtable@rtable_pkey
         │ equality: (rk1, rk2) = (rk1,rk2)
         │ equality cols are key
@@ -288,10 +283,10 @@ vectorized: true
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2, cont)
-            │ estimated row count: 10,000 (missing stats)
             │
             └── • inverted join (left outer)
                 │ columns: (lk, geom1, rk1, rk2, geom_inverted_key, cont)
+                │ estimated row count: 10,000 (missing stats)
                 │ table: rtable@geom_index
                 │ inverted expr: st_intersects(geom1, geom_inverted_key)
                 │
@@ -320,7 +315,6 @@ vectorized: true
 │
 ├── • render
 │   │ columns: (count, count)
-│   │ estimated row count: 333 (missing stats)
 │   │ render count: @S2
 │   │ render count_rows: count_rows
 │   │
@@ -335,10 +329,10 @@ vectorized: true
 │           │
 │           └── • project
 │               │ columns: (lk, geom1, geom)
-│               │ estimated row count: 3,333 (missing stats)
 │               │
 │               └── • lookup join (left outer)
 │                   │ columns: (lk, geom1, rk1, rk2, cont, geom)
+│                   │ estimated row count: 3,333 (missing stats)
 │                   │ table: rtable@rtable_pkey
 │                   │ equality: (rk1, rk2) = (rk1,rk2)
 │                   │ equality cols are key
@@ -346,19 +340,19 @@ vectorized: true
 │                   │
 │                   └── • project
 │                       │ columns: (lk, geom1, rk1, rk2, cont)
-│                       │ estimated row count: 3,333 (missing stats)
 │                       │
 │                       └── • inverted join (left outer)
 │                           │ columns: (lk, geom1, rk1, rk2, geom_inverted_key, cont)
+│                           │ estimated row count: 3,333 (missing stats)
 │                           │ table: rtable@geom_index
 │                           │ inverted expr: st_intersects(geom1, geom_inverted_key)
 │                           │
 │                           └── • project
 │                               │ columns: (lk, geom1)
-│                               │ estimated row count: 333 (missing stats)
 │                               │
 │                               └── • scan buffer
 │                                     columns: (lk, geom1, geom2)
+│                                     estimated row count: 333 (missing stats)
 │                                     label: buffer 1 (q)
 │
 ├── • subquery
@@ -388,10 +382,10 @@ vectorized: true
         │
         └── • project
             │ columns: ()
-            │ estimated row count: 333 (missing stats)
             │
             └── • scan buffer
                   columns: (lk, geom1, geom2)
+                  estimated row count: 333 (missing stats)
                   label: buffer 1 (q)
 
 # Anti joins are also converted to paired joins by the optimizer.
@@ -404,14 +398,13 @@ vectorized: true
 ·
 • project
 │ columns: (lk)
-│ estimated row count: 990 (missing stats)
 │
 └── • project
     │ columns: (lk, geom2)
-    │ estimated row count: 990 (missing stats)
     │
     └── • lookup join (anti)
         │ columns: (lk, geom2, rk1, rk2, cont)
+        │ estimated row count: 990 (missing stats)
         │ table: rtable@rtable_pkey
         │ equality: (rk1, rk2) = (rk1,rk2)
         │ equality cols are key
@@ -419,10 +412,10 @@ vectorized: true
         │
         └── • project
             │ columns: (lk, geom2, rk1, rk2, cont)
-            │ estimated row count: 10,000 (missing stats)
             │
             └── • inverted join (left outer)
                 │ columns: (lk, geom2, rk1, rk2, geom_inverted_key, cont)
+                │ estimated row count: 10,000 (missing stats)
                 │ table: rtable@geom_index
                 │ inverted expr: st_intersects(geom2, geom_inverted_key)
                 │
@@ -444,14 +437,13 @@ vectorized: true
 ·
 • project
 │ columns: (lk)
-│ estimated row count: 997 (missing stats)
 │
 └── • project
     │ columns: (lk, geom1)
-    │ estimated row count: 997 (missing stats)
     │
     └── • lookup join (anti)
         │ columns: (lk, geom1, rk1, rk2, cont)
+        │ estimated row count: 997 (missing stats)
         │ table: rtable@rtable_pkey
         │ equality: (rk1, rk2) = (rk1,rk2)
         │ equality cols are key
@@ -459,10 +451,10 @@ vectorized: true
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2, cont)
-            │ estimated row count: 1,111 (missing stats)
             │
             └── • inverted join (left outer)
                 │ columns: (lk, geom1, rk1, rk2, geom_inverted_key, cont)
+                │ estimated row count: 1,111 (missing stats)
                 │ table: rtable@geom_index
                 │ inverted expr: st_covers(geom1, geom_inverted_key)
                 │ on: (lk > 5) AND (rk1 > 12)
@@ -486,14 +478,13 @@ vectorized: true
 ·
 • project
 │ columns: (lk, rk1, rk2)
-│ estimated row count: 9,801 (missing stats)
 │
 └── • project
     │ columns: (lk, geom1, rk1, geom, rk2)
-    │ estimated row count: 9,801 (missing stats)
     │
     └── • lookup join (inner)
         │ columns: (lk, geom1, rk1, rk2, rk1, geom, rk2)
+        │ estimated row count: 9,801 (missing stats)
         │ table: rtable@rtable_pkey
         │ equality: (rk1, rk2) = (rk1,rk2)
         │ equality cols are key
@@ -501,10 +492,10 @@ vectorized: true
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2)
-            │ estimated row count: 10,000 (missing stats)
             │
             └── • inverted join (inner)
                 │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
+                │ estimated row count: 10,000 (missing stats)
                 │ table: rtable@geom_index
                 │ inverted expr: st_covers(geom1, geom_inverted_key)
                 │
@@ -523,14 +514,13 @@ vectorized: true
 ·
 • project
 │ columns: (lk, rk1, rk2)
-│ estimated row count: 9,801 (missing stats)
 │
 └── • project
     │ columns: (lk, geom1, rk1, geom, rk2)
-    │ estimated row count: 9,801 (missing stats)
     │
     └── • lookup join (inner)
         │ columns: (lk, geom1, rk1, rk2, rk1, geom, rk2)
+        │ estimated row count: 9,801 (missing stats)
         │ table: rtable@rtable_pkey
         │ equality: (rk1, rk2) = (rk1,rk2)
         │ equality cols are key
@@ -538,10 +528,10 @@ vectorized: true
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2)
-            │ estimated row count: 10,000 (missing stats)
             │
             └── • inverted join (inner)
                 │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
+                │ estimated row count: 10,000 (missing stats)
                 │ table: rtable@geom_index
                 │ inverted expr: st_coveredby(geom1, geom_inverted_key)
                 │
@@ -560,14 +550,13 @@ vectorized: true
 ·
 • project
 │ columns: (lk, rk1, rk2)
-│ estimated row count: 9,801 (missing stats)
 │
 └── • project
     │ columns: (lk, geom1, rk1, geom, rk2)
-    │ estimated row count: 9,801 (missing stats)
     │
     └── • lookup join (inner)
         │ columns: (lk, geom1, rk1, rk2, rk1, geom, rk2)
+        │ estimated row count: 9,801 (missing stats)
         │ table: rtable@rtable_pkey
         │ equality: (rk1, rk2) = (rk1,rk2)
         │ equality cols are key
@@ -575,10 +564,10 @@ vectorized: true
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2)
-            │ estimated row count: 10,000 (missing stats)
             │
             └── • inverted join (inner)
                 │ columns: (lk, geom1, rk1, rk2, geom_inverted_key)
+                │ estimated row count: 10,000 (missing stats)
                 │ table: rtable@geom_index
                 │ inverted expr: st_intersects(geom1, geom_inverted_key)
                 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -179,7 +179,6 @@ vectorized: true
 ·
 • project
 │ columns: (y)
-│ estimated row count: 9,801 (missing stats)
 │
 └── • hash join (inner)
     │ columns: (x, x, y)
@@ -206,7 +205,6 @@ vectorized: true
 ·
 • project
 │ columns: (y)
-│ estimated row count: 9,801 (missing stats)
 │
 └── • hash join (inner)
     │ columns: (x, x, y)
@@ -233,7 +231,6 @@ vectorized: true
 ·
 • project
 │ columns: (x)
-│ estimated row count: 326,700 (missing stats)
 │
 └── • cross join (inner)
     │ columns: (x, y)
@@ -260,7 +257,6 @@ vectorized: true
 ·
 • render
 │ columns: (x, two, plus1)
-│ estimated row count: 10,000 (missing stats)
 │ render x: COALESCE(x, x)
 │ render two: two
 │ render plus1: plus1
@@ -272,7 +268,6 @@ vectorized: true
     │
     ├── • render
     │   │ columns: (two, x)
-    │   │ estimated row count: 1,000 (missing stats)
     │   │ render two: 2
     │   │ render x: x
     │   │
@@ -284,7 +279,6 @@ vectorized: true
     │
     └── • render
         │ columns: (plus1, x)
-        │ estimated row count: 1,000 (missing stats)
         │ render plus1: y + 1
         │ render x: x
         │
@@ -310,7 +304,6 @@ vectorized: true
 │
 └── • project
     │ columns: (column1, column2, column2)
-    │ estimated row count: 2
     │
     └── • hash join (inner)
         │ columns: (column1, column2, column1, column2)
@@ -415,7 +408,6 @@ vectorized: true
     │
     └── • render
         │ columns: (pktable_cat, update_rule, delete_rule, deferrability, nspname, relname, attname, nspname, relname, attname, conname, generate_series, relname)
-        │ estimated row count: 110,908 (missing stats)
         │ render pktable_cat: CAST(NULL AS STRING)
         │ render update_rule: CASE confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
         │ render delete_rule: CASE confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE CAST(NULL AS INT8) END
@@ -603,7 +595,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, n, sq)
-│ estimated row count: 990 (missing stats)
 │
 └── • hash join (inner)
     │ columns: (column10, a, b, n, sq)
@@ -612,7 +603,6 @@ vectorized: true
     │
     ├── • render
     │   │ columns: (column10, a, b)
-    │   │ estimated row count: 1,000 (missing stats)
     │   │ render column10: a + b
     │   │ render a: a
     │   │ render b: b
@@ -639,7 +629,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, n, sq)
-│ estimated row count: 990 (missing stats)
 │
 └── • filter
     │ columns: (div, a, b, n, sq)
@@ -648,7 +637,6 @@ vectorized: true
     │
     └── • render
         │ columns: (div, a, b, n, sq)
-        │ estimated row count: 1,000,000 (missing stats)
         │ render div: (a * b) / 2
         │ render a: a
         │ render b: b
@@ -680,7 +668,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, n, sq)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • hash join (full outer)
     │ columns: (column10, a, b, n, sq)
@@ -689,7 +676,6 @@ vectorized: true
     │
     ├── • render
     │   │ columns: (column10, a, b)
-    │   │ estimated row count: 1,000 (missing stats)
     │   │ render column10: a + b
     │   │ render a: a
     │   │ render b: b
@@ -714,7 +700,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, n, sq)
-│ estimated row count: 333 (missing stats)
 │
 └── • filter
     │ columns: (column10, a, b, n, sq)
@@ -728,7 +713,6 @@ vectorized: true
         │
         ├── • render
         │   │ columns: (column10, a, b)
-        │   │ estimated row count: 1,000 (missing stats)
         │   │ render column10: a + b
         │   │ render a: a
         │   │ render b: b
@@ -874,7 +858,6 @@ vectorized: true
 ·
 • project
 │ columns: (x)
-│ estimated row count: 96 (missing stats)
 │
 └── • hash join (inner)
     │ columns: (x, y, y, x)
@@ -939,7 +922,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c, d)
-│ estimated row count: 0 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, c, d, a, b, c, d)
@@ -971,7 +953,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c, d, d)
-│ estimated row count: 1 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, c, d, a, b, c, d)
@@ -1090,7 +1071,6 @@ vectorized: true
 ·
 • render
 │ columns: (s, s, s)
-│ estimated row count: 10,000 (missing stats)
 │ render s: COALESCE(s, s)
 │ render s: s
 │ render s: s
@@ -1120,7 +1100,6 @@ vectorized: true
 ·
 • render
 │ columns: (s, s, s)
-│ estimated row count: 10,000 (missing stats)
 │ render s: COALESCE(s, s)
 │ render s: s
 │ render s: s
@@ -1152,7 +1131,6 @@ vectorized: true
 ·
 • render
 │ columns: (a, s)
-│ estimated row count: 1,000 (missing stats)
 │ render s: COALESCE(s, s)
 │ render a: a
 │
@@ -1193,7 +1171,6 @@ vectorized: true
 ·
 • project
 │ columns: (x, y, u, v)
-│ estimated row count: 34 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (x, y, u, x, y, v)
@@ -1223,7 +1200,6 @@ vectorized: true
 ·
 • project
 │ columns: (x, y, u, v)
-│ estimated row count: 333 (missing stats)
 │
 └── • merge join (left outer)
     │ columns: (x, y, u, x, y, v)
@@ -1253,7 +1229,6 @@ vectorized: true
 ·
 • project
 │ columns: (x, y, u, v)
-│ estimated row count: 333 (missing stats)
 │
 └── • merge join (left outer)
     │ columns: (x, y, v, x, y, u)
@@ -1288,7 +1263,6 @@ vectorized: true
 │
 └── • render
     │ columns: (x, y, u, v)
-    │ estimated row count: 1,900 (missing stats)
     │ render x: COALESCE(x, x)
     │ render y: COALESCE(y, y)
     │ render u: u
@@ -1430,7 +1404,6 @@ vectorized: true
 ·
 • project
 │ columns: (x, y, u, v)
-│ estimated row count: 333 (missing stats)
 │
 └── • merge join (left outer)
     │ columns: (x, y, u, x, y, v)
@@ -1460,7 +1433,6 @@ vectorized: true
 ·
 • project
 │ columns: (x, y, u, v)
-│ estimated row count: 333 (missing stats)
 │
 └── • merge join (left outer)
     │ columns: (x, y, v, x, y, u)
@@ -1495,7 +1467,6 @@ vectorized: true
 │
 └── • render
     │ columns: (x, y, u, v)
-    │ estimated row count: 1,900 (missing stats)
     │ render x: COALESCE(x, x)
     │ render y: COALESCE(y, y)
     │ render u: u
@@ -1582,7 +1553,6 @@ vectorized: true
 ·
 • project
 │ columns: (x, y, u, v)
-│ estimated row count: 33 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (x, y, v, x, y, u)
@@ -1623,7 +1593,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b1, b2)
-│ estimated row count: 1 (missing stats)
 │
 └── • merge join (left outer)
     │ columns: (a, b1, a, b2)
@@ -1679,7 +1648,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b1, b2)
-│ estimated row count: 1 (missing stats)
 │
 └── • merge join (left outer)
     │ columns: (a, b2, a, b1)
@@ -1793,7 +1761,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c, d)
-│ estimated row count: 0 (missing stats)
 │
 └── • hash join (inner)
     │ columns: (a, b, c, d, a, b, c, d)
@@ -1822,7 +1789,6 @@ vectorized: true
 ·
 • project
 │ columns: (b, a, c, d, a, c, d)
-│ estimated row count: 9,801 (missing stats)
 │
 └── • cross join (inner)
     │ columns: (a, b, c, d, a, b, c, d)
@@ -1850,7 +1816,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c, d, c, d)
-│ estimated row count: 96 (missing stats)
 │
 └── • hash join (inner)
     │ columns: (a, b, c, d, a, b, c, d)
@@ -1879,7 +1844,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c, d, d)
-│ estimated row count: 1 (missing stats)
 │
 └── • hash join (inner)
     │ columns: (a, b, c, d, a, b, c, d)

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -12,7 +12,6 @@ vectorized: true
 ·
 • limit
 │ columns: (k, v, w)
-│ estimated row count: 2 (missing stats)
 │ count: 2
 │
 └── • filter
@@ -46,7 +45,6 @@ vectorized: true
 ·
 • limit
 │ columns: (w)
-│ estimated row count: 25 (missing stats)
 │ count: 25
 │
 └── • distinct
@@ -91,7 +89,6 @@ vectorized: true
 ·
 • limit
 │ columns: (k, v)
-│ estimated row count: 995 (missing stats)
 │ offset: 5
 │
 └── • scan
@@ -109,7 +106,6 @@ vectorized: true
 ·
 • limit
 │ columns: (k, v)
-│ estimated row count: 5 (missing stats)
 │ offset: 1
 │
 └── • scan
@@ -128,7 +124,6 @@ vectorized: true
 ·
 • limit
 │ columns: (k, v)
-│ estimated row count: 5 (missing stats)
 │ offset: 1
 │
 └── • revscan
@@ -151,7 +146,6 @@ vectorized: true
 └── • project
     │ columns: (any_not_null, sum)
     │ ordering: -any_not_null
-    │ estimated row count: 10 (missing stats)
     │
     └── • top-k
         │ columns: (k, sum, any_not_null)
@@ -183,7 +177,6 @@ vectorized: true
 ·
 • project
 │ columns: (k)
-│ estimated row count: 4 (missing stats)
 │
 └── • scan
       columns: (k, v)
@@ -200,7 +193,6 @@ vectorized: true
 ·
 • project
 │ columns: (k)
-│ estimated row count: 4 (missing stats)
 │
 └── • scan
       columns: (k, v)
@@ -235,11 +227,9 @@ vectorized: true
 ·
 • project
 │ columns: (k, w)
-│ estimated row count: 10 (missing stats)
 │
 └── • limit
     │ columns: (k, v, w)
-    │ estimated row count: 10 (missing stats)
     │ count: 10
     │
     └── • filter
@@ -294,7 +284,6 @@ vectorized: true
     │
     └── • limit
         │ columns: (k, v, w)
-        │ estimated row count: 10 (missing stats)
         │ count: 10
         │
         └── • filter
@@ -323,7 +312,6 @@ vectorized: true
 ·
 • limit
 │ columns: (k, a)
-│ estimated row count: 1 (missing stats)
 │ count: 1
 │
 └── • filter
@@ -397,7 +385,6 @@ distribution: local
 vectorized: true
 ·
 • limit
-│ estimated row count: 5
 │ count: 5
 │
 └── • union all
@@ -515,7 +502,6 @@ distribution: local
 vectorized: true
 ·
 • limit
-│ estimated row count: 5
 │ count: 5
 │
 └── • lookup join

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -265,7 +265,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c, d)
-│ estimated row count: 0
 │
 └── • lookup join (inner)
     │ columns: (a, b, c, d, a, b, c, d)
@@ -469,7 +468,6 @@ vectorized: true
 • project
 │ columns: (name)
 │ ordering: +name
-│ estimated row count: 990
 │
 └── • lookup join (inner)
     │ columns: (name, book, title)
@@ -520,12 +518,12 @@ distribution: local
 vectorized: true
 ·
 • lookup join
+│ estimated row count: 99
 │ table: books2@books2_pkey
 │ equality: (book, lookup_join_const_col_@7) = (title,edition)
 │ equality cols are key
 │
 └── • render
-    │ estimated row count: 100
     │
     └── • scan
           estimated row count: 100 (100% of the table; stats collected <hidden> ago)
@@ -584,7 +582,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, c)
-│ estimated row count: 1,000
 │
 └── • lookup join (inner)
     │ columns: (a, b, c)
@@ -607,14 +604,13 @@ vectorized: true
 ·
 • project
 │ columns: (a, d)
-│ estimated row count: 1,000
 │
 └── • project
     │ columns: (a, b, d)
-    │ estimated row count: 1,000
     │
     └── • lookup join (inner)
         │ columns: (a, a, b, d)
+        │ estimated row count: 1,000
         │ table: large@large_pkey
         │ equality: (a, b) = (a,b)
         │ equality cols are key
@@ -664,7 +660,6 @@ vectorized: true
 • project
 │ columns: (a, b)
 │ ordering: +a
-│ estimated row count: 100
 │
 └── • lookup join (left outer)
     │ columns: (a, a, b)
@@ -709,7 +704,6 @@ vectorized: true
 ·
 • project
 │ columns: (c, c)
-│ estimated row count: 1,000
 │
 └── • lookup join (left outer)
     │ columns: (c, b, c)
@@ -732,14 +726,13 @@ vectorized: true
 ·
 • project
 │ columns: (c, d)
-│ estimated row count: 1,000
 │
 └── • project
     │ columns: (c, b, d)
-    │ estimated row count: 1,000
     │
     └── • lookup join (left outer)
         │ columns: (c, a, b, d)
+        │ estimated row count: 1,000
         │ table: large@large_pkey
         │ equality: (a, b) = (a,b)
         │ equality cols are key
@@ -765,7 +758,6 @@ vectorized: true
 ·
 • project
 │ columns: (c, c)
-│ estimated row count: 336
 │
 └── • lookup join (left outer)
     │ columns: (c, b, c)
@@ -789,14 +781,13 @@ vectorized: true
 ·
 • project
 │ columns: (c, d)
-│ estimated row count: 336
 │
 └── • project
     │ columns: (c, b, d)
-    │ estimated row count: 336
     │
     └── • lookup join (left outer)
         │ columns: (c, a, b, c, cont, b, d)
+        │ estimated row count: 336
         │ table: large@large_pkey
         │ equality: (a, b) = (a,b)
         │ equality cols are key
@@ -823,10 +814,10 @@ vectorized: true
 ·
 • project
 │ columns: (c)
-│ estimated row count: 100
 │
 └── • lookup join (semi)
     │ columns: (c, a, b, c, cont)
+    │ estimated row count: 100
     │ table: large@large_pkey
     │ equality: (a, b) = (a,b)
     │ equality cols are key
@@ -853,10 +844,10 @@ vectorized: true
 ·
 • project
 │ columns: (c)
-│ estimated row count: 0
 │
 └── • lookup join (anti)
     │ columns: (c, a, b, c, cont)
+    │ estimated row count: 0
     │ table: large@large_pkey
     │ equality: (a, b) = (a,b)
     │ equality cols are key
@@ -896,7 +887,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 1 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (a, d, e, a, d)
@@ -930,7 +920,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 0 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (a, d, e, a, d)
@@ -966,7 +955,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 0 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (a, b, d, e, a, b, d)
@@ -1000,7 +988,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 0 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (a, b, d, e, a, b, d)
@@ -1034,7 +1021,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 1 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (a, d, e, a, d)
@@ -1871,6 +1857,7 @@ vectorized: true
                 │ pred: l_receiptdate > l_commitdate
                 │
                 └── • lookup join
+                    │ estimated row count: 80,016
                     │ table: lineitem@lineitem_pkey
                     │ equality: (l_orderkey, l_linenumber) = (l_orderkey,l_linenumber)
                     │ equality cols are key
@@ -1917,21 +1904,19 @@ vectorized: true
 ·
 • project
 │ columns: (pk)
-│ estimated row count: 10 (missing stats)
 │
 └── • project
     │ columns: (pk, col0, col3)
-    │ estimated row count: 10 (missing stats)
     │
     └── • lookup join (semi)
         │ columns: ("lookup_join_const_col_@15", pk, col0, col3)
+        │ estimated row count: 10 (missing stats)
         │ table: tab4@tab4_col3_col4_key
         │ equality: (col0, lookup_join_const_col_@15) = (col3,col4)
         │ equality cols are key
         │
         └── • render
             │ columns: ("lookup_join_const_col_@15", pk, col0, col3)
-            │ estimated row count: 10 (missing stats)
             │ render lookup_join_const_col_@15: 495.6
             │ render pk: pk
             │ render col0: col0
@@ -2020,7 +2005,6 @@ vectorized: true
 │ lookup condition: ((((r IN ('east', 'west')) AND (column2 = x)) AND (y IN (10, 20))) AND ("lookup_join_const_col_@8" = z)) AND (column1 = w)
 │
 └── • render
-    │ estimated row count: 3
     │
     └── • values
           size: 2 columns, 3 rows
@@ -2040,7 +2024,6 @@ vectorized: true
 │ lookup condition: ((((r IN ('east', 'west')) AND (column2 = x)) AND (y IN (10, 20))) AND ("lookup_join_const_col_@8" = z)) AND (column1 = w)
 │
 └── • render
-    │ estimated row count: 3
     │
     └── • values
           size: 2 columns, 3 rows

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -84,9 +84,6 @@ network usage: <hidden>
 regions: <hidden>
 ·
 • limit
-│ nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 1
 │ count: 1
 │
 └── • union all
@@ -166,9 +163,6 @@ network usage: <hidden>
 regions: <hidden>
 ·
 • limit
-│ nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 1
 │ count: 1
 │
 └── • union all
@@ -321,15 +315,6 @@ network usage: <hidden>
 regions: <hidden>
 ·
 • limit
-│ nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 1
-│ KV time: 0µs
-│ KV contention time: 0µs
-│ KV rows read: 1
-│ KV bytes read: 8 B
-│ KV gRPC calls: 1
-│ estimated max memory allocated: 0 B
 │ count: 1
 │
 └── • lookup join

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
@@ -837,11 +837,11 @@ vectorized: true
         │ equality cols are key
         │
         └── • lookup join
+            │ estimated row count: 0
             │ table: metric_values@secondary
             │ lookup condition: ((id = metric_id) AND ("lookup_join_const_col_@3" = nullable)) AND ("time" < '2020-01-01 00:00:10+00:00')
             │
             └── • render
-                │ estimated row count: 1
                 │
                 └── • scan
                       estimated row count: 1 (10% of the table; stats collected <hidden> ago)
@@ -886,7 +886,6 @@ vectorized: true
 ·
 • project
 │ columns: (s_i_id, ol_o_id)
-│ estimated row count: 7,939 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (s_i_id, ol_o_id, ol_i_id)
@@ -915,7 +914,6 @@ vectorized: true
 ·
 • project
 │ columns: (s_i_id, ol_o_id)
-│ estimated row count: 196 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (s_i_id, ol_o_id, ol_i_id)

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -245,7 +245,6 @@ vectorized: true
 │
 └── • render
     │ columns: (r)
-    │ estimated row count: 1,000 (missing stats)
     │ render r: b + 2
     │
     └── • scan
@@ -269,7 +268,6 @@ vectorized: true
 │
 └── • render
     │ columns: (y)
-    │ estimated row count: 1,000 (missing stats)
     │ render y: b + 2
     │
     └── • scan
@@ -540,7 +538,6 @@ vectorized: true
 • project
 │ columns: (b, c)
 │ ordering: +b,+c
-│ estimated row count: 10 (missing stats)
 │
 └── • scan
       columns: (a, b, c)
@@ -717,7 +714,6 @@ vectorized: true
 ·
 • project
 │ columns: (b)
-│ estimated row count: 1
 │
 └── • insert fast path
       columns: (a, b)
@@ -737,7 +733,6 @@ vectorized: true
 ·
 • project
 │ columns: (b)
-│ estimated row count: 1 (missing stats)
 │
 └── • delete
     │ columns: (a, b)
@@ -759,7 +754,6 @@ vectorized: true
 ·
 • project
 │ columns: (b)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • update
     │ columns: (a, b)
@@ -770,7 +764,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a, b, c, c_new)
-        │ estimated row count: 1,000 (missing stats)
         │ render c_new: true
         │ render a: a
         │ render b: b
@@ -858,7 +851,6 @@ vectorized: true
 └── • render
     │ columns: (column6, a, b)
     │ ordering: +a
-    │ estimated row count: 1,000 (missing stats)
     │ render column6: a
     │ render a: a
     │ render b: b
@@ -887,7 +879,6 @@ vectorized: true
 └── • render
     │ columns: (column6, a, b)
     │ ordering: +b
-    │ estimated row count: 1,000 (missing stats)
     │ render column6: b
     │ render a: a
     │ render b: b
@@ -1111,7 +1102,6 @@ vectorized: true
     │
     └── • project
         │ columns: (k, v)
-        │ estimated row count: 2 (missing stats)
         │
         └── • lookup join (inner)
             │ columns: (column1, k, v)
@@ -1138,7 +1128,6 @@ vectorized: true
 └── • project
     │ columns: (k, k, v)
     │ ordering: -v,+k
-    │ estimated row count: 10 (missing stats)
     │
     └── • merge join (inner)
         │ columns: (k, v, k, v)
@@ -1233,7 +1222,6 @@ vectorized: true
     │
     └── • render
         │ columns: (nulls_ordering_b, a, b)
-        │ estimated row count: 1,000 (missing stats)
         │ render nulls_ordering_b: b IS NULL
         │ render a: a
         │ render b: b
@@ -1261,7 +1249,6 @@ vectorized: true
     │
     └── • render
         │ columns: (nulls_ordering_b, a, b)
-        │ estimated row count: 1,000 (missing stats)
         │ render nulls_ordering_b: b IS NULL
         │ render a: a
         │ render b: b
@@ -1307,7 +1294,6 @@ vectorized: true
     │
     └── • render
         │ columns: (nulls_ordering_b, nulls_ordering_c, a, b, c)
-        │ estimated row count: 1,000 (missing stats)
         │ render nulls_ordering_b: b IS NULL
         │ render nulls_ordering_c: c IS NULL
         │ render a: a
@@ -1343,7 +1329,6 @@ vectorized: true
     │
     └── • render
         │ columns: (nulls_ordering_b, a, b)
-        │ estimated row count: 1,000 (missing stats)
         │ render nulls_ordering_b: b IS NULL
         │ render a: a
         │ render b: b

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -70,7 +70,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: 3
 │
 └── • scan
@@ -87,7 +86,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a + 2
 │
 └── • scan
@@ -104,7 +102,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: ((a >= 5) AND (b <= 10)) AND (c < 4)
 │
 └── • scan
@@ -121,7 +118,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: ((a >= 5) OR (b <= 10)) OR (c < 4)
 │
 └── • scan
@@ -138,7 +134,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a != 5
 │
 └── • scan
@@ -155,7 +150,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: (a <= 5) OR (b < 10)
 │
 └── • scan
@@ -172,7 +166,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))
 │
 └── • scan
@@ -189,7 +182,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: ((a < 5) AND (b > 10)) AND (c < 10)
 │
 └── • scan
@@ -206,7 +198,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: (a = 1) AND (b = 2)
 │
 └── • scan
@@ -223,7 +214,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a IN (1, 2)
 │
 └── • scan
@@ -240,7 +230,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: (a, b) IN ((1, 2), (3, 4))
 │
 └── • scan
@@ -257,7 +246,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))
 │
 └── • scan
@@ -274,7 +262,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)
 │
 └── • scan
@@ -291,7 +278,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)
 │
 └── • scan
@@ -308,7 +294,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a IS NULL
 │
 └── • scan
@@ -325,7 +310,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a IS NULL
 │
 └── • scan
@@ -342,7 +326,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: (a, b) IS NULL
 │
 └── • scan
@@ -359,7 +342,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: false
 │
 └── • scan
@@ -376,7 +358,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a IS NOT DISTINCT FROM b
 │
 └── • scan
@@ -393,7 +374,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a IS NOT NULL
 │
 └── • scan
@@ -410,7 +390,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a IS NOT NULL
 │
 └── • scan
@@ -427,7 +406,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: (a, b) IS NOT NULL
 │
 └── • scan
@@ -444,7 +422,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: true
 │
 └── • scan
@@ -461,7 +438,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a IS DISTINCT FROM b
 │
 └── • scan
@@ -478,7 +454,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: a + (-b)
 │
 └── • scan
@@ -495,7 +470,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END
 │
 └── • scan
@@ -512,7 +486,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: CASE WHEN a = 2 THEN 1 ELSE 2 END
 │
 └── • scan
@@ -529,7 +502,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END
 │
 └── • scan
@@ -547,7 +519,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: CASE WHEN a = 2 THEN 1 ELSE CAST(NULL AS INT8) END
 │
 └── • scan
@@ -564,7 +535,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: CASE a WHEN 2 THEN 1 ELSE CAST(NULL AS INT8) END
 │
 └── • scan
@@ -591,7 +561,6 @@ vectorized: true
 ·
 • render
 │ columns: (length)
-│ estimated row count: 1,000 (missing stats)
 │ render length: length(s)
 │
 └── • scan
@@ -608,7 +577,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: j @> '{"a": 1}'
 │
 └── • scan
@@ -625,7 +593,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: '{"a": 1}' <@ j
 │
 └── • scan
@@ -642,7 +609,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: j->>'a'
 │
 └── • scan
@@ -659,7 +625,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: j->'a'
 │
 └── • scan
@@ -676,7 +641,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: j ? 'a'
 │
 └── • scan
@@ -693,7 +657,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: j ?| ARRAY['a','b','c']
 │
 └── • scan
@@ -710,7 +673,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: j ?& ARRAY['a','b','c']
 │
 └── • scan
@@ -727,7 +689,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: j#>ARRAY['a']
 │
 └── • scan
@@ -744,7 +705,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: j#>>ARRAY['a']
 │
 └── • scan
@@ -762,7 +722,6 @@ vectorized: true
 ·
 • render
 │ columns: (a, b)
-│ estimated row count: 1,000 (missing stats)
 │ render a: a::STRING
 │ render b: b::FLOAT8
 │
@@ -780,7 +739,6 @@ vectorized: true
 ·
 • render
 │ columns: (text)
-│ estimated row count: 1,000 (missing stats)
 │ render text: (c + (a + b))::STRING
 │
 └── • scan
@@ -797,7 +755,6 @@ vectorized: true
 ·
 • render
 │ columns: (s)
-│ estimated row count: 1,000 (missing stats)
 │ render s: s::VARCHAR(2)
 │
 └── • scan
@@ -814,7 +771,6 @@ vectorized: true
 ·
 • render
 │ columns: ("coalesce")
-│ estimated row count: 4
 │ render coalesce: COALESCE(column1, column2)
 │
 └── • values
@@ -837,7 +793,6 @@ vectorized: true
 ·
 • render
 │ columns: ("coalesce")
-│ estimated row count: 4
 │ render coalesce: COALESCE(column1, column2, column3)
 │
 └── • values
@@ -864,7 +819,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 110 (missing stats)
 │
 └── • filter
     │ columns: (a, b, d)
@@ -885,7 +839,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 330 (missing stats)
 │
 └── • filter
     │ columns: (a, b, d)
@@ -906,7 +859,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))
 │
 └── • scan
@@ -923,7 +875,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: ((a < b) OR (a > d)) AND ((a < d) OR (a > b))
 │
 └── • scan
@@ -940,7 +891,6 @@ vectorized: true
 ·
 • render
 │ columns: ("array")
-│ estimated row count: 1,000 (missing stats)
 │ render array: ARRAY[]
 │
 └── • scan
@@ -957,7 +907,6 @@ vectorized: true
 ·
 • render
 │ columns: ("array")
-│ estimated row count: 1,000 (missing stats)
 │ render array: ARRAY[1,2,3]
 │
 └── • scan
@@ -974,7 +923,6 @@ vectorized: true
 ·
 • render
 │ columns: ("array")
-│ estimated row count: 1,000 (missing stats)
 │ render array: ARRAY[a + 1, 2, 3]
 │
 └── • scan
@@ -991,7 +939,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1,000 (missing stats)
 │ render ?column?: 1 > ANY ARRAY[a + 1, 2, 3]
 │
 └── • scan
@@ -1008,7 +955,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1,000 (missing stats)
 │ render ?column?: true
 │
 └── • scan
@@ -1025,7 +971,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1,000 (missing stats)
 │ render ?column?: false
 │
 └── • scan
@@ -1042,7 +987,6 @@ vectorized: true
 ·
 • render
 │ columns: ("least")
-│ estimated row count: 1,000 (missing stats)
 │ render least: least(NULL, 3, 6, a)
 │
 └── • scan
@@ -1097,7 +1041,6 @@ vectorized: true
 ·
 • render
 │ columns: (r1, r2)
-│ estimated row count: 1,000 (missing stats)
 │ render r1: 4.0
 │ render r2: length(upper(concat('a', 'b', s)))::FLOAT8 + 1.0
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -402,7 +402,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: x + 1
 │
 └── • scan
@@ -419,7 +418,6 @@ vectorized: true
 ·
 • render
 │ columns: (a, b, y, c, d)
-│ estimated row count: 1,000 (missing stats)
 │ render b: x + 1
 │ render c: y + 1
 │ render d: x + y
@@ -440,12 +438,10 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 1,000 (missing stats)
 │ render r: "?column?" + ("?column?" * "?column?")
 │
 └── • render
     │ columns: ("?column?", "?column?")
-    │ estimated row count: 1,000 (missing stats)
     │ render ?column?: x + 3
     │ render ?column?: y + 10
     │
@@ -478,7 +474,6 @@ vectorized: true
 ·
 • render
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
 │ render a: x + 1
 │ render b: x + y
 │
@@ -737,7 +732,6 @@ vectorized: true
 ·
 • render
 │ columns: (a)
-│ estimated row count: 1,000 (missing stats)
 │ render a: 1
 │
 └── • scan
@@ -1354,7 +1348,6 @@ vectorized: true
 └── • render
     │ columns: ("?column?", a)
     │ ordering: +a
-    │ estimated row count: 1,000 (missing stats)
     │ render ?column?: a + (b + c)
     │ render a: a
     │
@@ -1382,7 +1375,6 @@ vectorized: true
     │
     └── • render
         │ columns: ("?column?", b)
-        │ estimated row count: 1,000 (missing stats)
         │ render ?column?: a + (c + (a + b))
         │ render b: b
         │
@@ -1405,7 +1397,6 @@ vectorized: true
 └── • render
     │ columns: ("?column?", a, b)
     │ ordering: -a,-b
-    │ estimated row count: 1,000 (missing stats)
     │ render ?column?: a + (c + (a + b))
     │ render a: a
     │ render b: b
@@ -1489,7 +1480,6 @@ vectorized: true
 • render
 │ columns: (a, x)
 │ ordering: +a
-│ estimated row count: 3 (missing stats)
 │ render x: c + (a + b)
 │ render a: a
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -131,7 +131,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1,000 (missing stats)
 │ render ?column?: 1
 │
 └── • scan
@@ -256,7 +255,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1 (missing stats)
 │ render ?column?: 1
 │
 └── • scan
@@ -760,7 +758,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b)
-│ estimated row count: 100 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (b, a, b)
@@ -789,7 +786,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b)
-│ estimated row count: 100 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (b, a, b)
@@ -818,7 +814,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b)
-│ estimated row count: 100 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (b, a, b)
@@ -847,7 +842,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b)
-│ estimated row count: 100 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (b, a, b)
@@ -887,7 +881,6 @@ vectorized: true
 ·
 • render
 │ columns: (a)
-│ estimated row count: 1,000 (missing stats)
 │ render a: a
 │
 └── • scan
@@ -904,7 +897,6 @@ vectorized: true
 ·
 • render
 │ columns: (a)
-│ estimated row count: 1,000 (missing stats)
 │ render a: a
 │
 └── • scan
@@ -1019,7 +1011,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1053,7 +1044,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1086,7 +1076,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1119,7 +1108,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1153,7 +1141,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1190,7 +1177,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1224,7 +1210,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1258,7 +1243,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1292,7 +1276,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1330,7 +1313,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1373,7 +1355,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1406,7 +1387,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1439,7 +1419,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1477,7 +1456,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1520,7 +1498,6 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, a, c)
@@ -1735,7 +1712,6 @@ vectorized: true
 ·
 • project
 │ columns: (c)
-│ estimated row count: 1 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, c)
@@ -1760,7 +1736,6 @@ vectorized: true
 ·
 • project
 │ columns: (c)
-│ estimated row count: 9 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, c)
@@ -1835,10 +1810,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, b_inverted_key, a, b_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: inverted@b_inv
           left columns: (a, b_inverted_key)
           left fixed values: 1 column
@@ -1868,10 +1843,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
+            │ estimated row count: 111 (missing stats)
             │ inverted column: b_inverted_key
             │ num spans: 2
             │
@@ -1890,10 +1865,10 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c, a, b, c)
-│ estimated row count: 10,000 (missing stats)
 │
 └── • lookup join (inner)
     │ columns: (a, b, c, a, a, b, c)
+    │ estimated row count: 10,000 (missing stats)
     │ table: inverted@inverted_pkey
     │ equality: (a) = (a)
     │ equality cols are key
@@ -1902,10 +1877,10 @@ vectorized: true
     │
     └── • project
         │ columns: (a, b, c, a)
-        │ estimated row count: 10,000 (missing stats)
         │
         └── • inverted join (inner)
             │ columns: (a, b, c, a, b_inverted_key)
+            │ estimated row count: 10,000 (missing stats)
             │ table: inverted@b_inv
             │ inverted expr: b_inverted_key @> b
             │ locking strength: for update
@@ -1940,10 +1915,10 @@ vectorized: true
 ·
 • project
 │ columns: (a, b, c)
-│ estimated row count: 1 (missing stats)
 │
 └── • zigzag join
       columns: (a, b, a, c)
+      estimated row count: 1 (missing stats)
       pred: (b = 5) AND (c = 6.0)
       left table: zigzag@b_idx
       left columns: (a, b)
@@ -1971,10 +1946,10 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 12 (missing stats)
     │
     └── • zigzag join
           columns: (a, d_inverted_key, a, d_inverted_key)
+          estimated row count: 12 (missing stats)
           left table: zigzag@d_idx
           left columns: (a, d_inverted_key)
           left fixed values: 1 column
@@ -2111,7 +2086,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1,000 (missing stats)
 │ render ?column?: 1
 │
 └── • scan
@@ -2245,7 +2219,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1 (missing stats)
 │ render ?column?: 1
 │
 └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -200,7 +200,6 @@ vectorized: true
 ·
 • project
 │ columns: (b, a, c, d, a, c, d)
-│ estimated row count: 100 (missing stats)
 │
 └── • merge join (inner)
     │ columns: (a, b, c, d, a, b, c, d)
@@ -488,7 +487,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 333 (missing stats)
 │
 └── • filter
     │ columns: (a, c)
@@ -509,7 +507,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 311 (missing stats)
 │
 └── • filter
     │ columns: (a, b, c)
@@ -530,7 +527,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 333 (missing stats)
 │
 └── • filter
     │ columns: (a, c)
@@ -551,7 +547,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 333 (missing stats)
 │
 └── • filter
     │ columns: (a, c)
@@ -572,7 +567,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 311 (missing stats)
 │
 └── • filter
     │ columns: (a, b, c)
@@ -593,7 +587,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 311 (missing stats)
 │
 └── • filter
     │ columns: (a, b, c)
@@ -614,7 +607,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 1 (missing stats)
 │
 └── • scan
       columns: (a, b, c)
@@ -630,7 +622,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 1 (missing stats)
 │
 └── • scan
       columns: (a, b, c)
@@ -646,7 +637,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 3 (missing stats)
 │
 └── • filter
     │ columns: (a, b, c)
@@ -668,7 +658,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 20 (missing stats)
 │
 └── • scan
       columns: (a, b)
@@ -696,7 +685,6 @@ vectorized: true
 ·
 • project
 │ columns: (b)
-│ estimated row count: 1 (missing stats)
 │
 └── • scan
       columns: (a, b)
@@ -712,7 +700,6 @@ vectorized: true
 ·
 • project
 │ columns: (b)
-│ estimated row count: 3 (missing stats)
 │
 └── • scan
       columns: (a, b)
@@ -819,7 +806,6 @@ vectorized: true
 ·
 • project
 │ columns: (k)
-│ estimated row count: 333 (missing stats)
 │
 └── • filter
     │ columns: (k, a, b)
@@ -1012,7 +998,6 @@ vectorized: true
 ·
 • project
 │ columns: (c)
-│ estimated row count: 1 (missing stats)
 │
 └── • scan
       columns: (a, c)
@@ -1033,7 +1018,6 @@ vectorized: true
 ·
 • project
 │ columns: (f)
-│ estimated row count: 1 (missing stats)
 │
 └── • filter
     │ columns: (d, f)
@@ -1062,7 +1046,6 @@ vectorized: true
 ·
 • project
 │ columns: (f)
-│ estimated row count: 1 (missing stats)
 │
 └── • filter
     │ columns: (d, f)
@@ -1465,7 +1448,6 @@ vectorized: true
 ·
 • limit
 │ columns: (a, b, c, d)
-│ estimated row count: 995 (missing stats)
 │ offset: 5
 │
 └── • sort
@@ -1489,7 +1471,6 @@ vectorized: true
 ·
 • limit
 │ columns: (a, b, c, d)
-│ estimated row count: 5 (missing stats)
 │ offset: 5
 │
 └── • index join
@@ -1729,7 +1710,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 3
 │
 └── • scan
       columns: (a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -115,7 +115,6 @@ vectorized: true
 • root
 │
 ├── • limit
-│   │ estimated row count: 1
 │   │ count: 1
 │   │
 │   └── • scan buffer
@@ -241,7 +240,6 @@ vectorized: true
 • root
 │
 ├── • limit
-│   │ estimated row count: 1
 │   │ count: 1
 │   │
 │   └── • scan buffer

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
@@ -32,7 +32,6 @@ vectorized: true
 ·
 • project
 │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
-│ estimated row count: 0 (missing stats)
 │
 └── • delete
     │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
@@ -42,25 +41,22 @@ vectorized: true
     │
     └── • project
         │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-        │ estimated row count: 0 (missing stats)
         │
         └── • project
             │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (inner)
                     │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                    │ estimated row count: 0 (missing stats)
                     │ table: statement_statistics@fingerprint_stats_idx
                     │ equality: (fingerprint_id, transaction_fingerprint_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, plan_hash, app_name, node_id) = (fingerprint_id,transaction_fingerprint_id,crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,aggregated_ts,plan_hash,app_name,node_id)
                     │ equality cols are key
                     │
                     └── • render
                         │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-                        │ estimated row count: 9 (missing stats)
                         │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id, plan_hash, transaction_fingerprint_id)), 8)
                         │ render aggregated_ts: aggregated_ts
                         │ render fingerprint_id: fingerprint_id
@@ -94,7 +90,6 @@ vectorized: true
 ·
 • project
 │ columns: (aggregated_ts, fingerprint_id, app_name, node_id)
-│ estimated row count: 0 (missing stats)
 │
 └── • delete
     │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
@@ -104,25 +99,22 @@ vectorized: true
     │
     └── • project
         │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-        │ estimated row count: 0 (missing stats)
         │
         └── • project
             │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (inner)
                     │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                    │ estimated row count: 0 (missing stats)
                     │ table: transaction_statistics@fingerprint_stats_idx
                     │ equality: (fingerprint_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, app_name, node_id) = (fingerprint_id,crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8,aggregated_ts,app_name,node_id)
                     │ equality cols are key
                     │
                     └── • render
                         │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-                        │ estimated row count: 9 (missing stats)
                         │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id)), 8)
                         │ render aggregated_ts: aggregated_ts
                         │ render fingerprint_id: fingerprint_id
@@ -164,7 +156,6 @@ vectorized: true
 ·
 • project
 │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
-│ estimated row count: 0 (missing stats)
 │
 └── • delete
     │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
@@ -174,25 +165,22 @@ vectorized: true
     │
     └── • project
         │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-        │ estimated row count: 0 (missing stats)
         │
         └── • project
             │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (inner)
                     │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
+                    │ estimated row count: 0 (missing stats)
                     │ table: statement_statistics@fingerprint_stats_idx
                     │ equality: (fingerprint_id, transaction_fingerprint_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, plan_hash, app_name, node_id) = (fingerprint_id,transaction_fingerprint_id,crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,aggregated_ts,plan_hash,app_name,node_id)
                     │ equality cols are key
                     │
                     └── • render
                         │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)
-                        │ estimated row count: 9 (missing stats)
                         │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id, plan_hash, transaction_fingerprint_id)), 8)
                         │ render aggregated_ts: aggregated_ts
                         │ render fingerprint_id: fingerprint_id
@@ -234,7 +222,6 @@ vectorized: true
 ·
 • project
 │ columns: (aggregated_ts, fingerprint_id, app_name, node_id)
-│ estimated row count: 0 (missing stats)
 │
 └── • delete
     │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
@@ -244,25 +231,22 @@ vectorized: true
     │
     └── • project
         │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-        │ estimated row count: 0 (missing stats)
         │
         └── • project
             │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id)
-            │ estimated row count: 0 (missing stats)
             │
             └── • project
                 │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-                │ estimated row count: 0 (missing stats)
                 │
                 └── • lookup join (inner)
                     │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
+                    │ estimated row count: 0 (missing stats)
                     │ table: transaction_statistics@fingerprint_stats_idx
                     │ equality: (fingerprint_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, app_name, node_id) = (fingerprint_id,crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8,aggregated_ts,app_name,node_id)
                     │ equality cols are key
                     │
                     └── • render
                         │ columns: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq, aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8)
-                        │ estimated row count: 9 (missing stats)
                         │ render crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8_eq: mod(fnv32(crdb_internal.datums_to_bytes(aggregated_ts, app_name, fingerprint_id, node_id)), 8)
                         │ render aggregated_ts: aggregated_ts
                         │ render fingerprint_id: fingerprint_id

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -168,7 +168,6 @@ vectorized: true
 │
 ├── • render
 │   │ columns: (k, addgeometrycolumn, addgeometrycolumn)
-│   │ estimated row count: 1,000 (missing stats)
 │   │ render addgeometrycolumn: addgeometrycolumn('my_spatial_table', 'geom7', 4326, 'POINT', 2)
 │   │ render addgeometrycolumn: addgeometrycolumn('my_spatial_table', 'geom8', 4326, 'POINT', 2)
 │   │ render k: k

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -158,7 +158,6 @@ vectorized: true
 │
 └── • render
     │ columns: ("information_schema._pg_expandarray", x, y, z)
-    │ estimated row count: 3,267 (missing stats)
     │ render information_schema._pg_expandarray: ((x, n) AS x, n)
     │ render x: x
     │ render y: y
@@ -200,7 +199,6 @@ vectorized: true
 ·
 • project
 │ columns: (generate_series)
-│ estimated row count: 3,333 (missing stats)
 │
 └── • project set
     │ columns: (x, z, generate_series)
@@ -238,7 +236,6 @@ vectorized: true
 ·
 • project
 │ columns: (generate_subscripts, generate_series, unnest, y, z)
-│ estimated row count: 10,000 (missing stats)
 │
 └── • project set
     │ columns: (x, y, x, z, generate_subscripts, generate_series, unnest)
@@ -280,7 +277,6 @@ vectorized: true
 │
 ├── • project
 │   │ columns: (generate_series)
-│   │ estimated row count: 10,000 (missing stats)
 │   │
 │   └── • project set
 │       │ columns: (z, generate_series)
@@ -304,7 +300,6 @@ vectorized: true
         │
         └── • project
             │ columns: (unnest)
-            │ estimated row count: 2,000 (missing stats)
             │
             └── • apply join (inner)
                 │ columns: (x, y, unnest)
@@ -336,7 +331,6 @@ vectorized: true
 ·
 • render
 │ columns: (group_name, jsonb_array_elements)
-│ estimated row count: 100,000 (missing stats)
 │ render group_name: data->>'name'
 │ render jsonb_array_elements: jsonb_array_elements
 │
@@ -361,7 +355,6 @@ vectorized: true
                 │
                 ├── • render
                 │   │ columns: (column12, id, data)
-                │   │ estimated row count: 1,000 (missing stats)
                 │   │ render column12: data->>'name'
                 │   │ render id: id
                 │   │ render data: data
@@ -374,7 +367,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (column13, "?column?")
-                    │ estimated row count: 1,000 (missing stats)
                     │ render column13: data->>'name'
                     │ render ?column?: data->'members'
                     │
@@ -476,7 +468,6 @@ vectorized: true
 ·
 • project
 │ columns: (generate_series)
-│ estimated row count: 10
 │
 └── • project set
     │ columns: (a, generate_series)
@@ -485,7 +476,6 @@ vectorized: true
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 1
         │
         └── • except all
             │ columns: (a, a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -137,7 +137,6 @@ vectorized: true
 │   │
 │   └── • limit
 │       │ columns: (a, b, c)
-│       │ estimated row count: 1 (missing stats)
 │       │ count: 1
 │       │
 │       └── • filter
@@ -163,7 +162,6 @@ vectorized: true
         │
         └── • limit
             │ columns: (a)
-            │ estimated row count: 1 (missing stats)
             │ count: 1
             │
             └── • filter
@@ -270,15 +268,12 @@ vectorized: true
 ·
 • project
 │ columns: (col0)
-│ estimated row count: 311 (missing stats)
 │
 └── • project
     │ columns: (col0, col3, col4)
-    │ estimated row count: 311 (missing stats)
     │
     └── • render
         │ columns: (col0, col3, col4, rowid)
-        │ estimated row count: 311 (missing stats)
         │ render col0: col0
         │ render col3: col3
         │ render col4: col4
@@ -350,7 +345,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column9)
-    │ estimated row count: 1,000 (missing stats)
     │ render column9: x - 1
     │
     └── • scan
@@ -407,7 +401,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column9)
-    │ estimated row count: 1,000 (missing stats)
     │ render column9: x - 1
     │
     └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/topk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/topk
@@ -74,7 +74,6 @@ vectorized: true
 ·
 • project
 │ columns: (k)
-│ estimated row count: 2 (missing stats)
 │
 └── • top-k
     │ columns: (k, w)

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -186,7 +186,6 @@ vectorized: true
 ·
 • render
 │ columns: (x tuple{int AS a, int AS b, int AS c})
-│ estimated row count: 1,000 (missing stats)
 │ render x: ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]
 │
 └── • scan
@@ -203,14 +202,12 @@ vectorized: true
 ·
 • render
 │ columns: (a int, b int, c int)
-│ estimated row count: 1,000 (missing stats)
 │ render a: (((x)[tuple{int AS a, int AS b, int AS c}]).a)[int]
 │ render b: (((x)[tuple{int AS a, int AS b, int AS c}]).b)[int]
 │ render c: (((x)[tuple{int AS a, int AS b, int AS c}]).c)[int]
 │
 └── • render
     │ columns: (x tuple{int AS a, int AS b, int AS c})
-    │ estimated row count: 1,000 (missing stats)
     │ render x: ((((v)[int], (v)[int], (v)[int]) AS a, b, c))[tuple{int AS a, int AS b, int AS c}]
     │
     └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -103,7 +103,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 1
 │
 └── • except all
     │ columns: (a, a)
@@ -134,7 +133,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?", "?column?", "?column?")
-│ estimated row count: 1
 │ render ?column?: column1
 │ render ?column?: column2
 │ render ?column?: column3
@@ -169,7 +167,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1,333 (missing stats)
 │ render ?column?: 1
 │
 └── • union all
@@ -178,7 +175,6 @@ vectorized: true
     │
     ├── • project
     │   │ columns: ()
-    │   │ estimated row count: 333 (missing stats)
     │   │
     │   └── • filter
     │       │ columns: (k)
@@ -764,7 +760,6 @@ vectorized: true
 └── • render
     │ columns: ("?column?", x, y)
     │ ordering: +x
-    │ estimated row count: 4
     │ render ?column?: 'e'
     │ render x: column1
     │ render y: column2

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -271,6 +271,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -287,6 +288,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 2
                   label: buffer 1
 
 # No need to plan checks for w since it's always null.
@@ -322,6 +324,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 2
                   label: buffer 1
 
 # Use all the unique indexes and constraints as arbiters for DO NOTHING with no
@@ -475,6 +478,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 ├── • constraint-check
@@ -487,6 +491,7 @@ vectorized: true
 │           │ pred: column2 != b
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -593,7 +598,6 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 2
 │           │
 │           └── • values
 │                 size: 3 columns, 2 rows
@@ -612,6 +616,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -628,6 +633,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 2
                   label: buffer 1
 
 # Combine unique checks with foreign keys. There should be two foreign key
@@ -647,7 +653,6 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 2
 │           │
 │           └── • values
 │                 size: 3 columns, 2 rows
@@ -666,6 +671,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 ├── • constraint-check
@@ -681,6 +687,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -696,6 +703,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 2
                   label: buffer 1
 
 # Test that we use the index when available for the insert checks.
@@ -719,7 +727,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (column1, column2, column3, column4, check1)
-│           │ estimated row count: 2
 │           │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
 │           │ render column1: column1
 │           │ render column2: column2
@@ -745,7 +752,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (column3)
-│           │ estimated row count: 1 (missing stats)
 │           │
 │           └── • lookup join (semi)
 │               │ columns: (column1, column3)
@@ -756,10 +762,10 @@ vectorized: true
 │               │
 │               └── • project
 │                   │ columns: (column1, column3)
-│                   │ estimated row count: 2
 │                   │
 │                   └── • scan buffer
 │                         columns: (column1, column2, column3, column4, check1)
+│                         estimated row count: 2
 │                         label: buffer 1
 │
 └── • constraint-check
@@ -769,7 +775,6 @@ vectorized: true
         │
         └── • project
             │ columns: (column2, column4)
-            │ estimated row count: 1 (missing stats)
             │
             └── • lookup join (semi)
                 │ columns: (column1, column2, column3, column4)
@@ -780,10 +785,10 @@ vectorized: true
                 │
                 └── • project
                     │ columns: (column1, column2, column3, column4)
-                    │ estimated row count: 2
                     │
                     └── • scan buffer
                           columns: (column1, column2, column3, column4, check1)
+                          estimated row count: 2
                           label: buffer 1
 
 # Test that we use the index when available for the insert checks. This uses
@@ -808,7 +813,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (r_default, column1, column2, j_default, check1)
-│           │ estimated row count: 2
 │           │ render check1: r_default IN ('us-east', 'us-west', 'eu-west')
 │           │ render column1: column1
 │           │ render column2: column2
@@ -817,7 +821,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (r_default, j_default, column1, column2)
-│               │ estimated row count: 2
 │               │ render r_default: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
 │               │ render j_default: CAST(NULL AS INT8)
 │               │ render column1: column1
@@ -838,7 +841,6 @@ vectorized: true
         │
         └── • project
             │ columns: (column2)
-            │ estimated row count: 1 (missing stats)
             │
             └── • lookup join (semi)
                 │ columns: (r_default, column2)
@@ -849,10 +851,10 @@ vectorized: true
                 │
                 └── • project
                     │ columns: (r_default, column2)
-                    │ estimated row count: 2
                     │
                     └── • scan buffer
                           columns: (r_default, column1, column2, j_default, check1)
+                          estimated row count: 2
                           label: buffer 1
 
 # Test that we use the index when available for de-duplicating INSERT ON
@@ -873,7 +875,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, column3, column4, check1)
-    │ estimated row count: 0 (missing stats)
     │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
     │ render column1: column1
     │ render column2: column2
@@ -969,6 +970,7 @@ vectorized: true
                 │ filter: column3 > 0
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 # No need to plan checks for a since it's always null.
@@ -1010,6 +1012,7 @@ vectorized: true
                 │ filter: column3 > 0
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 # Use all the unique indexes and constraints as arbiters for DO NOTHING with no
@@ -1030,7 +1033,6 @@ vectorized: true
 │
 └── • project
     │ columns: (column1, column2, column3)
-    │ estimated row count: 0 (missing stats)
     │
     └── • distinct
         │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
@@ -1040,7 +1042,6 @@ vectorized: true
         │
         └── • render
             │ columns: (arbiter_unique_b_distinct, column1, column2, column3)
-            │ estimated row count: 0 (missing stats)
             │ render arbiter_unique_b_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
             │ render column1: column1
             │ render column2: column2
@@ -1054,7 +1055,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (arbiter_unique_a_distinct, column1, column2, column3)
-                    │ estimated row count: 0 (missing stats)
                     │ render arbiter_unique_a_distinct: (column3 > 0) OR CAST(NULL AS BOOL)
                     │ render column1: column1
                     │ render column2: column2
@@ -1255,7 +1255,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (column1, column2, column3, column4, check1, partial_index_put1)
-│           │ estimated row count: 2
 │           │ render partial_index_put1: column4 IN ('bar', 'baz', 'foo')
 │           │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
 │           │ render column1: column1
@@ -1282,7 +1281,6 @@ vectorized: true
         │
         └── • project
             │ columns: (column3)
-            │ estimated row count: 1
             │
             └── • lookup join (semi)
                 │ columns: (column1, column2, column3, column4)
@@ -1298,10 +1296,10 @@ vectorized: true
                     │
                     └── • project
                         │ columns: (column1, column2, column3, column4)
-                        │ estimated row count: 2
                         │
                         └── • scan buffer
                               columns: (column1, column2, column3, column4, check1, partial_index_put1)
+                              estimated row count: 2
                               label: buffer 1
 
 # Test that we use the partial index when available for de-duplicating INSERT ON
@@ -1323,7 +1321,6 @@ vectorized: true
 │
 └── • render
     │ columns: (column1, column2, column3, column4, check1, partial_index_put1)
-    │ estimated row count: 0
     │ render partial_index_put1: column4 IN ('bar', 'baz', 'foo')
     │ render check1: column1 IN ('us-east', 'us-west', 'eu-west')
     │ render column1: column1
@@ -1339,7 +1336,6 @@ vectorized: true
         │
         └── • render
             │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4)
-            │ estimated row count: 0
             │ render arbiter_unique_b_distinct: (column4 IN ('bar', 'baz', 'foo')) OR CAST(NULL AS BOOL)
             │ render column1: column1
             │ render column2: column2
@@ -1390,7 +1386,6 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 2
 │           │
 │           └── • values
 │                 size: 3 columns, 2 rows
@@ -1409,6 +1404,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 2
                   label: buffer 1
 
 # By default, we do not require checks on UUID columns set to gen_random_uuid(),
@@ -1445,6 +1441,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 1
                   label: buffer 1
 
 # The default value of id1 is gen_random_uuid(), so we don't need to plan checks
@@ -1482,6 +1479,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 1
                   label: buffer 1
 
 # We can also detect gen_random_uuid() when it is a projection.
@@ -1558,6 +1556,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 1
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -1575,6 +1574,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 1
                   label: buffer 1
 
 statement ok
@@ -2088,7 +2088,6 @@ vectorized: true
 │       │
 │       └── • render
 │           │ columns: (r, s, i, j, r_new, s_new, i_new, check1)
-│           │ estimated row count: 9 (missing stats)
 │           │ render check1: r_new IN ('us-east', 'us-west', 'eu-west')
 │           │ render r: r
 │           │ render s: s
@@ -2100,7 +2099,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (r_new, s_new, i_new, r, s, i, j)
-│               │ estimated row count: 9 (missing stats)
 │               │ render r_new: CASE (random() * 3.0)::INT8 WHEN 0 THEN 'us-east' WHEN 1 THEN 'us-west' ELSE 'eu-west' END
 │               │ render s_new: 'baz'
 │               │ render i_new: 3
@@ -2124,7 +2122,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (i_new)
-│           │ estimated row count: 3 (missing stats)
 │           │
 │           └── • lookup join (semi)
 │               │ columns: (r_new, i_new)
@@ -2135,10 +2132,10 @@ vectorized: true
 │               │
 │               └── • project
 │                   │ columns: (r_new, i_new)
-│                   │ estimated row count: 9 (missing stats)
 │                   │
 │                   └── • scan buffer
 │                         columns: (r, s, i, j, r_new, s_new, i_new, check1)
+│                         estimated row count: 9 (missing stats)
 │                         label: buffer 1
 │
 └── • constraint-check
@@ -2148,7 +2145,6 @@ vectorized: true
         │
         └── • project
             │ columns: (s_new, j)
-            │ estimated row count: 3 (missing stats)
             │
             └── • lookup join (semi)
                 │ columns: (r_new, s_new, i_new, j)
@@ -2159,10 +2155,10 @@ vectorized: true
                 │
                 └── • project
                     │ columns: (r_new, s_new, i_new, j)
-                    │ estimated row count: 9 (missing stats)
                     │
                     └── • scan buffer
                           columns: (r, s, i, j, r_new, s_new, i_new, check1)
+                          estimated row count: 9 (missing stats)
                           label: buffer 1
 
 # None of the updated values have nulls.
@@ -2393,7 +2389,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (partial_index_put1, b_new, r, a, b, c)
-│               │ estimated row count: 1
 │               │ render partial_index_put1: c IN ('bar', 'baz', 'foo')
 │               │ render b_new: 20
 │               │ render r: r
@@ -2416,7 +2411,6 @@ vectorized: true
         │
         └── • project
             │ columns: (b_new)
-            │ estimated row count: 0
             │
             └── • lookup join (semi)
                 │ columns: (r, a, b_new, c)
@@ -2432,10 +2426,10 @@ vectorized: true
                     │
                     └── • project
                         │ columns: (r, a, b_new, c)
-                        │ estimated row count: 1
                         │
                         └── • scan buffer
                               columns: (r, a, b, b_new, partial_index_put1, partial_index_put1, c)
+                              estimated row count: 1
                               label: buffer 1
 
 # By default, we do not require checks on UUID columns set to gen_random_uuid(),
@@ -2630,7 +2624,6 @@ vectorized: true
 │               │ locking strength: for update
 │               │
 │               └── • render
-│                   │ estimated row count: 2
 │                   │
 │                   └── • values
 │                         size: 3 columns, 2 rows
@@ -2693,7 +2686,6 @@ vectorized: true
 │               │ locking strength: for update
 │               │
 │               └── • render
-│                   │ estimated row count: 2
 │                   │
 │                   └── • values
 │                         size: 3 columns, 2 rows
@@ -2757,7 +2749,6 @@ vectorized: true
 │               │ locking strength: for update
 │               │
 │               └── • render
-│                   │ estimated row count: 2
 │                   │
 │                   └── • values
 │                         size: 2 columns, 2 rows
@@ -2894,7 +2885,6 @@ vectorized: true
 │               │     spans: FULL SCAN
 │               │
 │               └── • render
-│                   │ estimated row count: 2
 │                   │
 │                   └── • values
 │                         size: 3 columns, 2 rows
@@ -3090,7 +3080,6 @@ vectorized: true
 │                   │ error on duplicate
 │                   │
 │                   └── • render
-│                       │ estimated row count: 2
 │                       │
 │                       └── • values
 │                             size: 3 columns, 2 rows
@@ -3168,7 +3157,6 @@ vectorized: true
 │       │ label: buffer 1
 │       │
 │       └── • render
-│           │ estimated row count: 2
 │           │
 │           └── • values
 │                 size: 3 columns, 2 rows
@@ -3187,6 +3175,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 ├── • constraint-check
@@ -3202,6 +3191,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 2
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -3217,6 +3207,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 2
                   label: buffer 1
 
 # Test that we use the index when available for the upsert checks.
@@ -3244,7 +3235,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, column1, column2, column3, column4, r, s, i, j, upsert_r, upsert_i)
-│               │ estimated row count: 2 (missing stats)
 │               │ render check1: upsert_r IN ('us-east', 'us-west', 'eu-west')
 │               │ render column1: column1
 │               │ render column2: column2
@@ -3259,7 +3249,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_r, upsert_i, column1, column2, column3, column4, r, s, i, j)
-│                   │ estimated row count: 2 (missing stats)
 │                   │ render upsert_r: CASE WHEN r IS NULL THEN column1 ELSE r END
 │                   │ render upsert_i: CASE WHEN r IS NULL THEN column3 ELSE i END
 │                   │ render column1: column1
@@ -3298,7 +3287,6 @@ vectorized: true
 │       │
 │       └── • project
 │           │ columns: (upsert_i)
-│           │ estimated row count: 1 (missing stats)
 │           │
 │           └── • lookup join (semi)
 │               │ columns: (upsert_r, upsert_i)
@@ -3309,10 +3297,10 @@ vectorized: true
 │               │
 │               └── • project
 │                   │ columns: (upsert_r, upsert_i)
-│                   │ estimated row count: 2 (missing stats)
 │                   │
 │                   └── • scan buffer
 │                         columns: (column1, column2, column3, column4, r, s, i, j, column2, column4, r, check1, upsert_r, upsert_i)
+│                         estimated row count: 2 (missing stats)
 │                         label: buffer 1
 │
 └── • constraint-check
@@ -3322,7 +3310,6 @@ vectorized: true
         │
         └── • project
             │ columns: (column2, column4)
-            │ estimated row count: 1 (missing stats)
             │
             └── • lookup join (semi)
                 │ columns: (upsert_r, column2, upsert_i, column4)
@@ -3333,10 +3320,10 @@ vectorized: true
                 │
                 └── • project
                     │ columns: (upsert_r, column2, upsert_i, column4)
-                    │ estimated row count: 2 (missing stats)
                     │
                     └── • scan buffer
                           columns: (column1, column2, column3, column4, r, s, i, j, column2, column4, r, check1, upsert_r, upsert_i)
+                          estimated row count: 2 (missing stats)
                           label: buffer 1
 
 # Test that we use the index when available for the ON CONFLICT checks.
@@ -3365,7 +3352,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (check1, column1, column2, column3, column4, r, s, i, j, upsert_r, upsert_i)
-│               │ estimated row count: 2 (missing stats)
 │               │ render check1: upsert_r IN ('us-east', 'us-west', 'eu-west')
 │               │ render column1: column1
 │               │ render column2: column2
@@ -3380,7 +3366,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_r, upsert_i, column1, column2, column3, column4, r, s, i, j)
-│                   │ estimated row count: 2 (missing stats)
 │                   │ render upsert_r: CASE WHEN r IS NULL THEN column1 ELSE r END
 │                   │ render upsert_i: CASE WHEN r IS NULL THEN column3 ELSE 3 END
 │                   │ render column1: column1
@@ -3419,7 +3404,6 @@ vectorized: true
         │
         └── • project
             │ columns: (upsert_i)
-            │ estimated row count: 1 (missing stats)
             │
             └── • lookup join (semi)
                 │ columns: (upsert_r, upsert_i)
@@ -3430,10 +3414,10 @@ vectorized: true
                 │
                 └── • project
                     │ columns: (upsert_r, upsert_i)
-                    │ estimated row count: 2 (missing stats)
                     │
                     └── • scan buffer
                           columns: (column1, column2, column3, column4, r, s, i, j, upsert_i, r, check1, upsert_r)
+                          estimated row count: 2 (missing stats)
                           label: buffer 1
 
 # None of the upserted values have nulls.
@@ -3475,6 +3459,7 @@ vectorized: true
 │               │ filter: column3 > 0
 │               │
 │               └── • scan buffer
+│                     estimated row count: 2
 │                     label: buffer 1
 │
 └── • constraint-check
@@ -3498,6 +3483,7 @@ vectorized: true
                 │ filter: column3 > 0
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 # TODO(rytaft/mgartner): The default value for b is NULL, and we're not updating
@@ -3526,7 +3512,6 @@ vectorized: true
 │               │ locking strength: for update
 │               │
 │               └── • render
-│                   │ estimated row count: 2
 │                   │
 │                   └── • values
 │                         size: 2 columns, 2 rows
@@ -3614,6 +3599,7 @@ vectorized: true
                 │ filter: column3 > 0
                 │
                 └── • scan buffer
+                      estimated row count: 2
                       label: buffer 1
 
 # On conflict do update with constant input.
@@ -3655,7 +3641,6 @@ vectorized: true
 │                   │ error on duplicate
 │                   │
 │                   └── • render
-│                       │ estimated row count: 2
 │                       │
 │                       └── • values
 │                             size: 2 columns, 2 rows
@@ -3877,7 +3862,6 @@ vectorized: true
 │           │
 │           └── • render
 │               │ columns: (partial_index_put1, partial_index_del1, check1, column1, column2, column3, column4, r, a, b, c, upsert_r, upsert_a)
-│               │ estimated row count: 2
 │               │ render partial_index_put1: column4 IN ('bar', 'baz', 'foo')
 │               │ render partial_index_del1: c IN ('bar', 'baz', 'foo')
 │               │ render check1: upsert_r IN ('us-east', 'us-west', 'eu-west')
@@ -3894,7 +3878,6 @@ vectorized: true
 │               │
 │               └── • render
 │                   │ columns: (upsert_r, upsert_a, column1, column2, column3, column4, r, a, b, c)
-│                   │ estimated row count: 2
 │                   │ render upsert_r: CASE WHEN r IS NULL THEN column1 ELSE r END
 │                   │ render upsert_a: CASE WHEN r IS NULL THEN column2 ELSE a END
 │                   │ render column1: column1
@@ -3933,7 +3916,6 @@ vectorized: true
         │
         └── • project
             │ columns: (column3)
-            │ estimated row count: 1
             │
             └── • lookup join (semi)
                 │ columns: (upsert_r, upsert_a, column3, column4)
@@ -3949,10 +3931,10 @@ vectorized: true
                     │
                     └── • project
                         │ columns: (upsert_r, upsert_a, column3, column4)
-                        │ estimated row count: 2
                         │
                         └── • scan buffer
                               columns: (column1, column2, column3, column4, r, a, b, c, column3, column4, r, check1, partial_index_put1, partial_index_del1, upsert_r, upsert_a)
+                              estimated row count: 2
                               label: buffer 1
 
 # Test that we use the partial index when available for de-duplicating INSERT ON
@@ -3976,7 +3958,6 @@ vectorized: true
     │
     └── • render
         │ columns: (partial_index_put1, partial_index_del1, check1, upsert_a, column1, column2, column3, column4, r, a, b, c)
-        │ estimated row count: 2
         │ render partial_index_put1: CASE WHEN r IS NULL THEN column4 ELSE c END IN ('bar', 'baz', 'foo')
         │ render partial_index_del1: c IN ('bar', 'baz', 'foo')
         │ render check1: CASE WHEN r IS NULL THEN column1 ELSE r END IN ('us-east', 'us-west', 'eu-west')
@@ -4013,7 +3994,6 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4)
-                        │ estimated row count: 2
                         │ render arbiter_unique_b_distinct: (column4 IN ('bar', 'baz', 'foo')) OR CAST(NULL AS BOOL)
                         │ render column1: column1
                         │ render column2: column2
@@ -4066,6 +4046,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 1
                   label: buffer 1
 
 statement ok
@@ -4104,6 +4085,7 @@ vectorized: true
 │           │     spans: FULL SCAN
 │           │
 │           └── • scan buffer
+│                 estimated row count: 1
 │                 label: buffer 1
 │
 └── • constraint-check
@@ -4121,6 +4103,7 @@ vectorized: true
             │     spans: FULL SCAN
             │
             └── • scan buffer
+                  estimated row count: 1
                   label: buffer 1
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -130,7 +130,6 @@ vectorized: true
 │
 └── • render
     │ columns: (x, y, z, x_new, y_new)
-    │ estimated row count: 1,000 (missing stats)
     │ render x_new: 1
     │ render y_new: 2
     │ render x: x
@@ -185,7 +184,6 @@ vectorized: true
     │
     └── • render
         │ columns: (x_new, x, y, z)
-        │ estimated row count: 1,000 (missing stats)
         │ render x_new: 2
         │ render x: x
         │ render y: y
@@ -219,7 +217,6 @@ vectorized: true
 │
 └── • render
     │ columns: (x, y, z, x_new)
-    │ estimated row count: 990 (missing stats)
     │ render x_new: 5
     │ render x: x
     │ render y: y
@@ -252,7 +249,6 @@ vectorized: true
 │
 └── • render
     │ columns: (x, y, z, x_new)
-    │ estimated row count: 990 (missing stats)
     │ render x_new: 5
     │ render x: x
     │ render y: y
@@ -395,7 +391,6 @@ vectorized: true
         │
         └── • project
             │ columns: (a)
-            │ estimated row count: 1,000 (missing stats)
             │
             └── • update
                 │ columns: (a, rowid)
@@ -456,7 +451,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, c, c_new)
-    │ estimated row count: 1 (missing stats)
     │ render c_new: 2
     │ render a: a
     │ render b: b
@@ -662,7 +656,6 @@ vectorized: true
 │
 └── • render
     │ columns: (x, y, z, x_new, y_new)
-    │ estimated row count: 1,000 (missing stats)
     │ render x_new: 1
     │ render y_new: 2
     │ render x: x
@@ -794,7 +787,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, c, d, c_new)
-    │ estimated row count: 1,000 (missing stats)
     │ render c_new: c + 1
     │ render a: a
     │ render c: c

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -117,7 +117,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, c, b_new, c_new, a, b, c)
-    │ estimated row count: 1,000 (missing stats)
     │ render b_new: b + 1
     │ render c_new: c + 2
     │ render a: a

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -123,7 +123,6 @@ vectorized: true
         │
         └── • render
             │ columns: (v_default, k)
-            │ estimated row count: 2 (missing stats)
             │ render v_default: CAST(NULL AS INT8)
             │ render k: k
             │
@@ -172,7 +171,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
-        │ estimated row count: 1 (missing stats)
         │ render check1: c_default > 0
         │ render column1: column1
         │ render b_default: b_default
@@ -220,7 +218,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
-        │ estimated row count: 4 (missing stats)
         │ render check1: c_default > 0
         │ render column1: column1
         │ render b_default: b_default
@@ -241,7 +238,6 @@ vectorized: true
             │
             └── • render
                 │ columns: (d_comp, b_default, c_default, column1)
-                │ estimated row count: 4
                 │ render d_comp: column1 + 10
                 │ render b_default: CAST(NULL AS INT8)
                 │ render c_default: 10
@@ -277,7 +273,6 @@ vectorized: true
     │
     └── • render
         │ columns: (check1, column1, column2, column3, d_comp, a, b, c, d, upsert_b, upsert_c, upsert_d)
-        │ estimated row count: 1 (missing stats)
         │ render check1: upsert_c > 0
         │ render column1: column1
         │ render column2: column2
@@ -293,7 +288,6 @@ vectorized: true
         │
         └── • render
             │ columns: (upsert_b, upsert_c, upsert_d, column1, column2, column3, d_comp, a, b, c, d)
-            │ estimated row count: 1 (missing stats)
             │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE 2 END
             │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE 3 END
             │ render upsert_d: CASE WHEN a IS NULL THEN d_comp ELSE a + 3 END
@@ -440,7 +434,6 @@ vectorized: true
         │
         └── • project
             │ columns: (z)
-            │ estimated row count: 1,000 (missing stats)
             │
             └── • upsert
                 │ columns: (z, rowid)
@@ -452,7 +445,6 @@ vectorized: true
                     │
                     └── • render
                         │ columns: (rowid_default, a, b, c)
-                        │ estimated row count: 1,000 (missing stats)
                         │ render rowid_default: unique_rowid()
                         │ render a: a
                         │ render b: b
@@ -566,7 +558,6 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_z, column1, column2, column3, x, y, z)
-        │ estimated row count: 2 (missing stats)
         │ render upsert_z: CASE WHEN x IS NULL THEN column3 ELSE 1 END
         │ render column1: column1
         │ render column2: column2
@@ -627,7 +618,6 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_b, x, y, z, a, b, c)
-        │ estimated row count: 311 (missing stats)
         │ render upsert_b: CASE WHEN a IS NULL THEN y ELSE 5 END
         │ render x: x
         │ render y: y

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -61,7 +61,6 @@ vectorized: true
 ·
 • render
 │ columns: (r)
-│ estimated row count: 3
 │ render r: column1 + column2
 │
 └── • values

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -84,7 +84,6 @@ vectorized: true
 ·
 • render
 │ columns: (a, b, v)
-│ estimated row count: 1,000 (missing stats)
 │ render v: a + b
 │ render a: a
 │ render b: b
@@ -128,7 +127,6 @@ vectorized: true
 ·
 • render
 │ columns: (a, v)
-│ estimated row count: 333 (missing stats)
 │ render v: a + b
 │ render a: a
 │
@@ -218,7 +216,6 @@ vectorized: true
 ·
 • project
 │ columns: (v)
-│ estimated row count: 1
 │
 └── • insert fast path
       columns: (a, v)
@@ -270,7 +267,6 @@ vectorized: true
 ·
 • project
 │ columns: (v)
-│ estimated row count: 333 (missing stats)
 │
 └── • delete
     │ columns: (a, v)
@@ -280,7 +276,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a, v)
-        │ estimated row count: 333 (missing stats)
         │ render v: a + b
         │ render a: a
         │
@@ -304,7 +299,6 @@ vectorized: true
 │
 └── • project
     │ columns: (a)
-    │ estimated row count: 333 (missing stats)
     │
     └── • filter
         │ columns: (a, b)
@@ -331,7 +325,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, v, w)
-    │ estimated row count: 333 (missing stats)
     │ render v: a + b
     │ render w: c + 1
     │ render a: a
@@ -350,7 +343,6 @@ vectorized: true
 ·
 • project
 │ columns: (v)
-│ estimated row count: 333 (missing stats)
 │
 └── • delete
     │ columns: (a, v)
@@ -360,7 +352,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a, v, w)
-        │ estimated row count: 333 (missing stats)
         │ render v: a + b
         │ render w: c + 1
         │ render a: a
@@ -385,7 +376,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, v, w)
-    │ estimated row count: 333 (missing stats)
     │ render v: a + b
     │ render w: c + 1
     │ render a: a
@@ -416,7 +406,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, v, w)
-    │ estimated row count: 333 (missing stats)
     │ render v: a + b
     │ render w: c + 1
     │ render a: a
@@ -450,7 +439,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, v, a_new, v_comp)
-    │ estimated row count: 1,000 (missing stats)
     │ render v_comp: a_new + b
     │ render a: a
     │ render b: b
@@ -459,7 +447,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a_new, v, a, b)
-        │ estimated row count: 1,000 (missing stats)
         │ render a_new: a + 1
         │ render v: a + b
         │ render a: a
@@ -487,7 +474,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, v, b_new, v_comp)
-    │ estimated row count: 333 (missing stats)
     │ render v_comp: a + b_new
     │ render a: a
     │ render b: b
@@ -496,7 +482,6 @@ vectorized: true
     │
     └── • render
         │ columns: (b_new, v, a, b)
-        │ estimated row count: 333 (missing stats)
         │ render b_new: b + 1
         │ render v: a + b
         │ render a: a
@@ -528,7 +513,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, c, v, w, a_new, v_comp)
-    │ estimated row count: 1,000 (missing stats)
     │ render v_comp: a_new + b
     │ render a: a
     │ render b: b
@@ -539,7 +523,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a_new, v, w, a, b, c)
-        │ estimated row count: 1,000 (missing stats)
         │ render a_new: a + 1
         │ render v: a + b
         │ render w: c + 1
@@ -562,7 +545,6 @@ vectorized: true
 ·
 • project
 │ columns: (v, w)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • update
     │ columns: (a, v, w)
@@ -573,7 +555,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a, b, v, w, b_new, v_comp)
-        │ estimated row count: 1,000 (missing stats)
         │ render v_comp: a + b_new
         │ render a: a
         │ render b: b
@@ -583,7 +564,6 @@ vectorized: true
         │
         └── • render
             │ columns: (b_new, v, w, a, b)
-            │ estimated row count: 1,000 (missing stats)
             │ render b_new: b + 1
             │ render v: a + b
             │ render w: c + 1
@@ -605,7 +585,6 @@ vectorized: true
 ·
 • project
 │ columns: (v, w)
-│ estimated row count: 333 (missing stats)
 │
 └── • update
     │ columns: (a, v, w)
@@ -616,7 +595,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a, b, v, w, b_new, v_comp)
-        │ estimated row count: 333 (missing stats)
         │ render v_comp: a + b_new
         │ render a: a
         │ render b: b
@@ -626,7 +604,6 @@ vectorized: true
         │
         └── • render
             │ columns: (b_new, v, w, a, b)
-            │ estimated row count: 333 (missing stats)
             │ render b_new: b + 1
             │ render v: a + b
             │ render w: c + 1
@@ -662,7 +639,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, c, w, c_new, w_comp)
-    │ estimated row count: 1 (missing stats)
     │ render w_comp: 7
     │ render c_new: 6
     │ render w: c + 1
@@ -691,7 +667,6 @@ vectorized: true
 │
 └── • render
     │ columns: (a, b, c, v, w, a_new, v_comp)
-    │ estimated row count: 1,000 (missing stats)
     │ render v_comp: a_new + b
     │ render a: a
     │ render b: b
@@ -702,7 +677,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a_new, v, w, a, b, c)
-        │ estimated row count: 1,000 (missing stats)
         │ render a_new: a + 1
         │ render v: a + b
         │ render w: c + 1
@@ -725,7 +699,6 @@ vectorized: true
 ·
 • project
 │ columns: (w)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • update
     │ columns: (a, w)
@@ -736,7 +709,6 @@ vectorized: true
     │
     └── • render
         │ columns: (a, b, v, w, b_new, v_comp)
-        │ estimated row count: 1,000 (missing stats)
         │ render v_comp: a + b_new
         │ render a: a
         │ render b: b
@@ -746,7 +718,6 @@ vectorized: true
         │
         └── • render
             │ columns: (b_new, v, w, a, b)
-            │ estimated row count: 1,000 (missing stats)
             │ render b_new: b + 1
             │ render v: a + b
             │ render w: c + 1
@@ -779,7 +750,6 @@ vectorized: true
     │
     └── • render
         │ columns: (v_comp, column1, column2)
-        │ estimated row count: 4
         │ render v_comp: column1 + column2
         │ render column1: column1
         │ render column2: column2
@@ -804,7 +774,6 @@ vectorized: true
 ·
 • project
 │ columns: (v)
-│ estimated row count: 0 (missing stats)
 │
 └── • insert
     │ columns: (a, v)
@@ -822,7 +791,6 @@ vectorized: true
         │
         └── • render
             │ columns: (v_comp, column1, column2)
-            │ estimated row count: 2
             │ render v_comp: column1 + column2
             │ render column1: column1
             │ render column2: column2
@@ -853,7 +821,6 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_b, upsert_v, column1, column2, v_comp, a, b, v)
-        │ estimated row count: 3 (missing stats)
         │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE v END
         │ render upsert_v: CASE WHEN a IS NULL THEN v_comp ELSE a + v END
         │ render column1: column1
@@ -865,7 +832,6 @@ vectorized: true
         │
         └── • render
             │ columns: (v, column1, column2, v_comp, a, b)
-            │ estimated row count: 3 (missing stats)
             │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
             │ render column1: column1
             │ render column2: column2
@@ -883,7 +849,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (v_comp, column1, column2)
-                    │ estimated row count: 3
                     │ render v_comp: column1 + column2
                     │ render column1: column1
                     │ render column2: column2
@@ -916,7 +881,6 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_b, upsert_v, column1, column2, v_comp, a, b, v)
-        │ estimated row count: 3 (missing stats)
         │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE v_comp END
         │ render upsert_v: CASE WHEN a IS NULL THEN v_comp ELSE a + v_comp END
         │ render column1: column1
@@ -928,7 +892,6 @@ vectorized: true
         │
         └── • render
             │ columns: (v, column1, column2, v_comp, a, b)
-            │ estimated row count: 3 (missing stats)
             │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
             │ render column1: column1
             │ render column2: column2
@@ -946,7 +909,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (v_comp, column1, column2)
-                    │ estimated row count: 3
                     │ render v_comp: column1 + column2
                     │ render column1: column1
                     │ render column2: column2
@@ -979,7 +941,6 @@ vectorized: true
     │
     └── • render
         │ columns: (v, w, column1, column2, column3, v_comp, w_comp, a, b, c)
-        │ estimated row count: 4 (missing stats)
         │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
         │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
         │ render column1: column1
@@ -1001,7 +962,6 @@ vectorized: true
             │
             └── • render
                 │ columns: (v_comp, w_comp, column1, column2, column3)
-                │ estimated row count: 4
                 │ render v_comp: column1 + column2
                 │ render w_comp: column3 + 1
                 │ render column1: column1
@@ -1042,7 +1002,6 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_a, column1, column2, column3, v_comp, w_comp, a, b, c, v, w)
-        │ estimated row count: 2 (missing stats)
         │ render upsert_a: CASE WHEN a IS NULL THEN column1 ELSE a END
         │ render column1: column1
         │ render column2: column2
@@ -1057,7 +1016,6 @@ vectorized: true
         │
         └── • render
             │ columns: (v, w, column1, column2, column3, v_comp, w_comp, a, b, c)
-            │ estimated row count: 2 (missing stats)
             │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
             │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
             │ render column1: column1
@@ -1079,7 +1037,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)
-                    │ estimated row count: 2
                     │ render v_comp: column1 + column2
                     │ render w_comp: column3 + 1
                     │ render column1: column1
@@ -1104,7 +1061,6 @@ vectorized: true
 ·
 • project
 │ columns: (w)
-│ estimated row count: 0 (missing stats)
 │
 └── • insert
     │ columns: (a, w)
@@ -1135,7 +1091,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)
-                    │ estimated row count: 3
                     │ render v_comp: column1 + column2
                     │ render w_comp: column3 + 1
                     │ render column1: column1
@@ -1173,7 +1128,6 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_c, upsert_w, column1, column2, column3, v_comp, w_comp, a, c, w)
-        │ estimated row count: 3 (missing stats)
         │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE 0 END
         │ render upsert_w: CASE WHEN a IS NULL THEN w_comp ELSE 1 END
         │ render column1: column1
@@ -1187,7 +1141,6 @@ vectorized: true
         │
         └── • render
             │ columns: (w, column1, column2, column3, v_comp, w_comp, a, c)
-            │ estimated row count: 3 (missing stats)
             │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
             │ render column1: column1
             │ render column2: column2
@@ -1207,7 +1160,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)
-                    │ estimated row count: 3
                     │ render v_comp: column1 + column2
                     │ render w_comp: column3 + 1
                     │ render column1: column1
@@ -1245,7 +1197,6 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_a, upsert_b, upsert_c, upsert_v, upsert_w, column1, column2, column3, v_comp, w_comp, a, b, c, v, w)
-        │ estimated row count: 3 (missing stats)
         │ render upsert_a: CASE WHEN a IS NULL THEN column1 ELSE a END
         │ render upsert_b: CASE WHEN a IS NULL THEN column2 ELSE b END
         │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE w END
@@ -1264,7 +1215,6 @@ vectorized: true
         │
         └── • render
             │ columns: (v, w, column1, column2, column3, v_comp, w_comp, a, b, c)
-            │ estimated row count: 3 (missing stats)
             │ render v: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE a + b END
             │ render w: CASE a IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE c + 1 END
             │ render column1: column1
@@ -1286,7 +1236,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)
-                    │ estimated row count: 3
                     │ render v_comp: column1 + column2
                     │ render w_comp: column3 + 1
                     │ render column1: column1
@@ -1324,7 +1273,6 @@ vectorized: true
     │
     └── • render
         │ columns: (upsert_c, upsert_v, upsert_w, column1, column2, column3, v_comp, w_comp, a, b, c, v, w)
-        │ estimated row count: 20 (missing stats)
         │ render upsert_c: CASE WHEN a IS NULL THEN column3 ELSE v_comp END
         │ render upsert_v: CASE WHEN a IS NULL THEN v_comp ELSE column1 + b END
         │ render upsert_w: CASE WHEN a IS NULL THEN w_comp ELSE v_comp + 1 END
@@ -1347,7 +1295,6 @@ vectorized: true
             │
             ├── • render
             │   │ columns: (v, w, a, b, c)
-            │   │ estimated row count: 1,000 (missing stats)
             │   │ render v: a + b
             │   │ render w: c + 1
             │   │ render a: a
@@ -1369,7 +1316,6 @@ vectorized: true
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)
-                    │ estimated row count: 2
                     │ render v_comp: column1 + column2
                     │ render w_comp: column3 + 1
                     │ render column1: column1
@@ -1405,7 +1351,6 @@ vectorized: true
 ·
 • project
 │ columns: (a)
-│ estimated row count: 60 (missing stats)
 │
 └── • scan
       columns: (a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -63,7 +63,6 @@ vectorized: true
 ·
 • project
 │ columns: (ntile)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • window
     │ columns: (ntile_1_arg1, ntile)
@@ -72,7 +71,6 @@ vectorized: true
     │
     └── • render
         │ columns: (ntile_1_arg1)
-        │ estimated row count: 1,000 (missing stats)
         │ render ntile_1_arg1: 1
         │
         └── • scan
@@ -89,7 +87,6 @@ vectorized: true
 ·
 • project
 │ columns: (nth_value)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • window
     │ columns: (nth_value_1_arg1, nth_value_1_arg2, nth_value)
@@ -98,7 +95,6 @@ vectorized: true
     │
     └── • render
         │ columns: (nth_value_1_arg1, nth_value_1_arg2)
-        │ estimated row count: 1,000 (missing stats)
         │ render nth_value_1_arg1: 1
         │ render nth_value_1_arg2: 2
         │
@@ -144,7 +140,6 @@ vectorized: true
     │
     └── • project
         │ columns: (k int, stddev decimal, variance decimal)
-        │ estimated row count: 1,000 (missing stats)
         │
         └── • window
             │ columns: (k int, v int, d decimal, stddev decimal, variance decimal)
@@ -175,7 +170,6 @@ vectorized: true
     │
     └── • project
         │ columns: (k int, stddev decimal, variance decimal)
-        │ estimated row count: 1,000 (missing stats)
         │
         └── • window
             │ columns: (k int, v int, d decimal, stddev decimal, variance decimal)
@@ -207,7 +201,6 @@ vectorized: true
 │
 └── • project
     │ columns: (k int, stddev decimal)
-    │ estimated row count: 1,000 (missing stats)
     │
     └── • window
         │ columns: (k int, v int, d decimal, stddev decimal)
@@ -237,7 +230,6 @@ vectorized: true
     │
     └── • render
         │ columns: ("?column?" decimal, k int, variance decimal)
-        │ estimated row count: 1,000 (missing stats)
         │ render ?column?: ((k)[int] + (stddev)[decimal])[decimal]
         │ render k: (k)[int]
         │ render variance: (variance)[decimal]
@@ -275,7 +267,6 @@ vectorized: true
     │
     └── • render
         │ columns: ("?column?" decimal, max int, variance decimal)
-        │ estimated row count: 1,000 (missing stats)
         │ render ?column?: ((max)[int] + (stddev)[decimal])[decimal]
         │ render max: (max)[int]
         │ render variance: (variance)[decimal]
@@ -316,7 +307,6 @@ vectorized: true
 │
 └── • project
     │ columns: (max int, stddev decimal)
-    │ estimated row count: 1,000 (missing stats)
     │
     └── • window
         │ columns: (v int, d decimal, max int, stddev decimal)
@@ -345,7 +335,6 @@ vectorized: true
 ·
 • project
 │ columns: (lag, lead)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • window
     │ columns: (lag, lag_1_arg1, lag_1_arg3, lag_1_partition_1, lead)
@@ -359,7 +348,6 @@ vectorized: true
         │
         └── • render
             │ columns: (lag_1_arg1, lag_1_arg3, lag_1_partition_1)
-            │ estimated row count: 1,000 (missing stats)
             │ render lag_1_arg1: 1
             │ render lag_1_arg3: CAST(NULL AS INT8)
             │ render lag_1_partition_1: 2
@@ -406,7 +394,6 @@ vectorized: true
 ·
 • project
 │ columns: (avg)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • window
     │ columns: (k, avg)
@@ -427,7 +414,6 @@ vectorized: true
 ·
 • project
 │ columns: (avg)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • window
     │ columns: (k, avg)
@@ -448,7 +434,6 @@ vectorized: true
 ·
 • project
 │ columns: (avg)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • window
     │ columns: (k, avg)
@@ -484,7 +469,6 @@ vectorized: true
 ·
 • project
 │ columns: (avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • window
     │ columns: (k, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg, avg)
@@ -531,7 +515,6 @@ distribution: local
 │
 ├── • project
 │   │ columns: (avg)
-│   │ estimated row count: 1,000 (missing stats)
 │   │
 │   └── • window
 │       │ columns: (v, w, avg)
@@ -575,7 +558,6 @@ vectorized: true
 ·
 • project
 │ columns: (avg, avg, avg, avg)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • window
     │ columns: (k, avg, avg, avg, avg)

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -54,7 +54,6 @@ vectorized: true
 ·
 • render
 │ columns: (a)
-│ estimated row count: 1,000 (missing stats)
 │ render a: a
 │
 └── • scan
@@ -89,7 +88,6 @@ vectorized: true
         │
         └── • project
             │ columns: (a)
-            │ estimated row count: 1
             │
             └── • insert
                 │ columns: (a, rowid)
@@ -154,7 +152,6 @@ vectorized: true
 │
 └── • render
     │ columns: (n)
-    │ estimated row count: 10 (missing stats)
     │ render n: column1
     │
     └── • recursive cte
@@ -185,7 +182,6 @@ vectorized: true
 │
 └── • render
     │ columns: (n)
-    │ estimated row count: 10 (missing stats)
     │ render n: column1
     │
     └── • recursive cte

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -89,7 +89,6 @@ network usage: 0 B (0 messages)
     │
     └── • render
         │ columns: (column8 decimal, cid int, sum decimal)
-        │ estimated row count: 98 (missing stats)
         │ render column8: ((1)[decimal] - (sum)[decimal])[decimal]
         │ render cid: (cid)[int]
         │ render sum: (sum)[decimal]
@@ -192,7 +191,6 @@ network usage: 0 B (0 messages)
 
 • project
 │ columns: (cid int, date date, value decimal)
-│ estimated row count: 1,000 (missing stats)
 │
 └── • hash join (inner)
     │ columns: (cid int, value decimal, date date, date date)
@@ -285,7 +283,6 @@ network usage: 0 B (0 messages)
 │
 ├── • render
 │   │ columns: (movie_id int, title string, name string)
-│   │ estimated row count: 1,000 (missing stats)
 │   │ render name: (@S1)[string]
 │   │ render id: (id)[int]
 │   │ render title: (title)[string]


### PR DESCRIPTION
This commit fixes a couple of issues with how we annotate nodes with the
execution stats and estimates for the EXPLAIN output:
- it makes it so that `limitOp`, `renderOp`, `serializingProjectOp`, and
`simpleProjectOp` no longer get annotated with the execution stats which
are duplicates of their child's execution stats (since they share the
same DistSQL processor ID). This removes some of the redundant and
confusing stuff.
- it fixes an issue with annotating some nodes with estimates when
a projection is put on top of the node. Previously, we had only a single
place where we'd attach the annotations in `buildRelational`, but when
building some of the relational operators, we need to apply projections,
so those project nodes would get the estimates. This is now fixed by
attaching the estimates before constructing the projection. The
projection node still gets annotated with the estimates (in the old code
path in `buildRelational`), but that information is not shown due to the
first change.

Fixes: #82185.

Release note (sql change): EXPLAIN output no longer annotates simple
operations (like `render` and `project`) with the execution statistics or
estimates since that information is redundant (it is copied from the
child operations).