### PR TITLE
colexec: reorder some fields to reduce memory footprint

### DIFF
--- a/pkg/sql/colexec/colexecargs/expr.go
+++ b/pkg/sql/colexec/colexecargs/expr.go
@@ -33,8 +33,8 @@ func NewExprHelper() *ExprHelper {
 // ExprHelper is a utility struct that helps with expression handling in the
 // vectorized engine.
 type ExprHelper struct {
-	helper  execinfrapb.ExprHelper
 	SemaCtx *tree.SemaContext
+	helper  execinfrapb.ExprHelper
 }
 
 // ProcessExpr processes the given expression and returns a well-typed

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -1122,13 +1122,12 @@ func IsCastSupported(fromType, toType *types.T) bool {
 }
 
 type castOpBase struct {
-	colexecop.OneInputInitCloserHelper
-
 	allocator *colmem.Allocator
-	colIdx    int
-	outputIdx int
 	evalCtx   *eval.Context
 	buf       bytes.Buffer
+	colexecop.OneInputInitCloserHelper
+	colIdx    int
+	outputIdx int
 }
 
 func (c *castOpBase) Reset(ctx context.Context) {

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -230,13 +230,12 @@ func IsCastSupported(fromType, toType *types.T) bool {
 }
 
 type castOpBase struct {
-	colexecop.OneInputInitCloserHelper
-
 	allocator *colmem.Allocator
-	colIdx    int
-	outputIdx int
 	evalCtx   *eval.Context
 	buf       bytes.Buffer
+	colexecop.OneInputInitCloserHelper
+	colIdx    int
+	outputIdx int
 }
 
 func (c *castOpBase) Reset(ctx context.Context) {

--- a/pkg/sql/colexec/colexecbase/distinct.eg.go
+++ b/pkg/sql/colexec/colexecbase/distinct.eg.go
@@ -156,6 +156,8 @@ func newSingleDistinct(
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctBoolOp struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -163,8 +165,6 @@ type distinctBoolOp struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal bool
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -435,6 +435,8 @@ func (p *distinctBoolOp) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctBytesOp struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -442,8 +444,6 @@ type distinctBytesOp struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal []byte
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -678,6 +678,8 @@ func (p *distinctBytesOp) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctDecimalOp struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -685,8 +687,6 @@ type distinctDecimalOp struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal apd.Decimal
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -925,6 +925,8 @@ func (p *distinctDecimalOp) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctInt16Op struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -932,8 +934,6 @@ type distinctInt16Op struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal int16
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -1216,6 +1216,8 @@ func (p *distinctInt16Op) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctInt32Op struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -1223,8 +1225,6 @@ type distinctInt32Op struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal int32
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -1507,6 +1507,8 @@ func (p *distinctInt32Op) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctInt64Op struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -1514,8 +1516,6 @@ type distinctInt64Op struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal int64
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -1798,6 +1798,8 @@ func (p *distinctInt64Op) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctFloat64Op struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -1805,8 +1807,6 @@ type distinctFloat64Op struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal float64
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -2121,6 +2121,8 @@ func (p *distinctFloat64Op) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctTimestampOp struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -2128,8 +2130,6 @@ type distinctTimestampOp struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal time.Time
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -2396,6 +2396,8 @@ func (p *distinctTimestampOp) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctIntervalOp struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -2403,8 +2405,6 @@ type distinctIntervalOp struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal duration.Duration
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -2643,6 +2643,8 @@ func (p *distinctIntervalOp) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctJSONOp struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -2650,8 +2652,6 @@ type distinctJSONOp struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal json.JSON
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int
@@ -2921,6 +2921,8 @@ func (p *distinctJSONOp) Next() coldata.Batch {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinctDatumOp struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -2928,8 +2930,6 @@ type distinctDatumOp struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal interface{}
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int

--- a/pkg/sql/colexec/colexecbase/distinct_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/distinct_tmpl.go
@@ -139,6 +139,8 @@ func newPartitioner(t *types.T, nullsAreDistinct bool) partitioner {
 // true to the resultant bool column for every value that differs from the
 // previous one.
 type distinct_TYPEOp struct {
+	colexecop.OneInputHelper
+
 	// outputCol is the boolean output column. It is shared by all of the
 	// other distinct operators in a distinct operator set.
 	outputCol []bool
@@ -146,8 +148,6 @@ type distinct_TYPEOp struct {
 	// lastVal is the last value seen by the operator, so that the distincting
 	// still works across batch boundaries.
 	lastVal _GOTYPE
-
-	colexecop.OneInputHelper
 
 	// distinctColIdx is the index of the column to distinct upon.
 	distinctColIdx int

--- a/pkg/sql/colexec/colexecbase/simple_project.go
+++ b/pkg/sql/colexec/colexecbase/simple_project.go
@@ -22,11 +22,10 @@ import (
 // simpleProjectOp is an operator that implements "simple projection" - removal of
 // columns that aren't needed by later operators.
 type simpleProjectOp struct {
-	colexecop.OneInputInitCloserHelper
 	colexecop.NonExplainable
-
+	batches map[coldata.Batch]*projectingBatch
+	colexecop.OneInputInitCloserHelper
 	projection []uint32
-	batches    map[coldata.Batch]*projectingBatch
 	// numBatchesLoggingThreshold is the threshold on the number of items in
 	// 'batches' map at which we will log a message when a new projectingBatch
 	// is created. It is growing exponentially.

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -813,8 +813,8 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 }
 
 type projBitandDatumDatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projBitandDatumDatumOp) Next() coldata.Batch {
@@ -1680,8 +1680,8 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 }
 
 type projBitorDatumDatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projBitorDatumDatumOp) Next() coldata.Batch {
@@ -2547,8 +2547,8 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 }
 
 type projBitxorDatumDatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projBitxorDatumDatumOp) Next() coldata.Batch {
@@ -3542,8 +3542,8 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 }
 
 type projPlusInt16DatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projPlusInt16DatumOp) Next() coldata.Batch {
@@ -4110,8 +4110,8 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 }
 
 type projPlusInt32DatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projPlusInt32DatumOp) Next() coldata.Batch {
@@ -4678,8 +4678,8 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 }
 
 type projPlusInt64DatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projPlusInt64DatumOp) Next() coldata.Batch {
@@ -5170,8 +5170,8 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 }
 
 type projPlusIntervalDatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projPlusIntervalDatumOp) Next() coldata.Batch {
@@ -5298,8 +5298,8 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 }
 
 type projPlusDatumIntervalOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projPlusDatumIntervalOp) Next() coldata.Batch {
@@ -5426,8 +5426,8 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 }
 
 type projPlusDatumInt16Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projPlusDatumInt16Op) Next() coldata.Batch {
@@ -5554,8 +5554,8 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 }
 
 type projPlusDatumInt32Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projPlusDatumInt32Op) Next() coldata.Batch {
@@ -5682,8 +5682,8 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 }
 
 type projPlusDatumInt64Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projPlusDatumInt64Op) Next() coldata.Batch {
@@ -6694,8 +6694,8 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 }
 
 type projMinusInt16DatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusInt16DatumOp) Next() coldata.Batch {
@@ -7262,8 +7262,8 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 }
 
 type projMinusInt32DatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusInt32DatumOp) Next() coldata.Batch {
@@ -7830,8 +7830,8 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 }
 
 type projMinusInt64DatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusInt64DatumOp) Next() coldata.Batch {
@@ -8314,8 +8314,8 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 }
 
 type projMinusIntervalDatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusIntervalDatumOp) Next() coldata.Batch {
@@ -8832,8 +8832,8 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 }
 
 type projMinusDatumDatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusDatumDatumOp) Next() coldata.Batch {
@@ -8943,8 +8943,8 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 }
 
 type projMinusDatumIntervalOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusDatumIntervalOp) Next() coldata.Batch {
@@ -9071,8 +9071,8 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 }
 
 type projMinusDatumBytesOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusDatumBytesOp) Next() coldata.Batch {
@@ -9197,8 +9197,8 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 }
 
 type projMinusDatumInt16Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusDatumInt16Op) Next() coldata.Batch {
@@ -9325,8 +9325,8 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 }
 
 type projMinusDatumInt32Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusDatumInt32Op) Next() coldata.Batch {
@@ -9453,8 +9453,8 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 }
 
 type projMinusDatumInt64Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projMinusDatumInt64Op) Next() coldata.Batch {
@@ -21205,8 +21205,8 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 }
 
 type projConcatDatumDatumOp struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projConcatDatumDatumOp) Next() coldata.Batch {
@@ -22288,8 +22288,8 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 }
 
 type projLShiftDatumInt16Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projLShiftDatumInt16Op) Next() coldata.Batch {
@@ -22416,8 +22416,8 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 }
 
 type projLShiftDatumInt32Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projLShiftDatumInt32Op) Next() coldata.Batch {
@@ -22544,8 +22544,8 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 }
 
 type projLShiftDatumInt64Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projLShiftDatumInt64Op) Next() coldata.Batch {
@@ -23644,8 +23644,8 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 }
 
 type projRShiftDatumInt16Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projRShiftDatumInt16Op) Next() coldata.Batch {
@@ -23772,8 +23772,8 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 }
 
 type projRShiftDatumInt32Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projRShiftDatumInt32Op) Next() coldata.Batch {
@@ -23900,8 +23900,8 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 }
 
 type projRShiftDatumInt64Op struct {
-	projOpBase
 	colexecutils.BinaryOverloadHelper
+	projOpBase
 }
 
 func (p projRShiftDatumInt64Op) Next() coldata.Batch {

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -89,10 +89,10 @@ type projOpBase struct {
 // {{define "projOp"}}
 
 type _OP_NAME struct {
-	projOpBase
 	// {{if .NeedsBinaryOverloadHelper}}
 	colexecutils.BinaryOverloadHelper
 	// {{end}}
+	projOpBase
 }
 
 func (p _OP_NAME) Next() coldata.Batch {

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -730,8 +730,8 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 }
 
 type projBitandDatumConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -1518,8 +1518,8 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 }
 
 type projBitorDatumConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -2306,8 +2306,8 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 }
 
 type projBitxorDatumConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -3230,8 +3230,8 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 }
 
 type projPlusInt16ConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int16
 }
 
