### PR TITLE
release-22.1: sql: add join types and algorithms to telemetry logging

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2447,6 +2447,21 @@ contains common SQL event/execution details.
 | `BytesRead` | The number of bytes read from disk. | no |
 | `RowsRead` | The number of rows read from disk. | no |
 | `RowsWritten` | The number of rows written. | no |
+| `InnerJoinCount` | The number of inner joins in the query plan. | no |
+| `LeftOuterJoinCount` | The number of left (or right) outer joins in the query plan. | no |
+| `FullOuterJoinCount` | The number of full outer joins in the query plan. | no |
+| `SemiJoinCount` | The number of semi joins in the query plan. | no |
+| `AntiJoinCount` | The number of anti joins in the query plan. | no |
+| `IntersectAllJoinCount` | The number of intersect all joins in the query plan. | no |
+| `ExceptAllJoinCount` | The number of except all joins in the query plan. | no |
+| `HashJoinCount` | The number of hash joins in the query plan. | no |
+| `CrossJoinCount` | The number of cross joins in the query plan. | no |
+| `IndexJoinCount` | The number of index joins in the query plan. | no |
+| `LookupJoinCount` | The number of lookup joins in the query plan. | no |
+| `MergeJoinCount` | The number of merge joins in the query plan. | no |
+| `InvertedJoinCount` | The number of inverted joins in the query plan. | no |
+| `ApplyJoinCount` | The number of apply joins in the query plan. | no |
+| `ZigZagJoinCount` | The number of zig zag joins in the query plan. | no |
 
 
 #### Common fields

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -409,6 +410,21 @@ func (p *planner) maybeLogStatementInternal(
 				BytesRead:                queryStats.bytesRead,
 				RowsRead:                 queryStats.rowsRead,
 				RowsWritten:              queryStats.rowsWritten,
+				InnerJoinCount:           int64(p.curPlan.instrumentation.joinTypeCounts[descpb.InnerJoin]),
+				LeftOuterJoinCount:       int64(p.curPlan.instrumentation.joinTypeCounts[descpb.LeftOuterJoin]),
+				FullOuterJoinCount:       int64(p.curPlan.instrumentation.joinTypeCounts[descpb.FullOuterJoin]),
+				SemiJoinCount:            int64(p.curPlan.instrumentation.joinTypeCounts[descpb.LeftSemiJoin]),
+				AntiJoinCount:            int64(p.curPlan.instrumentation.joinTypeCounts[descpb.LeftAntiJoin]),
+				IntersectAllJoinCount:    int64(p.curPlan.instrumentation.joinTypeCounts[descpb.IntersectAllJoin]),
+				ExceptAllJoinCount:       int64(p.curPlan.instrumentation.joinTypeCounts[descpb.ExceptAllJoin]),
+				HashJoinCount:            int64(p.curPlan.instrumentation.joinAlgorithmCounts[exec.HashJoin]),
+				CrossJoinCount:           int64(p.curPlan.instrumentation.joinAlgorithmCounts[exec.CrossJoin]),
+				IndexJoinCount:           int64(p.curPlan.instrumentation.joinAlgorithmCounts[exec.IndexJoin]),
+				LookupJoinCount:          int64(p.curPlan.instrumentation.joinAlgorithmCounts[exec.LookupJoin]),
+				MergeJoinCount:           int64(p.curPlan.instrumentation.joinAlgorithmCounts[exec.MergeJoin]),
+				InvertedJoinCount:        int64(p.curPlan.instrumentation.joinAlgorithmCounts[exec.InvertedJoin]),
+				ApplyJoinCount:           int64(p.curPlan.instrumentation.joinAlgorithmCounts[exec.ApplyJoin]),
+				ZigZagJoinCount:          int64(p.curPlan.instrumentation.joinAlgorithmCounts[exec.ZigZagJoin]),
 			}
 			p.logOperationalEventsOnlyExternally(ctx, eventLogEntry{event: &sampledQuery})
 		} else {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -149,6 +150,14 @@ type instrumentationHelper struct {
 	// nanosSinceStatsCollected is the maximum number of nanoseconds that have
 	// passed since stats were collected on any table scanned by this query.
 	nanosSinceStatsCollected time.Duration
+
+	// joinTypeCounts records the number of times each type of logical join was
+	// used in the query.
+	joinTypeCounts map[descpb.JoinType]int
+
+	// joinAlgorithmCounts records the number of times each type of join algorithm
+	// was used in the query.
+	joinAlgorithmCounts map[exec.JoinAlgorithm]int
 }
 
 // outputMode indicates how the statement output needs to be populated (for

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -13,6 +13,7 @@ package execbuilder
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -126,6 +127,14 @@ type Builder struct {
 	// NanosSinceStatsCollected is the maximum number of nanoseconds that have
 	// passed since stats were collected on any table scanned by this query.
 	NanosSinceStatsCollected time.Duration
+
+	// JoinTypeCounts records the number of times each type of logical join was
+	// used in the query.
+	JoinTypeCounts map[descpb.JoinType]int
+
+	// JoinAlgorithmCounts records the number of times each type of join algorithm
+	// was used in the query.
+	JoinAlgorithmCounts map[exec.JoinAlgorithm]int
 }
 
 // New constructs an instance of the execution node builder using the

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -360,3 +360,19 @@ const (
 	// Streaming means that the grouping columns are fully ordered.
 	Streaming
 )
+
+// JoinAlgorithm is the type of join algorithm used.
+type JoinAlgorithm int8
+
+// The following are all the supported join algorithms.
+const (
+	HashJoin JoinAlgorithm = iota
+	CrossJoin
+	IndexJoin
+	LookupJoin
+	MergeJoin
+	InvertedJoin
+	ApplyJoin
+	ZigZagJoin
+	NumJoinAlgorithms
+)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -624,6 +624,8 @@ func (opc *optPlanningCtx) runExecBuilder(
 		planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
 		planTop.instrumentation.totalScanRows = bld.TotalScanRows
 		planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
+		planTop.instrumentation.joinTypeCounts = bld.JoinTypeCounts
+		planTop.instrumentation.joinAlgorithmCounts = bld.JoinAlgorithmCounts
 	} else {
 		// Create an explain factory and record the explain.Plan.
 		explainFactory := explain.NewFactory(f)
@@ -645,6 +647,8 @@ func (opc *optPlanningCtx) runExecBuilder(
 		planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
 		planTop.instrumentation.totalScanRows = bld.TotalScanRows
 		planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
+		planTop.instrumentation.joinTypeCounts = bld.JoinTypeCounts
+		planTop.instrumentation.joinAlgorithmCounts = bld.JoinAlgorithmCounts
 
 		planTop.instrumentation.RecordExplainPlan(explainPlan)
 	}

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3354,6 +3354,141 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = strconv.AppendInt(b, int64(m.RowsWritten), 10)
 	}
 
+	if m.InnerJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"InnerJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.InnerJoinCount), 10)
+	}
+
+	if m.LeftOuterJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LeftOuterJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.LeftOuterJoinCount), 10)
+	}
+
+	if m.FullOuterJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"FullOuterJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.FullOuterJoinCount), 10)
+	}
+
+	if m.SemiJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SemiJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.SemiJoinCount), 10)
+	}
+
+	if m.AntiJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"AntiJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.AntiJoinCount), 10)
+	}
+
+	if m.IntersectAllJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IntersectAllJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.IntersectAllJoinCount), 10)
+	}
+
+	if m.ExceptAllJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ExceptAllJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.ExceptAllJoinCount), 10)
+	}
+
+	if m.HashJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"HashJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.HashJoinCount), 10)
+	}
+
+	if m.CrossJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"CrossJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.CrossJoinCount), 10)
+	}
+
+	if m.IndexJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.IndexJoinCount), 10)
+	}
+
+	if m.LookupJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LookupJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.LookupJoinCount), 10)
+	}
+
+	if m.MergeJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MergeJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.MergeJoinCount), 10)
+	}
+
+	if m.InvertedJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"InvertedJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.InvertedJoinCount), 10)
+	}
+
+	if m.ApplyJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ApplyJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.ApplyJoinCount), 10)
+	}
+
+	if m.ZigZagJoinCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ZigZagJoinCount\":"...)
+		b = strconv.AppendInt(b, int64(m.ZigZagJoinCount), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -91,6 +91,51 @@ message SampledQuery {
 
   // The number of rows written.
   int64 rows_written = 21 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of inner joins in the query plan.
+  int64 inner_join_count = 22 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of left (or right) outer joins in the query plan.
+  int64 left_outer_join_count = 23 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of full outer joins in the query plan.
+  int64 full_outer_join_count = 24 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of semi joins in the query plan.
+  int64 semi_join_count = 25 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of anti joins in the query plan.
+  int64 anti_join_count = 26 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of intersect all joins in the query plan.
+  int64 intersect_all_join_count = 27 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of except all joins in the query plan.
+  int64 except_all_join_count = 28 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of hash joins in the query plan.
+  int64 hash_join_count = 29 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of cross joins in the query plan.
+  int64 cross_join_count = 30 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of index joins in the query plan.
+  int64 index_join_count = 31 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of lookup joins in the query plan.
+  int64 lookup_join_count = 32 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of merge joins in the query plan.
+  int64 merge_join_count = 33 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of inverted joins in the query plan.
+  int64 inverted_join_count = 34 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of apply joins in the query plan.
+  int64 apply_join_count = 35 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The number of zig zag joins in the query plan.
+  int64 zig_zag_join_count = 36 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
Backport 1/1 commits from #85524.

/cc @cockroachdb/release

---

This commit adds several new fields to the `SampledQuery` structure used for
telemetry logging.

Closes #85425

Release note (sql change): The structured payloads used for telemetry
logs now include the following new fields:
`InnerJoinCount`: The number of inner joins in the query plan.
`LeftOuterJoinCount`: The number of left (or right) outer joins in the query
plan.
`FullOuterJoinCount`: The number of full outer joins in the query plan.
`SemiJoinCount`: The number of semi joins in the query plan.
`AntiJoinCount`: The number of anti joins in the query plan.
`IntersectAllJoinCount`: The number of intersect all joins in the query plan.
`ExceptAllJoinCount`: The number of except all joins in the query plan.
`HashJoinCount`: The number of hash joins in the query plan.
`CrossJoinCount`: The number of cross joins in the query plan.
`IndexJoinCount`: The number of index joins in the query plan.
`LookupJoinCount`: The number of lookup joins in the query plan.
`MergeJoinCount`: The number of merge joins in the query plan.
`InvertedJoinCount`: The number of inverted joins in the query plan.
`ApplyJoinCount`: The number of apply joins in the query plan.
`ZigZagJoinCount`: The number of zig zag joins in the query plan.

---

Release justification: Low risk telemetry change