### PR TITLE
[wip,dnm] experiment with fixed-len value encoding

### DIFF
--- a/pkg/sql/catalog/descpb/index_fetch.proto
+++ b/pkg/sql/catalog/descpb/index_fetch.proto
@@ -131,4 +131,6 @@ message IndexFetchSpec {
   //
   // Any other column IDs present in the fetched KVs will be ignored.
   repeated Column fetched_columns = 15 [(gogoproto.nullable) = false];
+
+  repeated Column all_columns = 17  [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/colencoding/BUILD.bazel
+++ b/pkg/sql/colencoding/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "key_encoding.go",
         "value_encoding.go",
+        "value_encoding2.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colencoding",
     visibility = ["//visibility:public"],

--- a/pkg/sql/colencoding/value_encoding2.go
+++ b/pkg/sql/colencoding/value_encoding2.go
@@ -1,0 +1,79 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colencoding
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/errors"
+)
+
+// DecodeTableValueToCol decodes a value encoded by EncodeTableValue, writing
+// the result to the rowIdx'th position of the vecIdx'th vector in
+// coldata.TypedVecs.
+// See the analog in rowenc/column_type_encoding.go.
+func DecodeTableValueToCol2(
+	da *tree.DatumAlloc,
+	colID descpb.ColumnID,
+	vecs *coldata.TypedVecs,
+	vecIdx int,
+	rowIdx int,
+	typ encoding.Type,
+	dataOffset int,
+	valTyp *types.T,
+	buf []byte,
+) ([]byte, error) {
+
+	// NULL is special because it is a valid value for any type.
+	if typ == encoding.Null {
+		vecs.Nulls[vecIdx].SetNull(rowIdx)
+		return buf[dataOffset:], nil
+	}
+
+	// Find the position of the target vector among the typed columns of its
+	// type.
+	colIdx := vecs.ColsMap[vecIdx]
+
+	var err error
+	switch valTyp.Family() {
+	case types.IntFamily:
+		var foundColID uint32
+		buf, foundColID, err = encoding.DecodeUint32Ascending(buf)
+		if err != nil {
+			return nil, err
+		}
+		if foundColID != uint32(colID) {
+			return buf, errors.AssertionFailedf("mismatch in col id %d != %d", foundColID, colID)
+		}
+		var i uint64
+		_, i, err = encoding.DecodeUint64Ascending(buf[4:])
+		if err != nil {
+			return nil, err
+		}
+		//fmt.Printf("Just successfully decoded int %d for colID %d\n", i, colID)
+		switch valTyp.Width() {
+		case 16:
+			vecs.Int16Cols[colIdx][rowIdx] = int16(i)
+		case 32:
+			vecs.Int32Cols[colIdx][rowIdx] = int32(i)
+		default:
+			// Pre-2.1 BIT was using INT encoding with arbitrary sizes.
+			// We map these to 64-bit INT now. See #34161.
+			vecs.Int64Cols[colIdx][rowIdx] = int64(i)
+		}
+	default:
+		return nil, errors.AssertionFailedf("unsupported type %s", valTyp)
+	}
+	return buf, err
+}

--- a/pkg/sql/colexecerror/error.go
+++ b/pkg/sql/colexecerror/error.go
@@ -61,7 +61,7 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 		err, ok := panicObj.(error)
 		if !ok {
 			// Not an error object. Definitely unexpected.
-			retErr = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v", panicObj)
+			retErr = errors.AssertionFailedf("unexpected error from the vectorized runtime: %+v (%s)", panicObj, panicEmittedFrom)
 			return
 		}
 		retErr = err
@@ -85,7 +85,7 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 			// Any error without a code already is "surprising" and
 			// needs to be annotated to indicate that it was
 			// unexpected.
-			retErr = errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error from the vectorized engine")
+			retErr = errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error from the vectorized engine (%s)", panicEmittedFrom)
 		}
 	}()
 	operation()

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -538,7 +538,7 @@ func NewColIndexJoin(
 		false, /* singleUse */
 	}
 	if err = fetcher.Init(
-		fetcherAllocator, kvFetcher, tableArgs,
+		ctx, fetcherAllocator, kvFetcher, tableArgs,
 	); err != nil {
 		fetcher.Release()
 		return nil, err

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3281,6 +3281,10 @@ func (m *sessionDataMutator) SetTroubleshootingModeEnabled(val bool) {
 	m.data.TroubleshootingMode = val
 }
 
+func (m *sessionDataMutator) SetHackNewEncodingEnabled(val bool) {
+	m.data.HackNewEncoding = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -157,7 +157,11 @@ func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) erro
 	}
 
 	// Queue the insert in the KV batch.
