### PR TITLE
backupccl,importer: remove `at_current_time` cluster settings

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -121,13 +121,6 @@ var numRestoreWorkers = settings.RegisterIntSetting(
 	settings.PositiveInt,
 )
 
-var restoreAtNow = settings.RegisterBoolSetting(
-	settings.TenantWritable,
-	"bulkio.restore_at_current_time.enabled",
-	"write restored data at the current timestamp",
-	true,
-)
-
 func newRestoreDataProcessor(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
@@ -401,12 +394,11 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	iter := sst.iter
 	defer sst.cleanup()
 
-	writeAtBatchTS := restoreAtNow.Get(&evalCtx.Settings.SV)
-
 	// If the system tenant is restoring a guest tenant span, we don't want to
 	// forward all the restored data to now, as there may be importing tables in
 	// that span, that depend on the difference in timestamps on restored existing
 	// vs importing keys to rollback.
+	writeAtBatchTS := true
 	if writeAtBatchTS && kr.fromSystemTenant &&
 		(bytes.HasPrefix(entry.Span.Key, keys.TenantPrefix) || bytes.HasPrefix(entry.Span.EndKey, keys.TenantPrefix)) {
 		log.Warningf(ctx, "restoring span %s at its original timestamps because it is a tenant span", entry.Span)

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -137,6 +137,8 @@ var retiredSettings = map[string]struct{}{
 	"sql.ttl.range_batch_size":                          {},
 
 	// removed as of 22.2.
+	"bulkio.restore_at_current_time.enabled":                    {},
+	"bulkio.import_at_current_time.enabled":                     {},
 	"kv.bulk_io_write.experimental_incremental_export_enabled":  {},
 	"kv.bulk_io_write.revert_range_time_bound_iterator.enabled": {},
 	"kv.rangefeed.catchup_scan_iterator_optimization.enabled":   {},


### PR DESCRIPTION
Release note (ops change): The cluster settings
`bulkio.restore_at_current_time.enabled` and
`bulkio.import_at_current_time.enabled`, which were introduced in 22.1
and defaulted to `true`, have been retired. They are now in effect
always enabled.