### PR TITLE
streamingccl: multi-node unit tests

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -120,7 +120,7 @@ func ingestionPlanHook(
 		}
 
 		// Create a new tenant for the replication stream
-		if _, err := sql.GetTenantRecord(ctx, p.ExecCfg(), nil, newTenantID.ToUint64()); err == nil {
+		if _, err := sql.GetTenantRecord(ctx, p.ExecCfg(), p.Txn(), newTenantID.ToUint64()); err == nil {
 			return errors.Newf("tenant with id %s already exists", newTenantID)
 		}
 		tenantInfo := &descpb.TenantInfoWithUsage{
@@ -129,7 +129,7 @@ func ingestionPlanHook(
 				State: descpb.TenantInfo_ADD,
 			},
 		}
-		if err := sql.CreateTenantRecord(ctx, p.ExecCfg(), nil, tenantInfo); err != nil {
+		if err := sql.CreateTenantRecord(ctx, p.ExecCfg(), p.Txn(), tenantInfo); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -328,7 +328,7 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 
 		if streamingKnobs, ok := sip.FlowCtx.TestingKnobs().StreamingTestingKnobs.(*sql.StreamingTestingKnobs); ok {
 			if streamingKnobs != nil && streamingKnobs.BeforeClientSubscribe != nil {
-				streamingKnobs.BeforeClientSubscribe(string(token), startTime)
+				streamingKnobs.BeforeClientSubscribe(addr, string(token), startTime)
 			}
 		}
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -286,7 +286,7 @@ func TestStreamIngestionProcessor(t *testing.T) {
 		}
 
 		lastClientStart := make(map[string]hlc.Timestamp)
-		streamingTestingKnobs := &sql.StreamingTestingKnobs{BeforeClientSubscribe: func(token string, clientStartTime hlc.Timestamp) {
+		streamingTestingKnobs := &sql.StreamingTestingKnobs{BeforeClientSubscribe: func(addr string, token string, clientStartTime hlc.Timestamp) {
 			lastClientStart[token] = clientStartTime
 		}}
 		out, err := runStreamIngestionProcessor(ctx, t, registry, kvDB,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1584,7 +1584,7 @@ type StreamingTestingKnobs struct {
 
 	// BeforeClientSubscribe allows observation of parameters about to be passed
 	// to a streaming client
-	BeforeClientSubscribe func(token string, startTime hlc.Timestamp)
+	BeforeClientSubscribe func(addr string, token string, startTime hlc.Timestamp)
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}


### PR DESCRIPTION
None of our tests used to run with multiple nodes and a scattered table,
so this PR re-enables the unavailable node test and creates a new basic
multinode test.

It also fixes a bug where if the stream creation statement was retried, it 
would now error on an existing tenant, since the tenant creation wasn't
associated with the overall transaction.

Release note: None