### PR TITLE
ui/cluster-ui: fix polling in fingerprints pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -247,6 +247,7 @@ const diagnosticsReportsInProgress: IStatementDiagnosticsReport[] = [
 ];
 
 const aggregatedTs = Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3;
+const lastUpdated = moment("Sep 15 2021 01:30:00 GMT");
 const aggregationInterval = 3600; // 1 hour
 
 const statementsPagePropsFixture: StatementsPageProps = {
@@ -285,6 +286,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
     regions: "",
     nodes: "",
   },
+  lastUpdated,
   // Aggregate key values in these statements will need to change if implementation
   // of 'statementKey' in appStats.ts changes.
   statements: [

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -46,6 +46,11 @@ export interface StatementsSummaryData {
   stats: StatementStatistics[];
 }
 
+export const selectStatementsLastUpdated = createSelector(
+  sqlStatsSelector,
+  sqlStats => sqlStats.lastUpdated,
+);
+
 // selectApps returns the array of all apps with statement statistics present
 // in the data.
 export const selectApps = createSelector(sqlStatsSelector, sqlStatsState => {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -33,6 +33,7 @@ import {
   selectSortSetting,
   selectFilters,
   selectSearch,
+  selectStatementsLastUpdated,
 } from "./statementsPage.selectors";
 import {
   selectIsTenant,
@@ -99,6 +100,7 @@ export const ConnectedStatementsPage = withRouter(
         search: selectSearch(state),
         sortSetting: selectSortSetting(state),
         statements: selectStatements(state, props),
+        lastUpdated: selectStatementsLastUpdated(state),
         statementsError: selectStatementsLastError(state),
         totalFingerprints: selectTotalFingerprints(state),
       },

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
@@ -13,6 +13,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { DOMAIN_NAME } from "../utils";
 import { StatementsRequest } from "src/api/statementsApi";
 import { TimeScale } from "../../timeScaleDropdown";
+import moment from "moment";
 
 export type StatementsResponse = cockroach.server.serverpb.StatementsResponse;
 
@@ -20,12 +21,14 @@ export type SQLStatsState = {
   data: StatementsResponse;
   lastError: Error;
   valid: boolean;
+  lastUpdated: moment.Moment | null;
 };
 
 const initialState: SQLStatsState = {
   data: null,
   lastError: null,
-  valid: true,
+  valid: false,
+  lastUpdated: null,
 };
 
 export type UpdateTimeScalePayload = {
@@ -40,10 +43,12 @@ const sqlStatsSlice = createSlice({
       state.data = action.payload;
       state.valid = true;
       state.lastError = null;
+      state.lastUpdated = moment.utc();
     },
     failed: (state, action: PayloadAction<Error>) => {
       state.valid = false;
       state.lastError = action.payload;
+      state.lastUpdated = moment.utc();
     },
     invalidated: state => {
       state.valid = false;

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
@@ -20,7 +20,6 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { getCombinedStatements } from "src/api/statementsApi";
 import { resetSQLStats } from "src/api/sqlStatsApi";
 import {
-  receivedSQLStatsSaga,
   refreshSQLStatsSaga,
   requestSQLStatsSaga,
   resetSQLStatsSaga,
@@ -28,8 +27,20 @@ import {
 import { actions, reducer, SQLStatsState } from "./sqlStats.reducer";
 import { actions as sqlDetailsStatsActions } from "../statementDetails/statementDetails.reducer";
 import Long from "long";
+import moment from "moment";
+
+const lastUpdated = moment();
 
 describe("SQLStats sagas", () => {
+  let spy: jest.SpyInstance;
+  beforeAll(() => {
+    spy = jest.spyOn(moment, "utc").mockImplementation(() => lastUpdated);
+  });
+
+  afterAll(() => {
+    spy.mockRestore();
+  });
+
   const payload = new cockroach.server.serverpb.StatementsRequest({
     start: Long.fromNumber(1596816675),
     end: Long.fromNumber(1596820675),
@@ -70,6 +81,7 @@ describe("SQLStats sagas", () => {
           data: sqlStatsResponse,
           lastError: null,
           valid: true,
+          lastUpdated,
         })
         .run();
     });
@@ -84,28 +96,9 @@ describe("SQLStats sagas", () => {
           data: null,
           lastError: error,
           valid: false,
+          lastUpdated,
         })
         .run();
-    });
-  });
-
-  describe("receivedSQLStatsSaga", () => {
-    it("sets valid status to false after specified period of time", () => {
-      const timeout = 500;
-      return expectSaga(receivedSQLStatsSaga, timeout)
-        .delay(timeout)
-        .put(actions.invalidated())
-        .withReducer(reducer, {
-          data: sqlStatsResponse,
-          lastError: null,
-          valid: true,
-        })
-        .hasFinalState<SQLStatsState>({
-          data: sqlStatsResponse,
-          lastError: null,
-          valid: false,
-        })
-        .run(1000);
     });
   });
 
@@ -116,7 +109,6 @@ describe("SQLStats sagas", () => {
     it("successfully resets SQL stats", () => {
       return expectSaga(resetSQLStatsSaga, payload)
         .provide([[matchers.call.fn(resetSQLStats), resetSQLStatsResponse]])
-        .put(actions.invalidated())
         .put(sqlDetailsStatsActions.invalidateAll())
         .put(actions.refresh())
         .withReducer(reducer)
@@ -124,6 +116,7 @@ describe("SQLStats sagas", () => {
           data: null,
           lastError: null,
           valid: false,
+          lastUpdated: null,
         })
         .run();
     });
@@ -138,6 +131,7 @@ describe("SQLStats sagas", () => {
           data: null,
           lastError: err,
           valid: false,
+          lastUpdated,
         })
         .run();
     });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactions.fixture.ts
@@ -67,6 +67,8 @@ export const filters: Filters = {
   nodes: "",
 };
 
+export const lastUpdated = moment();
+
 export const data: cockroach.server.serverpb.IStatementsResponse = {
   statements: [
     {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -20,6 +20,7 @@ import {
   timeScale,
   sortSetting,
   filters,
+  lastUpdated,
 } from "./transactions.fixture";
 
 import { TransactionsPage } from ".";
@@ -47,6 +48,7 @@ storiesOf("Transactions Page", module)
       resetSQLStats={noop}
       search={""}
       sortSetting={sortSetting}
+      lastUpdated={lastUpdated}
     />
   ))
   .add("without data", () => {
@@ -64,6 +66,7 @@ storiesOf("Transactions Page", module)
         resetSQLStats={noop}
         search={""}
         sortSetting={sortSetting}
+        lastUpdated={lastUpdated}
       />
     );
   })
@@ -89,6 +92,7 @@ storiesOf("Transactions Page", module)
         resetSQLStats={noop}
         search={""}
         sortSetting={sortSetting}
+        lastUpdated={lastUpdated}
       />
     );
   })
@@ -107,6 +111,7 @@ storiesOf("Transactions Page", module)
         resetSQLStats={noop}
         search={""}
         sortSetting={sortSetting}
+        lastUpdated={lastUpdated}
       />
     );
   })
@@ -132,6 +137,7 @@ storiesOf("Transactions Page", module)
         resetSQLStats={noop}
         search={""}
         sortSetting={sortSetting}
+        lastUpdated={lastUpdated}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -85,6 +85,7 @@ interface TState {
 export interface TransactionsPageStateProps {
   columns: string[];
   data: IStatementsResponse;
+  lastUpdated: moment.Moment | null;
   timeScale: TimeScale;
   error?: Error | null;
   filters: Filters;
@@ -127,6 +128,8 @@ export class TransactionsPage extends React.Component<
   TransactionsPageProps,
   TState
 > {
+  refreshDataTimeout: NodeJS.Timeout;
+
   constructor(props: TransactionsPageProps) {
     super(props);
     this.state = {
@@ -185,17 +188,56 @@ export class TransactionsPage extends React.Component<
     };
   };
 
+  clearRefreshDataTimeout() {
+    if (this.refreshDataTimeout != null) {
+      clearTimeout(this.refreshDataTimeout);
+    }
+  }
+
+  // Scheudle the next data request depending on the time
+  // range key.
+  resetPolling(key: string) {
+    this.clearRefreshDataTimeout();
+    if (key !== "Custom") {
+      this.refreshDataTimeout = setTimeout(
+        this.refreshData,
+        300000, // 5 minutes
+      );
+    }
+  }
+
   refreshData = (): void => {
     const req = statementsRequestFromProps(this.props);
     this.props.refreshData(req);
+    this.resetPolling(this.props.timeScale.key);
   };
+
   resetSQLStats = (): void => {
     const req = statementsRequestFromProps(this.props);
     this.props.resetSQLStats(req);
+    this.resetPolling(this.props.timeScale.key);
   };
 
   componentDidMount(): void {
-    this.refreshData();
+    // For the first data fetch for this page, we refresh if there are:
+    // - Last updated is null (no statements fetched previously)
+    // - The time interval is not custom, i.e. we have a moving window
+    // in which case we poll every 5 minutes. For the first fetch we will
+    // calculate the next time to refresh based on when the data was last
+    // updated.
+    if (this.props.timeScale.key !== "Custom" || !this.props.lastUpdated) {
+      const now = moment();
+      const nextRefresh =
+        this.props.lastUpdated?.clone().add(5, "minutes") || now;
+      setTimeout(
+        this.refreshData,
+        Math.max(0, nextRefresh.diff(now, "milliseconds")),
+      );
+    }
+  }
+
+  componentWillUnmount(): void {
+    this.clearRefreshDataTimeout();
   }
 
   updateQueryParams(): void {
@@ -340,6 +382,7 @@ export class TransactionsPage extends React.Component<
     if (this.props.onTimeScaleChange) {
       this.props.onTimeScaleChange(ts);
     }
+    this.resetPolling(ts.key);
   };
 
   render(): React.ReactElement {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -28,7 +28,10 @@ import {
 } from "./transactionsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
-import { selectTimeScale } from "src/statementsPage/statementsPage.selectors";
+import {
+  selectTimeScale,
+  selectStatementsLastUpdated,
+} from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
 import { Filters } from "../queryFilter";
@@ -69,6 +72,7 @@ export const TransactionsPageConnected = withRouter(
         ...props,
         columns: selectTxnColumns(state),
         data: selectTransactionsData(state),
+        lastUpdated: selectStatementsLastUpdated(state),
         timeScale: selectTimeScale(state),
         error: selectTransactionsLastError(state),
         filters: selectFilters(state),

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -315,7 +315,7 @@ export const refreshStores = storesReducerObj.refresh;
 const queriesReducerObj = new CachedDataReducer(
   api.getCombinedStatements,
   "statements",
-  moment.duration(5, "m"),
+  null,
   moment.duration(30, "m"),
 );
 export const invalidateStatements = queriesReducerObj.invalidateData;

--- a/pkg/ui/workspaces/db-console/src/selectors/executionFingerprintsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/selectors/executionFingerprintsSelectors.tsx
@@ -1,0 +1,14 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { AdminUIState } from "../redux/state";
+
+export const selectStatementsLastUpdated = (state: AdminUIState) =>
+  state.cachedData.statements?.setAt?.utc();

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -62,6 +62,7 @@ import {
   mapStateToActiveStatementViewProps,
 } from "./activeStatementsSelectors";
 import { selectTimeScale } from "src/redux/timeScale";
+import { selectStatementsLastUpdated } from "src/selectors/executionFingerprintsSelectors";
 
 type ICollectedStatementStatistics =
   protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
@@ -101,7 +102,7 @@ export const selectStatements = createSelector(
     props: RouteComponentProps<any>,
     diagnosticsReportsPerStatement,
   ): AggregateStatistics[] => {
-    if (!state.data || state.inFlight) {
+    if (!state.data || !state.valid) {
       return null;
     }
     let statements = flattenStatementStats(state.data.statements);
@@ -360,6 +361,7 @@ export default withRouter(
         search: searchLocalSetting.selector(state),
         sortSetting: sortSettingLocalSetting.selector(state),
         statements: selectStatements(state, props),
+        lastUpdated: selectStatementsLastUpdated(state),
         statementsError: state.cachedData.statements.lastError,
         totalFingerprints: selectTotalFingerprints(state),
         hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -39,13 +39,14 @@ import {
   mapStateToActiveTransactionsPageProps,
 } from "./activeTransactionsSelectors";
 import { selectTimeScale } from "src/redux/timeScale";
+import { selectStatementsLastUpdated } from "src/selectors/executionFingerprintsSelectors";
 
 // selectStatements returns the array of AggregateStatistics to show on the
 // TransactionsPage, based on if the appAttr route parameter is set.
 export const selectData = createSelector(
   (state: AdminUIState) => state.cachedData.statements,
   (state: CachedDataReducerState<StatementsResponseMessage>) => {
-    if (!state.data || state.inFlight || !state.valid) return null;
+    if (!state.data || !state.valid) return null;
     return state.data;
   },
 );
@@ -139,6 +140,7 @@ const TransactionsPageConnected = withRouter(
         ...props,
         columns: transactionColumnsLocalSetting.selectorToArray(state),
         data: selectData(state),
+        lastUpdated: selectStatementsLastUpdated(state),
         timeScale: selectTimeScale(state),
         error: selectLastError(state),
         filters: filtersLocalSetting.selector(state),


### PR DESCRIPTION
Fixes: #85236

Previously, SQL statement and transaction stats would be refreshed
every 5 minutes via sagas in CC and the cached api reducer in
db-console. This method relied on a refresh data call that resided
in `shouldComponentUpdate`, which was ignored by the respective
polling managers when the time interval was not complete. This
pattern was hacky as (unguarded calls in `shouldComponentUpdate`
are typically avoided in React. Polling in these pages were removed
with the introduciton of persisted stats, however we would like to
reintroduce polling when the selected time interval is `Latest xx..'
(i.e. not a custom interval). The removal of this polling introduced
a bug in the CC fingerprint pages, as the saga effects for when the
data was received would invalidate the data after the polling interval.
Now that the data was never refreshed, the page would get stuck on
the 'loading data' page.

This commit reintroduces polling via a `setTimeout` in the page
components, rather than through cached data reducer and sagasn for CC.
Data in the fingerprints overview pages is  now refreshed every
5 minutes for non-custom time ranges. The data invalidation in
CC is also cleaned up such that a call to invalidate data only
happens right before a request to fetch data (to signify new data
is being loaded).

Release note (bug fix): the statements and transaction fingerprint
will no longer get stuck on the loading page in CC after 5 minutes
idling on the page

Release note (ui change): the statements and transaction fingerprint
now refresh data every 5 minutes for non-custom time ranges

Release justification: bug fix