-	if err := r.ti.row(params.ctx, rowVals, pm, r.traceKV); err != nil {
+	ctx := params.ctx
+	if params.SessionData().HackNewEncoding {
+		ctx = context.WithValue(params.ctx, row.HackNewEncoding, "true")
+	}
+	if err := r.ti.row(ctx, rowVals, pm, r.traceKV); err != nil {
 		return err
 	}
 

--- a/pkg/sql/rowenc/index_fetch.go
+++ b/pkg/sql/rowenc/index_fetch.go
@@ -91,6 +91,19 @@ func InitIndexFetchSpec(
 		}
 	}
 
+	storedCols := index.IndexDesc().StoreColumnIDs
+	s.AllColumns = make([]descpb.IndexFetchSpec_Column, 0, len(storedCols))
+	for _, colID := range storedCols {
+		col, err := table.FindColumnWithID(colID)
+		if err != nil {
+			panic(err)
+		}
+		s.AllColumns = append(s.AllColumns, descpb.IndexFetchSpec_Column{
+			ColumnID: colID,
+			Type:     col.GetType(),
+		})
+	}
+
 	// In test builds, verify that we aren't trying to fetch columns that are not
 	// available in the index.
 	if buildutil.CrdbTestBuild && s.IsSecondaryIndex {

--- a/pkg/sql/rowenc/valueside/BUILD.bazel
+++ b/pkg/sql/rowenc/valueside/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "decode.go",
         "doc.go",
         "encode.go",
+        "encode2.go",
         "legacy.go",
         "tuple.go",
     ],

--- a/pkg/sql/rowenc/valueside/encode2.go
+++ b/pkg/sql/rowenc/valueside/encode2.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package valueside
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/errors"
+)
+
+func Encode2(
+	appendTo []byte, colID descpb.ColumnID, val tree.Datum, scratch []byte,
+) ([]byte, error) {
+	if val == tree.DNull {
+		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil
+	}
+	switch val.ResolvedType().Family() {
+	case types.IntFamily:
+		appendTo = encoding.EncodeUint32Ascending(appendTo, uint32(colID))
+		appendTo = encoding.EncodeUint32Ascending(appendTo, uint32(encoding.Int))
+		return encoding.EncodeUint64Ascending(appendTo, uint64(*val.(*tree.DInt))), nil
+	default:
+		return nil, errors.AssertionFailedf("not supported yet %s", val.ResolvedType())
+	}
+}

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -94,6 +94,8 @@ message SessionData {
   // the query (i.e. collect & emit telemetry data). Troubleshooting mode is
   // disabled by default.
   bool troubleshooting_mode = 21;
+
+  bool hack_new_encoding = 22;
 }
 
 // DataConversionConfig contains the parameters that influence the output

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1177,6 +1177,22 @@ var varGen = map[string]sessionVar{
 		GlobalDefault: globalFalse,
 	},
 
+	`hack_new_encoding`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`hack_new_encoding`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("hack_new_encoding", s)
+			if err != nil {
+				return err
+			}
+			m.SetHackNewEncodingEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().HackNewEncoding), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
 	// This is read-only in Postgres also.
 	// See https://www.postgresql.org/docs/14/sql-show.html and
 	// https://www.postgresql.org/docs/14/locale.html


### PR DESCRIPTION
This commit is a hacky experiment that plays around with the idea of a
fixed-length integer encoding for values, to permit decoding to avoid
having to read columns that are not requested by the SQL query.

When the session variable hack_new_encoding is set to true, the database
encodes integer values in the value component with the following
(inefficient) scheme:

32 bits of column id | 32 bits of column type | 64 bits of integer

Then, when the database reads values, it directly indexes into the value
slices based on the pre-existing knowledge that each column occupies 128
bits in the encoded value.

The hypothesis was that this would be more efficient for reading a
single column at the end of a wide table, because ordinarily, the
database has to read every column in a value to get to the one that it
is looking for.

However, in an interactive session, this mode seems to slow things down
by about 30%. The test setup is included in the benchmark.

I think the reason for the slowdown is that the value explodes in size
in this scheme: for 10 small integers, instead of just ~20 bytes (due to
varint encoding), we now have 160 bytes. This is more expensive for
Pebble to decode, not to mention read from disk, but perhaps the block
compression helps enough with the "read from disk" part to make it just
about Pebble decoding / memcopying.

I'm interested to see what would happen if this optimization was applied
to https://github.com/cockroachdb/cockroach/pull/52863, since it would
remove the necessity for Pebble to do any memcopying of the unnecessary
data whatsoever.