### PR TITLE
sql: parser and optimizer support FOR {UPDATE,SHARE} SKIP LOCKED

### DIFF
--- a/pkg/sql/catalog/descpb/locking.proto
+++ b/pkg/sql/catalog/descpb/locking.proto
@@ -124,9 +124,6 @@ enum ScanLockingWaitPolicy {
   BLOCK = 0;
 
   // SKIP_LOCKED represents SKIP LOCKED - skip rows that can't be locked.
-  //
-  // NOTE: SKIP_LOCKED is not currently implemented and does not make it out of
-  // the SQL optimizer without throwing an error.
   SKIP_LOCKED = 1;
 
   // ERROR represents NOWAIT - raise an error if a row cannot be locked.

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -53,30 +53,37 @@ SELECT 1 FOR UPDATE OF public.a
 query error pgcode 42601 FOR UPDATE must specify unqualified relation names
 SELECT 1 FOR UPDATE OF db.public.a
 
-# We don't currently support SKIP LOCKED, since it returns an inconsistent view
-# and generally has strange semantics with respect to serializable isolation.
-# Support may be added in the future.
-
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 SELECT 1 FOR UPDATE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 SELECT 1 FOR NO KEY UPDATE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 SELECT 1 FOR SHARE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 SELECT 1 FOR KEY SHARE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
 SELECT 1 FOR UPDATE OF a SKIP LOCKED
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
 SELECT 1 FOR UPDATE OF a SKIP LOCKED FOR NO KEY UPDATE OF b SKIP LOCKED
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
 SELECT 1 FOR UPDATE OF a SKIP LOCKED FOR NO KEY UPDATE OF b NOWAIT
+
+query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
+SELECT 1 FOR UPDATE OF a SKIP LOCKED FOR SHARE OF b, c SKIP LOCKED FOR NO KEY UPDATE OF d SKIP LOCKED FOR KEY SHARE OF e, f SKIP LOCKED
 
 query I
 SELECT 1 FOR UPDATE NOWAIT
@@ -105,18 +112,24 @@ query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM cla
 SELECT 1 FOR UPDATE OF a NOWAIT FOR NO KEY UPDATE OF b NOWAIT
 
 query error pgcode 42P01 relation "a" in FOR UPDATE clause not found in FROM clause
-SELECT 1 FOR UPDATE OF a NOWAIT FOR SHARE OF b, c NOWAIT FOR NO KEY UPDATE OF d NOWAIT  FOR KEY SHARE OF e, f NOWAIT 
+SELECT 1 FOR UPDATE OF a NOWAIT FOR SHARE OF b, c NOWAIT FOR NO KEY UPDATE OF d NOWAIT FOR KEY SHARE OF e, f NOWAIT
 
 # Locking clauses both inside and outside of parenthesis are handled correctly.
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 ((SELECT 1)) FOR UPDATE SKIP LOCKED
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 ((SELECT 1) FOR UPDATE SKIP LOCKED)
+----
+1
 
-query error unimplemented: SKIP LOCKED lock wait policy is not supported
+query I
 ((SELECT 1 FOR UPDATE SKIP LOCKED))
+----
+1
 
 # FOR READ ONLY is ignored, like in Postgres.
 query I
@@ -295,7 +308,7 @@ SELECT * FROM t FOR KEY SHARE
 statement ok
 ROLLBACK
 
-# The NOWAIT wait policy returns error when conflicting lock is encountered.
+# The NOWAIT wait policy returns error when a conflicting lock is encountered.
 
 statement ok
 INSERT INTO t VALUES (1, 1)
@@ -372,3 +385,50 @@ user root
 
 statement ok
 ROLLBACK
+
+# The SKIP LOCKED wait policy skip rows when a conflicting lock is encountered.
+
+statement ok
+INSERT INTO t VALUES (2, 2), (3, 3), (4, 4)
+
+statement ok
+BEGIN; UPDATE t SET v = 3 WHERE k = 2
+
+user testuser
+
+statement ok
+BEGIN
+
+query II
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+1  1
+3  3
+4  4
+
+statement ok
+UPDATE t SET v = 4 WHERE k = 3
+
+query II
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+1  1
+3  4
+4  4
+
+user root
+
+query II
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+2  3
+
+statement ok
+ROLLBACK
+
+user testuser
+
+statement ok
+ROLLBACK
+
+user root

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -204,7 +204,7 @@ SELECT * FROM (SELECT * FROM generate_series(1, 2)) a FOR UPDATE
 # Use of SELECT FOR UPDATE/SHARE requires SELECT and UPDATE privileges.
 
 statement ok
-CREATE TABLE t (k INT PRIMARY KEY, v int)
+CREATE TABLE t (k INT PRIMARY KEY, v int, FAMILY (k, v))
 
 user testuser
 
@@ -392,7 +392,19 @@ statement ok
 INSERT INTO t VALUES (2, 2), (3, 3), (4, 4)
 
 statement ok
-BEGIN; UPDATE t SET v = 3 WHERE k = 2
+CREATE TABLE t3 (
+  k INT PRIMARY KEY,
+  v INT,
+  u INT,
+  INDEX (u),
+  FAMILY (k, v, u)
+);
+INSERT INTO t3 VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 2);
+GRANT SELECT ON t3 TO testuser;
+GRANT UPDATE ON t3 TO testuser
+
+statement ok
+BEGIN; UPDATE t SET v = 3 WHERE k = 2; UPDATE t3 SET v = 3 WHERE k = 2
 
 user testuser
 
