### PR TITLE
sql: add column rollback does not clean up sequence back-refs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2311,3 +2311,18 @@ SELECT nextval('customer_seq_check_cache_and_bounds_3')
 
 statement error pgcode 2200H pq: nextval\(\): reached maximum value of sequence "customer_seq_check_cache_and_bounds_3" \(12\)
 SELECT nextval('customer_seq_check_cache_and_bounds_3')
+
+# Tests for issue #84673, which is linked to improper back reference clean up
+# for sequences when during add column rollback.
+subtest add_column_back_refs
+
+statement ok
+create table t_with_seq_back_ref(i int primary key);
+insert into t select generate_series(1 ,10);
+create sequence seq_for_back_ref_test;
+
+statement error pgcode 0A000 unimplemented: cannot evaluate scalar expressions containing sequence operations.*\nHINT.*\n.*42508
+alter table t add column j int not null default nextval('seq_for_back_ref_test');
+
+statement ok
+drop sequence seq_for_back_ref_test;


### PR DESCRIPTION
Fixes: #84673

Previously, if an add column statement rolled back, we would
not clean up any sequence back refs added by default/on update
expressions. This was inadequate because we would leave
dangling back references in sequence, which could lead
to the inability clean up a sequence. To address this,
this patch adds code to clean up sequence back refs on
add column rollbacks.

Release note (bug fix): Add column rollbacks did not clean up
sequence back references from default/ on update expressions, which
could prevent referenced sequence from being dropped without the
cascade option.