@@ -3760,8 +3760,8 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 }
 
 type projPlusInt32ConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int32
 }
 
@@ -4290,8 +4290,8 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 }
 
 type projPlusInt64ConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int64
 }
 
@@ -4744,8 +4744,8 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 }
 
 type projPlusIntervalConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg duration.Duration
 }
 
@@ -4866,8 +4866,8 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 }
 
 type projPlusDatumConstIntervalOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -4986,8 +4986,8 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 }
 
 type projPlusDatumConstInt16Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -5106,8 +5106,8 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 }
 
 type projPlusDatumConstInt32Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -5226,8 +5226,8 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 }
 
 type projPlusDatumConstInt64Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -6166,8 +6166,8 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 }
 
 type projMinusInt16ConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int16
 }
 
@@ -6696,8 +6696,8 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 }
 
 type projMinusInt32ConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int32
 }
 
@@ -7226,8 +7226,8 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 }
 
 type projMinusInt64ConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int64
 }
 
@@ -7672,8 +7672,8 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 }
 
 type projMinusIntervalConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg duration.Duration
 }
 
@@ -8154,8 +8154,8 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 }
 
 type projMinusDatumConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -8258,8 +8258,8 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 }
 
 type projMinusDatumConstIntervalOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -8378,8 +8378,8 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 }
 
 type projMinusDatumConstBytesOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -8498,8 +8498,8 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 }
 
 type projMinusDatumConstInt16Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -8618,8 +8618,8 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 }
 
 type projMinusDatumConstInt32Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -8738,8 +8738,8 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 }
 
 type projMinusDatumConstInt64Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -19678,8 +19678,8 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 }
 
 type projConcatDatumConstDatumOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -20682,8 +20682,8 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 }
 
 type projLShiftDatumConstInt16Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -20802,8 +20802,8 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 }
 
 type projLShiftDatumConstInt32Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -20922,8 +20922,8 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 }
 
 type projLShiftDatumConstInt64Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -21942,8 +21942,8 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 }
 
 type projRShiftDatumConstInt16Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -22062,8 +22062,8 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 }
 
 type projRShiftDatumConstInt32Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -22182,8 +22182,8 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 }
 
 type projRShiftDatumConstInt64Op struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