@@ -415,6 +427,28 @@ SELECT * FROM t FOR UPDATE SKIP LOCKED
 1  1
 3  4
 4  4
+
+# All columns are available from the secondary index on u, so no index join is
+# needed. The secondary index can produce the row where k=2 since the row is
+# only locked in the primary index.
+query II
+SELECT k, u FROM t3 WHERE u = 2 FOR UPDATE SKIP LOCKED
+----
+2  2
+4  2
+
+# An index join is needed to fetch column v. The index join filters out the
+# first row, which is locked.
+query III
+SELECT * FROM t3 WHERE u = 2 FOR UPDATE SKIP LOCKED
+----
+4  4  2
+
+# Since the limit is not pushed below the index join, we still see the second row.
+query III
+SELECT * FROM t3 WHERE u = 2 LIMIT 1 FOR UPDATE SKIP LOCKED
+----
+4  4  2
 
 user root
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -7,7 +7,7 @@ let $t_id
 SELECT id FROM system.namespace WHERE name='t'
 
 statement ok
-CREATE TABLE u (a INT PRIMARY KEY, c INT, FAMILY (a, c))
+CREATE TABLE u (a INT PRIMARY KEY, b INT, c INT, INDEX (b), FAMILY (a, b, c))
 
 statement ok
 CREATE VIEW v AS SELECT a FROM t AS t2
@@ -1010,10 +1010,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1029,7 +1029,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1043,10 +1043,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1062,7 +1062,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1075,10 +1075,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1093,7 +1093,7 @@ vectorized: true
     │     spans: FULL SCAN
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1107,10 +1107,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1126,7 +1126,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1140,10 +1140,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1159,7 +1159,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1176,10 +1176,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1195,7 +1195,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1209,10 +1209,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1228,7 +1228,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1242,10 +1242,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1261,7 +1261,7 @@ vectorized: true
     │     locking strength: for no key update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1275,10 +1275,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1294,7 +1294,7 @@ vectorized: true
     │     locking strength: for no key update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1312,10 +1312,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1331,7 +1331,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1354,10 +1354,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1373,7 +1373,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1386,10 +1386,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1404,7 +1404,7 @@ vectorized: true
     │     spans: FULL SCAN
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1418,10 +1418,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1437,7 +1437,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1455,10 +1455,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1474,7 +1474,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1497,10 +1497,10 @@ distribution: local
 vectorized: true
 ·
 • project
-│ columns: (a, b, c)
+│ columns: (a, b, b, c)
 │
 └── • merge join (inner)
-    │ columns: (a, b, a, c)
+    │ columns: (a, b, a, b, c)
     │ estimated row count: 1,000 (missing stats)
     │ equality: (a) = (a)
     │ left cols are key
@@ -1516,7 +1516,7 @@ vectorized: true
     │     locking strength: for update
     │
     └── • scan
