### PR TITLE
colexec: add support for ILIKE and NOT ILIKE

### DIFF
--- a/pkg/sql/colexec/colexeccmp/like_ops.go
+++ b/pkg/sql/colexec/colexeccmp/like_ops.go
@@ -25,56 +25,29 @@ const (
 	// LikeConstant is used when comparing against a constant string with no
 	// wildcards.
 	LikeConstant
-	// LikeConstantNegate is used when comparing against a constant string with
-	// no wildcards, and the result is negated.
-	LikeConstantNegate
 	// LikeContains is used when comparing against a constant substring.
 	LikeContains
-	// LikeContainsNegate is used when comparing against a constant substring,
-	// and the result is negated.
-	LikeContainsNegate
-	// LikeNeverMatch doesn't match anything.
-	LikeNeverMatch
 	// LikePrefix is used when comparing against a constant prefix.
 	LikePrefix
-	// LikePrefixNegate is used when comparing against a constant prefix, and
-	// the result is negated.
-	LikePrefixNegate
 	// LikeRegexp is the default slow case when we need to fallback to RegExp
 	// matching.
 	LikeRegexp
-	// LikeRegexpNegate is the default slow case when we need to fallback to
-	// RegExp matching, but the result is negated.
-	LikeRegexpNegate
 	// LikeSkeleton is used when comparing against a "skeleton" string (of the
 	// form '%foo%bar%' with any number of "skeleton words").
 	LikeSkeleton
-	// LikeSkeletonNegate is used when comparing against a "skeleton" string (of
-	// the form '%foo%bar%' with any number of "skeleton words"), and the result
-	// is negated.
-	LikeSkeletonNegate
 	// LikeSuffix is used when comparing against a constant suffix.
 	LikeSuffix
-	// LikeSuffixNegate is used when comparing against a constant suffix, and
-	// the result is negated.
-	LikeSuffixNegate
 )
 
 // GetLikeOperatorType returns LikeOpType corresponding to the inputs.
 //
 // The second return parameter always contains a single []byte, unless
 // "skeleton" LikeOpType is returned.
