### PR TITLE
sql: rename NullableArgs to CalledOnNullInput and populate pg_proc.proisstrict

### DIFF
--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -488,7 +488,7 @@ func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 	if err != nil {
 		return nil, err
 	}
-	ret.NullableArgs, err = desc.getOverloadNullableArgs()
+	ret.CalledOnNullInput, err = desc.calledOnNullInput()
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,10 @@ func (desc *immutable) getOverloadVolatility() (volatility.V, error) {
 	return ret, nil
 }
 
-func (desc *immutable) getOverloadNullableArgs() (bool, error) {
+// calledOnNullInput returns true if the function should be called when any of
+// its input arguments are NULL. See Overload.CalledOnNullInput for more
+// details.
+func (desc *immutable) calledOnNullInput() (bool, error) {
 	switch desc.NullInputBehavior {
 	case catpb.Function_CALLED_ON_NULL_INPUT:
 		return true, nil

--- a/pkg/sql/catalog/funcdesc/func_desc_test.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_test.go
@@ -544,7 +544,7 @@ func TestToOverload(t *testing.T) {
 			},
 		},
 		{
-			// Test NullableArgs matters.
+			// Test CalledOnNullInput matters.
 			desc: descpb.FunctionDescriptor{
 				ID:                1,
 				Args:              []descpb.FunctionDescriptor_Argument{{Name: "arg1", Type: types.Int}},
@@ -559,12 +559,12 @@ func TestToOverload(t *testing.T) {
 				Types: tree.ArgTypes{
 					{Name: "arg1", Typ: types.Int},
 				},
-				ReturnType:   tree.FixedReturnType(types.Int),
-				ReturnSet:    true,
-				Volatility:   volatility.Leakproof,
-				Body:         "ANY QUERIES",
-				IsUDF:        true,
-				NullableArgs: true,
+				ReturnType:        tree.FixedReturnType(types.Int),
+				ReturnSet:         true,
+				Volatility:        volatility.Leakproof,
+				Body:              "ANY QUERIES",
+				IsUDF:             true,
+				CalledOnNullInput: true,
 			},
 		},
 		{

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -70,7 +70,7 @@ func (b *defaultBuiltinFuncOperator) Next() coldata.Batch {
 					err error
 				)
 				// Some functions cannot handle null arguments.
-				if hasNulls && !b.funcExpr.ResolvedOverload().NullableArgs {
+				if hasNulls && !b.funcExpr.ResolvedOverload().CalledOnNullInput {
 					res = tree.DNull
 				} else {
 					res, err = b.funcExpr.ResolvedOverload().

--- a/pkg/sql/colexec/colexeccmp/default_cmp_expr.go
+++ b/pkg/sql/colexec/colexeccmp/default_cmp_expr.go
@@ -38,7 +38,7 @@ func NewComparisonExprAdapter(
 			expr:               expr,
 		}
 	}
-	nullable := expr.Op.NullableArgs
+	nullable := expr.Op.CalledOnNullInput
 	_, _, _, flipped, negate := tree.FoldComparisonExpr(op, nil /* left */, nil /* right */)
 	if nullable {
 		if flipped {

--- a/pkg/sql/colexec/colexeccmp/default_cmp_expr_tmpl.go
+++ b/pkg/sql/colexec/colexeccmp/default_cmp_expr_tmpl.go
@@ -41,7 +41,7 @@ type _EXPR_NAME struct {
 var _ ComparisonExprAdapter = &_EXPR_NAME{}
 
 func (c *_EXPR_NAME) Eval(left, right tree.Datum) (tree.Datum, error) {
-	// {{if not .NullableArgs}}
+	// {{if not .CalledOnNullInput}}
 	if left == tree.DNull || right == tree.DNull {
 		return tree.DNull, nil
 	}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -49,11 +49,11 @@ var (
 // projOpBase contains all of the fields for non-constant projections.
 type projOpBase struct {
 	colexecop.OneInputHelper
-	allocator    *colmem.Allocator
-	col1Idx      int
-	col2Idx      int
-	outputIdx    int
-	nullableArgs bool
+	allocator         *colmem.Allocator
+	col1Idx           int
+	col2Idx           int
+	outputIdx         int
+	calledOnNullInput bool
 }
 
 type projBitandInt16Int16Op struct {
@@ -75,8 +75,8 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -159,8 +159,8 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -243,8 +243,8 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -327,8 +327,8 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -411,8 +411,8 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -495,8 +495,8 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -579,8 +579,8 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -663,8 +663,8 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -747,8 +747,8 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -833,8 +833,9 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -941,8 +942,8 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1025,8 +1026,8 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1109,8 +1110,8 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1193,8 +1194,8 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1277,8 +1278,8 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1361,8 +1362,8 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1445,8 +1446,8 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1529,8 +1530,8 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1613,8 +1614,8 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1699,8 +1700,9 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1807,8 +1809,8 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1891,8 +1893,8 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -1975,8 +1977,8 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2059,8 +2061,8 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2143,8 +2145,8 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2227,8 +2229,8 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2311,8 +2313,8 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2395,8 +2397,8 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2479,8 +2481,8 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2565,8 +2567,9 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2673,8 +2676,8 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2785,8 +2788,8 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -2897,8 +2900,8 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3009,8 +3012,8 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3117,8 +3120,8 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3225,8 +3228,8 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3333,8 +3336,8 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3441,8 +3444,8 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3559,8 +3562,8 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3685,8 +3688,8 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3793,8 +3796,8 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -3901,8 +3904,8 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4009,8 +4012,8 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4127,8 +4130,8 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4253,8 +4256,8 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4361,8 +4364,8 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4469,8 +4472,8 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4577,8 +4580,8 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4695,8 +4698,8 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4821,8 +4824,8 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -4917,8 +4920,8 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5013,8 +5016,8 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5109,8 +5112,8 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5187,8 +5190,8 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5315,8 +5318,8 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5443,8 +5446,8 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5571,8 +5574,8 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5699,8 +5702,8 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5825,8 +5828,8 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -5937,8 +5940,8 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6049,8 +6052,8 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6161,8 +6164,8 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6269,8 +6272,8 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6377,8 +6380,8 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6485,8 +6488,8 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6593,8 +6596,8 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6711,8 +6714,8 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6837,8 +6840,8 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -6945,8 +6948,8 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7053,8 +7056,8 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7161,8 +7164,8 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7279,8 +7282,8 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7405,8 +7408,8 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7513,8 +7516,8 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7621,8 +7624,8 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7729,8 +7732,8 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7847,8 +7850,8 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -7973,8 +7976,8 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8069,8 +8072,8 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8157,8 +8160,8 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8253,8 +8256,8 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8331,8 +8334,8 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8457,8 +8460,8 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8565,8 +8568,8 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8659,8 +8662,8 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8753,8 +8756,8 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8849,8 +8852,9 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -8959,8 +8963,8 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9087,8 +9091,8 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9213,8 +9217,8 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9341,8 +9345,8 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9469,8 +9473,8 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9595,8 +9599,8 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9707,8 +9711,8 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9819,8 +9823,8 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -9931,8 +9935,8 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10039,8 +10043,8 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10135,8 +10139,8 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10275,8 +10279,8 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10415,8 +10419,8 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10555,8 +10559,8 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10671,8 +10675,8 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10747,8 +10751,8 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -10887,8 +10891,8 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11027,8 +11031,8 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11167,8 +11171,8 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11283,8 +11287,8 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11359,8 +11363,8 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11499,8 +11503,8 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11639,8 +11643,8 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11779,8 +11783,8 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11895,8 +11899,8 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -11971,8 +11975,8 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12067,8 +12071,8 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12143,8 +12147,8 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12219,8 +12223,8 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12295,8 +12299,8 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12371,8 +12375,8 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12447,8 +12451,8 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12543,8 +12547,8 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12671,8 +12675,8 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12799,8 +12803,8 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -12927,8 +12931,8 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13051,8 +13055,8 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13175,8 +13179,8 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13299,8 +13303,8 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13423,8 +13427,8 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13555,8 +13559,8 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13679,8 +13683,8 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13803,8 +13807,8 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -13927,8 +13931,8 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14059,8 +14063,8 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14183,8 +14187,8 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14307,8 +14311,8 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14431,8 +14435,8 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14563,8 +14567,8 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14675,8 +14679,8 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14767,8 +14771,8 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14859,8 +14863,8 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -14951,8 +14955,8 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15043,8 +15047,8 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15171,8 +15175,8 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15299,8 +15303,8 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15427,8 +15431,8 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15551,8 +15555,8 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15655,8 +15659,8 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15759,8 +15763,8 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15863,8 +15867,8 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -15995,8 +15999,8 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16099,8 +16103,8 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16203,8 +16207,8 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16307,8 +16311,8 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16439,8 +16443,8 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16543,8 +16547,8 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16647,8 +16651,8 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16751,8 +16755,8 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16883,8 +16887,8 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -16995,8 +16999,8 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17123,8 +17127,8 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17251,8 +17255,8 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17379,8 +17383,8 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17503,8 +17507,8 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17607,8 +17611,8 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17711,8 +17715,8 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17815,8 +17819,8 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -17947,8 +17951,8 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18051,8 +18055,8 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18155,8 +18159,8 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18259,8 +18263,8 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18391,8 +18395,8 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18495,8 +18499,8 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18599,8 +18603,8 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18703,8 +18707,8 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18835,8 +18839,8 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -18947,8 +18951,8 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19059,8 +19063,8 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19171,8 +19175,8 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19283,8 +19287,8 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19391,8 +19395,8 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19523,8 +19527,8 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19655,8 +19659,8 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19787,8 +19791,8 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -19903,8 +19907,8 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20035,8 +20039,8 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20167,8 +20171,8 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20299,8 +20303,8 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20415,8 +20419,8 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20547,8 +20551,8 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20679,8 +20683,8 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20811,8 +20815,8 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -20927,8 +20931,8 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21023,8 +21027,8 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21123,8 +21127,8 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21221,8 +21225,9 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21329,8 +21334,8 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21437,8 +21442,8 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21545,8 +21550,8 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21653,8 +21658,8 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21761,8 +21766,8 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21869,8 +21874,8 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -21977,8 +21982,8 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22085,8 +22090,8 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22193,8 +22198,8 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22303,8 +22308,8 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22431,8 +22436,8 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22559,8 +22564,8 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22685,8 +22690,8 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22793,8 +22798,8 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -22901,8 +22906,8 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23009,8 +23014,8 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23117,8 +23122,8 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23225,8 +23230,8 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23333,8 +23338,8 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23441,8 +23446,8 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23549,8 +23554,8 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23659,8 +23664,8 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23787,8 +23792,8 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -23915,8 +23920,8 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24041,8 +24046,8 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24161,8 +24166,8 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24271,8 +24276,8 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24381,8 +24386,8 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24491,8 +24496,8 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24647,8 +24652,8 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24793,8 +24798,8 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -24939,8 +24944,8 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25085,8 +25090,8 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25193,8 +25198,8 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25341,8 +25346,8 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25473,8 +25478,8 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25569,8 +25574,8 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25693,8 +25698,8 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25817,8 +25822,8 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -25941,8 +25946,8 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26073,8 +26078,8 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26173,8 +26178,8 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26317,8 +26322,8 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26461,8 +26466,8 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26605,8 +26610,8 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26781,8 +26786,8 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -26905,8 +26910,8 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27049,8 +27054,8 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27193,8 +27198,8 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27337,8 +27342,8 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27513,8 +27518,8 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27637,8 +27642,8 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27781,8 +27786,8 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -27925,8 +27930,8 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28069,8 +28074,8 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28245,8 +28250,8 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28369,8 +28374,8 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28545,8 +28550,8 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28721,8 +28726,8 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -28897,8 +28902,8 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29073,8 +29078,8 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29205,8 +29210,8 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29333,8 +29338,8 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29433,8 +29438,8 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29553,8 +29558,9 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29657,8 +29663,8 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29789,8 +29795,8 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -29885,8 +29891,8 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30009,8 +30015,8 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30133,8 +30139,8 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30257,8 +30263,8 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30389,8 +30395,8 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30489,8 +30495,8 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30633,8 +30639,8 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30777,8 +30783,8 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -30921,8 +30927,8 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31097,8 +31103,8 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31221,8 +31227,8 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31365,8 +31371,8 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31509,8 +31515,8 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31653,8 +31659,8 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31829,8 +31835,8 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -31953,8 +31959,8 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32097,8 +32103,8 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32241,8 +32247,8 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32385,8 +32391,8 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32561,8 +32567,8 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32685,8 +32691,8 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -32861,8 +32867,8 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33037,8 +33043,8 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33213,8 +33219,8 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33389,8 +33395,8 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33521,8 +33527,8 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33649,8 +33655,8 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33749,8 +33755,8 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33869,8 +33875,9 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -33973,8 +33980,8 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34105,8 +34112,8 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34201,8 +34208,8 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34325,8 +34332,8 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34449,8 +34456,8 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34573,8 +34580,8 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34705,8 +34712,8 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34805,8 +34812,8 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -34949,8 +34956,8 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35093,8 +35100,8 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35237,8 +35244,8 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35413,8 +35420,8 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35537,8 +35544,8 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35681,8 +35688,8 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35825,8 +35832,8 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -35969,8 +35976,8 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36145,8 +36152,8 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36269,8 +36276,8 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36413,8 +36420,8 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36557,8 +36564,8 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36701,8 +36708,8 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -36877,8 +36884,8 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37001,8 +37008,8 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37177,8 +37184,8 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37353,8 +37360,8 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37529,8 +37536,8 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37705,8 +37712,8 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37837,8 +37844,8 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -37965,8 +37972,8 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38065,8 +38072,8 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38185,8 +38192,9 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38289,8 +38297,8 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38421,8 +38429,8 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38517,8 +38525,8 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38641,8 +38649,8 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38765,8 +38773,8 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -38889,8 +38897,8 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39021,8 +39029,8 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39121,8 +39129,8 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39265,8 +39273,8 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39409,8 +39417,8 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39553,8 +39561,8 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39729,8 +39737,8 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39853,8 +39861,8 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -39997,8 +40005,8 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40141,8 +40149,8 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40285,8 +40293,8 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40461,8 +40469,8 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40585,8 +40593,8 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40729,8 +40737,8 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -40873,8 +40881,8 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41017,8 +41025,8 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41193,8 +41201,8 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41317,8 +41325,8 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41493,8 +41501,8 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41669,8 +41677,8 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -41845,8 +41853,8 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42021,8 +42029,8 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42153,8 +42161,8 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42281,8 +42289,8 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42381,8 +42389,8 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42501,8 +42509,9 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42605,8 +42614,8 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42737,8 +42746,8 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42833,8 +42842,8 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -42957,8 +42966,8 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43081,8 +43090,8 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43205,8 +43214,8 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43337,8 +43346,8 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43437,8 +43446,8 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43581,8 +43590,8 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43725,8 +43734,8 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -43869,8 +43878,8 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44045,8 +44054,8 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44169,8 +44178,8 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44313,8 +44322,8 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44457,8 +44466,8 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44601,8 +44610,8 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44777,8 +44786,8 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -44901,8 +44910,8 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45045,8 +45054,8 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45189,8 +45198,8 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45333,8 +45342,8 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45509,8 +45518,8 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45633,8 +45642,8 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45809,8 +45818,8 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -45985,8 +45994,8 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46161,8 +46170,8 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46337,8 +46346,8 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46469,8 +46478,8 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46597,8 +46606,8 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46697,8 +46706,8 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46817,8 +46826,9 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -46921,8 +46931,8 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47053,8 +47063,8 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47149,8 +47159,8 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47273,8 +47283,8 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47397,8 +47407,8 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47521,8 +47531,8 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47653,8 +47663,8 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47753,8 +47763,8 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -47897,8 +47907,8 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48041,8 +48051,8 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48185,8 +48195,8 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48361,8 +48371,8 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48485,8 +48495,8 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48629,8 +48639,8 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48773,8 +48783,8 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -48917,8 +48927,8 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49093,8 +49103,8 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49217,8 +49227,8 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49361,8 +49371,8 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49505,8 +49515,8 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49649,8 +49659,8 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49825,8 +49835,8 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -49949,8 +49959,8 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50125,8 +50135,8 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50301,8 +50311,8 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50477,8 +50487,8 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50653,8 +50663,8 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50785,8 +50795,8 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -50913,8 +50923,8 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51013,8 +51023,8 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51133,8 +51143,9 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
@@ -51232,16 +51243,16 @@ func GetProjectionOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
-	nullableArgs bool,
+	calledOnNullInput bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projOpBase := projOpBase{
-		OneInputHelper: colexecop.MakeOneInputHelper(input),
-		allocator:      allocator,
-		col1Idx:        col1Idx,
-		col2Idx:        col2Idx,
-		outputIdx:      outputIdx,
-		nullableArgs:   nullableArgs,
+		OneInputHelper:    colexecop.MakeOneInputHelper(input),
+		allocator:         allocator,
+		col1Idx:           col1Idx,
+		col2Idx:           col2Idx,
+		outputIdx:         outputIdx,
+		calledOnNullInput: calledOnNullInput,
 	}
 
 	leftType, rightType := inputTypes[col1Idx], inputTypes[col2Idx]

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -79,11 +79,11 @@ func _ASSIGN(_, _, _, _, _, _ interface{}) {
 // projOpBase contains all of the fields for non-constant projections.
 type projOpBase struct {
 	colexecop.OneInputHelper
-	allocator    *colmem.Allocator
-	col1Idx      int
-	col2Idx      int
-	outputIdx    int
-	nullableArgs bool
+	allocator         *colmem.Allocator
+	col1Idx           int
+	col2Idx           int
+	outputIdx         int
+	calledOnNullInput bool
 }
 
 // {{define "projOp"}}
@@ -125,21 +125,23 @@ func (p _OP_NAME) Next() coldata.Batch {
 		_outNulls := projVec.Nulls()
 
 		// {{/*
-		// If nullableArgs is true, the function’s definition can handle null
-		// arguments. We would still want to perform the projection, and there is no
-		// need to call projVec.SetNulls(). The behaviour will just be the same as
-		// _HAS_NULLS is false. Since currently only ConcatDatumDatum needs this
-		// nullableArgs == true behaviour, logic for nullableArgs is only added to
-		// the if statement for function with Datum, Datum. If we later introduce
-		// another projection operation that has nullableArgs == true, we should
-		// update this code accordingly.
+		// If calledOnNullInput is true, the function’s definition can handle
+		// null arguments. We would still want to perform the projection, and
+		// there is no need to call projVec.SetNulls(). The behaviour will just
+		// be the same as _HAS_NULLS is false. Since currently only
+		// ConcatDatumDatum needs this calledOnNullInput == true behaviour,
+		// logic for calledOnNullInput is only added to the if statement for
+		// function with Datum, Datum. If we later introduce another projection
+		// operation that has calledOnNullInput == true, we should update this
+		// code accordingly.
 		// */}}
 		// {{if and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum")}}
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
+		hasNullsAndNotCalledOnNullInput :=
+			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
 		// {{else}}
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
+		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
 		// {{end}}
-		if hasNullsAndNotNullable {
+		if hasNullsAndNotCalledOnNullInput {
 			_SET_PROJECTION(true)
 		} else {
 			_SET_PROJECTION(false)
@@ -262,16 +264,16 @@ func GetProjectionOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
-	nullableArgs bool,
+	calledOnNullInput bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projOpBase := projOpBase{
-		OneInputHelper: colexecop.MakeOneInputHelper(input),
-		allocator:      allocator,
-		col1Idx:        col1Idx,
-		col2Idx:        col2Idx,
-		outputIdx:      outputIdx,
-		nullableArgs:   nullableArgs,
+		OneInputHelper:    colexecop.MakeOneInputHelper(input),
+		allocator:         allocator,
+		col1Idx:           col1Idx,
+		col2Idx:           col2Idx,
+		outputIdx:         outputIdx,
+		calledOnNullInput: calledOnNullInput,
 	}
 
 	leftType, rightType := inputTypes[col1Idx], inputTypes[col2Idx]

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -211,22 +211,22 @@ func TestGetProjectionOperator(t *testing.T) {
 	inputTypes[col1Idx] = typ
 	inputTypes[col2Idx] = typ
 	outputIdx := 9
-	nullableArgs := false
+	calledOnNullInput := false
 	op, err := GetProjectionOperator(
 		testAllocator, inputTypes, types.Int2, binOp, input, col1Idx, col2Idx,
-		outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
+		outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, calledOnNullInput,
 	)
 	if err != nil {
 		t.Error(err)
 	}
 	expected := &projMultInt16Int16Op{
 		projOpBase: projOpBase{
-			OneInputHelper: colexecop.MakeOneInputHelper(op.(*projMultInt16Int16Op).Input),
-			allocator:      testAllocator,
-			col1Idx:        col1Idx,
-			col2Idx:        col2Idx,
-			outputIdx:      outputIdx,
-			nullableArgs:   nullableArgs,
+			OneInputHelper:    colexecop.MakeOneInputHelper(op.(*projMultInt16Int16Op).Input),
+			allocator:         testAllocator,
+			col1Idx:           col1Idx,
+			col2Idx:           col2Idx,
+			outputIdx:         outputIdx,
+			calledOnNullInput: calledOnNullInput,
 		},
 	}
 	if !reflect.DeepEqual(op, expected) {

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -67,8 +67,8 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -143,8 +143,8 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -219,8 +219,8 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -295,8 +295,8 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -371,8 +371,8 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -447,8 +447,8 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -523,8 +523,8 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -599,8 +599,8 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -675,8 +675,8 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -753,8 +753,8 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -855,8 +855,8 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -931,8 +931,8 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1007,8 +1007,8 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1083,8 +1083,8 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1159,8 +1159,8 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1235,8 +1235,8 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1311,8 +1311,8 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1387,8 +1387,8 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1463,8 +1463,8 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1541,8 +1541,8 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1643,8 +1643,8 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1719,8 +1719,8 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1795,8 +1795,8 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1871,8 +1871,8 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1947,8 +1947,8 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2023,8 +2023,8 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2099,8 +2099,8 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2175,8 +2175,8 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2251,8 +2251,8 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2329,8 +2329,8 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2431,8 +2431,8 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2535,8 +2535,8 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2639,8 +2639,8 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2743,8 +2743,8 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2843,8 +2843,8 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2943,8 +2943,8 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3043,8 +3043,8 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3143,8 +3143,8 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3253,8 +3253,8 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3373,8 +3373,8 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3473,8 +3473,8 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3573,8 +3573,8 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3673,8 +3673,8 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3783,8 +3783,8 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3903,8 +3903,8 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4003,8 +4003,8 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4103,8 +4103,8 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4203,8 +4203,8 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4313,8 +4313,8 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4433,8 +4433,8 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4521,8 +4521,8 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4609,8 +4609,8 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4697,8 +4697,8 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4767,8 +4767,8 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4889,8 +4889,8 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5009,8 +5009,8 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5129,8 +5129,8 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5249,8 +5249,8 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5367,8 +5367,8 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5471,8 +5471,8 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5575,8 +5575,8 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5679,8 +5679,8 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5779,8 +5779,8 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5879,8 +5879,8 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5979,8 +5979,8 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6079,8 +6079,8 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6189,8 +6189,8 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6309,8 +6309,8 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6409,8 +6409,8 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6509,8 +6509,8 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6609,8 +6609,8 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6719,8 +6719,8 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6839,8 +6839,8 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6939,8 +6939,8 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7039,8 +7039,8 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7139,8 +7139,8 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7249,8 +7249,8 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7369,8 +7369,8 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7457,8 +7457,8 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7537,8 +7537,8 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7625,8 +7625,8 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7695,8 +7695,8 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7815,8 +7815,8 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7917,8 +7917,8 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8003,8 +8003,8 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8089,8 +8089,8 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8177,8 +8177,8 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8281,8 +8281,8 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8401,8 +8401,8 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8521,8 +8521,8 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8641,8 +8641,8 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8761,8 +8761,8 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8879,8 +8879,8 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8983,8 +8983,8 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9087,8 +9087,8 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9191,8 +9191,8 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9291,8 +9291,8 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9379,8 +9379,8 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9511,8 +9511,8 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9643,8 +9643,8 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9775,8 +9775,8 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9883,8 +9883,8 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9951,8 +9951,8 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10083,8 +10083,8 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10215,8 +10215,8 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10347,8 +10347,8 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10455,8 +10455,8 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10523,8 +10523,8 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10655,8 +10655,8 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10787,8 +10787,8 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10919,8 +10919,8 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11027,8 +11027,8 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11095,8 +11095,8 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11183,8 +11183,8 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11251,8 +11251,8 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11319,8 +11319,8 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11387,8 +11387,8 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11455,8 +11455,8 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11523,8 +11523,8 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11611,8 +11611,8 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11731,8 +11731,8 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11851,8 +11851,8 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11971,8 +11971,8 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12087,8 +12087,8 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12203,8 +12203,8 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12319,8 +12319,8 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12435,8 +12435,8 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12559,8 +12559,8 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12675,8 +12675,8 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12791,8 +12791,8 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12907,8 +12907,8 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13031,8 +13031,8 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13147,8 +13147,8 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13263,8 +13263,8 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13379,8 +13379,8 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13503,8 +13503,8 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13607,8 +13607,8 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13691,8 +13691,8 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13775,8 +13775,8 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13859,8 +13859,8 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13943,8 +13943,8 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14063,8 +14063,8 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14183,8 +14183,8 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14303,8 +14303,8 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14419,8 +14419,8 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14515,8 +14515,8 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14611,8 +14611,8 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14707,8 +14707,8 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14831,8 +14831,8 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14927,8 +14927,8 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15023,8 +15023,8 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15119,8 +15119,8 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15243,8 +15243,8 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15339,8 +15339,8 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15435,8 +15435,8 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15531,8 +15531,8 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15655,8 +15655,8 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15759,8 +15759,8 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15879,8 +15879,8 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15999,8 +15999,8 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16119,8 +16119,8 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16235,8 +16235,8 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16331,8 +16331,8 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16427,8 +16427,8 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16523,8 +16523,8 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16647,8 +16647,8 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16743,8 +16743,8 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16839,8 +16839,8 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16935,8 +16935,8 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17059,8 +17059,8 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17155,8 +17155,8 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17251,8 +17251,8 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17347,8 +17347,8 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17471,8 +17471,8 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17575,8 +17575,8 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17679,8 +17679,8 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17783,8 +17783,8 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17887,8 +17887,8 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17987,8 +17987,8 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18111,8 +18111,8 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18235,8 +18235,8 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18359,8 +18359,8 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18467,8 +18467,8 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18591,8 +18591,8 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18715,8 +18715,8 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18839,8 +18839,8 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18947,8 +18947,8 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19071,8 +19071,8 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19195,8 +19195,8 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19319,8 +19319,8 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19427,8 +19427,8 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19515,8 +19515,8 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19609,8 +19609,8 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19701,8 +19701,8 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19803,8 +19803,8 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19903,8 +19903,8 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20003,8 +20003,8 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20103,8 +20103,8 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20203,8 +20203,8 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20303,8 +20303,8 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20403,8 +20403,8 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20503,8 +20503,8 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20603,8 +20603,8 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20705,8 +20705,8 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20825,8 +20825,8 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20945,8 +20945,8 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21063,8 +21063,8 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21163,8 +21163,8 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21263,8 +21263,8 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21363,8 +21363,8 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21463,8 +21463,8 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21563,8 +21563,8 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21663,8 +21663,8 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21763,8 +21763,8 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21863,8 +21863,8 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21965,8 +21965,8 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22085,8 +22085,8 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22205,8 +22205,8 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22323,8 +22323,8 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22437,8 +22437,8 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22539,8 +22539,8 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22641,8 +22641,8 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22743,8 +22743,8 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22893,8 +22893,8 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23031,8 +23031,8 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23169,8 +23169,8 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23307,8 +23307,8 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23409,8 +23409,8 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23544,15 +23544,15 @@ func GetProjectionLConstOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
-	nullableArgs bool,
+	calledOnNullInput bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
-		OneInputHelper: colexecop.MakeOneInputHelper(input),
-		allocator:      allocator,
-		colIdx:         colIdx,
-		outputIdx:      outputIdx,
-		nullableArgs:   nullableArgs,
+		OneInputHelper:    colexecop.MakeOneInputHelper(input),
+		allocator:         allocator,
+		colIdx:            colIdx,
+		outputIdx:         outputIdx,
+		calledOnNullInput: calledOnNullInput,
 	}
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	leftType, rightType := constType, inputTypes[colIdx]

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_base.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_base.go
@@ -19,8 +19,8 @@ import (
 // except for the constant itself.
 type projConstOpBase struct {
 	colexecop.OneInputHelper
-	allocator    *colmem.Allocator
-	colIdx       int
-	outputIdx    int
-	nullableArgs bool
+	allocator         *colmem.Allocator
+	colIdx            int
+	outputIdx         int
+	calledOnNullInput bool
 }

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
@@ -131,21 +131,21 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 		_outNulls := projVec.Nulls()
 
 		// {{/*
-		// If nullableArgs is true, the function’s definition can handle null
+		// If calledOnNullInput is true, the function’s definition can handle null
 		// arguments. We would still want to perform the projection, and there is no
 		// need to call projVec.SetNulls(). The behaviour will just be the same as
 		// _HAS_NULLS is false. Since currently only ConcatDatumDatum needs this
-		// nullableArgs == true behaviour, logic for nullableArgs is only added to
+		// calledOnNullInput == true behaviour, logic for calledOnNullInput is only added to
 		// the if statement for function with Datum, Datum. If we later introduce
-		// another projection operation that has nullableArgs == true, we should
+		// another projection operation that has calledOnNullInput == true, we should
 		// update this code accordingly.
 		// */}}
 		// {{if and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum")}}
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
 		// {{else}}
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
 		// {{end}}
-		if hasNullsAndNotNullable {
+		if hasNullsAndNotCalledOnNullInput {
 			_SET_PROJECTION(true)
 		} else {
 			_SET_PROJECTION(false)
@@ -281,15 +281,15 @@ func GetProjection_CONST_SIDEConstOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
-	nullableArgs bool,
+	calledOnNullInput bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
-		OneInputHelper: colexecop.MakeOneInputHelper(input),
-		allocator:      allocator,
-		colIdx:         colIdx,
-		outputIdx:      outputIdx,
-		nullableArgs:   nullableArgs,
+		OneInputHelper:    colexecop.MakeOneInputHelper(input),
+		allocator:         allocator,
+		colIdx:            colIdx,
+		outputIdx:         outputIdx,
+		calledOnNullInput: calledOnNullInput,
 	}
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	// {{if _IS_CONST_LEFT}}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -70,8 +70,8 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -146,8 +146,8 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -222,8 +222,8 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -298,8 +298,8 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -374,8 +374,8 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -450,8 +450,8 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -526,8 +526,8 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -602,8 +602,8 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -678,8 +678,8 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -756,8 +756,8 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -858,8 +858,8 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -934,8 +934,8 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1010,8 +1010,8 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1086,8 +1086,8 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1162,8 +1162,8 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1238,8 +1238,8 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1314,8 +1314,8 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1390,8 +1390,8 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1466,8 +1466,8 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1544,8 +1544,8 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1646,8 +1646,8 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1722,8 +1722,8 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1798,8 +1798,8 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1874,8 +1874,8 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1950,8 +1950,8 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2026,8 +2026,8 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2102,8 +2102,8 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2178,8 +2178,8 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2254,8 +2254,8 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2332,8 +2332,8 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2434,8 +2434,8 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2538,8 +2538,8 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2642,8 +2642,8 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2746,8 +2746,8 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2846,8 +2846,8 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2946,8 +2946,8 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3046,8 +3046,8 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3146,8 +3146,8 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3256,8 +3256,8 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3374,8 +3374,8 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3474,8 +3474,8 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3574,8 +3574,8 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3674,8 +3674,8 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3784,8 +3784,8 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -3902,8 +3902,8 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4002,8 +4002,8 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4102,8 +4102,8 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4202,8 +4202,8 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4312,8 +4312,8 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4430,8 +4430,8 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4518,8 +4518,8 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4606,8 +4606,8 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4694,8 +4694,8 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4764,8 +4764,8 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -4884,8 +4884,8 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5006,8 +5006,8 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5128,8 +5128,8 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5250,8 +5250,8 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5370,8 +5370,8 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5474,8 +5474,8 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5578,8 +5578,8 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5682,8 +5682,8 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5782,8 +5782,8 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5882,8 +5882,8 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -5982,8 +5982,8 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6082,8 +6082,8 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6192,8 +6192,8 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6310,8 +6310,8 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6410,8 +6410,8 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6510,8 +6510,8 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6610,8 +6610,8 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6720,8 +6720,8 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6838,8 +6838,8 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -6938,8 +6938,8 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7038,8 +7038,8 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7138,8 +7138,8 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7248,8 +7248,8 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7366,8 +7366,8 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7454,8 +7454,8 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7534,8 +7534,8 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7622,8 +7622,8 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7692,8 +7692,8 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7810,8 +7810,8 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -7912,8 +7912,8 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8000,8 +8000,8 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8088,8 +8088,8 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8178,8 +8178,8 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8282,8 +8282,8 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8404,8 +8404,8 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8524,8 +8524,8 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8646,8 +8646,8 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8768,8 +8768,8 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8888,8 +8888,8 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8992,8 +8992,8 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9096,8 +9096,8 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9200,8 +9200,8 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9300,8 +9300,8 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9388,8 +9388,8 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9520,8 +9520,8 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9652,8 +9652,8 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9784,8 +9784,8 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9892,8 +9892,8 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9960,8 +9960,8 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10092,8 +10092,8 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10224,8 +10224,8 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10356,8 +10356,8 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10464,8 +10464,8 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10532,8 +10532,8 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10664,8 +10664,8 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10796,8 +10796,8 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -10928,8 +10928,8 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11036,8 +11036,8 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11104,8 +11104,8 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11192,8 +11192,8 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11260,8 +11260,8 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11328,8 +11328,8 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11396,8 +11396,8 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11464,8 +11464,8 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11532,8 +11532,8 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11620,8 +11620,8 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11740,8 +11740,8 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11860,8 +11860,8 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -11980,8 +11980,8 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12096,8 +12096,8 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12212,8 +12212,8 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12328,8 +12328,8 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12444,8 +12444,8 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12568,8 +12568,8 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12684,8 +12684,8 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12800,8 +12800,8 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -12916,8 +12916,8 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13040,8 +13040,8 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13156,8 +13156,8 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13272,8 +13272,8 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13388,8 +13388,8 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13512,8 +13512,8 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13616,8 +13616,8 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13700,8 +13700,8 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13784,8 +13784,8 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13868,8 +13868,8 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -13952,8 +13952,8 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14072,8 +14072,8 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14192,8 +14192,8 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14312,8 +14312,8 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14428,8 +14428,8 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14524,8 +14524,8 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14620,8 +14620,8 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14716,8 +14716,8 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14840,8 +14840,8 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -14936,8 +14936,8 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15032,8 +15032,8 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15128,8 +15128,8 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15252,8 +15252,8 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15348,8 +15348,8 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15444,8 +15444,8 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15540,8 +15540,8 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15664,8 +15664,8 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15768,8 +15768,8 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -15888,8 +15888,8 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16008,8 +16008,8 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16128,8 +16128,8 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16244,8 +16244,8 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16340,8 +16340,8 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16436,8 +16436,8 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16532,8 +16532,8 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16656,8 +16656,8 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16752,8 +16752,8 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16848,8 +16848,8 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -16944,8 +16944,8 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17068,8 +17068,8 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17164,8 +17164,8 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17260,8 +17260,8 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17356,8 +17356,8 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17480,8 +17480,8 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17584,8 +17584,8 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17688,8 +17688,8 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17792,8 +17792,8 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17896,8 +17896,8 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -17996,8 +17996,8 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18120,8 +18120,8 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18244,8 +18244,8 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18368,8 +18368,8 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18476,8 +18476,8 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18600,8 +18600,8 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18724,8 +18724,8 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18848,8 +18848,8 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -18956,8 +18956,8 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19080,8 +19080,8 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19204,8 +19204,8 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19328,8 +19328,8 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19436,8 +19436,8 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19524,8 +19524,8 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19618,8 +19618,8 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19710,8 +19710,8 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19812,8 +19812,8 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19912,8 +19912,8 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20012,8 +20012,8 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20112,8 +20112,8 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20212,8 +20212,8 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20312,8 +20312,8 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20412,8 +20412,8 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20512,8 +20512,8 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20612,8 +20612,8 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20714,8 +20714,8 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20836,8 +20836,8 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20958,8 +20958,8 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21078,8 +21078,8 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21178,8 +21178,8 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21278,8 +21278,8 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21378,8 +21378,8 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21478,8 +21478,8 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21578,8 +21578,8 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21678,8 +21678,8 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21778,8 +21778,8 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21878,8 +21878,8 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21980,8 +21980,8 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22102,8 +22102,8 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22224,8 +22224,8 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22344,8 +22344,8 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22458,8 +22458,8 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22562,8 +22562,8 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22666,8 +22666,8 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22770,8 +22770,8 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22920,8 +22920,8 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23060,8 +23060,8 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23200,8 +23200,8 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23340,8 +23340,8 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23442,8 +23442,8 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23584,8 +23584,8 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23708,8 +23708,8 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23798,8 +23798,8 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -23914,8 +23914,8 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24030,8 +24030,8 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24146,8 +24146,8 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24270,8 +24270,8 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24362,8 +24362,8 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24498,8 +24498,8 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24634,8 +24634,8 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24770,8 +24770,8 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -24938,8 +24938,8 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25054,8 +25054,8 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25190,8 +25190,8 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25326,8 +25326,8 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25462,8 +25462,8 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25630,8 +25630,8 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25746,8 +25746,8 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -25882,8 +25882,8 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26018,8 +26018,8 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26154,8 +26154,8 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26322,8 +26322,8 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26438,8 +26438,8 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26606,8 +26606,8 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26774,8 +26774,8 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -26942,8 +26942,8 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27110,8 +27110,8 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27234,8 +27234,8 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27354,8 +27354,8 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27446,8 +27446,8 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27560,8 +27560,8 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27658,8 +27658,8 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27782,8 +27782,8 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27872,8 +27872,8 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27988,8 +27988,8 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28104,8 +28104,8 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28220,8 +28220,8 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28344,8 +28344,8 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28436,8 +28436,8 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28572,8 +28572,8 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28708,8 +28708,8 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28844,8 +28844,8 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29012,8 +29012,8 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29128,8 +29128,8 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29264,8 +29264,8 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29400,8 +29400,8 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29536,8 +29536,8 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29704,8 +29704,8 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29820,8 +29820,8 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29956,8 +29956,8 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30092,8 +30092,8 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30228,8 +30228,8 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30396,8 +30396,8 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30512,8 +30512,8 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30680,8 +30680,8 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30848,8 +30848,8 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31016,8 +31016,8 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31184,8 +31184,8 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31308,8 +31308,8 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31428,8 +31428,8 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31520,8 +31520,8 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31634,8 +31634,8 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31732,8 +31732,8 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31856,8 +31856,8 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31946,8 +31946,8 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32062,8 +32062,8 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32178,8 +32178,8 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32294,8 +32294,8 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32418,8 +32418,8 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32510,8 +32510,8 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32646,8 +32646,8 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32782,8 +32782,8 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -32918,8 +32918,8 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33086,8 +33086,8 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33202,8 +33202,8 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33338,8 +33338,8 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33474,8 +33474,8 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33610,8 +33610,8 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33778,8 +33778,8 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33894,8 +33894,8 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34030,8 +34030,8 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34166,8 +34166,8 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34302,8 +34302,8 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34470,8 +34470,8 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34586,8 +34586,8 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34754,8 +34754,8 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -34922,8 +34922,8 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35090,8 +35090,8 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35258,8 +35258,8 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35382,8 +35382,8 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35502,8 +35502,8 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35594,8 +35594,8 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35708,8 +35708,8 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35806,8 +35806,8 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35930,8 +35930,8 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36020,8 +36020,8 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36136,8 +36136,8 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36252,8 +36252,8 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36368,8 +36368,8 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36492,8 +36492,8 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36584,8 +36584,8 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36720,8 +36720,8 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36856,8 +36856,8 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -36992,8 +36992,8 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37160,8 +37160,8 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37276,8 +37276,8 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37412,8 +37412,8 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37548,8 +37548,8 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37684,8 +37684,8 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37852,8 +37852,8 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37968,8 +37968,8 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38104,8 +38104,8 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38240,8 +38240,8 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38376,8 +38376,8 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38544,8 +38544,8 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38660,8 +38660,8 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38828,8 +38828,8 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38996,8 +38996,8 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39164,8 +39164,8 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39332,8 +39332,8 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39456,8 +39456,8 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39576,8 +39576,8 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39668,8 +39668,8 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39782,8 +39782,8 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39880,8 +39880,8 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40004,8 +40004,8 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40094,8 +40094,8 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40210,8 +40210,8 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40326,8 +40326,8 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40442,8 +40442,8 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40566,8 +40566,8 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40658,8 +40658,8 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40794,8 +40794,8 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -40930,8 +40930,8 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41066,8 +41066,8 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41234,8 +41234,8 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41350,8 +41350,8 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41486,8 +41486,8 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41622,8 +41622,8 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41758,8 +41758,8 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41926,8 +41926,8 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42042,8 +42042,8 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42178,8 +42178,8 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42314,8 +42314,8 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42450,8 +42450,8 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42618,8 +42618,8 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42734,8 +42734,8 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42902,8 +42902,8 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43070,8 +43070,8 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43238,8 +43238,8 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43406,8 +43406,8 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43530,8 +43530,8 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43650,8 +43650,8 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43742,8 +43742,8 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43856,8 +43856,8 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43954,8 +43954,8 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44078,8 +44078,8 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44168,8 +44168,8 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44284,8 +44284,8 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44400,8 +44400,8 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44516,8 +44516,8 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44640,8 +44640,8 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44732,8 +44732,8 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44868,8 +44868,8 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45004,8 +45004,8 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45140,8 +45140,8 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45308,8 +45308,8 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45424,8 +45424,8 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45560,8 +45560,8 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45696,8 +45696,8 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45832,8 +45832,8 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46000,8 +46000,8 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46116,8 +46116,8 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46252,8 +46252,8 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46388,8 +46388,8 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46524,8 +46524,8 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46692,8 +46692,8 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46808,8 +46808,8 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46976,8 +46976,8 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47144,8 +47144,8 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47312,8 +47312,8 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47480,8 +47480,8 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47604,8 +47604,8 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47724,8 +47724,8 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47816,8 +47816,8 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -47930,8 +47930,8 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48021,15 +48021,15 @@ func GetProjectionRConstOperator(
 	evalCtx *eval.Context,
 	binOp tree.BinaryEvalOp,
 	cmpExpr *tree.ComparisonExpr,
-	nullableArgs bool,
+	calledOnNullInput bool,
 ) (colexecop.Operator, error) {
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)
 	projConstOpBase := projConstOpBase{
-		OneInputHelper: colexecop.MakeOneInputHelper(input),
-		allocator:      allocator,
-		colIdx:         colIdx,
-		outputIdx:      outputIdx,
-		nullableArgs:   nullableArgs,
+		OneInputHelper:    colexecop.MakeOneInputHelper(input),
+		allocator:         allocator,
+		colIdx:            colIdx,
+		outputIdx:         outputIdx,
+		calledOnNullInput: calledOnNullInput,
 	}
 	c := colconv.GetDatumToPhysicalFn(constType)(constArg)
 	leftType, rightType := inputTypes[colIdx], constType

--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -39,8 +39,8 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -105,8 +105,8 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -171,8 +171,8 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -237,8 +237,8 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -351,8 +351,8 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -417,8 +417,8 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -483,8 +483,8 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -549,8 +549,8 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -615,8 +615,8 @@ func (p projNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -729,8 +729,8 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
 
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
+		if hasNullsAndNotCalledOnNullInput {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]

--- a/pkg/sql/colexec/colexecprojconst/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecprojconst/projection_ops_test.go
@@ -34,20 +34,20 @@ func TestGetProjectionConstOperator(t *testing.T) {
 	constVal := 31.37
 	constArg := tree.NewDFloat(tree.DFloat(constVal))
 	outputIdx := 5
-	nullableArgs := false
+	calledOnNullInput := false
 	op, err := GetProjectionRConstOperator(
 		nil /* allocator */, inputTypes, types.Float, types.Float, binOp, input, colIdx,
-		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
+		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, calledOnNullInput,
 	)
 	if err != nil {
 		t.Error(err)
 	}
 	expected := &projMultFloat64Float64ConstOp{
 		projConstOpBase: projConstOpBase{
-			OneInputHelper: colexecop.MakeOneInputHelper(op.(*projMultFloat64Float64ConstOp).Input),
-			colIdx:         colIdx,
-			outputIdx:      outputIdx,
-			nullableArgs:   nullableArgs,
+			OneInputHelper:    colexecop.MakeOneInputHelper(op.(*projMultFloat64Float64ConstOp).Input),
+			colIdx:            colIdx,
+			outputIdx:         outputIdx,
+			calledOnNullInput: calledOnNullInput,
 		},
 		constArg: constVal,
 	}
@@ -67,20 +67,20 @@ func TestGetProjectionConstMixedTypeOperator(t *testing.T) {
 	constVal := int16(31)
 	constArg := tree.NewDInt(tree.DInt(constVal))
 	outputIdx := 5
-	nullableArgs := false
+	calledOnNullInput := false
 	op, err := GetProjectionRConstOperator(
 		nil /* allocator */, inputTypes, types.Int2, types.Int, cmpOp, input, colIdx,
-		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, nullableArgs,
+		constArg, outputIdx, nil /* EvalCtx */, nil /* BinFn */, nil /* cmpExpr */, calledOnNullInput,
 	)
 	if err != nil {
 		t.Error(err)
 	}
 	expected := &projGEInt64Int16ConstOp{
 		projConstOpBase: projConstOpBase{
-			OneInputHelper: colexecop.MakeOneInputHelper(op.(*projGEInt64Int16ConstOp).Input),
-			colIdx:         colIdx,
-			outputIdx:      outputIdx,
-			nullableArgs:   nullableArgs,
+			OneInputHelper:    colexecop.MakeOneInputHelper(op.(*projGEInt64Int16ConstOp).Input),
+			colIdx:            colIdx,
+			outputIdx:         outputIdx,
+			calledOnNullInput: calledOnNullInput,
 		},
 		constArg: constVal,
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/default_cmp_expr_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/default_cmp_expr_gen.go
@@ -17,16 +17,16 @@ import (
 )
 
 type defaultCmpExprTmplInfo struct {
-	NullableArgs bool
-	FlippedArgs  bool
-	Negate       bool
+	CalledOnNullInput bool
+	FlippedArgs       bool
+	Negate            bool
 }
 
 const defaultCmpExprTmpl = "pkg/sql/colexec/colexeccmp/default_cmp_expr_tmpl.go"
 
 func genDefaultCmpExpr(inputFileContents string, wr io.Writer) error {
 	s := strings.ReplaceAll(
-		inputFileContents, "_EXPR_NAME", "cmp{{if .NullableArgs}}Nullable{{end}}"+
+		inputFileContents, "_EXPR_NAME", "cmp{{if .CalledOnNullInput}}Nullable{{end}}"+
 			"{{if .FlippedArgs}}Flipped{{end}}{{if .Negate}}Negate{{end}}ExprAdapter",
 	)
 
@@ -39,9 +39,9 @@ func genDefaultCmpExpr(inputFileContents string, wr io.Writer) error {
 		for _, flipped := range []bool{false, true} {
 			for _, negate := range []bool{false, true} {
 				info = append(info, defaultCmpExprTmplInfo{
-					NullableArgs: nullable,
-					FlippedArgs:  flipped,
-					Negate:       negate,
+					CalledOnNullInput: nullable,
+					FlippedArgs:       flipped,
+					Negate:            negate,
 				})
 			}
 		}

--- a/pkg/sql/execinfra/execagg/base.go
+++ b/pkg/sql/execinfra/execagg/base.go
@@ -48,7 +48,7 @@ func GetAggregateInfo(
 		match := true
 		for i, t := range typs {
 			if !inputTypes[i].Equivalent(t) {
-				if b.NullableArgs && inputTypes[i].IsAmbiguous() {
+				if b.CalledOnNullInput && inputTypes[i].IsAmbiguous() {
 					continue
 				}
 				match = false
@@ -141,7 +141,7 @@ func GetWindowFunctionInfo(
 		match := true
 		for i, t := range typs {
 			if !inputTypes[i].Equivalent(t) {
-				if b.NullableArgs && inputTypes[i].IsAmbiguous() {
+				if b.CalledOnNullInput && inputTypes[i].IsAmbiguous() {
 					continue
 				}
 				match = false

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -983,7 +983,8 @@ SELECT NULL::INT[] || NULL::INT[]
 ----
 NULL
 
-# The following test check for projection operators that can handle nullable arguments.
+# The following test check for projection operators that are called when an
+# argument is NULL.
 statement ok
 CREATE TABLE t_bool (b BOOL[]);
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3657,14 +3657,14 @@ FROM pg_catalog.pg_proc
 WHERE proname='substring'
 ----
 proname    proisstrict  proretset  provolatile  proparallel
-substring  false        false      i            NULL
-substring  false        false      i            NULL
-substring  false        false      i            NULL
-substring  false        false      i            NULL
-substring  false        false      i            NULL
-substring  false        false      i            NULL
-substring  false        false      i            NULL
-substring  false        false      i            NULL
+substring  true         false      i            NULL
+substring  true         false      i            NULL
+substring  true         false      i            NULL
+substring  true         false      i            NULL
+substring  true         false      i            NULL
+substring  true         false      i            NULL
+substring  true         false      i            NULL
+substring  true         false      i            NULL
 
 query TIIOTTTT colnames
 SELECT proname, pronargs, pronargdefaults, prorettype, proargtypes, proallargtypes, proargmodes, proargdefaults
@@ -3696,29 +3696,29 @@ substring  NULL         substring  NULL    NULL       NULL
 substring  NULL         substring  NULL    NULL       NULL
 substring  NULL         substring  NULL    NULL       NULL
 
-query TOIOTT colnames
-SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes
+query TOIOTTB colnames
+SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes, proisstrict
 FROM pg_catalog.pg_proc
 WHERE proname='least'
 ----
-proname  provariadic  pronargs  prorettype  proargtypes  proargmodes
-least    2283         1         2283        2283         {v}
+proname  provariadic  pronargs  prorettype  proargtypes  proargmodes  proisstrict
+least    2283         1         2283        2283         {v}          false
 
-query TOIOTT colnames
-SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes
+query TOIOTTB colnames
+SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes, proisstrict
 FROM pg_catalog.pg_proc
 WHERE proname='json_extract_path'
 ----
-proname            provariadic  pronargs  prorettype  proargtypes  proargmodes
-json_extract_path  25           2         3802        3802 25      {i,v}
+proname            provariadic  pronargs  prorettype  proargtypes  proargmodes  proisstrict
+json_extract_path  25           2         3802        3802 25      {i,v}        true
 
-query TOIOTT colnames
-SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes
+query TOIOTTB colnames
+SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes, proisstrict
 FROM pg_catalog.pg_proc
 WHERE proname='json_extract_path_text'
 ----
-proname                 provariadic  pronargs  prorettype  proargtypes  proargmodes
-json_extract_path_text  25           2         25          3802 25      {i,v}
+proname                 provariadic  pronargs  prorettype  proargtypes  proargmodes  proisstrict
+json_extract_path_text  25           2         25          3802 25      {i,v}        true
 
 user testuser
 

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -434,7 +434,7 @@ func (cb *constraintsBuilder) buildConstraintForTupleInequality(
 func (cb *constraintsBuilder) buildFunctionConstraints(
 	f *FunctionExpr,
 ) (_ *constraint.Set, tight bool) {
-	if f.FunctionPrivate.Overload.NullableArgs {
+	if f.FunctionPrivate.Overload.CalledOnNullInput {
 		return unconstrained, false
 	}
 

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -94,7 +94,7 @@ func BinaryAllowsNullArgs(op opt.Operator, leftType, rightType *types.T) bool {
 	if !ok {
 		panic(errors.AssertionFailedf("could not find overload for binary expression %s", redact.Safe(op)))
 	}
-	return o.NullableArgs
+	return o.CalledOnNullInput
 }
 
 // GetBuiltinProperties is set to builtinsregistry.GetBuiltinProperties in an init

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -557,12 +557,13 @@ func (c *CustomFuncs) FoldColumnAccess(
 // to Null when any of its arguments are Null. A function can be folded to Null
 // in this case if all of the following are true:
 //
-//   1. It does not allow Null arguments (NullableArgs=false).
+//   1. It is not evaluated when any of its arguments are null
+//      (CalledOnNullInput=false).
 //   2. It is a normal function, not an aggregate, window, or generator.
 //
 // See FoldFunctionWithNullArg for more details.
 func (c *CustomFuncs) CanFoldFunctionWithNullArg(private *memo.FunctionPrivate) bool {
-	return !private.Overload.NullableArgs &&
+	return !private.Overload.CalledOnNullInput &&
 		private.Properties.Class == tree.NormalClass
 }
 

--- a/pkg/sql/opt/norm/rules/fold_constants.opt
+++ b/pkg/sql/opt/norm/rules/fold_constants.opt
@@ -180,23 +180,24 @@ $result
 # FoldFunctionWithNullArg folds a Function to Null when one of its arguments is
 # Null and all of the following are true:
 #
-#   1. The function does not allow Null arguments (NullableArgs=false).
+#   1. The function is not called when any of its inputs are null
+#      (CalledOnNullInput=false).
 #   2. The function is a normal function not an aggregate, window, or generator.
 #
 # It is safe to fold functions to Null in this case because a function with
-# NullableArgs=false would never error with a Null argument, even if the other
-# args are invalid. For example, calling encode with NULL bytes and an invalid
-# encoding format does not error:
+# CalledOnNullInput=false would never error with a Null argument, even if the
+# other args are invalid. For example, calling encode with NULL bytes and an
+# invalid encoding format does not error:
 #
 #     SELECT encode(NULL::BYTES, 'foo')
 #       => NULL
 #
 # Stable and volatile functions that rely on context or produce side-effects can
-# also be folded to Null in this case because a function with NullableArgs=false
-# is never evaluated if any of its arguments are Null. The function results
-# directly in Null without being invoked, so it is guaranteed not to rely on
-# context or produce side-effects. See FunctionProperties.NullableArgs for more
-# details.
+# also be folded to Null in this case because a function with
+# CalledOnNullInput=false is never evaluated if any of its arguments are Null.
+# The function results directly in Null without being invoked, so it is
+# guaranteed not to rely on context or produce side-effects. See
+# Overload.CalledOnNullInput for more details.
 #
 # FoldFunctionWithNullArg is defined before FoldFunction so that we can avoid
 # the overhead of evaluating the function in FoldFunction if it has any Null

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -63,7 +63,7 @@ func (b *Builder) buildSQLFn(
 			))
 		}
 		exprs[i] = memo.ExtractConstDatum(info.args[i])
-		if exprs[i] == tree.DNull && !info.def.Overload.NullableArgs {
+		if exprs[i] == tree.DNull && !info.def.Overload.CalledOnNullInput {
 			return b.factory.ConstructNull(info.ResolvedType())
 		}
 	}

--- a/pkg/sql/opt/optgen/lang/doc.go
+++ b/pkg/sql/opt/optgen/lang/doc.go
@@ -462,13 +462,13 @@ The OpName built-in function can also be a parameter to a custom match or
 replace function which needs to know which name matched. For example:
 
   [FoldBinaryNull]
-  (Binary $left:* (Null) & ^(HasNullableArgs (OpName)))
+  (Binary $left:* (Null) & ^(IsCalledOnNullInput (OpName)))
   =>
   (Null)
 
 The name of the matched Binary node (e.g. Plus, In, Contains) is passed to the
-HasNullableArgs function as a symbolic identifier. Here is an example that uses
-a custom replace function and the OpName function with an argument:
+IsCalledOnNullInput function as a symbolic identifier. Here is an example that
+uses a custom replace function and the OpName function with an argument:
 
   [NegateComparison]
   (Not $input:(Comparison $left:* $right:*))

--- a/pkg/sql/opt/testutils/testcat/testdata/udf
+++ b/pkg/sql/opt/testutils/testcat/testdata/udf
@@ -53,5 +53,5 @@ CREATE FUNCTION e(i INT) RETURNS INT IMMUTABLE STRICT LANGUAGE SQL AS 'SELECT i'
 exec-ddl
 SHOW CREATE FUNCTION e
 ----
-FUNCTION e(i: int) -> int [immutable, nullable-args=false]
+FUNCTION e(i: int) -> int [immutable, called-on-null-input=false]
  └── SELECT i

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -490,12 +490,12 @@ https://www.postgresql.org/docs/9.6/catalog-pg-cast.html`,
 				castCtx := cCtx.PGString()
 
 				_ = addRow(
-					h.CastOid(src, tgt),      //oid
-					tree.NewDOid(src),        //cast source
-					tree.NewDOid(tgt),        //casttarget
-					tree.DNull,               //castfunc
-					tree.NewDString(castCtx), //castcontext
-					tree.DNull,               //castmethod
+					h.CastOid(src, tgt),      // oid
+					tree.NewDOid(src),        // cast source
+					tree.NewDOid(tgt),        // casttarget
+					tree.DNull,               // castfunc
+					tree.NewDString(castCtx), // castcontext
+					tree.DNull,               // castmethod
 				)
 			}
 		})
@@ -2370,6 +2370,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-proc.html`,
 							variadicType = oidZero
 						}
 						provolatile, proleakproof := builtin.Volatility.ToPostgres()
+						proisstrict := !builtin.CalledOnNullInput
 
 						err := addRow(
 							tree.NewDOid(builtin.Oid),                // oid
@@ -2385,7 +2386,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-proc.html`,
 							tree.MakeDBool(tree.DBool(isWindow)),     // proiswindow
 							tree.DBoolFalse,                          // prosecdef
 							tree.MakeDBool(tree.DBool(proleakproof)), // proleakproof
-							tree.DBoolFalse,                          // proisstrict
+							tree.MakeDBool(tree.DBool(proisstrict)),  // proisstrict
 							tree.MakeDBool(tree.DBool(isRetSet)),     // proretset
 							tree.NewDString(provolatile),             // provolatile
 							tree.DNull,                               // proparallel

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -383,9 +383,9 @@ var regularBuiltins = map[string]builtinDefinition{
 				}
 				return tree.NewDString(buffer.String()), nil
 			},
-			Info:         "Concatenates a comma-separated list of strings.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Concatenates a comma-separated list of strings.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 			// In Postgres concat can take any arguments, converting them to
 			// their text representation. Since the text representation can
 			// depend on the context (e.g. timezone), the function is Stable. In
@@ -429,8 +429,8 @@ var regularBuiltins = map[string]builtinDefinition{
 			Info: "Uses the first argument as a separator between the concatenation of the " +
 				"subsequent arguments. \n\nFor example `concat_ws('!','wow','great')` " +
 				"returns `wow!great`.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 			// In Postgres concat_ws can take any arguments, converting them to
 			// their text representation. Since the text representation can
 			// depend on the context (e.g. timezone), the function is Stable. In
@@ -2014,9 +2014,9 @@ var regularBuiltins = map[string]builtinDefinition{
 				s := tree.MustBeDString(args[0])
 				return tree.NewDString(lexbase.EscapeSQLString(string(s))), nil
 			},
-			Info:         "Coerce `val` to a string and then quote it as a literal. If `val` is NULL, returns 'NULL'.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Coerce `val` to a string and then quote it as a literal. If `val` is NULL, returns 'NULL'.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Any}},
@@ -2034,9 +2034,9 @@ var regularBuiltins = map[string]builtinDefinition{
 				}
 				return tree.NewDString(strD.String()), nil
 			},
-			Info:         "Coerce `val` to a string and then quote it as a literal. If `val` is NULL, returns 'NULL'.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "Coerce `val` to a string and then quote it as a literal. If `val` is NULL, returns 'NULL'.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -2379,9 +2379,9 @@ var regularBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return eval.PickFromTuple(ctx, true /* greatest */, args)
 			},
-			Info:         "Returns the element with the greatest value.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Returns the element with the greatest value.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -2395,9 +2395,9 @@ var regularBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return eval.PickFromTuple(ctx, false /* greatest */, args)
 			},
-			Info:         "Returns the element with the lowest value.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Returns the element with the lowest value.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -3484,9 +3484,9 @@ value if you rely on the HLC for accuracy.`,
 				delimOrNil := stringOrNil(args[1])
 				return stringToArray(str, delimOrNil, nil)
 			},
-			Info:         "Split a string into components on a delimiter.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Split a string into components on a delimiter.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.String}, {"delimiter", types.String}, {"null", types.String}},
@@ -3500,9 +3500,9 @@ value if you rely on the HLC for accuracy.`,
 				nullStr := stringOrNil(args[2])
 				return stringToArray(str, delimOrNil, nullStr)
 			},
-			Info:         "Split a string into components on a delimiter with a specified string to consider NULL.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Split a string into components on a delimiter with a specified string to consider NULL.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -3518,9 +3518,9 @@ value if you rely on the HLC for accuracy.`,
 				delim := string(tree.MustBeDString(args[1]))
 				return arrayToString(evalCtx, arr, delim, nil)
 			},
-			Info:         "Join an array into a string with a delimiter.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "Join an array into a string with a delimiter.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.AnyArray}, {"delimiter", types.String}, {"null", types.String}},
@@ -3534,9 +3534,9 @@ value if you rely on the HLC for accuracy.`,
 				nullStr := stringOrNil(args[2])
 				return arrayToString(evalCtx, arr, delim, nullStr)
 			},
-			Info:         "Join an array into a string with a delimiter, replacing NULLs with a null string.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "Join an array into a string with a delimiter, replacing NULLs with a null string.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -3615,9 +3615,9 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.AppendToMaybeNullArray(typ, args[0], args[1])
 			},
-			Info:         "Appends `elem` to `array`, returning the result.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Appends `elem` to `array`, returning the result.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		}
 	})),
 
@@ -3635,9 +3635,9 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.PrependToMaybeNullArray(typ, args[0], args[1])
 			},
-			Info:         "Prepends `elem` to `array`, returning the result.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Prepends `elem` to `array`, returning the result.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		}
 	})),
 
@@ -3660,9 +3660,9 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.ConcatArrays(typ, args[0], args[1])
 			},
-			Info:         "Appends two arrays.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Appends two arrays.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		}
 	})),
 
@@ -3688,9 +3688,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return result, nil
 			},
-			Info:         "Remove from `array` all elements equal to `elem`.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Remove from `array` all elements equal to `elem`.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		}
 	})),
 
@@ -3720,9 +3720,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return result, nil
 			},
-			Info:         "Replace all occurrences of `toreplace` in `array` with `replacewith`.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Replace all occurrences of `toreplace` in `array` with `replacewith`.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		}
 	})),
 
@@ -3745,9 +3745,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return tree.DNull, nil
 			},
-			Info:         "Return the index of the first occurrence of `elem` in `array`.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Return the index of the first occurrence of `elem` in `array`.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		}
 	})),
 
@@ -3773,9 +3773,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return result, nil
 			},
-			Info:         "Returns and array of indexes of all occurrences of `elem` in `array`.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Returns and array of indexes of all occurrences of `elem` in `array`.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		}
 	})),
 
@@ -4174,8 +4174,8 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return tree.NewDBytes(tree.DBytes(out)), nil
 			},
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 	),
 	"crdb_internal.merge_statement_stats": makeBuiltin(arrayProps(),
@@ -4311,9 +4311,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return min, nil
 			},
-			Info:         "Returns the first value of the input enum type.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "Returns the first value of the input enum type.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -4333,9 +4333,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return max, nil
 			},
-			Info:         "Returns the last value of the input enum type.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "Returns the last value of the input enum type.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -4367,9 +4367,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return arr, nil
 			},
-			Info:         "Returns all values of the input enum in an ordered array.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "Returns all values of the input enum in an ordered array.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"lower", types.AnyEnum}, {"upper", types.AnyEnum}},
@@ -4435,9 +4435,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return arr, nil
 			},
-			Info:         "Returns all values of the input enum in an ordered array between the two arguments (inclusive).",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "Returns all values of the input enum in an ordered array between the two arguments (inclusive).",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -4915,9 +4915,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return args[0], nil
 			},
-			Info:         "Creates a new tenant with the provided ID. Must be run by the System tenant.",
-			Volatility:   volatility.Volatile,
-			NullableArgs: true,
+			Info:              "Creates a new tenant with the provided ID. Must be run by the System tenant.",
+			Volatility:        volatility.Volatile,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -5685,9 +5685,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return tree.NewDInt(tree.DInt(n)), nil
 			},
-			Info:         "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -5709,9 +5709,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return tree.NewDInt(tree.DInt(n)), nil
 			},
-			Info:         "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		}),
 	// Returns the number of distinct inverted index entries that would be
 	// generated for a value.
@@ -5725,9 +5725,9 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return jsonNumInvertedIndexEntries(ctx, args[0])
 			},
-			Info:         "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.AnyArray}},
@@ -5735,9 +5735,9 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return arrayNumInvertedIndexEntries(ctx, args[0], tree.DNull)
 			},
-			Info:         "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -5753,9 +5753,9 @@ value if you rely on the HLC for accuracy.`,
 				// arrays.)
 				return jsonNumInvertedIndexEntries(ctx, args[0])
 			},
-			Info:         "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -5774,9 +5774,9 @@ value if you rely on the HLC for accuracy.`,
 				s := string(tree.MustBeDString(args[0]))
 				return tree.NewDInt(tree.DInt(len(trigram.MakeTrigrams(s, true /* pad */)))), nil
 			},
-			Info:         "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -5787,9 +5787,9 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return arrayNumInvertedIndexEntries(ctx, args[0], args[1])
 			},
-			Info:         "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -5878,7 +5878,7 @@ value if you rely on the HLC for accuracy.`,
 			Volatility: volatility.Stable,
 			// The idiomatic usage of this function is to "pass" a target type T
 			// by passing NULL::T, so we must allow NULL arguments.
-			NullableArgs: true,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -6345,9 +6345,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return tree.NewDInt(tree.DInt(numNulls)), nil
 			},
-			Info:         "Returns the number of null arguments.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Returns the number of null arguments.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 	),
 	"num_nonnulls": makeBuiltin(
@@ -6368,9 +6368,9 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return tree.NewDInt(tree.DInt(numNonNulls)), nil
 			},
-			Info:         "Returns the number of nonnull arguments.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Info:              "Returns the number of nonnull arguments.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -7999,9 +7999,9 @@ var jsonBuildObjectImpl = tree.Overload{
 
 		return tree.NewDJSON(builder.Build()), nil
 	},
-	Info:         "Builds a JSON object out of a variadic argument list.",
-	Volatility:   volatility.Stable,
-	NullableArgs: true,
+	Info:              "Builds a JSON object out of a variadic argument list.",
+	Volatility:        volatility.Stable,
+	CalledOnNullInput: true,
 }
 
 var toJSONImpl = tree.Overload{
@@ -8057,9 +8057,9 @@ var jsonBuildArrayImpl = tree.Overload{
 		}
 		return tree.NewDJSON(builder.Build()), nil
 	},
-	Info:         "Builds a possibly-heterogeneously-typed JSON or JSONB array out of a variadic argument list.",
-	Volatility:   volatility.Stable,
-	NullableArgs: true,
+	Info:              "Builds a possibly-heterogeneously-typed JSON or JSONB array out of a variadic argument list.",
+	Volatility:        volatility.Stable,
+	CalledOnNullInput: true,
 }
 
 func jsonObjectImpls() builtinDefinition {
@@ -8168,7 +8168,7 @@ var jsonArrayLengthImpl = tree.Overload{
 	Volatility: volatility.Immutable,
 }
 
-func similarOverloads(nullableArgs bool) []tree.Overload {
+func similarOverloads(calledOnNullInput bool) []tree.Overload {
 	return []tree.Overload{
 		{
 			Types:      tree.ArgTypes{{"pattern", types.String}},
@@ -8180,9 +8180,9 @@ func similarOverloads(nullableArgs bool) []tree.Overload {
 				pattern := string(tree.MustBeDString(args[0]))
 				return eval.SimilarPattern(pattern, "")
 			},
-			Info:         "Converts a SQL regexp `pattern` to a POSIX regexp `pattern`.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: nullableArgs,
+			Info:              "Converts a SQL regexp `pattern` to a POSIX regexp `pattern`.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: calledOnNullInput,
 		},
 		{
 			Types:      tree.ArgTypes{{"pattern", types.String}, {"escape", types.String}},
@@ -8198,9 +8198,9 @@ func similarOverloads(nullableArgs bool) []tree.Overload {
 				escape := string(tree.MustBeDString(args[1]))
 				return eval.SimilarPattern(pattern, escape)
 			},
-			Info:         "Converts a SQL regexp `pattern` to a POSIX regexp `pattern` using `escape` as an escape token.",
-			Volatility:   volatility.Immutable,
-			NullableArgs: nullableArgs,
+			Info:              "Converts a SQL regexp `pattern` to a POSIX regexp `pattern` using `escape` as an escape token.",
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: calledOnNullInput,
 		},
 	}
 }
@@ -8403,9 +8403,9 @@ func hashBuiltin(newHash func() hash.Hash, info string) builtinDefinition {
 				}
 				return tree.NewDString(fmt.Sprintf("%x", h.Sum(nil))), nil
 			},
-			Info:         info,
-			Volatility:   volatility.Leakproof,
-			NullableArgs: true,
+			Info:              info,
+			Volatility:        volatility.Leakproof,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.Bytes},
@@ -8417,9 +8417,9 @@ func hashBuiltin(newHash func() hash.Hash, info string) builtinDefinition {
 				}
 				return tree.NewDString(fmt.Sprintf("%x", h.Sum(nil))), nil
 			},
-			Info:         info,
-			Volatility:   volatility.Leakproof,
-			NullableArgs: true,
+			Info:              info,
+			Volatility:        volatility.Leakproof,
+			CalledOnNullInput: true,
 		},
 	)
 }
@@ -8436,9 +8436,9 @@ func hash32Builtin(newHash func() hash.Hash32, info string) builtinDefinition {
 				}
 				return tree.NewDInt(tree.DInt(h.Sum32())), nil
 			},
-			Info:         info,
-			Volatility:   volatility.Leakproof,
-			NullableArgs: true,
+			Info:              info,
+			Volatility:        volatility.Leakproof,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.Bytes},
@@ -8450,9 +8450,9 @@ func hash32Builtin(newHash func() hash.Hash32, info string) builtinDefinition {
 				}
 				return tree.NewDInt(tree.DInt(h.Sum32())), nil
 			},
-			Info:         info,
-			Volatility:   volatility.Leakproof,
-			NullableArgs: true,
+			Info:              info,
+			Volatility:        volatility.Leakproof,
+			CalledOnNullInput: true,
 		},
 	)
 }
@@ -8469,9 +8469,9 @@ func hash64Builtin(newHash func() hash.Hash64, info string) builtinDefinition {
 				}
 				return tree.NewDInt(tree.DInt(h.Sum64())), nil
 			},
-			Info:         info,
-			Volatility:   volatility.Leakproof,
-			NullableArgs: true,
+			Info:              info,
+			Volatility:        volatility.Leakproof,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.Bytes},
@@ -8483,9 +8483,9 @@ func hash64Builtin(newHash func() hash.Hash64, info string) builtinDefinition {
 				}
 				return tree.NewDInt(tree.DInt(h.Sum64())), nil
 			},
-			Info:         info,
-			Volatility:   volatility.Leakproof,
-			NullableArgs: true,
+			Info:              info,
+			Volatility:        volatility.Leakproof,
+			CalledOnNullInput: true,
 		},
 	)
 }

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1497,9 +1497,10 @@ func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree
 		GeneratorWithExprs: gen,
 		Info:               info,
 		Volatility:         volatility.Stable,
-		// The typical way to call json_populate_record is to send NULL::atype as the
-		// first argument, so we have to accept nullable args.
-		NullableArgs: true,
+		// The typical way to call json_populate_record is to send NULL::atype
+		// as the first argument, so we have to call the function with NULL
+		// inputs.
+		CalledOnNullInput: true,
 	}
 }
 

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -1217,8 +1217,8 @@ SELECT ST_S2Covering(geography, 's2_max_level=15,s2_level_mod=3').
 			Info: infoBuilder{
 				info: "Return a Box2D from a GeoHash string with supplied precision.",
 			}.String(),
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 		tree.Overload{
 			Types: tree.ArgTypes{
@@ -1240,8 +1240,8 @@ SELECT ST_S2Covering(geography, 's2_max_level=15,s2_level_mod=3').
 			Info: infoBuilder{
 				info: "Return a Box2D from a GeoHash string with max precision.",
 			}.String(),
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -6104,8 +6104,8 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 			Info: infoBuilder{
 				info: "Combines the current bounding box with the bounding box of the Geometry.",
 			}.String(),
-			Volatility:   volatility.Immutable,
-			NullableArgs: true,
+			Volatility:        volatility.Immutable,
+			CalledOnNullInput: true,
 		},
 	),
 	"st_expand": makeBuiltin(

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -829,9 +829,9 @@ var pgBuiltins = map[string]builtinDefinition{
 			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(args[0].ResolvedType().SQLStandardName()), nil
 			},
-			Info:         notUsableInfo,
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Info:              notUsableInfo,
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 	),
 
