### PR TITLE
storage: add benchmark for scanning MVCC garbage

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -86,6 +86,32 @@ func BenchmarkMVCCScan_Pebble(b *testing.B) {
 	}
 }
 
+func BenchmarkMVCCScanGarbage_Pebble(b *testing.B) {
+	skip.UnderShort(b)
+	ctx := context.Background()
+	for _, numRows := range []int{1, 10, 100, 1000, 10000, 50000} {
+		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
+			for _, numVersions := range []int{1, 2, 10, 100, 1000} {
+				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
+					for _, numRangeKeys := range []int{0, 1, 100} {
+						b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
+							runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
+								benchDataOptions: benchDataOptions{
+									numVersions:  numVersions,
+									numRangeKeys: numRangeKeys,
+									garbage:      true,
+								},
+								numRows: numRows,
+								reverse: false,
+							})
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
 func BenchmarkMVCCScanSQLRows_Pebble(b *testing.B) {
 	skip.UnderShort(b)
 	ctx := context.Background()


### PR DESCRIPTION
This patch adds `BenchmarkMVCCScanGarbage`, which benchmarks MVCC scans
across garbage. It builds a dataset similarly to `BenchmarkMVCCScan`,
but writes point tombstones instead of values, and any MVCC range
tombstones are written above the point keys rather than below them.

```
name                                                               time/op
MVCCScanGarbage_Pebble/rows=50000/versions=1/numRangeKeys=0-24     8.37ms ± 0%
MVCCScanGarbage_Pebble/rows=50000/versions=1/numRangeKeys=1-24     4.03ms ± 1%
MVCCScanGarbage_Pebble/rows=50000/versions=1/numRangeKeys=100-24   60.4ms ± 7%
MVCCScanGarbage_Pebble/rows=50000/versions=10/numRangeKeys=0-24    45.5ms ± 3%
MVCCScanGarbage_Pebble/rows=50000/versions=10/numRangeKeys=1-24    22.9ms ± 0%
MVCCScanGarbage_Pebble/rows=50000/versions=10/numRangeKeys=100-24   109ms ±13%
```

Resolves #84383.

Release note: None