### PR TITLE
sql/randgen: avoid invalid inverted indexes in CREATE TABLE

### DIFF
--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -544,6 +544,11 @@ func randIndexTableDefFromCols(
 			}
 		}
 
+		// Last column for inverted indexes must always be ascending.
+		if i == nCols-1 && def.Inverted {
+			elem.Direction = tree.Ascending
+		}
+
 		if !stopPrefix {
 			prefix = append(prefix, cols[i].Name)
 		}


### PR DESCRIPTION
Previously, the create table made via the randgen component
could create invalid CREATE TABLE statements where the last
columns of an inverted index were descending. This could
lead to unexpected failures in certain workloads, which
expected valid statements from this components. To address
this, this patch stops randgen from generating CREATE table
statements with invalid inverted indexes.

Release note: None