### PR TITLE
lint: add a linter to prohibit map[...]bool in favor of map[...]struct{}

### DIFF
--- a/pkg/sql/opt/norm/groupby_funcs.go
+++ b/pkg/sql/opt/norm/groupby_funcs.go
@@ -219,7 +219,7 @@ func (c *CustomFuncs) AreValuesDistinct(
 func (c *CustomFuncs) areRowsDistinct(
 	rows memo.ScalarListExpr, cols opt.ColList, groupingCols opt.ColSet, nullsAreDistinct bool,
 ) bool {
-	var seen map[string]bool
+	var seen map[string]struct{}
 	var encoded []byte
 	for _, scalar := range rows {
 		row := scalar.(*memo.TupleExpr)
@@ -263,7 +263,7 @@ func (c *CustomFuncs) areRowsDistinct(
 		}
 
 		if seen == nil {
-			seen = make(map[string]bool, len(rows))
+			seen = make(map[string]struct{}, len(rows))
 		}
 
 		// Determine whether key has already been seen.
@@ -274,7 +274,7 @@ func (c *CustomFuncs) areRowsDistinct(
 		}
 
 		// Add the key to the seen map.
-		seen[key] = true
+		seen[key] = struct{}{}
 	}
 
 	return true


### PR DESCRIPTION
The linter is currently limited to `sql/opt/norm` package. This commit
was prompted by an article mentioned in the Golang Weekly newsletter.
The rationale is that `map[...]struct{}` is more efficient, but in some
cases the bool map value is actually desired, so this commit introduces
an opt-out `//nolint:maptobool` comment.

Release justification: low-risk performance improvement.

Release note: None