@@ -960,8 +960,8 @@ var pgBuiltins = map[string]builtinDefinition{
 			Info: "Returns the SQL name of a data type that is " +
 				"identified by its type OID and possibly a type modifier. " +
 				"Currently, the type modifier is ignored.",
-			Volatility:   volatility.Stable,
-			NullableArgs: true,
+			Volatility:        volatility.Stable,
+			CalledOnNullInput: true,
 		},
 	),
 

--- a/pkg/sql/sem/eval/comparison.go
+++ b/pkg/sql/sem/eval/comparison.go
@@ -25,7 +25,7 @@ func ComparisonExprWithSubOperator(
 ) (tree.Datum, error) {
 	var datums tree.Datums
 	// Right is either a tuple or an array of Datums.
-	if !expr.Op.NullableArgs && right == tree.DNull {
+	if !expr.Op.CalledOnNullInput && right == tree.DNull {
 		return tree.DNull, nil
 	} else if tuple, ok := tree.AsDTuple(right); ok {
 		datums = tuple.D

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -101,14 +101,14 @@ func (e *evaluator) EvalBinaryExpr(expr *tree.BinaryExpr) (tree.Datum, error) {
 	if err != nil {
 		return nil, err
 	}
-	if left == tree.DNull && !expr.Op.NullableArgs {
+	if left == tree.DNull && !expr.Op.CalledOnNullInput {
 		return tree.DNull, nil
 	}
 	right, err := expr.Right.(tree.TypedExpr).Eval(e)
 	if err != nil {
 		return nil, err
 	}
-	if right == tree.DNull && !expr.Op.NullableArgs {
+	if right == tree.DNull && !expr.Op.CalledOnNullInput {
 		return tree.DNull, nil
 	}
 	res, err := expr.Op.EvalOp.Eval(e, left, right)
@@ -247,7 +247,7 @@ func (e *evaluator) EvalComparisonExpr(expr *tree.ComparisonExpr) (tree.Datum, e
 	}
 
 	_, newLeft, newRight, _, not := tree.FoldComparisonExpr(op, left, right)
-	if !expr.Op.NullableArgs && (newLeft == tree.DNull || newRight == tree.DNull) {
+	if !expr.Op.CalledOnNullInput && (newLeft == tree.DNull || newRight == tree.DNull) {
 		return tree.DNull, nil
 	}
 	d, err := expr.Op.EvalOp.Eval(e, newLeft.(tree.Datum), newRight.(tree.Datum))
@@ -477,7 +477,7 @@ func (e *evaluator) evalFuncArgs(
 		if err != nil {
 			return false, nil, err
 		}
-		if arg == tree.DNull && !expr.ResolvedOverload().NullableArgs {
+		if arg == tree.DNull && !expr.ResolvedOverload().CalledOnNullInput {
 			return true, nil, nil
 		}
 		args[i] = arg

--- a/pkg/sql/sem/normalize/normalize_exprs.go
+++ b/pkg/sql/sem/normalize/normalize_exprs.go
@@ -103,7 +103,7 @@ func normalizeBinaryExpr(v *Visitor, expr *tree.BinaryExpr) tree.TypedExpr {
 	right := expr.TypedRight()
 	expectedType := expr.ResolvedType()
 
-	if !expr.Op.NullableArgs && (left == tree.DNull || right == tree.DNull) {
+	if !expr.Op.CalledOnNullInput && (left == tree.DNull || right == tree.DNull) {
 		return tree.DNull
 	}
 

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -155,21 +155,21 @@ type Overload struct {
 	// cannot be recovered.
 	DistsqlBlocklist bool
 
-	// NullableArgs is set to true when a function's definition can handle NULL
-	// arguments. When set to true, the function will be given the chance to see NULL
-	// arguments.
+	// CalledOnNullInput is set to true when a function is called when any of
+	// its inputs are NULL. When true, the function implementation must be able
+	// to handle NULL arguments.
 	//
 	// When set to false, the function will directly result in NULL in the
 	// presence of any NULL arguments without evaluating the function's
-	// implementation defined in Overload.Fn. Therefore, if the function is
-	// expected to produce side-effects with a NULL argument, NullableArgs must
-	// be true. Note that if this behavior changes so that NullableArgs=false
-	// functions can produce side-effects, the FoldFunctionWithNullArg optimizer
-	// rule must be changed to avoid folding those functions.
+	// implementation. Therefore, if the function is expected to produce
+	// side-effects with a NULL argument, CalledOnNullInput must be true. Note
+	// that if this behavior changes so that CalledOnNullInput=false functions
+	// can produce side-effects, the FoldFunctionWithNullArg optimizer rule must
+	// be changed to avoid folding those functions.
 	//
 	// NOTE: when set, a function should be prepared for any of its arguments to
 	// be NULL and should act accordingly.
-	NullableArgs bool
+	CalledOnNullInput bool
 
 	// FunctionProperties are the properties of this overload.
 	FunctionProperties

--- a/pkg/sql/sem/tree/typing_test.go
+++ b/pkg/sql/sem/tree/typing_test.go
@@ -22,7 +22,7 @@ import (
 // assumptions we're making in the type inference code:
 //   1. The return type can be inferred from the operator type and the data
 //      types of its operands.
-//   2. When of the operands is null, and if NullableArgs is true, then the
+//   2. When of the operands is null, and if CalledOnNullInput is true, then the
 //      return type can be inferred from just the non-null operand.
 func TestTypingBinaryAssumptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -47,14 +47,14 @@ func TestTypingBinaryAssumptions(t *testing.T) {
 
 			// Handle ops that allow null operands. Check for ambiguity where
 			// the return type cannot be inferred from the non-null operand.
-			if op.NullableArgs {
+			if op.CalledOnNullInput {
 				for i2, overload2 := range overloads {
 					if i == i2 {
 						continue
 					}
 
 					op2 := overload2.(*tree.BinOp)
-					if !op2.NullableArgs {
+					if !op2.CalledOnNullInput {
 						continue
 					}
 


### PR DESCRIPTION
#### sql: rename NullableArgs to CalledOnNullInput

Previously, the `Overload.NullableArgs` boolean indicated whether or not
a function was evaluated in the presence of `NULL` inputs. This name was
confusing because it did not describe the behavior of the function.
Arguments to all functions can be `NULL` (i.e., "nullable") so the
difference between `NullableArgs` being `true` and `false` was unclear
without reading the detailed description of the field.

This commit renames the field, and all related variables throughout the
codebase, to `CalledOnNullInput`, making it clear that `true` indicates
that the function is called if any inputs are `NULL`, and `false`
indicates that the function is not called if any inputs are `NULL`. This
name also maps more closely to SQL syntax such as
`CREATE FUNCTION ... CALLED ON NULL INPUT ...`.

Release note: None

#### sql: correctly populate pg_proc.proisstrict

The `pg_proc.proisstrict` column, which is the inverse of
`Overload.CalledOnNullInput`, is now correctly populated instead of
always being `false`. From the PG docs:

    proisstrict bool
    Function returns null if any call argument is null. In that case the
    function won't actually be called at all. Functions that are not
    "strict" must be prepared to handle null inputs.

Release note (sql change): The `pg_proc.proisstrict` column is now
correctly populated instead of always being `false`. If this column is
`true`, it indicates that the function will not be called if any of its
inputs are `NULL`. Instead, it will directly evaluate to `NULL`.