-func GetLikeOperatorType(pattern string, negate bool) (LikeOpType, [][]byte, error) {
+func GetLikeOperatorType(pattern string) (LikeOpType, [][]byte, error) {
 	if pattern == "" {
-		if negate {
-			return LikeConstantNegate, [][]byte{{}}, nil
-		}
 		return LikeConstant, [][]byte{{}}, nil
 	}
 	if pattern == "%" {
-		if negate {
-			return LikeNeverMatch, [][]byte{{}}, nil
-		}
 		return LikeAlwaysMatch, [][]byte{{}}, nil
 	}
 	hasEscape := strings.Contains(pattern, `\`)
@@ -94,30 +67,18 @@ func GetLikeOperatorType(pattern string, negate bool) (LikeOpType, [][]byte, err
 		lastChar := pattern[len(pattern)-1]
 		if !isWildcard(firstChar) && !isWildcard(lastChar) {
 			// No wildcards, so this is just an exact string match.
-			if negate {
-				return LikeConstantNegate, [][]byte{[]byte(pattern)}, nil
-			}
 			return LikeConstant, [][]byte{[]byte(pattern)}, nil
 		}
 		if firstChar == '%' && !isWildcard(lastChar) {
 			suffix := pattern[1:]
-			if negate {
-				return LikeSuffixNegate, [][]byte{[]byte(suffix)}, nil
-			}
 			return LikeSuffix, [][]byte{[]byte(suffix)}, nil
 		}
 		if lastChar == '%' && !isWildcard(firstChar) {
 			prefix := pattern[:len(pattern)-1]
-			if negate {
-				return LikePrefixNegate, [][]byte{[]byte(prefix)}, nil
-			}
 			return LikePrefix, [][]byte{[]byte(prefix)}, nil
 		}
 		if firstChar == '%' && lastChar == '%' {
 			contains := pattern[1 : len(pattern)-1]
-			if negate {
-				return LikeContainsNegate, [][]byte{[]byte(contains)}, nil
-			}
 			return LikeContains, [][]byte{[]byte(contains)}, nil
 		}
 	}
@@ -136,15 +97,9 @@ func GetLikeOperatorType(pattern string, negate bool) (LikeOpType, [][]byte, err
 			skeleton = append(skeleton, pat[:idx])
 			pat = pat[idx+1:]
 		}
-		if negate {
-			return LikeSkeletonNegate, skeleton, nil
-		}
 		return LikeSkeleton, skeleton, nil
 	}
 	// Default (slow) case: execute as a regular expression match.
-	if negate {
-		return LikeRegexpNegate, [][]byte{[]byte(pattern)}, nil
-	}
 	return LikeRegexp, [][]byte{[]byte(pattern)}, nil
 }
 

--- a/pkg/sql/colexec/colexeccmp/like_ops.go
+++ b/pkg/sql/colexec/colexeccmp/like_ops.go
@@ -43,12 +43,15 @@ const (
 //
 // The second return parameter always contains a single []byte, unless
 // "skeleton" LikeOpType is returned.
-func GetLikeOperatorType(pattern string) (LikeOpType, [][]byte, error) {
+func GetLikeOperatorType(pattern string, caseInsensitive bool) (LikeOpType, [][]byte, error) {
 	if pattern == "" {
 		return LikeConstant, [][]byte{{}}, nil
 	}
 	if pattern == "%" {
 		return LikeAlwaysMatch, [][]byte{{}}, nil
+	}
+	if caseInsensitive {
+		pattern = strings.ToUpper(pattern)
 	}
 	hasEscape := strings.Contains(pattern, `\`)
 	if !hasEscape && len(pattern) > 1 && !strings.ContainsAny(pattern[1:len(pattern)-1], "_%") {

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
@@ -93,6 +93,9 @@ type _OP_CONST_NAME struct {
 	// {{else}}
 	constArg _R_GO_TYPE
 	// {{end}}
+	// {{if .Negatable}}
+	negate bool
+	// {{end}}
 }
 
 func (p _OP_CONST_NAME) Next() coldata.Batch {
@@ -103,6 +106,14 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 	//     variable of type `colexecutils.BinaryOverloadHelper`.
 	// */}}
 	_overloadHelper := p.BinaryOverloadHelper
+	// {{end}}
+	// {{if .Negatable}}
+	// {{/*
+	//     In order to inline the templated code of the LIKE overloads, we need
+	//     to have a `_negate` local variable indicating whether the assignment
+	//     should be negated.
+	// */}}
+	_negate := p.negate
 	// {{end}}
 	batch := p.Input.Next()
 	n := batch.Length()

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
@@ -96,6 +96,9 @@ type _OP_CONST_NAME struct {
 	// {{if .Negatable}}
 	negate bool
 	// {{end}}
+	// {{if .CaseInsensitive}}
+	caseInsensitive bool
+	// {{end}}
 }
 
 func (p _OP_CONST_NAME) Next() coldata.Batch {
@@ -114,6 +117,14 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 	//     should be negated.
 	// */}}
 	_negate := p.negate
+	// {{ end }}
+	// {{if .CaseInsensitive}}
+	// {{/*
+	//     In order to inline the templated code of the LIKE overloads, we need
+	//     to have a `_caseInsensitive` local variable indicating whether the
+	//     operator is case insensitive.
+	// */}}
+	_caseInsensitive := p.caseInsensitive
 	// {{end}}
 	batch := p.Input.Next()
 	n := batch.Length()

--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -20,9 +20,11 @@ import (
 type projPrefixBytesBytesConstOp struct {
 	projConstOpBase
 	constArg []byte
+	negate   bool
 }
 
 func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -48,7 +50,7 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
-						projCol[i] = bytes.HasPrefix(arg, p.constArg)
+						projCol[i] = bytes.HasPrefix(arg, p.constArg) != _negate
 					}
 				}
 			} else {
@@ -58,7 +60,7 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
-						projCol[i] = bytes.HasPrefix(arg, p.constArg)
+						projCol[i] = bytes.HasPrefix(arg, p.constArg) != _negate
 					}
 				}
 			}
@@ -68,14 +70,14 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					arg := col.Get(i)
-					projCol[i] = bytes.HasPrefix(arg, p.constArg)
+					projCol[i] = bytes.HasPrefix(arg, p.constArg) != _negate
 				}
 			} else {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
-					projCol[i] = bytes.HasPrefix(arg, p.constArg)
+					projCol[i] = bytes.HasPrefix(arg, p.constArg) != _negate
 				}
 			}
 		}
@@ -86,9 +88,11 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 type projSuffixBytesBytesConstOp struct {
 	projConstOpBase
 	constArg []byte
+	negate   bool
 }
 
 func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -114,7 +118,7 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
-						projCol[i] = bytes.HasSuffix(arg, p.constArg)
+						projCol[i] = bytes.HasSuffix(arg, p.constArg) != _negate
 					}
 				}
 			} else {
@@ -124,7 +128,7 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
-						projCol[i] = bytes.HasSuffix(arg, p.constArg)
+						projCol[i] = bytes.HasSuffix(arg, p.constArg) != _negate
 					}
 				}
 			}
@@ -134,14 +138,14 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					arg := col.Get(i)
-					projCol[i] = bytes.HasSuffix(arg, p.constArg)
+					projCol[i] = bytes.HasSuffix(arg, p.constArg) != _negate
 				}
 			} else {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
-					projCol[i] = bytes.HasSuffix(arg, p.constArg)
+					projCol[i] = bytes.HasSuffix(arg, p.constArg) != _negate
 				}
 			}
 		}
@@ -152,9 +156,11 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 type projContainsBytesBytesConstOp struct {
 	projConstOpBase
 	constArg []byte
+	negate   bool
 }
 
 func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -180,7 +186,7 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
-						projCol[i] = bytes.Contains(arg, p.constArg)
+						projCol[i] = bytes.Contains(arg, p.constArg) != _negate
 					}
 				}
 			} else {
@@ -190,7 +196,7 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
-						projCol[i] = bytes.Contains(arg, p.constArg)
+						projCol[i] = bytes.Contains(arg, p.constArg) != _negate
 					}
 				}
 			}
@@ -200,14 +206,14 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					arg := col.Get(i)
-					projCol[i] = bytes.Contains(arg, p.constArg)
+					projCol[i] = bytes.Contains(arg, p.constArg) != _negate
 				}
 			} else {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
-					projCol[i] = bytes.Contains(arg, p.constArg)
+					projCol[i] = bytes.Contains(arg, p.constArg) != _negate
 				}
 			}
 		}
@@ -218,9 +224,11 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 type projSkeletonBytesBytesConstOp struct {
 	projConstOpBase
 	constArg [][]byte
+	negate   bool
 }
 
 func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -257,7 +265,7 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 								arg = arg[idx+len(p.constArg[skeletonIdx]):]
 								skeletonIdx++
 							}
-							projCol[i] = skeletonIdx == len(p.constArg)
+							projCol[i] = skeletonIdx == len(p.constArg) != _negate
 						}
 					}
 				}
@@ -279,7 +287,7 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 								arg = arg[idx+len(p.constArg[skeletonIdx]):]
 								skeletonIdx++
 							}
-							projCol[i] = skeletonIdx == len(p.constArg)
+							projCol[i] = skeletonIdx == len(p.constArg) != _negate
 						}
 					}
 				}
@@ -301,7 +309,7 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 							arg = arg[idx+len(p.constArg[skeletonIdx]):]
 							skeletonIdx++
 						}
-						projCol[i] = skeletonIdx == len(p.constArg)
+						projCol[i] = skeletonIdx == len(p.constArg) != _negate
 					}
 				}
 			} else {
@@ -320,7 +328,7 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 							arg = arg[idx+len(p.constArg[skeletonIdx]):]
 							skeletonIdx++
 						}
-						projCol[i] = skeletonIdx == len(p.constArg)
+						projCol[i] = skeletonIdx == len(p.constArg) != _negate
 					}
 				}
 			}
@@ -332,9 +340,11 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 type projRegexpBytesBytesConstOp struct {
 	projConstOpBase
 	constArg *regexp.Regexp
+	negate   bool
 }
 
 func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -360,7 +370,7 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
-						projCol[i] = p.constArg.Match(arg)
+						projCol[i] = p.constArg.Match(arg) != _negate
 					}
 				}
 			} else {
@@ -370,7 +380,7 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
-						projCol[i] = p.constArg.Match(arg)
+						projCol[i] = p.constArg.Match(arg) != _negate
 					}
 				}
 			}
@@ -380,392 +390,14 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					arg := col.Get(i)
-					projCol[i] = p.constArg.Match(arg)
+					projCol[i] = p.constArg.Match(arg) != _negate
 				}
 			} else {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
-					projCol[i] = p.constArg.Match(arg)
-				}
-			}
-		}
-	})
-	return batch
-}
-
-type projNotPrefixBytesBytesConstOp struct {
-	projConstOpBase
-	constArg []byte
-}
-
-func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
-	n := batch.Length()
-	if n == 0 {
-		return coldata.ZeroBatch
-	}
-	vec := batch.ColVec(p.colIdx)
-	var col *coldata.Bytes
-	col = vec.Bytes()
-	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		projCol := projVec.Bool()
-		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
-			colNulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-						projCol[i] = !bytes.HasPrefix(arg, p.constArg)
-					}
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-						projCol[i] = !bytes.HasPrefix(arg, p.constArg)
-					}
-				}
-			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					arg := col.Get(i)
-					projCol[i] = !bytes.HasPrefix(arg, p.constArg)
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					arg := col.Get(i)
-					projCol[i] = !bytes.HasPrefix(arg, p.constArg)
-				}
-			}
-		}
-	})
-	return batch
-}
-
-type projNotSuffixBytesBytesConstOp struct {
-	projConstOpBase
-	constArg []byte
-}
-
-func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
-	n := batch.Length()
-	if n == 0 {
-		return coldata.ZeroBatch
-	}
-	vec := batch.ColVec(p.colIdx)
-	var col *coldata.Bytes
-	col = vec.Bytes()
-	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		projCol := projVec.Bool()
-		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
-			colNulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-						projCol[i] = !bytes.HasSuffix(arg, p.constArg)
-					}
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-						projCol[i] = !bytes.HasSuffix(arg, p.constArg)
-					}
-				}
-			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					arg := col.Get(i)
-					projCol[i] = !bytes.HasSuffix(arg, p.constArg)
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					arg := col.Get(i)
-					projCol[i] = !bytes.HasSuffix(arg, p.constArg)
-				}
-			}
-		}
-	})
-	return batch
-}
-
-type projNotContainsBytesBytesConstOp struct {
-	projConstOpBase
-	constArg []byte
-}
-
-func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
-	n := batch.Length()
-	if n == 0 {
-		return coldata.ZeroBatch
-	}
-	vec := batch.ColVec(p.colIdx)
-	var col *coldata.Bytes
-	col = vec.Bytes()
-	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		projCol := projVec.Bool()
-		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
-			colNulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-						projCol[i] = !bytes.Contains(arg, p.constArg)
-					}
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-						projCol[i] = !bytes.Contains(arg, p.constArg)
-					}
-				}
-			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					arg := col.Get(i)
-					projCol[i] = !bytes.Contains(arg, p.constArg)
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					arg := col.Get(i)
-					projCol[i] = !bytes.Contains(arg, p.constArg)
-				}
-			}
-		}
-	})
-	return batch
-}
-
-type projNotSkeletonBytesBytesConstOp struct {
-	projConstOpBase
-	constArg [][]byte
-}
-
-func (p projNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
-	n := batch.Length()
-	if n == 0 {
-		return coldata.ZeroBatch
-	}
-	vec := batch.ColVec(p.colIdx)
-	var col *coldata.Bytes
-	col = vec.Bytes()
-	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		projCol := projVec.Bool()
-		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
-			colNulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-
-						{
-							var idx, skeletonIdx int
-							for skeletonIdx < len(p.constArg) {
-								idx = bytes.Index(arg, p.constArg[skeletonIdx])
-								if idx < 0 {
-									break
-								}
-								arg = arg[idx+len(p.constArg[skeletonIdx]):]
-								skeletonIdx++
-							}
-							projCol[i] = skeletonIdx != len(p.constArg)
-						}
-					}
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-
-						{
-							var idx, skeletonIdx int
-							for skeletonIdx < len(p.constArg) {
-								idx = bytes.Index(arg, p.constArg[skeletonIdx])
-								if idx < 0 {
-									break
-								}
-								arg = arg[idx+len(p.constArg[skeletonIdx]):]
-								skeletonIdx++
-							}
-							projCol[i] = skeletonIdx != len(p.constArg)
-						}
-					}
-				}
-			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					arg := col.Get(i)
-
-					{
-						var idx, skeletonIdx int
-						for skeletonIdx < len(p.constArg) {
-							idx = bytes.Index(arg, p.constArg[skeletonIdx])
-							if idx < 0 {
-								break
-							}
-							arg = arg[idx+len(p.constArg[skeletonIdx]):]
-							skeletonIdx++
-						}
-						projCol[i] = skeletonIdx != len(p.constArg)
-					}
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					arg := col.Get(i)
-
-					{
-						var idx, skeletonIdx int
-						for skeletonIdx < len(p.constArg) {
-							idx = bytes.Index(arg, p.constArg[skeletonIdx])
-							if idx < 0 {
-								break
-							}
-							arg = arg[idx+len(p.constArg[skeletonIdx]):]
-							skeletonIdx++
-						}
-						projCol[i] = skeletonIdx != len(p.constArg)
-					}
-				}
-			}
-		}
-	})
-	return batch
-}
-
-type projNotRegexpBytesBytesConstOp struct {
-	projConstOpBase
-	constArg *regexp.Regexp
-}
-
-func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
-	batch := p.Input.Next()
-	n := batch.Length()
-	if n == 0 {
-		return coldata.ZeroBatch
-	}
-	vec := batch.ColVec(p.colIdx)
-	var col *coldata.Bytes
-	col = vec.Bytes()
-	projVec := batch.ColVec(p.outputIdx)
-	p.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
-		// Capture col to force bounds check to work. See
-		// https://github.com/golang/go/issues/39756
-		col := col
-		projCol := projVec.Bool()
-		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
-			colNulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-						projCol[i] = !p.constArg.Match(arg)
-					}
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
-						// We only want to perform the projection operation if the value is not null.
-						arg := col.Get(i)
-						projCol[i] = !p.constArg.Match(arg)
-					}
-				}
-			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					arg := col.Get(i)
-					projCol[i] = !p.constArg.Match(arg)
-				}
-			} else {
-				_ = projCol.Get(n - 1)
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					arg := col.Get(i)
-					projCol[i] = !p.constArg.Match(arg)
+					projCol[i] = p.constArg.Match(arg) != _negate
 				}
 			}
 		}

--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -19,12 +19,14 @@ import (
 
 type projPrefixBytesBytesConstOp struct {
 	projConstOpBase
-	constArg []byte
-	negate   bool
+	constArg        []byte
+	negate          bool
+	caseInsensitive bool
 }
 
 func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 	_negate := p.negate
+	_caseInsensitive := p.caseInsensitive
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -50,6 +52,9 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						projCol[i] = bytes.HasPrefix(arg, p.constArg) != _negate
 					}
 				}
@@ -60,6 +65,9 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						projCol[i] = bytes.HasPrefix(arg, p.constArg) != _negate
 					}
 				}
@@ -70,6 +78,9 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					projCol[i] = bytes.HasPrefix(arg, p.constArg) != _negate
 				}
 			} else {
@@ -77,6 +88,9 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					projCol[i] = bytes.HasPrefix(arg, p.constArg) != _negate
 				}
 			}
@@ -87,12 +101,14 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 
 type projSuffixBytesBytesConstOp struct {
 	projConstOpBase
-	constArg []byte
-	negate   bool
+	constArg        []byte
+	negate          bool
+	caseInsensitive bool
 }
 
 func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 	_negate := p.negate
+	_caseInsensitive := p.caseInsensitive
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -118,6 +134,9 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						projCol[i] = bytes.HasSuffix(arg, p.constArg) != _negate
 					}
 				}
@@ -128,6 +147,9 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						projCol[i] = bytes.HasSuffix(arg, p.constArg) != _negate
 					}
 				}
@@ -138,6 +160,9 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					projCol[i] = bytes.HasSuffix(arg, p.constArg) != _negate
 				}
 			} else {
@@ -145,6 +170,9 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					projCol[i] = bytes.HasSuffix(arg, p.constArg) != _negate
 				}
 			}
@@ -155,12 +183,14 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 
 type projContainsBytesBytesConstOp struct {
 	projConstOpBase
-	constArg []byte
-	negate   bool
+	constArg        []byte
+	negate          bool
+	caseInsensitive bool
 }
 
 func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 	_negate := p.negate
+	_caseInsensitive := p.caseInsensitive
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -186,6 +216,9 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						projCol[i] = bytes.Contains(arg, p.constArg) != _negate
 					}
 				}
@@ -196,6 +229,9 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 					if !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						projCol[i] = bytes.Contains(arg, p.constArg) != _negate
 					}
 				}
@@ -206,6 +242,9 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 				sel = sel[:n]
 				for _, i := range sel {
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					projCol[i] = bytes.Contains(arg, p.constArg) != _negate
 				}
 			} else {
@@ -213,6 +252,9 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					projCol[i] = bytes.Contains(arg, p.constArg) != _negate
 				}
 			}
@@ -223,12 +265,14 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 
 type projSkeletonBytesBytesConstOp struct {
 	projConstOpBase
-	constArg [][]byte
-	negate   bool
+	constArg        [][]byte
+	negate          bool
+	caseInsensitive bool
 }
 
 func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 	_negate := p.negate
+	_caseInsensitive := p.caseInsensitive
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -256,6 +300,9 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
+							if _caseInsensitive {
+								arg = bytes.ToUpper(arg)
+							}
 							var idx, skeletonIdx int
 							for skeletonIdx < len(p.constArg) {
 								idx = bytes.Index(arg, p.constArg[skeletonIdx])
@@ -278,6 +325,9 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 						arg := col.Get(i)
 
 						{
+							if _caseInsensitive {
+								arg = bytes.ToUpper(arg)
+							}
 							var idx, skeletonIdx int
 							for skeletonIdx < len(p.constArg) {
 								idx = bytes.Index(arg, p.constArg[skeletonIdx])
@@ -300,6 +350,9 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						var idx, skeletonIdx int
 						for skeletonIdx < len(p.constArg) {
 							idx = bytes.Index(arg, p.constArg[skeletonIdx])
@@ -319,6 +372,9 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						var idx, skeletonIdx int
 						for skeletonIdx < len(p.constArg) {
 							idx = bytes.Index(arg, p.constArg[skeletonIdx])

--- a/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
@@ -20,9 +20,11 @@ import (
 type selPrefixBytesBytesConstOp struct {
 	selConstOpBase
 	constArg []byte
+	negate   bool
 }
 
 func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -43,7 +45,7 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.HasPrefix(arg, p.constArg)
+					cmp = bytes.HasPrefix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -59,7 +61,7 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.HasPrefix(arg, p.constArg)
+					cmp = bytes.HasPrefix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -72,7 +74,7 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.HasPrefix(arg, p.constArg)
+					cmp = bytes.HasPrefix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -85,7 +87,7 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.HasPrefix(arg, p.constArg)
+					cmp = bytes.HasPrefix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -103,9 +105,11 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 type selSuffixBytesBytesConstOp struct {
 	selConstOpBase
 	constArg []byte
+	negate   bool
 }
 
 func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -126,7 +130,7 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.HasSuffix(arg, p.constArg)
+					cmp = bytes.HasSuffix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -142,7 +146,7 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.HasSuffix(arg, p.constArg)
+					cmp = bytes.HasSuffix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -155,7 +159,7 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.HasSuffix(arg, p.constArg)
+					cmp = bytes.HasSuffix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -168,7 +172,7 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.HasSuffix(arg, p.constArg)
+					cmp = bytes.HasSuffix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -186,9 +190,11 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 type selContainsBytesBytesConstOp struct {
 	selConstOpBase
 	constArg []byte
+	negate   bool
 }
 
 func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -209,7 +215,7 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.Contains(arg, p.constArg)
+					cmp = bytes.Contains(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -225,7 +231,7 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.Contains(arg, p.constArg)
+					cmp = bytes.Contains(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -238,7 +244,7 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.Contains(arg, p.constArg)
+					cmp = bytes.Contains(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -251,7 +257,7 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					var cmp bool
 					arg := col.Get(i)
-					cmp = bytes.Contains(arg, p.constArg)
+					cmp = bytes.Contains(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -269,9 +275,11 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 type selSkeletonBytesBytesConstOp struct {
 	selConstOpBase
 	constArg [][]byte
+	negate   bool
 }
 
 func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -303,7 +311,7 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 							arg = arg[idx+len(p.constArg[skeletonIdx]):]
 							skeletonIdx++
 						}
-						cmp = skeletonIdx == len(p.constArg)
+						cmp = skeletonIdx == len(p.constArg) != _negate
 					}
 					if cmp {
 						sel[idx] = i
@@ -331,7 +339,7 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 							arg = arg[idx+len(p.constArg[skeletonIdx]):]
 							skeletonIdx++
 						}
-						cmp = skeletonIdx == len(p.constArg)
+						cmp = skeletonIdx == len(p.constArg) != _negate
 					}
 					if cmp {
 						sel[idx] = i
@@ -356,7 +364,7 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 							arg = arg[idx+len(p.constArg[skeletonIdx]):]
 							skeletonIdx++
 						}
-						cmp = skeletonIdx == len(p.constArg)
+						cmp = skeletonIdx == len(p.constArg) != _negate
 					}
 					if cmp {
 						sel[idx] = i
@@ -381,7 +389,7 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 							arg = arg[idx+len(p.constArg[skeletonIdx]):]
 							skeletonIdx++
 						}
-						cmp = skeletonIdx == len(p.constArg)
+						cmp = skeletonIdx == len(p.constArg) != _negate
 					}
 					if cmp {
 						sel[idx] = i
@@ -400,9 +408,11 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 type selRegexpBytesBytesConstOp struct {
 	selConstOpBase
 	constArg *regexp.Regexp
+	negate   bool
 }
 
 func (p *selRegexpBytesBytesConstOp) Next() coldata.Batch {
+	_negate := p.negate
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -423,7 +433,7 @@ func (p *selRegexpBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
-					cmp = p.constArg.Match(arg)
+					cmp = p.constArg.Match(arg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -439,7 +449,7 @@ func (p *selRegexpBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
-					cmp = p.constArg.Match(arg)
+					cmp = p.constArg.Match(arg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -452,7 +462,7 @@ func (p *selRegexpBytesBytesConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					var cmp bool
 					arg := col.Get(i)
-					cmp = p.constArg.Match(arg)
+					cmp = p.constArg.Match(arg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++
@@ -465,470 +475,7 @@ func (p *selRegexpBytesBytesConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					var cmp bool
 					arg := col.Get(i)
-					cmp = p.constArg.Match(arg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-type selNotPrefixBytesBytesConstOp struct {
-	selConstOpBase
-	constArg []byte
-}
-
-func (p *selNotPrefixBytesBytesConstOp) Next() coldata.Batch {
-	for {
-		batch := p.Input.Next()
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		vec := batch.ColVec(p.colIdx)
-		col := vec.Bytes()
-		var idx int
-		n := batch.Length()
-		if vec.MaybeHasNulls() {
-			nulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.HasPrefix(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.HasPrefix(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.HasPrefix(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.HasPrefix(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-type selNotSuffixBytesBytesConstOp struct {
-	selConstOpBase
-	constArg []byte
-}
-
-func (p *selNotSuffixBytesBytesConstOp) Next() coldata.Batch {
-	for {
-		batch := p.Input.Next()
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		vec := batch.ColVec(p.colIdx)
-		col := vec.Bytes()
-		var idx int
-		n := batch.Length()
-		if vec.MaybeHasNulls() {
-			nulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.HasSuffix(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.HasSuffix(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.HasSuffix(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.HasSuffix(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-type selNotContainsBytesBytesConstOp struct {
-	selConstOpBase
-	constArg []byte
-}
-
-func (p *selNotContainsBytesBytesConstOp) Next() coldata.Batch {
-	for {
-		batch := p.Input.Next()
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		vec := batch.ColVec(p.colIdx)
-		col := vec.Bytes()
-		var idx int
-		n := batch.Length()
-		if vec.MaybeHasNulls() {
-			nulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.Contains(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.Contains(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.Contains(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !bytes.Contains(arg, p.constArg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-type selNotSkeletonBytesBytesConstOp struct {
-	selConstOpBase
-	constArg [][]byte
-}
-
-func (p *selNotSkeletonBytesBytesConstOp) Next() coldata.Batch {
-	for {
-		batch := p.Input.Next()
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		vec := batch.ColVec(p.colIdx)
-		col := vec.Bytes()
-		var idx int
-		n := batch.Length()
-		if vec.MaybeHasNulls() {
-			nulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-
-					{
-						var idx, skeletonIdx int
-						for skeletonIdx < len(p.constArg) {
-							idx = bytes.Index(arg, p.constArg[skeletonIdx])
-							if idx < 0 {
-								break
-							}
-							arg = arg[idx+len(p.constArg[skeletonIdx]):]
-							skeletonIdx++
-						}
-						cmp = skeletonIdx != len(p.constArg)
-					}
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-
-					{
-						var idx, skeletonIdx int
-						for skeletonIdx < len(p.constArg) {
-							idx = bytes.Index(arg, p.constArg[skeletonIdx])
-							if idx < 0 {
-								break
-							}
-							arg = arg[idx+len(p.constArg[skeletonIdx]):]
-							skeletonIdx++
-						}
-						cmp = skeletonIdx != len(p.constArg)
-					}
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					var cmp bool
-					arg := col.Get(i)
-
-					{
-						var idx, skeletonIdx int
-						for skeletonIdx < len(p.constArg) {
-							idx = bytes.Index(arg, p.constArg[skeletonIdx])
-							if idx < 0 {
-								break
-							}
-							arg = arg[idx+len(p.constArg[skeletonIdx]):]
-							skeletonIdx++
-						}
-						cmp = skeletonIdx != len(p.constArg)
-					}
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					var cmp bool
-					arg := col.Get(i)
-
-					{
-						var idx, skeletonIdx int
-						for skeletonIdx < len(p.constArg) {
-							idx = bytes.Index(arg, p.constArg[skeletonIdx])
-							if idx < 0 {
-								break
-							}
-							arg = arg[idx+len(p.constArg[skeletonIdx]):]
-							skeletonIdx++
-						}
-						cmp = skeletonIdx != len(p.constArg)
-					}
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		}
-		if idx > 0 {
-			batch.SetLength(idx)
-			return batch
-		}
-	}
-}
-
-type selNotRegexpBytesBytesConstOp struct {
-	selConstOpBase
-	constArg *regexp.Regexp
-}
-
-func (p *selNotRegexpBytesBytesConstOp) Next() coldata.Batch {
-	for {
-		batch := p.Input.Next()
-		if batch.Length() == 0 {
-			return batch
-		}
-
-		vec := batch.ColVec(p.colIdx)
-		col := vec.Bytes()
-		var idx int
-		n := batch.Length()
-		if vec.MaybeHasNulls() {
-			nulls := vec.Nulls()
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !p.constArg.Match(arg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					if nulls.NullAt(i) {
-						continue
-					}
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !p.constArg.Match(arg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			}
-		} else {
-			if sel := batch.Selection(); sel != nil {
-				sel = sel[:n]
-				for _, i := range sel {
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !p.constArg.Match(arg)
-					if cmp {
-						sel[idx] = i
-						idx++
-					}
-				}
-			} else {
-				batch.SetSelection(true)
-				sel := batch.Selection()
-				_ = col.Get(n - 1)
-				for i := 0; i < n; i++ {
-					var cmp bool
-					arg := col.Get(i)
-					cmp = !p.constArg.Match(arg)
+					cmp = p.constArg.Match(arg) != _negate
 					if cmp {
 						sel[idx] = i
 						idx++

--- a/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/sel_like_ops.eg.go
@@ -19,12 +19,14 @@ import (
 
 type selPrefixBytesBytesConstOp struct {
 	selConstOpBase
-	constArg []byte
-	negate   bool
+	constArg        []byte
+	negate          bool
+	caseInsensitive bool
 }
 
 func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 	_negate := p.negate
+	_caseInsensitive := p.caseInsensitive
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -45,6 +47,9 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.HasPrefix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -61,6 +66,9 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.HasPrefix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -74,6 +82,9 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.HasPrefix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -87,6 +98,9 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.HasPrefix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -104,12 +118,14 @@ func (p *selPrefixBytesBytesConstOp) Next() coldata.Batch {
 
 type selSuffixBytesBytesConstOp struct {
 	selConstOpBase
-	constArg []byte
-	negate   bool
+	constArg        []byte
+	negate          bool
+	caseInsensitive bool
 }
 
 func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 	_negate := p.negate
+	_caseInsensitive := p.caseInsensitive
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -130,6 +146,9 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.HasSuffix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -146,6 +165,9 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.HasSuffix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -159,6 +181,9 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.HasSuffix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -172,6 +197,9 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.HasSuffix(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -189,12 +217,14 @@ func (p *selSuffixBytesBytesConstOp) Next() coldata.Batch {
 
 type selContainsBytesBytesConstOp struct {
 	selConstOpBase
-	constArg []byte
-	negate   bool
+	constArg        []byte
+	negate          bool
+	caseInsensitive bool
 }
 
 func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 	_negate := p.negate
+	_caseInsensitive := p.caseInsensitive
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -215,6 +245,9 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.Contains(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -231,6 +264,9 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 					}
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.Contains(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -244,6 +280,9 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.Contains(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -257,6 +296,9 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					var cmp bool
 					arg := col.Get(i)
+					if _caseInsensitive {
+						arg = bytes.ToUpper(arg)
+					}
 					cmp = bytes.Contains(arg, p.constArg) != _negate
 					if cmp {
 						sel[idx] = i
@@ -274,12 +316,14 @@ func (p *selContainsBytesBytesConstOp) Next() coldata.Batch {
 
 type selSkeletonBytesBytesConstOp struct {
 	selConstOpBase
-	constArg [][]byte
-	negate   bool
+	constArg        [][]byte
+	negate          bool
+	caseInsensitive bool
 }
 
 func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 	_negate := p.negate
+	_caseInsensitive := p.caseInsensitive
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {
@@ -302,6 +346,9 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						var idx, skeletonIdx int
 						for skeletonIdx < len(p.constArg) {
 							idx = bytes.Index(arg, p.constArg[skeletonIdx])
@@ -330,6 +377,9 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						var idx, skeletonIdx int
 						for skeletonIdx < len(p.constArg) {
 							idx = bytes.Index(arg, p.constArg[skeletonIdx])
@@ -355,6 +405,9 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						var idx, skeletonIdx int
 						for skeletonIdx < len(p.constArg) {
 							idx = bytes.Index(arg, p.constArg[skeletonIdx])
@@ -380,6 +433,9 @@ func (p *selSkeletonBytesBytesConstOp) Next() coldata.Batch {
 					arg := col.Get(i)
 
 					{
+						if _caseInsensitive {
+							arg = bytes.ToUpper(arg)
+						}
 						var idx, skeletonIdx int
 						for skeletonIdx < len(p.constArg) {
 							idx = bytes.Index(arg, p.constArg[skeletonIdx])

--- a/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
@@ -191,9 +191,20 @@ type selOpBase struct {
 type _OP_CONST_NAME struct {
 	selConstOpBase
 	constArg _R_GO_TYPE
+	// {{if .Negatable}}
+	negate bool
+	// {{end}}
 }
 
 func (p *_OP_CONST_NAME) Next() coldata.Batch {
+	// {{if .Negatable}}
+	// {{/*
+	//     In order to inline the templated code of the LIKE overloads, we need
+	//     to have a `_negate` local variable indicating whether the assignment
+	//     should be negated.
+	// */}}
+	_negate := p.negate
+	// {{end}}
 	for {
 		batch := p.Input.Next()
 		if batch.Length() == 0 {

--- a/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/selection_ops_tmpl.go
@@ -194,6 +194,9 @@ type _OP_CONST_NAME struct {
 	// {{if .Negatable}}
 	negate bool
 	// {{end}}
+	// {{if .CaseInsensitive}}
+	caseInsensitive bool
+	// {{end}}
 }
 
 func (p *_OP_CONST_NAME) Next() coldata.Batch {
@@ -204,6 +207,14 @@ func (p *_OP_CONST_NAME) Next() coldata.Batch {
 	//     should be negated.
 	// */}}
 	_negate := p.negate
+	// {{end}}
+	// {{if .CaseInsensitive}}
+	// {{/*
+	//     In order to inline the templated code of the LIKE overloads, we need
+	//     to have a `_caseInsensitive` local variable indicating whether the
+	//     operator is case insensitive.
+	// */}}
+	_caseInsensitive := p.caseInsensitive
 	// {{end}}
 	for {
 		batch := p.Input.Next()

--- a/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/like_ops_gen.go
@@ -73,7 +73,10 @@ func genLikeOps(
 			return err
 		}
 		bytesRepresentation := toPhysicalRepresentation(types.BytesFamily, anyWidth)
-		makeOverload := func(name string, rightGoType string, assignFunc func(targetElem, leftElem, rightElem string) string) *twoArgsResolvedOverload {
+		makeOverload := func(
+			name string, rightGoType string, caseInsensitive bool,
+			assignFunc func(targetElem, leftElem, rightElem string) string,
+		) *twoArgsResolvedOverload {
 			base := &overloadBase{
 				Name: name,
 			}
@@ -112,16 +115,34 @@ func genLikeOps(
 			}
 			rightTypeOverload.WidthOverloads[0] = rightWidthOverload
 			return &twoArgsResolvedOverload{
-				overloadBase: base,
-				Left:         leftWidthOverload,
-				Right:        rightWidthOverload,
-				Negatable:    true,
+				overloadBase:    base,
+				Left:            leftWidthOverload,
+				Right:           rightWidthOverload,
+				Negatable:       true,
+				CaseInsensitive: caseInsensitive,
 			}
 		}
+		caseInsensitivePrelude := func(leftElem string) string {
+			return fmt.Sprintf(`if _caseInsensitive {
+						%[1]s = bytes.ToUpper(%[1]s)
+					}`, leftElem)
+		}
+		// makeSimpleOverload returns the overload for "simple" patterns which
+		// call a single method from 'bytes' package for comparison.
+		makeSimpleOverload := func(name string, bytesFunc string) *twoArgsResolvedOverload {
+			return makeOverload(name, bytesRepresentation, true, /* caseInsensitive */
+				func(targetElem, leftElem, rightElem string) string {
+					return fmt.Sprintf(
+						`%[4]s
+						%[1]s = bytes.%[5]s(%[2]s, %[3]s) != _negate`,
+						targetElem, leftElem, rightElem, caseInsensitivePrelude(leftElem), bytesFunc)
+				})
+		}
 		// makeSkeletonAssignFunc returns a string that assigns 'targetElem' to
-		// the result of evaluation 'leftElem' (LIKE | NOT LIKE) pattern where
-		// pattern is of the form '%word1%word2%...%' where "words" come from
-		// 'rightElem' (which is [][]byte).
+		// the result of evaluation
+		//   'leftElem' (LIKE | NOT LIKE | ILIKE | NOT ILIKE) pattern
+		// where pattern is of the form '%word1%word2%...%' where "words" come
+		// from 'rightElem' (which is [][]byte).
 		//
 		// The logic for evaluating such expression is that for each word we
 		// find its first occurrence in the unprocessed part of 'leftElem'. If
@@ -130,6 +151,7 @@ func genLikeOps(
 		makeSkeletonAssignFunc := func(targetElem, leftElem, rightElem string) string {
 			return fmt.Sprintf(`
 				{
+					%[4]s
 					var idx, skeletonIdx int
 					for skeletonIdx < len(%[3]s) {
 						idx = bytes.Index(%[2]s, %[3]s[skeletonIdx])
@@ -140,24 +162,24 @@ func genLikeOps(
 						skeletonIdx++
 					}
 					%[1]s = skeletonIdx == len(%[3]s) != _negate
-				}`, targetElem, leftElem, rightElem)
+				}`, targetElem, leftElem, rightElem, caseInsensitivePrelude(leftElem))
 		}
 		overloads := []*twoArgsResolvedOverload{
-			makeOverload("Prefix", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
-				return fmt.Sprintf("%s = bytes.HasPrefix(%s, %s) != _negate", targetElem, leftElem, rightElem)
-			}),
-			makeOverload("Suffix", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
-				return fmt.Sprintf("%s = bytes.HasSuffix(%s, %s) != _negate", targetElem, leftElem, rightElem)
-			}),
-			makeOverload("Contains", bytesRepresentation, func(targetElem, leftElem, rightElem string) string {
-				return fmt.Sprintf("%s = bytes.Contains(%s, %s) != _negate", targetElem, leftElem, rightElem)
-			}),
-			makeOverload("Skeleton", "[][]byte", func(targetElem, leftElem, rightElem string) string {
-				return makeSkeletonAssignFunc(targetElem, leftElem, rightElem)
-			}),
-			makeOverload("Regexp", "*regexp.Regexp", func(targetElem, leftElem, rightElem string) string {
-				return fmt.Sprintf("%s = %s.Match(%s) != _negate", targetElem, rightElem, leftElem)
-			}),
+			makeSimpleOverload("Prefix", "HasPrefix"),
+			makeSimpleOverload("Suffix", "HasSuffix"),
+			makeSimpleOverload("Contains", "Contains"),
+			makeOverload("Skeleton", "[][]byte", true, /* caseInsensitive */
+				func(targetElem, leftElem, rightElem string) string {
+					return makeSkeletonAssignFunc(
+						targetElem, leftElem, rightElem,
+					)
+				}),
+			// Note that the Regexp overload handles the case sensitivity
+			// itself.
+			makeOverload("Regexp", "*regexp.Regexp", false, /* caseInsensitive */
+				func(targetElem, leftElem, rightElem string) string {
+					return fmt.Sprintf("%s = %s.Match(%s) != _negate", targetElem, rightElem, leftElem)
+				}),
 		}
 		return tmpl.Execute(wr, overloads)
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -312,6 +312,11 @@ type twoArgsResolvedOverload struct {
 	*overloadBase
 	Left  *argWidthOverload
 	Right *lastArgWidthOverload
+
+	// Negatable is only used by the LIKE overloads. We cannot easily extract
+	// out a separate struct for those since we're reusing the same templates as
+	// all of the selection / projection operators.
+	Negatable bool
 }
 
 // NeedsBinaryOverloadHelper returns true iff the overload is such that it needs

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -313,10 +313,11 @@ type twoArgsResolvedOverload struct {
 	Left  *argWidthOverload
 	Right *lastArgWidthOverload
 
-	// Negatable is only used by the LIKE overloads. We cannot easily extract
-	// out a separate struct for those since we're reusing the same templates as
-	// all of the selection / projection operators.
-	Negatable bool
+	// Negatable and CaseInsensitive are only used by the LIKE overloads. We
+	// cannot easily extract out a separate struct for those since we're reusing
+	// the same templates as all of the selection / projection operators.
+	Negatable       bool
+	CaseInsensitive bool
 }
 
 // NeedsBinaryOverloadHelper returns true iff the overload is such that it needs