-          columns: (a, c)
+          columns: (a, b, c)
           ordering: +a
           estimated row count: 1,000 (missing stats)
           table: u@u_pkey
@@ -1534,7 +1534,7 @@ distribution: local
 vectorized: true
 ·
 • cross join (inner)
-│ columns: (a, b, a, c)
+│ columns: (a, b, a, b, c)
 │ estimated row count: 1,000,000 (missing stats)
 │
 ├── • scan
@@ -1545,7 +1545,7 @@ vectorized: true
 │     locking strength: for update
 │
 └── • scan
-      columns: (a, c)
+      columns: (a, b, c)
       estimated row count: 1,000 (missing stats)
       table: u@u_pkey
       spans: FULL SCAN
@@ -1558,7 +1558,7 @@ distribution: local
 vectorized: true
 ·
 • cross join (inner)
-│ columns: (a, b, a, c)
+│ columns: (a, b, a, b, c)
 │ estimated row count: 1,000,000 (missing stats)
 │
 ├── • scan
@@ -1569,7 +1569,7 @@ vectorized: true
 │     locking strength: for update
 │
 └── • scan
-      columns: (a, c)
+      columns: (a, b, c)
       estimated row count: 1,000 (missing stats)
       table: u@u_pkey
       spans: FULL SCAN
@@ -1581,7 +1581,7 @@ distribution: local
 vectorized: true
 ·
 • cross join (inner)
-│ columns: (a, b, a, c)
+│ columns: (a, b, a, b, c)
 │ estimated row count: 1,000,000 (missing stats)
 │
 ├── • scan
@@ -1592,7 +1592,7 @@ vectorized: true
 │     locking strength: for share
 │
 └── • scan
-      columns: (a, c)
+      columns: (a, b, c)
       estimated row count: 1,000 (missing stats)
       table: u@u_pkey
       spans: FULL SCAN
@@ -1605,7 +1605,7 @@ distribution: local
 vectorized: true
 ·
 • cross join (inner)
-│ columns: (a, b, a, c)
+│ columns: (a, b, a, b, c)
 │ estimated row count: 1,000,000 (missing stats)
 │
 ├── • scan
@@ -1616,7 +1616,7 @@ vectorized: true
 │     locking strength: for update
 │
 └── • scan
-      columns: (a, c)
+      columns: (a, b, c)
       estimated row count: 1,000 (missing stats)
       table: u@u_pkey
       spans: FULL SCAN
@@ -1632,7 +1632,7 @@ distribution: local
 vectorized: true
 ·
 • cross join (inner)
-│ columns: (a, b, a, c)
+│ columns: (a, b, a, b, c)
 │ estimated row count: 1,000,000 (missing stats)
 │
 ├── • scan
@@ -1642,7 +1642,7 @@ vectorized: true
 │     spans: FULL SCAN
 │
 └── • scan
-      columns: (a, c)
+      columns: (a, b, c)
       estimated row count: 1,000 (missing stats)
       table: u@u_pkey
       spans: FULL SCAN
@@ -2356,7 +2356,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1,000 (missing stats)
 │ render ?column?: 1
 │
 └── • scan
@@ -2490,7 +2489,6 @@ vectorized: true
 ·
 • render
 │ columns: ("?column?")
-│ estimated row count: 1 (missing stats)
 │ render ?column?: 1
 │
 └── • scan
@@ -2500,3 +2498,67 @@ vectorized: true
       spans: /1/0
       locking strength: for update
       locking wait policy: skip locked
+
+# Tests with a secondary index.
+
+query T
+EXPLAIN (VERBOSE) SELECT a, b FROM u WHERE b = 2 FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 10 (missing stats)
+  table: u@u_b_idx
+  spans: /2-/3
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM u WHERE b = 2 FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b, c)
+│ estimated row count: 10 (missing stats)
+│ table: u@u_pkey
+│ key columns: a
+│ locking strength: for update
+│ locking wait policy: skip locked
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 10 (missing stats)
+      table: u@u_b_idx
+      spans: /2-/3
+      locking strength: for update
+      locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM u WHERE b = 2 LIMIT 1 FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• limit
+│ columns: (a, b, c)
+│ count: 1
+│
+└── • index join
+    │ columns: (a, b, c)
+    │ estimated row count: 10 (missing stats)
+    │ table: u@u_pkey
+    │ key columns: a
+    │ locking strength: for update
+    │ locking wait policy: skip locked
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 10 (missing stats)
+          table: u@u_b_idx
+          spans: /2-/3
+          locking strength: for update
+          locking wait policy: skip locked

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -2228,3 +2228,275 @@ vectorized: true
       spans: /1/0
       locking strength: for update
       locking wait policy: nowait