@@ -84,10 +84,10 @@ func _ASSIGN(_, _, _, _, _, _ interface{}) {
 // {{define "projConstOp"}}
 
 type _OP_CONST_NAME struct {
-	projConstOpBase
 	// {{if .NeedsBinaryOverloadHelper}}
 	colexecutils.BinaryOverloadHelper
 	// {{end}}
+	projConstOpBase
 	// {{if _IS_CONST_LEFT}}
 	constArg _L_GO_TYPE
 	// {{else}}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -733,8 +733,8 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 }
 
 type projBitandDatumDatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -1521,8 +1521,8 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 }
 
 type projBitorDatumDatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -2309,8 +2309,8 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 }
 
 type projBitxorDatumDatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -3233,8 +3233,8 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 }
 
 type projPlusInt16DatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -3761,8 +3761,8 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 }
 
 type projPlusInt32DatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -4289,8 +4289,8 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 }
 
 type projPlusInt64DatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -4741,8 +4741,8 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 }
 
 type projPlusIntervalDatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -4861,8 +4861,8 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 }
 
 type projPlusDatumIntervalConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg duration.Duration
 }
 
@@ -4983,8 +4983,8 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 }
 
 type projPlusDatumInt16ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int16
 }
 
@@ -5105,8 +5105,8 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 }
 
 type projPlusDatumInt32ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int32
 }
 
@@ -5227,8 +5227,8 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 }
 
 type projPlusDatumInt64ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int64
 }
 
