### PR TITLE
storage: load `pebbleMVCCScanner` position when enabling point synthesis

### DIFF
--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -362,6 +362,34 @@ scan: "j"-"k" -> <no data>
 scan: "k"-"l" -> <no data>
 scan: "l"-"m" -> <no data>
 
+# Start forward and reverse scans in the middle of range tombstones.
+run ok
+scan k=h end=z ts=4 tombstones
+----
+scan: "h" -> /<empty> @4.000000000,0
+scan: "j" -> /<empty> @4.000000000,0
+
+run ok
+scan k=a end=h+ ts=4 tombstones reverse
+----
+scan: "h" -> /<empty> @4.000000000,0
+scan: "f" -> /<empty> @4.000000000,0
+scan: "e" -> /<empty> @4.000000000,0
+scan: "d" -> /<empty> @4.000000000,0
+scan: "c" -> /<empty> @4.000000000,0
+scan: "b" -> /<empty> @2.000000000,0
+scan: "a" -> /<empty> @3.000000000,0
+
+run ok
+scan k=k end=l ts=4 tombstones
+----
+scan: "k" -> /<empty> @4.000000000,0
+
+run ok
+scan k=j end=k ts=4 tombstones
+----
+scan: "j" -> /<empty> @4.000000000,0
+
 # failOnMoreRecent: a-d
 run error
 scan k=a end=d ts=3 failOnMoreRecent


### PR DESCRIPTION
This patch loads the current iterator position when switching to point
synthesis in `pebbleMVCCScanner`, rather than initializing the point
synthesizing iterator using an additional seek.

An attempt was also made at pooling the `pointSynthesizingIter` together
with the `pebbleMVCCScanner` instead of using a separate pool, but this
didn't appear to have a significant effect on performance.

```
name                                                                   old time/op    new time/op    delta
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=0-24       2.74µs ± 1%    2.76µs ± 1%   +0.84%  (p=0.013 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=1-24       5.40µs ± 2%    3.57µs ± 1%  -33.86%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=100-24      171µs ± 2%     166µs ± 1%   -2.40%  (p=0.000 n=9+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8/numRangeKeys=0-24      3.90µs ± 0%    3.90µs ± 1%     ~     (p=0.968 n=9+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8/numRangeKeys=1-24      7.11µs ± 1%    5.13µs ± 1%  -27.87%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8/numRangeKeys=100-24     179µs ± 1%     174µs ± 1%   -2.52%  (p=0.000 n=10+10)
```

Resolves #84380.

Release note: None