### PR TITLE
kvserver: remove redundant Tracer from RaftTransport

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2456,7 +2456,6 @@ func TestStoreReplicaGCAfterMerge(t *testing.T) {
 	transport := kvserver.NewRaftTransport(
 		tc.Servers[0].AmbientCtx(),
 		cluster.MakeTestingClusterSettings(),
-		tc.Servers[0].AmbientCtx().Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(), gossip.AddressResolver(tc.Servers[0].Gossip())),
 		nil, /* grpcServer */
 		tc.Servers[0].Stopper(),

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3043,7 +3043,6 @@ func TestReplicaGCRace(t *testing.T) {
 	fromTransport := kvserver.NewRaftTransport(
 		ambient,
 		cluster.MakeTestingClusterSettings(),
-		ambient.Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(), gossip.AddressResolver(fromStore.Gossip())),
 		nil, /* grpcServer */
 		tc.Servers[0].Stopper(),
@@ -3541,7 +3540,6 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	transport0 := kvserver.NewRaftTransport(
 		tc.Servers[0].AmbientCtx(),
 		cluster.MakeTestingClusterSettings(),
-		tc.Servers[0].AmbientCtx().Tracer,
 		nodedialer.New(tc.Servers[0].RPCContext(),
 			gossip.AddressResolver(tc.GetFirstStoreFromServer(t, 0).Gossip())),
 		nil, /* grpcServer */

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -198,7 +198,7 @@ func NewDummyRaftTransport(st *cluster.Settings, tracer *tracing.Tracer) *RaftTr
 	resolver := func(roachpb.NodeID) (net.Addr, error) {
 		return nil, errors.New("dummy resolver")
 	}
-	return NewRaftTransport(log.MakeTestingAmbientContext(tracer), st, tracer,
+	return NewRaftTransport(log.MakeTestingAmbientContext(tracer), st,
 		nodedialer.New(nil, resolver), nil, nil)
 }
 
@@ -206,7 +206,6 @@ func NewDummyRaftTransport(st *cluster.Settings, tracer *tracing.Tracer) *RaftTr
 func NewRaftTransport(
 	ambient log.AmbientContext,
 	st *cluster.Settings,
-	tracer *tracing.Tracer,
 	dialer *nodedialer.Dialer,
 	grpcServer *grpc.Server,
 	stopper *stop.Stopper,
@@ -214,7 +213,7 @@ func NewRaftTransport(
 	t := &RaftTransport{
 		AmbientContext: ambient,
 		st:             st,
-		tracer:         tracer,
+		tracer:         ambient.Tracer,
 
 		stopper: stopper,
 		dialer:  dialer,

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -181,8 +181,7 @@ func (s raftTransportStatsSlice) Less(i, j int) bool { return s[i].nodeID < s[j]
 // which remote hung up.
 type RaftTransport struct {
 	log.AmbientContext
-	st     *cluster.Settings
-	tracer *tracing.Tracer
+	st *cluster.Settings
 
 	stopper *stop.Stopper
 
@@ -213,7 +212,6 @@ func NewRaftTransport(
 	t := &RaftTransport{
 		AmbientContext: ambient,
 		st:             st,
-		tracer:         ambient.Tracer,
 
 		stopper: stopper,
 		dialer:  dialer,
@@ -754,7 +752,7 @@ func (t *RaftTransport) SendSnapshot(
 			log.Warningf(ctx, "failed to close snapshot stream: %+v", err)
 		}
 	}()
-	return sendSnapshot(ctx, t.st, t.tracer, stream, storePool, header, snap, newBatch, sent, recordBytesSent)
+	return sendSnapshot(ctx, t.st, t.Tracer, stream, storePool, header, snap, newBatch, sent, recordBytesSent)
 }
 
 // DelegateSnapshot creates a rpc stream between the leaseholder and the

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -173,7 +173,6 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 	transport := kvserver.NewRaftTransport(
 		ctwWithTracer,
 		cluster.MakeTestingClusterSettings(),
-		ctwWithTracer.Tracer,
 		nodedialer.New(rttc.nodeRPCContext, gossip.AddressResolver(rttc.gossip)),
 		grpcServer,
 		rttc.stopper,

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -71,7 +71,6 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 	tp := NewRaftTransport(
 		ctxWithTracer,
 		cluster.MakeTestingClusterSettings(),
-		ctxWithTracer.Tracer,
 		nodedialer.New(rpcC, resolver),
 		grpcServer,
 		stopper,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -464,7 +464,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 
 	raftTransport := kvserver.NewRaftTransport(
-		cfg.AmbientCtx, st, cfg.AmbientCtx.Tracer, nodeDialer, grpcServer.Server, stopper,
+		cfg.AmbientCtx, st, nodeDialer, grpcServer.Server, stopper,
 	)
 
 	ctSender := sidetransport.NewSender(stopper, st, clock, nodeDialer)


### PR DESCRIPTION
All the call sites of `NewRaftTransport` take the `Tracer` from the `AmbientContext`
which is also passed in. This PR removes `Tracer` from the argument list, and the
duplicate `tracer` stored in the struct.

Release note: None