@@ -6169,8 +6169,8 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 }
 
 type projMinusInt16DatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -6697,8 +6697,8 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 }
 
 type projMinusInt32DatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -7225,8 +7225,8 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 }
 
 type projMinusInt64DatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -7669,8 +7669,8 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 }
 
 type projMinusIntervalDatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -8155,8 +8155,8 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 }
 
 type projMinusDatumDatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -8259,8 +8259,8 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 }
 
 type projMinusDatumIntervalConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg duration.Duration
 }
 
@@ -8381,8 +8381,8 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 }
 
 type projMinusDatumBytesConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg []byte
 }
 
@@ -8501,8 +8501,8 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 }
 
 type projMinusDatumInt16ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int16
 }
 
@@ -8623,8 +8623,8 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 }
 
 type projMinusDatumInt32ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int32
 }
 
@@ -8745,8 +8745,8 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 }
 
 type projMinusDatumInt64ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int64
 }
 
@@ -19687,8 +19687,8 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 }
 
 type projConcatDatumDatumConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg interface{}
 }
 
@@ -20691,8 +20691,8 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 }
 
 type projLShiftDatumInt16ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int16
 }
 
@@ -20813,8 +20813,8 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 }
 
 type projLShiftDatumInt32ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int32
 }
 
@@ -20935,8 +20935,8 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 }
 
 type projLShiftDatumInt64ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int64
 }
 
@@ -21957,8 +21957,8 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 }
 
 type projRShiftDatumInt16ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int16
 }
 
@@ -22079,8 +22079,8 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 }
 
 type projRShiftDatumInt32ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int32
 }
 
@@ -22201,8 +22201,8 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 }
 
 type projRShiftDatumInt64ConstOp struct {
-	projConstOpBase
 	colexecutils.BinaryOverloadHelper
+	projConstOpBase
 	constArg int64
 }
 