+
+# ------------------------------------------------------------------------------
+# Tests with the SKIP LOCKED lock wait policy.
+# ------------------------------------------------------------------------------
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for no key update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for key share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for no key update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1,000 (missing stats)
+  table: t@t_pkey
+  spans: FULL SCAN
+  locking strength: for update
+  locking wait policy: skip locked
+
+query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
+EXPLAIN (VERBOSE) SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
+
+query T
+EXPLAIN (VERBOSE) SELECT 1 FROM t FOR UPDATE OF t SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1,000 (missing stats)
+│ render ?column?: 1
+│
+└── • scan
+      columns: ()
+      estimated row count: 1,000 (missing stats)
+      table: t@t_pkey
+      spans: FULL SCAN
+      locking strength: for update
+      locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR NO KEY UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for no key update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for key share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for share
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for no key update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for update
+  locking wait policy: skip locked
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /1/0
+  locking strength: for update
+  locking wait policy: skip locked
+
+query error pgcode 42P01 relation "t2" in FOR UPDATE clause not found in FROM clause
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 1 FOR UPDATE OF t2 SKIP LOCKED
+
+query T
+EXPLAIN (VERBOSE) SELECT 1 FROM t WHERE a = 1 FOR UPDATE OF t SKIP LOCKED
+----
+distribution: local
+vectorized: true
+·
+• render
+│ columns: ("?column?")
+│ estimated row count: 1 (missing stats)
+│ render ?column?: 1
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1 (missing stats)
+      table: t@t_pkey
+      spans: /1/0
+      locking strength: for update
+      locking wait policy: skip locked

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -678,7 +678,8 @@ func (s *ScanPrivate) IsUnfiltered(md *opt.Metadata) bool {
 	return (s.Constraint == nil || s.Constraint.IsUnconstrained()) &&
 		s.InvertedConstraint == nil &&
 		s.HardLimit == 0 &&
-		s.PartialIndexPredicate(md) == nil
+		s.PartialIndexPredicate(md) == nil &&
+		s.Locking.WaitPolicy != tree.LockWaitSkipLocked
 }
 
 // IsFullIndexScan returns true if the ScanPrivate will produce all rows in the

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -495,6 +495,10 @@ func (b *logicalPropsBuilder) buildIndexJoinProps(indexJoin *IndexJoinExpr, rel 
 	// -----------
 	// Inherit cardinality from input.
 	rel.Cardinality = inputProps.Cardinality
+	if indexJoin.Locking.WaitPolicy == tree.LockWaitSkipLocked {
+		// SKIP LOCKED can act like a filter.
+		rel.Cardinality = rel.Cardinality.AsLowAs(0)
+	}
 
 	// Statistics
 	// ----------

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1933,6 +1933,102 @@ inner-join (hash)
            ├── variable: x:7 [type=int]
            └── variable: r1:3 [type=int]
 
+# Foreign keys should be ignored when the referenced table uses SKIP LOCKED.
+norm
+SELECT * FROM fk INNER JOIN xysd ON x = r1 FOR UPDATE SKIP LOCKED
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (7)-->(8-10), (9,10)~~>(7,8), (3)==(7), (7)==(3)
+ ├── prune: (1,2,4,8-10)
+ ├── interesting orderings: (+1) (+7) (-9,+10,+7)
+ ├── scan fk
+ │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
+ ├── scan xysd
+ │    ├── columns: x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile
+ │    ├── key: (7)
+ │    ├── fd: (7)-->(8-10), (9,10)~~>(7,8)
+ │    ├── prune: (7-10)
+ │    └── interesting orderings: (+7) (-9,+10,+7)
+ └── filters
+      └── eq [type=bool, outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+           ├── variable: x:7 [type=int]
+           └── variable: r1:3 [type=int]
+
+norm
+SELECT * FROM fk INNER JOIN xysd ON x = r1 FOR SHARE OF xysd SKIP LOCKED
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (7)-->(8-10), (9,10)~~>(7,8), (3)==(7), (7)==(3)
+ ├── prune: (1,2,4,8-10)
+ ├── interesting orderings: (+1) (+7) (-9,+10,+7)
+ ├── scan fk
+ │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── prune: (1-4)
+ │    ├── interesting orderings: (+1)
+ │    └── unfiltered-cols: (1-6)
+ ├── scan xysd
+ │    ├── columns: x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ │    ├── locking: for-share,skip-locked
+ │    ├── volatile
+ │    ├── key: (7)
+ │    ├── fd: (7)-->(8-10), (9,10)~~>(7,8)
+ │    ├── prune: (7-10)
+ │    └── interesting orderings: (+7) (-9,+10,+7)
+ └── filters
+      └── eq [type=bool, outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+           ├── variable: x:7 [type=int]
+           └── variable: r1:3 [type=int]
+
+# Foreign keys are valid when only the referencing table uses SKIP LOCKED.
+norm
+SELECT * FROM fk INNER JOIN xysd ON x = r1 FOR UPDATE OF fk SKIP LOCKED
+----
+inner-join (hash)
+ ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int) x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2-4), (7)-->(8-10), (9,10)~~>(7,8), (3)==(7), (7)==(3)
+ ├── prune: (1,2,4,8-10)
+ ├── interesting orderings: (+1) (+7) (-9,+10,+7)
+ ├── scan fk
+ │    ├── columns: k:1(int!null) v:2(int) r1:3(int!null) r2:4(int)
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4)
+ │    ├── prune: (1-4)
+ │    └── interesting orderings: (+1)
+ ├── scan xysd
+ │    ├── columns: x:7(int!null) y:8(int) s:9(string) d:10(decimal!null)
+ │    ├── key: (7)
+ │    ├── fd: (7)-->(8-10), (9,10)~~>(7,8)
+ │    ├── prune: (7-10)
+ │    ├── interesting orderings: (+7) (-9,+10,+7)
+ │    └── unfiltered-cols: (7-12)
+ └── filters
+      └── eq [type=bool, outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+           ├── variable: x:7 [type=int]
+           └── variable: r1:3 [type=int]
+
 # InnerJoin with a nullable foreign key equality condition.
 norm
 SELECT * FROM fk INNER JOIN xysd ON x = r2

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -490,6 +490,7 @@ func (md *Metadata) DuplicateTable(
 		Table:                    tabMeta.Table,
 		Alias:                    tabMeta.Alias,
 		IgnoreForeignKeys:        tabMeta.IgnoreForeignKeys,
+		IsSkipLocked:             tabMeta.IsSkipLocked,
 		Constraints:              constraints,
 		ComputedCols:             computedCols,
 		partialIndexPredicates:   partialIndexPredicates,

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -933,6 +933,12 @@ func (c *CustomFuncs) JoinPreservesRightRows(join memo.RelExpr) bool {
 	return mult.JoinPreservesRightRows(join.Op())
 }
 
+// IndexJoinPreservesRows returns true if the index join is guaranteed to
+// produce the same number of rows as its input.
+func (c *CustomFuncs) IndexJoinPreservesRows(p *memo.IndexJoinPrivate) bool {
+	return p.Locking.WaitPolicy != tree.LockWaitSkipLocked
+}
+
 // NoJoinHints returns true if no hints were specified for this join.
 func (c *CustomFuncs) NoJoinHints(p *memo.JoinPrivate) bool {
 	return p.Flags.Empty()

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1317,8 +1317,7 @@ func (b *Builder) validateLockingInFrom(
 		case tree.LockWaitBlock:
 			// Default. Block on conflicting locks.
 		case tree.LockWaitSkipLocked:
-			panic(unimplementedWithIssueDetailf(40476, "",
-				"SKIP LOCKED lock wait policy is not supported"))
+			// Skip rows that can't be locked.
 		case tree.LockWaitError:
 			// Raise an error on conflicting locks.
 		default:

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -592,6 +592,16 @@ func (b *Builder) buildScan(
 	}
 	if locking.isSet() {
 		private.Locking = locking.get()
+		if private.Locking.WaitPolicy == tree.LockWaitSkipLocked {
+			if tab.FamilyCount() > 1 {
+				// TODO(rytaft): We may be able to support this if enough columns are
+				// pruned that only a single family is scanned.
+				panic(pgerror.Newf(pgcode.FeatureNotSupported,
+					"SKIP LOCKED cannot be used for tables with multiple column families",
+				))
+			}
+			tabMeta.IsSkipLocked = true
+		}
 	}
 	if b.evalCtx.AsOfSystemTime != nil && b.evalCtx.AsOfSystemTime.BoundedStaleness {
 		private.Flags.NoIndexJoin = true

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -1305,3 +1305,95 @@ project
  │    └── locking: for-update,nowait
  └── projections
       └── 1 [as="?column?":5]
+
+# ------------------------------------------------------------------------------
+# Tests with the SKIP LOCKED lock wait policy.
+# ------------------------------------------------------------------------------
+
+build
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-update,skip-locked
+
+build
+SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-no-key-update,skip-locked
+
+build
+SELECT * FROM t FOR SHARE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-share,skip-locked
+
+build
+SELECT * FROM t FOR KEY SHARE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-key-share,skip-locked
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-share,skip-locked
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-no-key-update,skip-locked
+
+build
+SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-update,skip-locked
+
+build
+SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
+----
+project
+ ├── columns: a:1!null b:2
+ └── scan t
+      ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── locking: for-update,skip-locked
+
+build
+SELECT * FROM t FOR UPDATE OF t2 SKIP LOCKED
+----
+error (42P01): relation "t2" in FOR UPDATE clause not found in FROM clause
+
+build
+SELECT 1 FROM t FOR UPDATE OF t SKIP LOCKED
+----
+project
+ ├── columns: "?column?":5!null
+ ├── scan t
+ │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ │    └── locking: for-update,skip-locked
+ └── projections
+      └── 1 [as="?column?":5]

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -10,6 +10,10 @@ exec-ddl
 CREATE VIEW v AS SELECT a FROM t AS t2
 ----
 
+exec-ddl
+CREATE TABLE families (a INT PRIMARY KEY, b INT, c INT, FAMILY (a, b), FAMILY (c))
+----
+
 # ------------------------------------------------------------------------------
 # Basic tests.
 # ------------------------------------------------------------------------------
@@ -1397,3 +1401,14 @@ project
  │    └── locking: for-update,skip-locked
  └── projections
       └── 1 [as="?column?":5]
+
+# SKIP LOCKED cannot be used with multiple column families.
+build
+SELECT 1 FROM families FOR UPDATE OF families SKIP LOCKED
+----
+error (0A000): SKIP LOCKED cannot be used for tables with multiple column families
+
+build
+SELECT 1 FROM families FOR SHARE SKIP LOCKED
+----
+error (0A000): SKIP LOCKED cannot be used for tables with multiple column families

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -141,6 +141,12 @@ type TableMeta struct {
 	// depend on the consistency of unique without index constraints.
 	IgnoreUniqueWithoutIndexKeys bool
 
+	// IsSkipLocked is true if this table is scanned with SKIP LOCKED. If true, we
+	// should disable any rules that depend on preserved-multiplicity consistency
+	// of this table (i.e. rules that assume there is always a PK row for every
+	// secondary index row or a FK row for every FK reference).
+	IsSkipLocked bool
+
 	// Constraints stores a *FiltersExpr containing filters that are known to
 	// evaluate to true on the table data. This list is extracted from validated
 	// check constraints; specifically, those check constraints that we can prove
@@ -202,6 +208,7 @@ func (tm *TableMeta) copyFrom(from *TableMeta, copyScalarFn func(Expr) Expr) {
 		Alias:                        from.Alias,
 		IgnoreForeignKeys:            from.IgnoreForeignKeys,
 		IgnoreUniqueWithoutIndexKeys: from.IgnoreUniqueWithoutIndexKeys,
+		IsSkipLocked:                 from.IsSkipLocked,
 		// Annotations are not copied.
 	}
 

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -41,7 +41,8 @@
 # TODO(radu): we can similarly push Offset too.
 [PushLimitIntoIndexJoin, Explore]
 (Limit
-    (IndexJoin $input:* $indexJoinPrivate:*)
+    (IndexJoin $input:* $indexJoinPrivate:*) &
+        (IndexJoinPreservesRows $indexJoinPrivate)
     $limitExpr:(Const $limit:* & (IsPositiveInt $limit))
     $ordering:* &
         (OrderingCanProjectCols

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -338,6 +338,36 @@ top-k
       └── filters
            └── (u:2 > 1) AND (u:2 < 10) [outer=(2), constraints=(/2: [/2 - /9]; tight)]
 
+# Ensure that the limit is not pushed down when using SKIP LOCKED.
+# We can push down a limit hint, though.
+opt expect-not=PushLimitIntoIndexJoin
+SELECT * FROM kuv WHERE k = 1 ORDER BY u LIMIT 5 FOR UPDATE SKIP LOCKED
+----
+limit
+ ├── columns: k:1!null u:2 v:3
+ ├── internal-ordering: +2 opt(1)
+ ├── cardinality: [0 - 5]
+ ├── volatile
+ ├── fd: ()-->(1)
+ ├── ordering: +2 opt(1) [actual: +2]
+ ├── index-join kuv
+ │    ├── columns: k:1!null u:2 v:3
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile
+ │    ├── fd: ()-->(1)
+ │    ├── ordering: +2 opt(1) [actual: +2]
+ │    ├── limit hint: 5.00
+ │    └── scan kuv@kuv_k_u_idx
+ │         ├── columns: k:1!null u:2 rowid:4!null
+ │         ├── constraint: /1/2/4: [/1 - /1]
+ │         ├── locking: for-update,skip-locked
+ │         ├── volatile
+ │         ├── key: (4)
+ │         ├── fd: ()-->(1), (4)-->(2)
+ │         ├── ordering: +2 opt(1) [actual: +2]
+ │         └── limit hint: 5.00
+ └── 5
+
 exec-ddl
 CREATE TABLE abcd (
   a INT PRIMARY KEY,

--- a/pkg/sql/row/locking.go
+++ b/pkg/sql/row/locking.go
@@ -52,8 +52,7 @@ func getWaitPolicy(lockWaitPolicy descpb.ScanLockingWaitPolicy) lock.WaitPolicy 
 		return lock.WaitPolicy_Block
 
 	case descpb.ScanLockingWaitPolicy_SKIP_LOCKED:
-		// Should not get here. Query should be rejected during planning.
-		panic(errors.AssertionFailedf("unsupported wait policy %s", lockWaitPolicy))
+		return lock.WaitPolicy_SkipLocked
 
 	case descpb.ScanLockingWaitPolicy_ERROR:
 		return lock.WaitPolicy_Error


### PR DESCRIPTION
This PR adds support for `SKIP LOCKED` by building on commits from https://github.com/cockroachdb/cockroach/pull/83627 and https://github.com/cockroachdb/cockroach/pull/82188. See below for details.

**sql: enable the skip-locked wait policy**

Now that KV support this, we can pass the wait policy through.

Fixes #40476

Release note (sql change): `SELECT ... FOR {UPDATE,SHARE} SKIP LOCKED`
is now supported. The option can be used to skip rows that cannot be
immediately locked instead of blocking on contended row-level lock
acquisition.

**opt: optimizer updates for support of SKIP LOCKED**

For queries using `SELECT FOR {SHARE,UPDATE} SKIP LOCKED`, we need to disable
optimizations that depend on preserved-multiplicity consistency of
tables. When `SKIP LOCKED` is used, we will no longer use optimizations that
assume:
- a PK row exists for every secondary index row
- a PK row exists for every referencing FK (if the PK table uses `SKIP LOCKED`)

One result of this change is that we will no longer push limits into index
joins if the primary index uses locking wait policy `SKIP LOCKED`.

This commit also disallows use of multiple column families in tables scanned
with `SKIP LOCKED`, since it could result in returning partial rows.

Release note: None

Co-authored-by: Michael Erickson <michae2@cockroachlabs.com>
