### PR TITLE
scripts: update benchmarking script to use `dev`

### DIFF
--- a/scripts/bench
+++ b/scripts/bench
@@ -46,8 +46,9 @@ for (( i=0; i<${#shas[@]}; i+=1 )); do
   sha=${shas[i]}
   echo "Switching to $name"
   git checkout -q "$sha"
-  (set -x; make bench PKG="${PKG}" BENCHTIMEOUT="${BENCHTIMEOUT:-5m}" BENCHES="${BENCHES}" TESTFLAGS="-count 10 -benchmem" > "${dest}/bench.${name}" 2> "${dest}/log.txt")
+  (set -x; ./dev bench ${PKG} --timeout=${BENCHTIMEOUT:-5m} --filter=${BENCHES} --count=10 --bench-mem -v --ignore-cache > "${dest}/bench.${name}" 2> "${dest}/log.txt")
 done
+
 benchstat "${dest}/bench.$OLDNAME" "${dest}/bench.$NEWNAME"
 
 git checkout "$ORIG"


### PR DESCRIPTION
Fixes #80407. Usage:

    BENCHES=BenchmarkTracing/1node/scan/trace=off \
      PKG=./pkg/bench \
      scripts/bench HEAD HEAD~1

Invokes the following underneath the hood:

    dev bench ./pkg/bench --timeout=5m \
      --filter=BenchmarkTracing/1node/scan/trace=off --count=10 \
      --bench-mem -v --ignore-cache

Release note: None