--- a/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
@@ -20812,7 +20812,7 @@ EXPLAIN (VEC) SELECT c_count, count(*) AS custdist FROM ( SELECT c_custkey, coun
     └ *colexec.hashAggregator
       └ *colexec.hashAggregator
         └ *colexecjoin.hashJoiner
-          ├ *colexecsel.selNotSkeletonBytesBytesConstOp
+          ├ *colexecsel.selSkeletonBytesBytesConstOp
           │ └ *colfetcher.ColBatchScan
           └ *colfetcher.ColBatchScan
 
@@ -20876,7 +20876,7 @@ EXPLAIN (VEC) SELECT p_brand, p_type, p_size, count(distinct ps_suppkey) AS supp
         └ *colexecjoin.hashJoiner
           ├ *rowexec.joinReader
           │ └ *colexec.selectInOpInt64
-          │   └ *colexecsel.selNotPrefixBytesBytesConstOp
+          │   └ *colexecsel.selPrefixBytesBytesConstOp
           │     └ *colexecsel.selNEBytesBytesConstOp
           │       └ *colfetcher.ColBatchScan
           └ *colexecsel.selSkeletonBytesBytesConstOp


### PR DESCRIPTION
**colexec: clean up NOT LIKE operator generation**

This commit cleans up the way we generate operators for NOT LIKE.
Previously, they would get their own copy which was exactly the same as
for LIKE with a difference in a single line, and now the same underlying
operator will handle both LIKE and NOT LIKE - the result of comparison
just needs to be negated. The performance hit of this extra boolean
comparison is negligible yet we can remove some of the duplicated
generated code.

```
name                                     old time/op    new time/op    delta
LikeOps/selPrefixBytesBytesConstOp-24      17.8µs ± 1%    16.9µs ± 0%   -4.93%  (p=0.000 n=10+10)
LikeOps/selSuffixBytesBytesConstOp-24      18.5µs ± 0%    18.7µs ± 0%   +1.37%  (p=0.000 n=10+10)
LikeOps/selContainsBytesBytesConstOp-24    27.8µs ± 0%    28.0µs ± 0%   +1.02%  (p=0.000 n=9+10)
LikeOps/selRegexpBytesBytesConstOp-24       479µs ± 1%     484µs ± 0%   +1.10%  (p=0.000 n=10+10)
LikeOps/selSkeletonBytesBytesConstOp-24    39.9µs ± 0%    40.3µs ± 0%   +0.85%  (p=0.000 n=10+10)
LikeOps/selRegexpSkeleton-24                871µs ± 2%     871µs ± 0%     ~     (p=1.000 n=10+10)
```

Release note: None

**colexec: add support for ILIKE and NOT ILIKE**

This commit adds the native vectorized support for ILIKE and NOT ILIKE
comparisons. The idea is simple - convert both the argument and the
pattern to capital letters. This required minor changes to the templates
to add a "prelude" step of that conversion as well as conversion of the
pattern to the upper case during planning.

Initially, I generated separate operators for case-insensitive cases,
but the benchmarks shown that the performance impact of a single
conditional inside of the `for` loop is barely noticeable given that the
branch prediction will always be right, so I refactored the existing
operators to support case insensitivity.

```
name                                     old time/op    new time/op    delta
LikeOps/selPrefixBytesBytesConstOp-24      16.8µs ± 0%    17.7µs ± 0%  +5.30%  (p=0.000 n=10+10)
LikeOps/selSuffixBytesBytesConstOp-24      18.7µs ± 0%    19.2µs ± 0%  +2.99%  (p=0.000 n=10+10)
LikeOps/selContainsBytesBytesConstOp-24    28.0µs ± 0%    27.8µs ± 0%  -0.73%  (p=0.000 n=10+10)
LikeOps/selRegexpBytesBytesConstOp-24       479µs ± 0%     480µs ± 0%  +0.33%  (p=0.008 n=9+10)
LikeOps/selSkeletonBytesBytesConstOp-24    40.2µs ± 0%    41.4µs ± 0%  +3.20%  (p=0.000 n=9+10)
LikeOps/selRegexpSkeleton-24                860µs ± 0%     857µs ± 0%  -0.36%  (p=0.023 n=10+10)
```

Addresses: #49781.

Release note (performance improvement): ILIKE and NOT ILIKE filters can
now be evaluated more efficiently in some cases.