### PR TITLE
builtins: add strptime/strftime builtins without experimental prefix

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -637,6 +637,14 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="statement_timestamp"></a><code>statement_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns the start time of the current statement.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="strftime"></a><code>strftime(input: <a href="date.html">date</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="strftime"></a><code>strftime(input: <a href="timestamp.html">timestamp</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="strftime"></a><code>strftime(input: <a href="timestamp.html">timestamptz</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="strptime"></a><code>strptime(input: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns <code>input</code> as a timestamptz using <code>format</code> (which uses standard <code>strptime</code> formatting).</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="timeofday"></a><code>timeofday() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current system time on one of the cluster nodes as a string.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="timezone"></a><code>timezone(timezone: <a href="string.html">string</a>, time: <a href="time.html">time</a>) &rarr; timetz</code></td><td><span class="funcdesc"><p>Treat given time without time zone as located in the specified time zone.</p>

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4640,7 +4640,7 @@ FROM pg_proc p
 JOIN pg_type t ON t.typinput = p.oid
 WHERE t.typname = '_int4'
 ----
-2006  array_in  array_in
+2010  array_in  array_in
 
 ## #16285
 ## int2vectors should be 0-indexed

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2403,84 +2403,11 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	// Timestamp/Date functions.
 
-	"experimental_strftime": makeBuiltin(
-		tree.FunctionProperties{
-			Category: builtinconstants.CategoryDateAndTime,
-		},
-		tree.Overload{
-			Types:      tree.ArgTypes{{"input", types.Timestamp}, {"extract_format", types.String}},
-			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				fromTime := args[0].(*tree.DTimestamp).Time
-				format := string(tree.MustBeDString(args[1]))
-				t, err := strtime.Strftime(fromTime, format)
-				if err != nil {
-					return nil, err
-				}
-				return tree.NewDString(t), nil
-			},
-			Info: "From `input`, extracts and formats the time as identified in `extract_format` " +
-				"using standard `strftime` notation (though not all formatting is supported).",
-			Volatility: volatility.Immutable,
-		},
-		tree.Overload{
-			Types:      tree.ArgTypes{{"input", types.Date}, {"extract_format", types.String}},
-			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				fromTime, err := args[0].(*tree.DDate).ToTime()
-				if err != nil {
-					return nil, err
-				}
-				format := string(tree.MustBeDString(args[1]))
-				t, err := strtime.Strftime(fromTime, format)
-				if err != nil {
-					return nil, err
-				}
-				return tree.NewDString(t), nil
-			},
-			Info: "From `input`, extracts and formats the time as identified in `extract_format` " +
-				"using standard `strftime` notation (though not all formatting is supported).",
-			Volatility: volatility.Immutable,
-		},
-		tree.Overload{
-			Types:      tree.ArgTypes{{"input", types.TimestampTZ}, {"extract_format", types.String}},
-			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				fromTime := args[0].(*tree.DTimestampTZ).Time
-				format := string(tree.MustBeDString(args[1]))
-				t, err := strtime.Strftime(fromTime, format)
-				if err != nil {
-					return nil, err
-				}
-				return tree.NewDString(t), nil
-			},
-			Info: "From `input`, extracts and formats the time as identified in `extract_format` " +
-				"using standard `strftime` notation (though not all formatting is supported).",
-			Volatility: volatility.Immutable,
-		},
-	),
+	"strftime":              strftimeImpl(),
+	"experimental_strftime": strftimeImpl(),
 
-	"experimental_strptime": makeBuiltin(
-		tree.FunctionProperties{
-			Category: builtinconstants.CategoryDateAndTime,
-		},
-		tree.Overload{
-			Types:      tree.ArgTypes{{"input", types.String}, {"format", types.String}},
-			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				toParse := string(tree.MustBeDString(args[0]))
-				format := string(tree.MustBeDString(args[1]))
-				t, err := strtime.Strptime(toParse, format)
-				if err != nil {
-					return nil, err
-				}
-				return tree.MakeDTimestampTZ(t.UTC(), time.Microsecond)
-			},
-			Info: "Returns `input` as a timestamptz using `format` (which uses standard " +
-				"`strptime` formatting).",
-			Volatility: volatility.Immutable,
-		},
-	),
+	"strptime":              strptimeImpl(),
+	"experimental_strptime": strptimeImpl(),
 
 	"to_char": makeBuiltin(
 		defProps(),
@@ -7564,6 +7491,89 @@ func generateRandomUUID4Impl() builtinDefinition {
 			},
 			Info:       "Generates a random version 4 UUID, and returns it as a value of UUID type.",
 			Volatility: volatility.Volatile,
+		},
+	)
+}
+
+func strftimeImpl() builtinDefinition {
+	return makeBuiltin(
+		tree.FunctionProperties{
+			Category: builtinconstants.CategoryDateAndTime,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"input", types.Timestamp}, {"extract_format", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				fromTime := args[0].(*tree.DTimestamp).Time
+				format := string(tree.MustBeDString(args[1]))
+				t, err := strtime.Strftime(fromTime, format)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDString(t), nil
+			},
+			Info: "From `input`, extracts and formats the time as identified in `extract_format` " +
+				"using standard `strftime` notation (though not all formatting is supported).",
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"input", types.Date}, {"extract_format", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				fromTime, err := args[0].(*tree.DDate).ToTime()
+				if err != nil {
+					return nil, err
+				}
+				format := string(tree.MustBeDString(args[1]))
+				t, err := strtime.Strftime(fromTime, format)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDString(t), nil
+			},
+			Info: "From `input`, extracts and formats the time as identified in `extract_format` " +
+				"using standard `strftime` notation (though not all formatting is supported).",
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"input", types.TimestampTZ}, {"extract_format", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				fromTime := args[0].(*tree.DTimestampTZ).Time
+				format := string(tree.MustBeDString(args[1]))
+				t, err := strtime.Strftime(fromTime, format)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDString(t), nil
+			},
+			Info: "From `input`, extracts and formats the time as identified in `extract_format` " +
+				"using standard `strftime` notation (though not all formatting is supported).",
+			Volatility: volatility.Immutable,
+		},
+	)
+}
+
+func strptimeImpl() builtinDefinition {
+	return makeBuiltin(
+		tree.FunctionProperties{
+			Category: builtinconstants.CategoryDateAndTime,
+		},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"input", types.String}, {"format", types.String}},
+			ReturnType: tree.FixedReturnType(types.TimestampTZ),
+			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				toParse := string(tree.MustBeDString(args[0]))
+				format := string(tree.MustBeDString(args[1]))
+				t, err := strtime.Strptime(toParse, format)
+				if err != nil {
+					return nil, err
+				}
+				return tree.MakeDTimestampTZ(t.UTC(), time.Microsecond)
+			},
+			Info: "Returns `input` as a timestamptz using `format` (which uses standard " +
+				"`strptime` formatting).",
+			Volatility: volatility.Immutable,
 		},
 	)
 }


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/52139

These are just an alias for the existing implementation.

Release note (sql change): The strptime and strftime builtin functions
were added as aliases for experimental_strptime and
experimental_strftime.