### PR TITLE
cliflags: deprecate using without `--sql-addr`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -443,8 +443,6 @@ in a later version.`,
 The address/hostname and port to listen on for intra-cluster
 communication, for example --listen-addr=myhost:26257 or
 --listen-addr=:26257 (listen on all interfaces).
-Unless --sql-addr is also specified, this address is also
-used to accept SQL client connections.
 <PRE>
 
 </PRE>
@@ -462,7 +460,15 @@ example [::1]:26257 or [fe80::f6f2:::]:26257.
 If --advertise-addr is left unspecified, the node will also announce
 this address for use by other nodes. It is strongly recommended to use
 --advertise-addr in cloud and container deployments or any setup where
-NAT is present between cluster nodes.`,
+NAT is present between cluster nodes.
+<PRE>
+
+</PRE>
+Unless --sql-addr is also specified, this address is also
+used to accept SQL client connections. Using --listen-addr
+to specify the SQL address without --sql-addr is a deprecated
+feature.
+`,
 	}
 
 	ServerHost = FlagInfo{
@@ -515,8 +521,6 @@ forwarding is set up on an intermediate firewall/router.`,
 		Description: `
 The hostname or IP address to bind to for SQL clients, for example
 --sql-addr=myhost:26257 or --sql-addr=:26257 (listen on all interfaces).
-If left unspecified, the address specified by --listen-addr will be
-used for both RPC and SQL connections.
 <PRE>
 
 </PRE>
@@ -536,7 +540,14 @@ to use the same port number but separate host addresses.
 
 </PRE>
 An IPv6 address can also be specified with the notation [...], for
-example [::1]:26257 or [fe80::f6f2:::]:26257.`,
+example [::1]:26257 or [fe80::f6f2:::]:26257.
+<PRE>
+
+</PRE>
+If --sql-addr is left unspecified, the address specified by
+--listen-addr will be used for both RPC and SQL connections.
+This default behavior is deprecated; we recommend always
+setting --sql-addr.`,
 	}
 
 	SQLAdvertiseAddr = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -1046,7 +1046,7 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 		serverSQLPort = serverListenPort
 	}
 	serverCfg.SQLAddr = net.JoinHostPort(serverSQLAddr, serverSQLPort)
-	serverCfg.SplitListenSQL = fs.Lookup(cliflags.ListenSQLAddr.Name).Changed
+	serverCfg.SplitListenSQL = changed(fs, cliflags.ListenSQLAddr.Name)
 
 	// Fill in the defaults for --advertise-sql-addr, if the flag exists on `cmd`.
 	advSpecified := changed(fs, cliflags.AdvertiseAddr.Name) ||


### PR DESCRIPTION
Fixes #85670.

Release note (backward-incompatible change): Using a single TCP port
listener for both RPC (node-node) and SQL client connections is now
deprecated. This capability will be removed in the next version of
CockroachDB. Deployments are invited to perform either one of the
following changes:

- (preferred:) keep port 26257 for SQL, and allocate a new port,
  e.g. 36257, for node-node RPC connections. For example:

       --listen-addr=:36257 --sql-addr=:26257 \
       --join=othernode:36257,othernode:26257

  This will become the default configuration in the next version
  of CockroachDB.

  When using this mode of operation, care should be taken to
  use a `--join` flag that include both the old and new
  port numbers for other nodes, so that no network partition
  occurs during the upgrade.

- (optional:) keep port 26257 for RPC, and allocate a new port,
  e.g. 36257, for SQL connections. For example:

      --listen-addr=:26257 --sql-addr=:36257

  When using this mode of operation, the `--join` flags do not
  need to be modified. However, SQL client apps or the SQL
  load balancer configuration (when in use) should be updated
  to use the new SQL port number.