### PR TITLE
sql: support creation of UDFs that reference arguments in body

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1,5 +1,11 @@
 # LogicTest: local-udf
 
+statement ok
+CREATE TABLE ab (
+  a INT PRIMARY KEY,
+  b INT
+)
+
 statement error pq: unimplemented: replacing function
 CREATE OR REPLACE FUNCTION f(a int) RETURNS INT LANGUAGE SQL AS 'SELECT 1'
 
@@ -9,6 +15,43 @@ CREATE FUNCTION f(a int) RETURNS INT LEAKPROOF STABLE LANGUAGE SQL AS 'SELECT 1'
 statement error pq: return type mismatch in function declared to return int\nDETAIL: Actual return type is string
 CREATE FUNCTION f() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 'hello' $$
 
+statement ok
+CREATE FUNCTION a(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT i'
+
+statement ok
+CREATE FUNCTION b(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT a FROM ab WHERE a = i'
+
+statement ok
+CREATE FUNCTION c(i INT, j INT) RETURNS INT LANGUAGE SQL AS 'SELECT i - j'
+
+statement error column \"j\" does not exist
+CREATE FUNCTION err(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT j'
+
+statement error column \"j\" does not exist
+CREATE FUNCTION err(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT * FROM ab WHERE a = j'
+
+statement ok
+CREATE FUNCTION d(i INT2) RETURNS INT4 LANGUAGE SQL AS 'SELECT i'
+
+# TODO(mgartner): This should be allowed because the cast from INT2::FLOAT4 is
+# allowed in implicit contexts.
+statement error return type mismatch in function declared to return float4\nDETAIL: Actual return type is int2
+CREATE FUNCTION e(i INT2) RETURNS FLOAT4 LANGUAGE SQL AS 'SELECT i'
+
+# TODO(mgartner): This should be allowed because the cast from BOOL::STRING is
+# allowed in assignment contexts.
+statement error return type mismatch in function declared to return string\nDETAIL: Actual return type is bool
+CREATE FUNCTION f(b BOOL) RETURNS STRING LANGUAGE SQL AS 'SELECT b'
+
+statement error return type mismatch in function declared to return bool\nDETAIL: Actual return type is int
+CREATE FUNCTION err(i INT, j INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i - j'
+
+statement error return type mismatch in function declared to return int\nDETAIL: Actual return type is bool
+CREATE FUNCTION err(b BOOL) RETURNS INT LANGUAGE SQL AS 'SELECT b'
+
+statement error return type mismatch in function declared to return bool\nDETAIL: Actual return type is int
+CREATE FUNCTION err(i INT, j INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i - j'
+
 # Make sure using table name as tuple type name works properly.
 # It should pass the return type validation and stored as a tuple type.
 statement ok
@@ -17,7 +60,7 @@ CREATE TABLE t_implicit_type(a INT PRIMARY KEY, b STRING);
 statement error pq: return type mismatch in function declared to return int\nDETAIL: Actual return type is record
 CREATE FUNCTION f() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT a, b from t_implicit_type $$
 
-statement error pq: unimplemented: functions do not currently support \* expressions.*
+statement ok
 CREATE FUNCTION f() RETURNS t_implicit_type IMMUTABLE LANGUAGE SQL AS $$ SELECT * from t_implicit_type $$
 
 statement ok
@@ -38,11 +81,11 @@ WHERE id = $max_desc_id;
 {
     "function": {
         "dependsOn": [
-            107,
-            107
+            112,
+            112
         ],
         "functionBody": "SELECT a, b FROM test.public.t_implicit_type;",
-        "id": 108,
+        "id": 114,
         "lang": "SQL",
         "modificationTime": {},
         "name": "f",
@@ -68,7 +111,7 @@ WHERE id = $max_desc_id;
         "returnType": {
             "type": {
                 "family": "TupleFamily",
-                "oid": 100107,
+                "oid": 100112,
                 "tupleContents": [
                     {
                         "family": "IntFamily",
@@ -121,7 +164,7 @@ WHERE id = $max_desc_id;
             }
         ],
         "functionBody": "SELECT 1;",
-        "id": 109,
+        "id": 115,
         "lang": "SQL",
         "modificationTime": {},
         "name": "f",
@@ -201,23 +244,23 @@ WHERE id = $max_desc_id;
                 "name": "a",
                 "type": {
                     "family": "EnumFamily",
-                    "oid": 100112,
+                    "oid": 100118,
                     "udtMetadata": {
-                        "arrayTypeOid": 100113
+                        "arrayTypeOid": 100119
                     }
                 }
             }
         ],
         "dependsOn": [
-            110,
-            111
+            116,
+            117
         ],
         "dependsOnTypes": [
-            112,
-            113
+            118,
+            119
         ],
-        "functionBody": "SELECT a FROM test.public.t;\nSELECT b FROM test.public.t@t_idx_b;\nSELECT c FROM test.public.t@t_idx_c;\nSELECT nextval(111:::REGCLASS);",
-        "id": 114,
+        "functionBody": "SELECT a FROM test.public.t;\nSELECT b FROM test.public.t@t_idx_b;\nSELECT c FROM test.public.t@t_idx_c;\nSELECT nextval(117:::REGCLASS);",
+        "id": 120,
         "lang": "SQL",
         "modificationTime": {},
         "name": "f",

--- a/pkg/sql/opt/optbuilder/testdata/create_function
+++ b/pkg/sql/opt/optbuilder/testdata/create_function
@@ -57,7 +57,7 @@ create-function
 build
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT * FROM ab $$
 ----
-error (0A000): unimplemented: functions do not currently support * expressions
+error (42P13): return type mismatch in function declared to return int
 
 build
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL BEGIN ATOMIC SELECT 1; END;

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -64,9 +64,6 @@ func (b *Builder) expandStar(
 	if b.insideViewDef {
 		panic(unimplemented.NewWithIssue(10028, "views do not currently support * expressions"))
 	}
-	if b.insideFuncDef {
-		panic(unimplemented.NewWithIssue(10028, "functions do not currently support * expressions"))
-	}
 	switch t := expr.(type) {
 	case *tree.TupleStar:
 		texpr := inScope.resolveType(t.Expr, types.Any)
@@ -633,7 +630,8 @@ func (b *Builder) resolveDataSource(
 ) (cat.DataSource, opt.MDDepName, cat.DataSourceName) {
 	var flags cat.Flags
 	if b.insideViewDef || b.insideFuncDef {
-		// Avoid taking descriptor leases when we're creating a view/function.
+		// Avoid taking descriptor leases when we're creating a view or a
+		// function.
 		flags.AvoidDescriptorCaches = true
 	}
 	ds, resName, err := b.catalog.ResolveDataSource(b.ctx, flags, tn)
@@ -660,7 +658,7 @@ func (b *Builder) resolveDataSourceRef(
 ) (cat.DataSource, opt.MDDepName) {
 	var flags cat.Flags
 	if b.insideViewDef || b.insideFuncDef {
-		// Avoid taking table leases when we're creating a view.
+		// Avoid taking table leases when we're creating a view or a function.
 		flags.AvoidDescriptorCaches = true
 	}
 	ds, _, err := b.catalog.ResolveDataSourceByID(b.ctx, flags, cat.StableID(ref.TableID))


### PR DESCRIPTION
It is now possible to create UDFs that contain argument references in
the function body. Upon creation, each statement in the function body is
built by optbuilder to validate it and track dependencies. Previously
these statements were built with an empty scope, so references to the
function's arguments could not be resolved. Now the scope is populated
with the named arguments of the function.

Note that execution of UDFs is not yet supported. This commit only
affects the creation of UDFs.

Release note: None
