### PR TITLE
opt: add more tests for user-defined type dependency tracking

### DIFF
--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/sem/cast",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/tree/treewindow",

--- a/pkg/sql/opt/optbuilder/testdata/create_function
+++ b/pkg/sql/opt/optbuilder/testdata/create_function
@@ -1,4 +1,3 @@
-# This table has ID 53.
 exec-ddl
 CREATE TABLE ab (a INT PRIMARY KEY, b INT, INDEX idx(b))
 ----
@@ -9,6 +8,10 @@ CREATE SEQUENCE s
 
 exec-ddl
 CREATE TYPE workday AS ENUM ('MON', 'TUE')
+----
+
+exec-ddl
+CREATE TABLE workdays (w workday)
 ----
 
 build
@@ -29,7 +32,42 @@ create-function
  │   	RETURNS INT8
  │   	LANGUAGE SQL
  │   	AS $$SELECT 1;$$
- └── no dependencies
+ └── dependencies
+      └── workday
+
+build
+CREATE FUNCTION f() RETURNS workday LANGUAGE SQL AS $$SELECT w FROM workdays$$
+----
+create-function
+ ├── CREATE FUNCTION f()
+ │   	RETURNS workday
+ │   	LANGUAGE SQL
+ │   	AS $$SELECT w FROM t.public.workdays;$$
+ └── dependencies
+      ├── workdays [columns: w]
+      └── workday
+
+build
+CREATE FUNCTION f() RETURNS STRING LANGUAGE SQL AS $$ SELECT 'MON'::workday::STRING $$
+----
+create-function
+ ├── CREATE FUNCTION f()
+ │   	RETURNS STRING
+ │   	LANGUAGE SQL
+ │   	AS $$SELECT 'MON'::STRING;$$
+ └── dependencies
+      └── workday
+
+build
+CREATE FUNCTION f() RETURNS STRING LANGUAGE SQL AS $$SELECT w::STRING FROM workdays$$
+----
+create-function
+ ├── CREATE FUNCTION f()
+ │   	RETURNS STRING
+ │   	LANGUAGE SQL
+ │   	AS $$SELECT w::STRING FROM t.public.workdays;$$
+ └── dependencies
+      └── workdays [columns: w]
 
 build
 CREATE FUNCTION f(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM ab $$

--- a/pkg/sql/opt/optbuilder/testdata/create_view
+++ b/pkg/sql/opt/optbuilder/testdata/create_view
@@ -11,6 +11,14 @@ exec-ddl
 CREATE SEQUENCE s
 ----
 
+exec-ddl
+CREATE TYPE foobar AS ENUM ('foo', 'bar')
+----
+
+exec-ddl
+CREATE TABLE foobars (fb foobar)
+----
+
 build
 CREATE VIEW v1 AS VALUES (1)
 ----
@@ -352,3 +360,21 @@ create-view t.public.v24
  ├── columns: setval:1
  └── dependencies
       └── s
+
+build
+CREATE VIEW v25 AS VALUES ('foo'::foobar)
+----
+create-view t.public.v25
+ ├── VALUES ('foo'::foobar)
+ ├── columns: column1:1
+ └── dependencies
+      └── foobar
+
+build
+CREATE VIEW v26 AS SELECT fb FROM foobars
+----
+create-view t.public.v26
+ ├── SELECT fb FROM t.public.foobars
+ ├── columns: fb:1
+ └── dependencies
+      └── foobars [columns: fb]


### PR DESCRIPTION
This commit updates the expression formatter to format user-defined type
dependencies, which were previously omitted. It also adds some
additional tests to ensure that user-defined type dependency tracking is
working as intended for `CREATE VIEW` and `CREATE FUNCTION`.

Release note: None

Release justification: This is a test-only change.