--- a/pkg/sql/colexec/colexecspan/span_encoder.eg.go
+++ b/pkg/sql/colexec/colexecspan/span_encoder.eg.go
@@ -167,8 +167,7 @@ type spanEncoder interface {
 }
 
 type spanEncoderBase struct {
-	allocator    *colmem.Allocator
-	encodeColIdx int
+	allocator *colmem.Allocator
 
 	// outputBytes contains the encoding for each row of the key column. It is
 	// reused between calls to next().
@@ -177,6 +176,8 @@ type spanEncoderBase struct {
 	// A scratch bytes slice used to hold each encoding before it is appended to
 	// the output column. It is reused to avoid allocating for every row.
 	scratch []byte
+
+	encodeColIdx int
 }
 
 type spanEncoderBoolAsc struct {

--- a/pkg/sql/colexec/colexecspan/span_encoder_tmpl.go
+++ b/pkg/sql/colexec/colexecspan/span_encoder_tmpl.go
@@ -99,8 +99,7 @@ type spanEncoder interface {
 }
 
 type spanEncoderBase struct {
-	allocator    *colmem.Allocator
-	encodeColIdx int
+	allocator *colmem.Allocator
 
 	// outputBytes contains the encoding for each row of the key column. It is
 	// reused between calls to next().
@@ -109,6 +108,8 @@ type spanEncoderBase struct {
 	// A scratch bytes slice used to hold each encoding before it is appended to
 	// the output column. It is reused to avoid allocating for every row.
 	scratch []byte
+
+	encodeColIdx int
 }
 
 // {{range .}}

--- a/pkg/sql/colexec/colexecutils/operator.go
+++ b/pkg/sql/colexec/colexecutils/operator.go
@@ -113,12 +113,11 @@ func (s *fixedNumTuplesNoInputOp) Next() coldata.Batch {
 //   ---------------------              in column at position of N+1)
 //
 type vectorTypeEnforcer struct {
-	colexecop.OneInputInitCloserHelper
 	colexecop.NonExplainable
-
 	allocator *colmem.Allocator
 	typ       *types.T
-	idx       int
+	colexecop.OneInputInitCloserHelper
+	idx int
 }
 
 var _ colexecop.ResettableOperator = &vectorTypeEnforcer{}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -34,9 +34,9 @@ import (
 // message originated from.
 // Note that either a batch or metadata must be sent, but not both.
 type unorderedSynchronizerMsg struct {
-	inputIdx int
 	b        coldata.Batch
 	meta     []execinfrapb.ProducerMetadata
+	inputIdx int
 }
 
 var _ colexecop.Operator = &ParallelUnorderedSynchronizer{}

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -355,8 +355,8 @@ func GetInOperator(
 
 type selectInOpBool struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []bool
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -366,9 +366,9 @@ var _ colexecop.Operator = &selectInOpBool{}
 type projectInOpBool struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []bool
 	colIdx    int
 	outputIdx int
-	filterRow []bool
 	hasNulls  bool
 	negate    bool
 }
@@ -589,8 +589,8 @@ func (pi *projectInOpBool) Next() coldata.Batch {
 
 type selectInOpBytes struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow [][]byte
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -600,9 +600,9 @@ var _ colexecop.Operator = &selectInOpBytes{}
 type projectInOpBytes struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow [][]byte
 	colIdx    int
 	outputIdx int
-	filterRow [][]byte
 	hasNulls  bool
 	negate    bool
 }
@@ -811,8 +811,8 @@ func (pi *projectInOpBytes) Next() coldata.Batch {
 
 type selectInOpDecimal struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []apd.Decimal
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -822,9 +822,9 @@ var _ colexecop.Operator = &selectInOpDecimal{}
 type projectInOpDecimal struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []apd.Decimal
 	colIdx    int
 	outputIdx int
-	filterRow []apd.Decimal
 	hasNulls  bool
 	negate    bool
 }
@@ -1037,8 +1037,8 @@ func (pi *projectInOpDecimal) Next() coldata.Batch {
 
 type selectInOpInt16 struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []int16
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -1048,9 +1048,9 @@ var _ colexecop.Operator = &selectInOpInt16{}
 type projectInOpInt16 struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []int16
 	colIdx    int
 	outputIdx int
-	filterRow []int16
 	hasNulls  bool
 	negate    bool
 }
@@ -1274,8 +1274,8 @@ func (pi *projectInOpInt16) Next() coldata.Batch {
 
 type selectInOpInt32 struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []int32
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -1285,9 +1285,9 @@ var _ colexecop.Operator = &selectInOpInt32{}
 type projectInOpInt32 struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []int32
 	colIdx    int
 	outputIdx int
-	filterRow []int32
 	hasNulls  bool
 	negate    bool
 }
@@ -1511,8 +1511,8 @@ func (pi *projectInOpInt32) Next() coldata.Batch {
 
 type selectInOpInt64 struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []int64
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -1522,9 +1522,9 @@ var _ colexecop.Operator = &selectInOpInt64{}
 type projectInOpInt64 struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []int64
 	colIdx    int
 	outputIdx int
-	filterRow []int64
 	hasNulls  bool
 	negate    bool
 }
@@ -1748,8 +1748,8 @@ func (pi *projectInOpInt64) Next() coldata.Batch {
 
 type selectInOpFloat64 struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []float64
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -1759,9 +1759,9 @@ var _ colexecop.Operator = &selectInOpFloat64{}
 type projectInOpFloat64 struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []float64
 	colIdx    int
 	outputIdx int
-	filterRow []float64
 	hasNulls  bool
 	negate    bool
 }
@@ -1993,8 +1993,8 @@ func (pi *projectInOpFloat64) Next() coldata.Batch {
 
 type selectInOpTimestamp struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []time.Time
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -2004,9 +2004,9 @@ var _ colexecop.Operator = &selectInOpTimestamp{}
 type projectInOpTimestamp struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []time.Time
 	colIdx    int
 	outputIdx int
-	filterRow []time.Time
 	hasNulls  bool
 	negate    bool
 }
@@ -2226,8 +2226,8 @@ func (pi *projectInOpTimestamp) Next() coldata.Batch {
 
 type selectInOpInterval struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []duration.Duration
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -2237,9 +2237,9 @@ var _ colexecop.Operator = &selectInOpInterval{}
 type projectInOpInterval struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []duration.Duration
 	colIdx    int
 	outputIdx int
-	filterRow []duration.Duration
 	hasNulls  bool
 	negate    bool
 }
@@ -2452,8 +2452,8 @@ func (pi *projectInOpInterval) Next() coldata.Batch {
 
 type selectInOpJSON struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []json.JSON
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -2463,9 +2463,9 @@ var _ colexecop.Operator = &selectInOpJSON{}
 type projectInOpJSON struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []json.JSON
 	colIdx    int
 	outputIdx int
-	filterRow []json.JSON
 	hasNulls  bool
 	negate    bool
 }
@@ -2680,8 +2680,8 @@ func (pi *projectInOpJSON) Next() coldata.Batch {
 
 type selectInOpDatum struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []interface{}
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -2691,9 +2691,9 @@ var _ colexecop.Operator = &selectInOpDatum{}
 type projectInOpDatum struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []interface{}
 	colIdx    int
 	outputIdx int
-	filterRow []interface{}
 	hasNulls  bool
 	negate    bool
 }

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -146,8 +146,8 @@ func GetInOperator(
 
 type selectInOp_TYPE struct {
 	colexecop.OneInputHelper
-	colIdx    int
 	filterRow []_GOTYPE
+	colIdx    int
 	hasNulls  bool
 	negate    bool
 }
@@ -157,9 +157,9 @@ var _ colexecop.Operator = &selectInOp_TYPE{}
 type projectInOp_TYPE struct {
 	colexecop.OneInputHelper
 	allocator *colmem.Allocator
+	filterRow []_GOTYPE
 	colIdx    int
 	outputIdx int
-	filterRow []_GOTYPE
 	hasNulls  bool
 	negate    bool
 }

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -296,10 +296,10 @@ func newSingleSorterWithoutNulls(t *types.T, dir execinfrapb.Ordering_Column_Dir
 }
 
 type sortBoolAscWithNullsOp struct {
-	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Bools
+	order         []int
 }
 
 func (s *sortBoolAscWithNullsOp) init(
@@ -384,12 +384,12 @@ func (s *sortBoolAscWithNullsOp) Len() int {
 }
 
 type sortBytesAscWithNullsOp struct {
-	sortCol            *coldata.Bytes
 	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	nulls              *coldata.Nulls
-	order              []int
 	cancelChecker      colexecutils.CancelChecker
+	sortCol            *coldata.Bytes
+	order              []int
 }
 
 func (s *sortBytesAscWithNullsOp) init(
@@ -481,10 +481,10 @@ func (s *sortBytesAscWithNullsOp) Len() int {
 }
 
 type sortDecimalAscWithNullsOp struct {
-	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Decimals
+	order         []int
 }
 
 func (s *sortDecimalAscWithNullsOp) init(
@@ -561,10 +561,10 @@ func (s *sortDecimalAscWithNullsOp) Len() int {
 }
 
 type sortInt16AscWithNullsOp struct {
-	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int16s
+	order         []int
 }
 
 func (s *sortInt16AscWithNullsOp) init(
@@ -652,10 +652,10 @@ func (s *sortInt16AscWithNullsOp) Len() int {
 }
 
 type sortInt32AscWithNullsOp struct {
-	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int32s
+	order         []int
 }
 
 func (s *sortInt32AscWithNullsOp) init(
@@ -743,10 +743,10 @@ func (s *sortInt32AscWithNullsOp) Len() int {
 }
 
 type sortInt64AscWithNullsOp struct {
-	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int64s
+	order         []int
 }
 
 func (s *sortInt64AscWithNullsOp) init(
@@ -834,10 +834,10 @@ func (s *sortInt64AscWithNullsOp) Len() int {
 }
 
 type sortFloat64AscWithNullsOp struct {
-	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Float64s
+	order         []int
 }
 
 func (s *sortFloat64AscWithNullsOp) init(
@@ -933,10 +933,10 @@ func (s *sortFloat64AscWithNullsOp) Len() int {
 }
 
 type sortTimestampAscWithNullsOp struct {
-	sortCol       coldata.Times
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Times
+	order         []int
 }
 
 func (s *sortTimestampAscWithNullsOp) init(
@@ -1020,10 +1020,10 @@ func (s *sortTimestampAscWithNullsOp) Len() int {
 }
 
 type sortIntervalAscWithNullsOp struct {
-	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Durations
+	order         []int
 }
 
 func (s *sortIntervalAscWithNullsOp) init(
@@ -1100,10 +1100,10 @@ func (s *sortIntervalAscWithNullsOp) Len() int {
 }
 
 type sortJSONAscWithNullsOp struct {
-	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       *coldata.JSONs
+	order         []int
 }
 
 func (s *sortJSONAscWithNullsOp) init(
@@ -1186,10 +1186,10 @@ func (s *sortJSONAscWithNullsOp) Len() int {
 }
 
 type sortDatumAscWithNullsOp struct {
-	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.DatumVec
+	order         []int
 }
 
 func (s *sortDatumAscWithNullsOp) init(
@@ -1268,10 +1268,10 @@ func (s *sortDatumAscWithNullsOp) Len() int {
 }
 
 type sortBoolDescWithNullsOp struct {
-	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Bools
+	order         []int
 }
 
 func (s *sortBoolDescWithNullsOp) init(
@@ -1356,12 +1356,12 @@ func (s *sortBoolDescWithNullsOp) Len() int {
 }
 
 type sortBytesDescWithNullsOp struct {
-	sortCol            *coldata.Bytes
 	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	nulls              *coldata.Nulls
-	order              []int
 	cancelChecker      colexecutils.CancelChecker
+	sortCol            *coldata.Bytes
+	order              []int
 }
 
 func (s *sortBytesDescWithNullsOp) init(
@@ -1453,10 +1453,10 @@ func (s *sortBytesDescWithNullsOp) Len() int {
 }
 
 type sortDecimalDescWithNullsOp struct {
-	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Decimals
+	order         []int
 }
 
 func (s *sortDecimalDescWithNullsOp) init(
@@ -1533,10 +1533,10 @@ func (s *sortDecimalDescWithNullsOp) Len() int {
 }
 
 type sortInt16DescWithNullsOp struct {
-	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int16s
+	order         []int
 }
 
 func (s *sortInt16DescWithNullsOp) init(
@@ -1624,10 +1624,10 @@ func (s *sortInt16DescWithNullsOp) Len() int {
 }
 
 type sortInt32DescWithNullsOp struct {
-	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int32s
+	order         []int
 }
 
 func (s *sortInt32DescWithNullsOp) init(
@@ -1715,10 +1715,10 @@ func (s *sortInt32DescWithNullsOp) Len() int {
 }
 
 type sortInt64DescWithNullsOp struct {
-	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int64s
+	order         []int
 }
 
 func (s *sortInt64DescWithNullsOp) init(
@@ -1806,10 +1806,10 @@ func (s *sortInt64DescWithNullsOp) Len() int {
 }
 
 type sortFloat64DescWithNullsOp struct {
-	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Float64s
+	order         []int
 }
 
 func (s *sortFloat64DescWithNullsOp) init(
@@ -1905,10 +1905,10 @@ func (s *sortFloat64DescWithNullsOp) Len() int {
 }
 
 type sortTimestampDescWithNullsOp struct {
-	sortCol       coldata.Times
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Times
+	order         []int
 }
 
 func (s *sortTimestampDescWithNullsOp) init(
@@ -1992,10 +1992,10 @@ func (s *sortTimestampDescWithNullsOp) Len() int {
 }
 
 type sortIntervalDescWithNullsOp struct {
-	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Durations
+	order         []int
 }
 
 func (s *sortIntervalDescWithNullsOp) init(
@@ -2072,10 +2072,10 @@ func (s *sortIntervalDescWithNullsOp) Len() int {
 }
 
 type sortJSONDescWithNullsOp struct {
-	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       *coldata.JSONs
+	order         []int
 }
 
 func (s *sortJSONDescWithNullsOp) init(
@@ -2158,10 +2158,10 @@ func (s *sortJSONDescWithNullsOp) Len() int {
 }
 
 type sortDatumDescWithNullsOp struct {
-	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.DatumVec
+	order         []int
 }
 
 func (s *sortDatumDescWithNullsOp) init(
@@ -2240,10 +2240,10 @@ func (s *sortDatumDescWithNullsOp) Len() int {
 }
 
 type sortBoolAscOp struct {
-	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Bools
+	order         []int
 }
 
 func (s *sortBoolAscOp) init(
@@ -2318,12 +2318,12 @@ func (s *sortBoolAscOp) Len() int {
 }
 
 type sortBytesAscOp struct {
-	sortCol            *coldata.Bytes
 	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	nulls              *coldata.Nulls
-	order              []int
 	cancelChecker      colexecutils.CancelChecker
+	sortCol            *coldata.Bytes
+	order              []int
 }
 
 func (s *sortBytesAscOp) init(
@@ -2405,10 +2405,10 @@ func (s *sortBytesAscOp) Len() int {
 }
 
 type sortDecimalAscOp struct {
-	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Decimals
+	order         []int
 }
 
 func (s *sortDecimalAscOp) init(
@@ -2475,10 +2475,10 @@ func (s *sortDecimalAscOp) Len() int {
 }
 
 type sortInt16AscOp struct {
-	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int16s
+	order         []int
 }
 
 func (s *sortInt16AscOp) init(
@@ -2557,10 +2557,10 @@ func (s *sortInt16AscOp) Len() int {
 }
 
 type sortInt32AscOp struct {
-	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int32s
+	order         []int
 }
 
 func (s *sortInt32AscOp) init(
@@ -2639,10 +2639,10 @@ func (s *sortInt32AscOp) Len() int {
 }
 
 type sortInt64AscOp struct {
-	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int64s
+	order         []int
 }
 
 func (s *sortInt64AscOp) init(
@@ -2721,10 +2721,10 @@ func (s *sortInt64AscOp) Len() int {
 }
 
 type sortFloat64AscOp struct {
-	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Float64s
+	order         []int
 }
 
 func (s *sortFloat64AscOp) init(
@@ -2810,10 +2810,10 @@ func (s *sortFloat64AscOp) Len() int {
 }
 
 type sortTimestampAscOp struct {
-	sortCol       coldata.Times
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Times
+	order         []int
 }
 
 func (s *sortTimestampAscOp) init(
@@ -2887,10 +2887,10 @@ func (s *sortTimestampAscOp) Len() int {
 }
 
 type sortIntervalAscOp struct {
-	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Durations
+	order         []int
 }
 
 func (s *sortIntervalAscOp) init(
@@ -2957,10 +2957,10 @@ func (s *sortIntervalAscOp) Len() int {
 }
 
 type sortJSONAscOp struct {
-	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       *coldata.JSONs
+	order         []int
 }
 
 func (s *sortJSONAscOp) init(
@@ -3033,10 +3033,10 @@ func (s *sortJSONAscOp) Len() int {
 }
 
 type sortDatumAscOp struct {
-	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.DatumVec
+	order         []int
 }
 
 func (s *sortDatumAscOp) init(
@@ -3105,10 +3105,10 @@ func (s *sortDatumAscOp) Len() int {
 }
 
 type sortBoolDescOp struct {
-	sortCol       coldata.Bools
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Bools
+	order         []int
 }
 
 func (s *sortBoolDescOp) init(
@@ -3183,12 +3183,12 @@ func (s *sortBoolDescOp) Len() int {
 }
 
 type sortBytesDescOp struct {
-	sortCol            *coldata.Bytes
 	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	nulls              *coldata.Nulls
-	order              []int
 	cancelChecker      colexecutils.CancelChecker
+	sortCol            *coldata.Bytes
+	order              []int
 }
 
 func (s *sortBytesDescOp) init(
@@ -3270,10 +3270,10 @@ func (s *sortBytesDescOp) Len() int {
 }
 
 type sortDecimalDescOp struct {
-	sortCol       coldata.Decimals
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Decimals
+	order         []int
 }
 
 func (s *sortDecimalDescOp) init(
@@ -3340,10 +3340,10 @@ func (s *sortDecimalDescOp) Len() int {
 }
 
 type sortInt16DescOp struct {
-	sortCol       coldata.Int16s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int16s
+	order         []int
 }
 
 func (s *sortInt16DescOp) init(
@@ -3422,10 +3422,10 @@ func (s *sortInt16DescOp) Len() int {
 }
 
 type sortInt32DescOp struct {
-	sortCol       coldata.Int32s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int32s
+	order         []int
 }
 
 func (s *sortInt32DescOp) init(
@@ -3504,10 +3504,10 @@ func (s *sortInt32DescOp) Len() int {
 }
 
 type sortInt64DescOp struct {
-	sortCol       coldata.Int64s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Int64s
+	order         []int
 }
 
 func (s *sortInt64DescOp) init(
@@ -3586,10 +3586,10 @@ func (s *sortInt64DescOp) Len() int {
 }
 
 type sortFloat64DescOp struct {
-	sortCol       coldata.Float64s
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Float64s
+	order         []int
 }
 
 func (s *sortFloat64DescOp) init(
@@ -3675,10 +3675,10 @@ func (s *sortFloat64DescOp) Len() int {
 }
 
 type sortTimestampDescOp struct {
-	sortCol       coldata.Times
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Times
+	order         []int
 }
 
 func (s *sortTimestampDescOp) init(
@@ -3752,10 +3752,10 @@ func (s *sortTimestampDescOp) Len() int {
 }
 
 type sortIntervalDescOp struct {
-	sortCol       coldata.Durations
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.Durations
+	order         []int
 }
 
 func (s *sortIntervalDescOp) init(
@@ -3822,10 +3822,10 @@ func (s *sortIntervalDescOp) Len() int {
 }
 
 type sortJSONDescOp struct {
-	sortCol       *coldata.JSONs
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       *coldata.JSONs
+	order         []int
 }
 
 func (s *sortJSONDescOp) init(
@@ -3898,10 +3898,10 @@ func (s *sortJSONDescOp) Len() int {
 }
 
 type sortDatumDescOp struct {
-	sortCol       coldata.DatumVec
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       coldata.DatumVec
+	order         []int
 }
 
 func (s *sortDatumDescOp) init(

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -104,14 +104,14 @@ func newSingleSorter_WITH_NULLS(t *types.T, dir execinfrapb.Ordering_Column_Dire
 // {{range .WidthOverloads}}
 
 type sort_TYPE_DIR_HANDLES_NULLSOp struct {
-	sortCol _GOTYPESLICE
 	// {{if .CanAbbreviate}}
 	allocator          *colmem.Allocator
 	abbreviatedSortCol []uint64
 	// {{end}}
 	nulls         *coldata.Nulls
-	order         []int
 	cancelChecker colexecutils.CancelChecker
+	sortCol       _GOTYPESLICE
+	order         []int
 }
 
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) init(

--- a/pkg/sql/colexec/tuple_proj_op.go
+++ b/pkg/sql/colexec/tuple_proj_op.go
@@ -45,11 +45,10 @@ func NewTupleProjOp(
 
 type tupleProjOp struct {
 	colexecop.OneInputHelper
-
 	allocator         *colmem.Allocator
 	converter         *colconv.VecToDatumConverter
-	tupleContentsIdxs []int
 	outputType        *types.T
+	tupleContentsIdxs []int
 	outputIdx         int
 }
 


### PR DESCRIPTION
This commit applies some of the fixes found by the `fieldalignment` tool
on the colexec packages which reorder some fields in the structs so that
the memory footprint is reduced.

Release note: None