### PR TITLE
storage: add importEpoch predicate to DeleteRange

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -474,7 +474,7 @@ func EvalAddSSTable(
 // * Only SST set operations (not explicitly verified).
 // * No intents or unversioned values.
 // * If sstTimestamp is set, all MVCC timestamps equal it.
-// * MVCCValueHeader is empty.
+// * The LocalTimestamp in the MVCCValueHeader is empty.
 // * Given MVCC stats match the SST contents.
 func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.MVCCStats) error {
 
@@ -508,8 +508,9 @@ func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.M
 			return errors.NewAssertionErrorWithWrappedErrf(err,
 				"SST contains invalid value for key %s", key)
 		}
-		if value.MVCCValueHeader != (enginepb.MVCCValueHeader{}) {
-			return errors.AssertionFailedf("SST contains non-empty MVCC value header for key %s", key)
+		if !value.MVCCValueHeader.LocalTimestamp.IsEmpty() {
+			return errors.AssertionFailedf("SST contains non-empty Local Timestamp in the MVCC value"+
+				" header for key %s", key)
 		}
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -140,7 +140,7 @@ func TestEvalAddSSTable(t *testing.T) {
 			sst:            kvs{pointKVWithLocalTS("a", 2, 1, "a2")},
 			expect:         kvs{pointKVWithLocalTS("a", 2, 1, "a2")},
 			expectStatsEst: true,
-			expectErrRace:  `SST contains non-empty MVCC value header for key "a"/0.000000002,0`,
+			expectErrRace:  `SST contains non-empty Local Timestamp in the MVCC value header for key "a"/0.000000002,0`,
 		},
 		"blind rejects local timestamp on range key under race only": { // unfortunately, for performance
 			sst:            kvs{rangeKVWithLocalTS("a", "d", 2, 1, "")},
@@ -293,7 +293,7 @@ func TestEvalAddSSTable(t *testing.T) {
 			sst:            kvs{pointKVWithLocalTS("a", 2, 1, "a2")},
 			expect:         kvs{pointKVWithLocalTS("a", 10, 1, "a2")},
 			expectStatsEst: true,
-			expectErrRace:  `SST contains non-empty MVCC value header for key "a"/0.000000002,0`,
+			expectErrRace:  `SST contains non-empty Local Timestamp in the MVCC value header for key "a"/0.000000002,0`,
 		},
 
 		// DisallowConflicts

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDeleteRangeTombstone tests DeleteRange range tombstones and predicated based DeleteRange
+// TestDeleteRangeTombstone tests DeleteRange range tombstones and predicate based DeleteRange
 // directly, using only a Pebble engine.
 //
 // MVCC range tombstone logic is tested exhaustively in the MVCC history tests,
@@ -164,7 +164,7 @@ func TestDeleteRangeTombstone(t *testing.T) {
 			ts:                 10e9,
 			predicateStartTime: 1,
 			maxBatchSize:       0,
-			expectErr:          "MaxSpanRequestKeys must be greater than zero when using predicated based DeleteRange",
+			expectErr:          "MaxSpanRequestKeys must be greater than zero when using predicate based DeleteRange",
 		},
 	}
 	for name, tc := range testcases {

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -384,6 +384,43 @@ message DeleteRangePredicates {
   //  - t must be < endTime
   //  - if t in (startTime, endTime), then there is no other k@t' where t' <= startTime.
   util.hlc.Timestamp start_time = 6 [(gogoproto.nullable) = false];
+
+  //  ImportEpoch specifies the import epoch of the versioned keys which Delete
+  //  Range will match and delete. In other words, if the caller specifies an
+  //  ImportEpoch, predicate based delete range will only issue tombstones on
+  //  versioned keys with the matching import epoch in its MVCCValueHeader.
+  //  NOTE: the importEpoch filter cannot be passed with a startTime filter.
+  //
+  // The main application for this is a rollback of IMPORT INTO on a non-empty
+  // table, where the table was backed up and restored during the import job.
+  // Consider the following example:
+  //
+  //  t0: user begins IMPORT INTO on _non-empty_ table foo in cluster A
+  //
+  //  t1: user backs up table foo, part way through IMPORT job
+  //
+  //  t2: user restores table foo into cluster B, which rewrites all keys in
+  //  table foo to new timestamps.
+  //
+  //  t3: user rolls back IMPORT job on table foo, in cluster B, using the
+  //  ImportEpoch predicate filter, as the StartTime predicate filter does not
+  //  accurately partition imported and non-imported keys in the table.
+  //
+  // ImportEpoch based delete range assumes the client is passing an ImportEpoch
+  // for an in-progress Import INTO on a single table. This implies that the
+  // ImportEpoch predicate must be the highest ImportEpoch in the MVCC history
+  // for the table. These invariants cause the cmd to fail if:
+  //
+  //  1. The client passes a span that covers more than one table.
+  // (CURRENTLY, I DONT CHECK THIS, BUT I'D LIKE TO)
+  //
+  //  2. An MVCC Value is encountered that contains a higher importEpoch than
+  //  the predicate.
+  //
+  // Because IMPORT INTO takes a table offline and does not allow masking an
+  // existing key, this operation _assumes_ that any key encountered with the
+  // matching ImportEpoch does not collide with any pre-import data.
+  uint32 import_epoch = 2;
 }
 
 // A DeleteRangeResponse is the return value from the DeleteRange()

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -170,6 +170,10 @@ message MVCCValueHeader {
   // to stale reads.
   util.hlc.Timestamp local_timestamp = 1 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
+
+  // ImportEpoch identifies the number of times a user has called IMPORT
+  // INTO on the table this key belongs to when the table was not empty.
+  uint32 import_epoch = 2;
 }
 
 // MVCCStatsDelta is convertible to MVCCStats, but uses signed variable width

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5596,10 +5596,12 @@ func MVCCExportToSST(
 			if err != nil {
 				return roachpb.BulkOpSummary{}, MVCCKey{}, errors.Wrapf(err, "decoding mvcc value %s", unsafeKey)
 			}
-
-			// Export only the inner roachpb.Value, not the MVCCValue header.
-			unsafeValue = mvccValue.Value.RawBytes
-
+			unsafeValue, err = EncodeForExport(mvccValue)
+			if err != nil {
+				return roachpb.BulkOpSummary{}, MVCCKey{}, errors.Wrapf(err,
+					"repackaging imported mvcc value %s",
+					unsafeKey)
+			}
 			// Skip tombstone records when start time is zero (non-incremental)
 			// and we are not exporting all versions.
 			skip = skipTombstones && mvccValue.IsTombstone()

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_import_epoch
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_import_epoch
@@ -1,0 +1,129 @@
+# Tests MVCC Del Range with import epoch predicate
+#
+# Set up some point keys (some with ,importEpoch), and point tombstones x
+#
+# 7
+# 6
+# 5
+# 4  x              d4,2           f4,2
+# 3       b3,1
+# 2  a2        c2,2           e2          g2
+# 1                 d1,2
+# 0
+#    a    b    c    d         e     f     g
+run ok
+put k=a ts=2 v=a2
+del k=a ts=4
+importput k=b ts=3 v=b3 epoch=2
+importput put k=c ts=2 v=c2 epoch=1
+importput put k=d ts=1 v=d1 epoch=2
+importput put k=d ts=4 v=d4 epoch=2
+put k=e ts=2 v=e2
+importput k=f ts=4 v=f4 epoch=2
+put k=g ts=2 v=g2
+----
+>> at end:
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> {importEpoch=2}/BYTES/b3
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
+data: "d"/4.000000000,0 -> {importEpoch=2}/BYTES/d4
+data: "d"/1.000000000,0 -> {importEpoch=2}/BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/2.000000000,0 -> /BYTES/g2
+
+# Assert the command fails if a new importEpoch is found
+run stats error
+del_range_pred k=a end=g ts=5 importEpoch=1
+----
+>> del_range_pred k=a end=g ts=5 importEpoch=1
+stats: no change
+>> at end:
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> {importEpoch=2}/BYTES/b3
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
+data: "d"/4.000000000,0 -> {importEpoch=2}/BYTES/d4
+data: "d"/1.000000000,0 -> {importEpoch=2}/BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/2.000000000,0 -> /BYTES/g2
+stats: key_count=7 key_bytes=122 val_count=9 val_bytes=101 live_count=6 live_bytes=162 gc_bytes_age=5856
+error: (*assert.withAssertionFailure:) Encountered MVCCValue with newer ImportEpoch (2) than the predicate filter (1)
+
+# PredicateImport Epoch should only delete keys that have the matching predicate
+# Note that only point tombstones are created because no run is greater than or equal to
+# rangeThreshold=2.
+run stats ok
+del_range_pred k=a end=g ts=5 importEpoch=2 rangeThreshold=2
+----
+>> del_range_pred k=a end=g ts=5 importEpoch=2 rangeThreshold=2
+stats: key_bytes=+36 val_count=+3 live_count=-3 live_bytes=-90 gc_bytes_age=+11970
+>> at end:
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/3.000000000,0 -> {importEpoch=2}/BYTES/b3
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> {importEpoch=2}/BYTES/d4
+data: "d"/1.000000000,0 -> {importEpoch=2}/BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
+data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/2.000000000,0 -> /BYTES/g2
+stats: key_count=7 key_bytes=158 val_count=12 val_bytes=101 live_count=3 live_bytes=72 gc_bytes_age=17826
+
+# Issue a few more import puts
+run ok
+importput k=b ts=6 v=b6 epoch=3
+importput put k=c ts=6 v=c6 epoch=4
+importput put k=d ts=6 v=d6 epoch=4
+importput put k=f ts=6 v=f6 epoch=4
+----
+>> at end:
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/6.000000000,0 -> {importEpoch=3}/BYTES/b6
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/3.000000000,0 -> {importEpoch=2}/BYTES/b3
+data: "c"/6.000000000,0 -> {importEpoch=4}/BYTES/c6
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
+data: "d"/6.000000000,0 -> {importEpoch=4}/BYTES/d6
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> {importEpoch=2}/BYTES/d4
+data: "d"/1.000000000,0 -> {importEpoch=2}/BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/6.000000000,0 -> {importEpoch=4}/BYTES/f6
+data: "f"/5.000000000,0 -> /<empty>
+data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/2.000000000,0 -> /BYTES/g2
+
+# Assert range tombstones are created at every imported key, since
+# the rangeThreshold is set 1,
+run stats ok
+del_range_pred k=a end=g ts=7 importEpoch=4 rangeThreshold=1
+----
+>> del_range_pred k=a end=g ts=7 importEpoch=4 rangeThreshold=1
+stats: range_key_count=+2 range_key_bytes=+28 range_val_count=+2 live_count=-3 live_bytes=-90 gc_bytes_age=+10974
+>> at end:
+rangekey: {c-d\x00}/[7.000000000,0=/<empty>]
+rangekey: f{-\x00}/[7.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/6.000000000,0 -> {importEpoch=3}/BYTES/b6
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/3.000000000,0 -> {importEpoch=2}/BYTES/b3
+data: "c"/6.000000000,0 -> {importEpoch=4}/BYTES/c6
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
+data: "d"/6.000000000,0 -> {importEpoch=4}/BYTES/d6
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> {importEpoch=2}/BYTES/d4
+data: "d"/1.000000000,0 -> {importEpoch=2}/BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/6.000000000,0 -> {importEpoch=4}/BYTES/f6
+data: "f"/5.000000000,0 -> /<empty>
+data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/2.000000000,0 -> /BYTES/g2
+stats: key_count=7 key_bytes=206 val_count=16 val_bytes=165 range_key_count=2 range_key_bytes=28 range_val_count=2 live_count=3 live_bytes=72 gc_bytes_age=30862


### PR DESCRIPTION
the first commit is from a [separate PR](https://github.com/cockroachdb/cockroach/pull/85138) that will get merged before this.
 
----
This patch adds an ImportEpoch field to the predicate that clients can pass to
DeleteRange. When the client passes the ImportEpoch predicate, DeleteRange will
delete keys whose latest version contains the matching ImportEpoch in its
MVCCValueHeader.

The typical use case for predicate based DeleteRange will be rolling back and
IMPORT on a table with pre-existing data that was restored after the IMPORT
began. In this situation, the pre-Import and Imported data's timestamps are
intermingled; so during a rollback, the invariants assumed in
Predicate.StartTime DeleteRange do not hold. Instead, rollbacks must rely on
the ImportEpoch stored in each imported versioned key's MVCCValueHeader.

Since the cannot pass a Predicate.StartTime to ImportEpoch based
DeleteRange, time bound iteration is not used, implying
that ImportEpoch based DeleteRange can be significantly slower.

Informs https://github.com/cockroachdb/cockroach/issues/76722

Release note: none