### PR TITLE
kvserver: replace Raft transport stats with metrics

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "raft_log_truncator.go",
         "raft_snapshot_queue.go",
         "raft_transport.go",
+        "raft_transport_metrics.go",
         "raft_truncator_replica.go",
         "replica.go",
         "replica_application_cmd.go",

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -11,12 +11,8 @@
 package kvserver
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"net"
-	"sort"
-	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -139,29 +135,6 @@ type RaftMessageHandler interface {
 	) error
 }
 
-// TODO(tbg): remove all of these metrics. The "NodeID" in this struct refers to the remote NodeID, i.e. when we send
-// a message it refers to the recipient and when we receive a message it refers to the sender. This doesn't map to
-// metrics well, where everyone should report on their local decisions. Instead have a *RaftTransportMetrics struct
-// that is per-Store and tracks metrics on behalf of that Store.
-//
-// See: https://github.com/cockroachdb/cockroach/issues/83917
-type raftTransportStats struct {
-	nodeID        roachpb.NodeID
-	queue         int
-	queueMax      int32
-	clientSent    int64
-	clientRecv    int64
-	clientDropped int64
-	serverSent    int64
-	serverRecv    int64
-}
-
-type raftTransportStatsSlice []*raftTransportStats
-
-func (s raftTransportStatsSlice) Len() int           { return len(s) }
-func (s raftTransportStatsSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s raftTransportStatsSlice) Less(i, j int) bool { return s[i].nodeID < s[j].nodeID }
-
 // RaftTransport handles the rpc messages for raft.
 //
 // The raft transport is asynchronous with respect to the caller, and
@@ -182,7 +155,7 @@ type RaftTransport struct {
 	stopper *stop.Stopper
 
 	queues   [rpc.NumConnectionClasses]syncutil.IntMap // map[roachpb.NodeID]*chan *RaftMessageRequest
-	stats    [rpc.NumConnectionClasses]syncutil.IntMap // map[roachpb.NodeID]*raftTransportStats
+	metrics  *RaftTransportMetrics
 	dialer   *nodedialer.Dialer
 	handlers syncutil.IntMap // map[roachpb.StoreID]*RaftMessageHandler
 }
