### PR TITLE
kvserver: simplify and track entire set of gossiped  IOThresholds

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -636,7 +636,7 @@ type Replica struct {
 		// Followers to which replication traffic is currently dropped.
 		//
 		// Never mutated in place (always replaced wholesale), so can be leaked
-		// outside of the surrounding mutex.
+		// outside the surrounding mutex.
 		pausedFollowers map[roachpb.ReplicaID]struct{}
 	}
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -8117,7 +8118,8 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		r.mu.Unlock()
 
 		// Tick raft.
-		if _, err := r.tick(ctx, nil, nil); err != nil {
+		iot := ioThresholdMap{m: map[roachpb.StoreID]*admissionpb.IOThreshold{}}
+		if _, err := r.tick(ctx, nil, &iot); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -932,10 +932,10 @@ type Store struct {
 	// liveness. It is updated periodically in raftTickLoop()
 	// and reactively in nodeIsLiveCallback() on liveness updates.
 	livenessMap atomic.Value
-	// ioOverloadedStores is analogous to livenessMap, but stores a
-	// map[StoreID]*IOThreshold. It is gossip-backed but is not updated
+	// ioThresholds is analogous to livenessMap, but stores the *IOThresholds for
+	// the stores in the cluster . It is gossip-backed but is not updated
 	// reactively, i.e. will refresh on each tick loop iteration only.
-	ioOverloadedStores overloadedStoresMap
+	ioThresholds *ioThresholds
 
 	// cachedCapacity caches information on store capacity to prevent
 	// expensive recomputations in case leases or replicas are rapidly
@@ -1177,13 +1177,16 @@ func NewStore(
 	if !cfg.Valid() {
 		log.Fatalf(ctx, "invalid store configuration: %+v", &cfg)
 	}
+	iot := ioThresholds{}
+	iot.Replace(nil, 1.0) // init as empty
 	s := &Store{
-		cfg:      cfg,
-		db:       cfg.DB, // TODO(tschottdorf): remove redundancy.
-		engine:   eng,
-		nodeDesc: nodeDesc,
-		metrics:  newStoreMetrics(cfg.HistogramWindowInterval),
-		ctSender: cfg.ClosedTimestampSender,
+		cfg:          cfg,
+		db:           cfg.DB, // TODO(tschottdorf): remove redundancy.
+		engine:       eng,
+		nodeDesc:     nodeDesc,
+		metrics:      newStoreMetrics(cfg.HistogramWindowInterval),
+		ctSender:     cfg.ClosedTimestampSender,
+		ioThresholds: &iot,
 	}
 	s.ioThreshold.t = &admissionpb.IOThreshold{}
 	if cfg.RPCContext != nil {

--- a/pkg/kv/kvserver/testdata/io_threshold_map.txt
+++ b/pkg/kv/kvserver/testdata/io_threshold_map.txt
@@ -1,0 +1,6 @@
+# Note that the [L0-overload] triggers on a threshold of 1.0; IO overload
+# is different from being considered pausable. We generally want followers
+# to be paused before they hit IO overload.
+echo
+----
+s1: 0.700, s7: 0.900, s9: 1.100[L0-overload] [pausable-threshold=0.80]

--- a/pkg/util/admission/admissionpb/io_threshold.go
+++ b/pkg/util/admission/admissionpb/io_threshold.go
@@ -31,8 +31,8 @@ import (
 // to compactions falling behind (though that may change if we increase the
 // max number of compactions). And we will need to incorporate overload due to
 // disk bandwidth bottleneck.
-func (iot IOThreshold) Score() (float64, bool) {
-	if iot == (IOThreshold{}) {
+func (iot *IOThreshold) Score() (float64, bool) {
+	if iot == nil {
 		return 0, false
 	}
 	f := math.Max(
@@ -43,8 +43,8 @@ func (iot IOThreshold) Score() (float64, bool) {
 }
 
 // SafeFormat implements redact.SafeFormatter.
-func (iot IOThreshold) SafeFormat(s interfaces.SafePrinter, _ rune) {
-	if iot == (IOThreshold{}) {
+func (iot *IOThreshold) SafeFormat(s interfaces.SafePrinter, _ rune) {
+	if iot == nil {
 		s.Printf("N/A")
 		return
 	}
@@ -55,6 +55,6 @@ func (iot IOThreshold) SafeFormat(s interfaces.SafePrinter, _ rune) {
 	}
 }
 
-func (iot IOThreshold) String() string {
+func (iot *IOThreshold) String() string {
 	return redact.StringWithoutMarkers(iot)
 }


### PR DESCRIPTION
This commit makes the following changes:

- track *all* IOThresholds in the store's map, not just the ones for
  overloaded stores.
- improve the container for these IOThresholds to be easier to work
  with.
- Rather than "hard-coding" a value of "1.0" to mean overloaded,
  use (and plumb) the value of the cluster setting. "1.0" is the
  value at which I/O admission control chooses to engage; but
  the cluster setting is usually smaller and determines when to
  consider followers on a remote store pausable. The API now
  reflects that and avoids this kind of confusion.
- Rename all uses of the container away from "overload" towards
  "IOThreshold".
- add a Sequence() method that is bumped whenever the set of Stores
  whose IOThreshold score indicates pausability changes.

I originally started to work on this to address #84465, but realized
that we couldn't "just" leave the set of paused followers untouched
absent sequence changes. This is because the set of paused followers
has additional inputs, most importantly the set of live followers.
This set is per-Replica and subject to change, so we can't be too
sure the outcome would be the same, and we do want to be reactive
to followers becoming nonresponsive by, if necessary, unpausing
followers.

I think we will have to address #84465 by reducing the frequency
at which the paused stores are revisited, but adding an eager
pass whenever the sequence is bumped.

Additionally, for #84252, we are likely also going to be able to rely on
the sequence number to trigger unquiescing of ranges that were
previously quiesced in the presence of a paused follower.

Regardless of these future possible uses, this is a nice conceptual
clean-up and a good last PR to land for pausing in the 22.2 cycle
(unless we find time to add quiescence in presence of paused followers,
in which case that would be worthy follow-up).

I verified that with this commit, the [roachtest] still works and
effectively avoids I/O admission control activation a large percentage
of the time at a setting of 0.8. This gives good confidence - at least
for this exact test - that with 0.5 we'd probably never see admission
control throttle foreground writes. However, the test is fairly
specific since it severely constrains n3's disk throughput, so
0.8 might be perfectly appropriate in practice still. We'll need
some more experience to tell.

[roachtest]: https://github.com/cockroachdb/cockroach/pull/81516

Touches https://github.com/cockroachdb/cockroach/issues/84465.
Touches https://github.com/cockroachdb/cockroach/issues/84252.

Release note: None
Release justification: low-risk improvement to new functionality