@@ -213,84 +186,31 @@ func NewRaftTransport(
 
 		stopper: stopper,
 		dialer:  dialer,
+
+		metrics: newRaftTransportMetrics(),
 	}
 
 	if grpcServer != nil {
 		RegisterMultiRaftServer(grpcServer, t)
-	}
-	// statsMap is used to associate a queue with its raftTransportStats.
-	statsMap := make(map[roachpb.NodeID]*raftTransportStats)
-	clearStatsMap := func() {
-		for k := range statsMap {
-			delete(statsMap, k)
-		}
 	}
 	if t.stopper != nil && log.V(1) {
 		ctx := t.AnnotateCtx(context.Background())
 		_ = t.stopper.RunAsyncTask(ctx, "raft-transport", func(ctx context.Context) {
 			ticker := time.NewTicker(10 * time.Second)
 			defer ticker.Stop()
-			lastStats := make(map[roachpb.NodeID]raftTransportStats)
-			lastTime := timeutil.Now()
-			var stats raftTransportStatsSlice
 			for {
 				select {
 				case <-ticker.C:
-					stats = stats[:0]
-					getStats := func(k int64, v unsafe.Pointer) bool {
-						s := (*raftTransportStats)(v)
-						// Clear the queue length stat. Note that this field is only
-						// mutated by this goroutine.
-						s.queue = 0
-						stats = append(stats, s)
-						statsMap[roachpb.NodeID(k)] = s
-						return true
+					// TODO(pavelkalinnikov): add connection class label.
+					var size int64
+					for c := range t.queues {
+						t.queues[c].Range(func(k int64, v unsafe.Pointer) bool {
+							ch := *(*chan *kvserverpb.RaftMessageRequest)(v)
+							size += int64(len(ch))
+							return true
+						})
 					}
-					setQueueLength := func(k int64, v unsafe.Pointer) bool {
-						ch := *(*chan *kvserverpb.RaftMessageRequest)(v)
-						if s, ok := statsMap[roachpb.NodeID(k)]; ok {
-							s.queue += len(ch)
-						}
-						return true
-					}
-					for c := range t.stats {
-						clearStatsMap()
-						t.stats[c].Range(getStats)
-						t.queues[c].Range(setQueueLength)
-					}
-					clearStatsMap() // no need to hold on to references to stats
-
-					now := timeutil.Now()
-					elapsed := now.Sub(lastTime).Seconds()
-					sort.Sort(stats)
-
-					var buf bytes.Buffer
-					// NB: The header is 80 characters which should display in a single
-					// line on most terminals.
-					fmt.Fprintf(&buf,
-						"         qlen   qmax   qdropped client-sent client-recv server-sent server-recv\n")
-					for _, s := range stats {
-						last := lastStats[s.nodeID]
-						cur := raftTransportStats{
-							nodeID:        s.nodeID,
-							queue:         s.queue,
-							queueMax:      atomic.LoadInt32(&s.queueMax),
-							clientDropped: atomic.LoadInt64(&s.clientDropped),
-							clientSent:    atomic.LoadInt64(&s.clientSent),
-							clientRecv:    atomic.LoadInt64(&s.clientRecv),
-							serverSent:    atomic.LoadInt64(&s.serverSent),
-							serverRecv:    atomic.LoadInt64(&s.serverRecv),
-						}
-						fmt.Fprintf(&buf, "  %3d: %6d %6d %10d %11.1f %11.1f %11.1f %11.1f\n",
-							cur.nodeID, cur.queue, cur.queueMax, cur.clientDropped,
-							float64(cur.clientSent-last.clientSent)/elapsed,
-							float64(cur.clientRecv-last.clientRecv)/elapsed,
-							float64(cur.serverSent-last.serverSent)/elapsed,
-							float64(cur.serverRecv-last.serverRecv)/elapsed)
-						lastStats[s.nodeID] = cur
-					}
-					lastTime = now
-					log.Infof(ctx, "stats:\n%s", buf.String())
+					t.metrics.RaftClientQueueSize.Update(size)
 				case <-t.stopper.ShouldQuiesce():
 					return
 				}
@@ -352,18 +272,6 @@ func newRaftMessageResponse(
 	return resp
 }
 
-func (t *RaftTransport) getStats(
-	nodeID roachpb.NodeID, class rpc.ConnectionClass,
-) *raftTransportStats {
-	statsMap := &t.stats[class]
-	value, ok := statsMap.Load(int64(nodeID))
-	if !ok {
-		stats := &raftTransportStats{nodeID: nodeID}
-		value, _ = statsMap.LoadOrStore(int64(nodeID), unsafe.Pointer(stats))
-	}
-	return (*raftTransportStats)(value)
-}
-
 // RaftMessageBatch proxies the incoming requests to the listening server interface.
 func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer) error {
 	errCh := make(chan error, 1)
@@ -378,7 +286,6 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 			SpanOpt:  stop.ChildSpan,
 		}, func(ctx context.Context) {
 			errCh <- func() error {
-				var stats *raftTransportStats
 				stream := &lockedRaftMessageResponseStream{wrapped: stream}
 				for {
 					batch, err := stream.Recv()
@@ -389,28 +296,15 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 						continue
 					}
 
-					// This code always uses the DefaultClass. Class is primarily a
-					// client construct and the server has no way to determine which
-					// class an inbound connection holds on the client side. Because of
-					// this we associate all server receives and sends with the
-					// DefaultClass. This data is exclusively used to print a debug
-					// log message periodically. Using this policy may lead to a
-					// DefaultClass log line showing a high rate of server recv but
-					// a low rate of client sends if most of the traffic is due to
-					// system ranges.
-					//
 					// TODO(ajwerner): consider providing transport metadata to inform
 					// the server of the connection class or keep shared stats for all
 					// connection with a host.
-					if stats == nil {
-						stats = t.getStats(batch.Requests[0].FromReplica.NodeID, rpc.DefaultClass)
-					}
 
 					for i := range batch.Requests {
 						req := &batch.Requests[i]
-						atomic.AddInt64(&stats.serverRecv, 1)
+						t.metrics.RaftServerRecvMessages.Inc(1)
 						if pErr := t.handleRaftRequest(ctx, req, stream); pErr != nil {
-							atomic.AddInt64(&stats.serverSent, 1)
+							t.metrics.RaftServerSentMessages.Inc(1)
 							if err := stream.Send(newRaftMessageResponse(req, pErr)); err != nil {
 								return err
 							}
@@ -509,7 +403,6 @@ func (t *RaftTransport) Stop(storeID roachpb.StoreID) {
 func (t *RaftTransport) processQueue(
 	nodeID roachpb.NodeID,
 	ch chan *kvserverpb.RaftMessageRequest,
-	stats *raftTransportStats,
 	stream MultiRaft_RaftMessageBatchClient,
 	class rpc.ConnectionClass,
 ) error {
@@ -526,7 +419,8 @@ func (t *RaftTransport) processQueue(
 					if err != nil {
 						return err
 					}
-					atomic.AddInt64(&stats.clientRecv, 1)
+					// TODO(pavelkalinnikov): add connection class label.
+					t.metrics.RaftClientRecvMessages.Inc(1)
 					handler, ok := t.getHandler(resp.ToReplica.StoreID)
 					if !ok {
 						log.Warningf(ctx, "no handler found for store %s in response %s",
@@ -583,7 +477,8 @@ func (t *RaftTransport) processQueue(
 			}
 			batch.Requests = batch.Requests[:0]
 
-			atomic.AddInt64(&stats.clientSent, 1)
+			// TODO(pavelkalinnikov): add connection class label.
+			t.metrics.RaftClientSentMessages.Inc(1)
 		}
 	}
 }
@@ -611,10 +506,10 @@ func (t *RaftTransport) SendAsync(
 	req *kvserverpb.RaftMessageRequest, class rpc.ConnectionClass,
 ) (sent bool) {
 	toNodeID := req.ToReplica.NodeID
-	stats := t.getStats(toNodeID, class)
 	defer func() {
 		if !sent {
-			atomic.AddInt64(&stats.clientDropped, 1)
+			// TODO(pavelkalinnikov): add connection class label.
+			t.metrics.RaftClientDroppedMessages.Inc(1)
 		}
 	}()
 
@@ -635,17 +530,13 @@ func (t *RaftTransport) SendAsync(
 	if !existingQueue {
 		// Note that startProcessNewQueue is in charge of deleting the queue.
 		ctx := t.AnnotateCtx(context.Background())
-		if !t.startProcessNewQueue(ctx, toNodeID, class, stats) {
+		if !t.startProcessNewQueue(ctx, toNodeID, class) {
 			return false
 		}
 	}
 
 	select {
 	case ch <- req:
-		l := int32(len(ch))
-		if v := atomic.LoadInt32(&stats.queueMax); v < l {
-			atomic.CompareAndSwapInt32(&stats.queueMax, v, l)
-		}
 		return true
 	default:
 		releaseRaftMessageRequest(req)
@@ -663,10 +554,7 @@ func (t *RaftTransport) SendAsync(
 //
 // Returns whether the worker was started (the queue is deleted either way).
 func (t *RaftTransport) startProcessNewQueue(
-	ctx context.Context,
-	toNodeID roachpb.NodeID,
-	class rpc.ConnectionClass,
-	stats *raftTransportStats,
+	ctx context.Context, toNodeID roachpb.NodeID, class rpc.ConnectionClass,
 ) (started bool) {
 	cleanup := func(ch chan *kvserverpb.RaftMessageRequest) {
 		// Account for the remainder of `ch` which was never sent.
@@ -678,7 +566,8 @@ func (t *RaftTransport) startProcessNewQueue(
 		for {
 			select {
 			case <-ch:
-				atomic.AddInt64(&stats.clientDropped, 1)
+				// TODO(pavelkalinnikov): add connection class label.
+				t.metrics.RaftClientDroppedMessages.Inc(1)
 			default:
 				return
 			}
@@ -710,7 +599,7 @@ func (t *RaftTransport) startProcessNewQueue(
 			return
 		}
 
-		if err := t.processQueue(toNodeID, ch, stats, stream, class); err != nil {
+		if err := t.processQueue(toNodeID, ch, stream, class); err != nil {
 			log.Warningf(ctx, "while processing outgoing Raft queue to node %d: %s:", toNodeID, err)
 		}
 	}

--- a/pkg/kv/kvserver/raft_transport_metrics.go
+++ b/pkg/kv/kvserver/raft_transport_metrics.go
@@ -1,0 +1,85 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// Raft transport metrics.
+var (
+	metaRaftClientQueueSize = metric.Metadata{
+		Name:        "raft.client.queue-size",
+		Help:        "Number of Raft requests in the outgoing queue",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaRaftClientSentMessages = metric.Metadata{
+		Name:        "raft.client.sent-messages",
+		Help:        "Number of Raft requests sent",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaRaftClientRecvMessages = metric.Metadata{
+		Name:        "raft.client.recv-messages",
+		Help:        "Number of Raft replies received",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaRaftClientDroppedMessages = metric.Metadata{
+		Name:        "raft.client.dropped-messages",
+		Help:        "Number of Raft requests dropped",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaRaftServerSentMessages = metric.Metadata{
+		Name:        "raft.server.sent-messages",
+		Help:        "Number of Raft replies sent",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaRaftServerRecvMessages = metric.Metadata{
+		Name:        "raft.server.recv-messages",
+		Help:        "Number of Raft requests received",
+		Measurement: "Messages",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// RaftTransportMetrics is the set of metrics for a given Raft transport.
+type RaftTransportMetrics struct {
+	registry *metric.Registry
+
+	RaftClientQueueSize       *metric.Gauge
+	RaftClientSentMessages    *metric.Counter
+	RaftClientRecvMessages    *metric.Counter
+	RaftClientDroppedMessages *metric.Counter
+	RaftServerSentMessages    *metric.Counter
+	RaftServerRecvMessages    *metric.Counter
+}
+
+func newRaftTransportMetrics() *RaftTransportMetrics {
+	reg := metric.NewRegistry()
+	m := &RaftTransportMetrics{
+		registry:                  reg,
+		RaftClientQueueSize:       metric.NewGauge(metaRaftClientQueueSize),
+		RaftClientSentMessages:    metric.NewCounter(metaRaftClientSentMessages),
+		RaftClientRecvMessages:    metric.NewCounter(metaRaftClientRecvMessages),
+		RaftClientDroppedMessages: metric.NewCounter(metaRaftClientDroppedMessages),
+		RaftServerSentMessages:    metric.NewCounter(metaRaftServerSentMessages),
+		RaftServerRecvMessages:    metric.NewCounter(metaRaftServerRecvMessages),
+	}
+	reg.AddMetricStruct(m)
+	return m
+}

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -107,8 +107,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 		ln = nil
 		wg.Done()
 	}()
-	var stats raftTransportStats
-	tp.startProcessNewQueue(ctxBoom, 1, rpc.SystemClass, &stats)
+	tp.startProcessNewQueue(ctxBoom, 1, rpc.SystemClass)
 
 	wg.Wait()
 }


### PR DESCRIPTION
RaftTransport computes ad-hoc stats on sending and receiving messages, and
prints them to log. This is inconvenient to match with other metrics when
doing forensics. This commit changes the stats to be proper metrics exported by
the server.

Part of #83917.

Release note: None