### PR TITLE
sql/catalog/tabledesc: fixed a bug in `maybeAddConstraintIDs`

### DIFF
--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -780,10 +780,20 @@ func maybeAddConstraintIDs(desc *descpb.TableDescriptor) (hasChanged bool) {
 				newIdx.ConstraintID = oldIdx.ConstraintID
 			}
 		} else if constraint := mutation.GetConstraint(); constraint != nil {
-			nextID := nextConstraintID()
-			constraint.UniqueWithoutIndexConstraint.ConstraintID = nextID
-			constraint.ForeignKey.ConstraintID = nextID
-			constraint.Check.ConstraintID = nextID
+			switch constraint.ConstraintType {
+			case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
+				if constraint.UniqueWithoutIndexConstraint.ConstraintID == 0 {
+					constraint.UniqueWithoutIndexConstraint.ConstraintID = nextConstraintID()
+				}
+			case descpb.ConstraintToUpdate_CHECK, descpb.ConstraintToUpdate_NOT_NULL:
+				if constraint.Check.ConstraintID == 0 {
+					constraint.Check.ConstraintID = nextConstraintID()
+				}
+			case descpb.ConstraintToUpdate_FOREIGN_KEY:
+				if constraint.ForeignKey.ConstraintID == 0 {
+					constraint.ForeignKey.ConstraintID = nextConstraintID()
+				}
+			}
 		}
 
 	}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_index
@@ -61,7 +61,7 @@ DROP INDEX idx3 CASCADE
   {indexId: 6, isCreatedExplicitly: true, sharding: {columnNames: [i], isSharded: true, name: crdb_internal_i_shard_16, shardBuckets: 16}, tableId: 104}
 - [[IndexName:{DescID: 104, Name: idx3, IndexID: 6}, ABSENT], PUBLIC]
   {indexId: 6, name: idx3, tableId: 104}
-- [[CheckConstraint:{DescID: 104, ConstraintID: 4}, ABSENT], PUBLIC]
-  {columnIds: [5], constraintId: 4, expr: 'crdb_internal_i_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)', referencedColumnIds: [5], tableId: 104}
-- [[ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 4}, ABSENT], PUBLIC]
-  {constraintId: 4, name: check_crdb_internal_i_shard_16, tableId: 104}
+- [[CheckConstraint:{DescID: 104, ConstraintID: 2}, ABSENT], PUBLIC]
+  {columnIds: [5], constraintId: 2, expr: 'crdb_internal_i_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)', referencedColumnIds: [5], tableId: 104}
+- [[ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC]
+  {constraintId: 2, name: check_crdb_internal_i_shard_16, tableId: 104}

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -403,14 +403,14 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 9 MutationType ops
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
-    [[CheckConstraint:{DescID: 104, ConstraintID: 4}, ABSENT], PUBLIC] -> ABSENT
-    [[ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 4}, ABSENT], PUBLIC] -> ABSENT
+    [[CheckConstraint:{DescID: 104, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MakeDroppedColumnDeleteOnly
       ColumnID: 5
       TableID: 104
     *scop.RemoveCheckConstraint
-      ConstraintID: 4
+      ConstraintID: 2
       TableID: 104
     *scop.NotImplemented
       ElementType: scpb.ConstraintName
@@ -562,7 +562,7 @@ DROP INDEX idx4 CASCADE
 ----
 StatementPhase stage 1 of 1 with 3 MutationType ops
   transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, ABSENT], PUBLIC] -> VALIDATED
+    [[SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, ABSENT], PUBLIC] -> VALIDATED
     [[IndexName:{DescID: 104, Name: idx4, IndexID: 8}, ABSENT], PUBLIC] -> ABSENT
     [[View:{DescID: 105}, ABSENT], PUBLIC] -> OFFLINE
     [[Column:{DescID: 105, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
@@ -605,7 +605,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
   transitions:
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 8}, ABSENT], PUBLIC] -> ABSENT
-    [[SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[Namespace:{DescID: 105, Name: v, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
@@ -657,7 +657,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
       JobID: 1
 PostCommitNonRevertiblePhase stage 2 of 2 with 11 MutationType ops
   transitions:
-    [[SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, ABSENT], DELETE_ONLY] -> ABSENT
     [[View:{DescID: 105}, ABSENT], DROPPED] -> ABSENT
     [[Column:{DescID: 105, ColumnID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[Column:{DescID: 105, ColumnID: 4294967295}, ABSENT], DELETE_ONLY] -> ABSENT
@@ -666,7 +666,7 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 11 MutationType ops
     *scop.LogEvent
       Element:
         SecondaryIndex:
-          constraintId: 9
+          constraintId: 3
           indexId: 8
           isCreatedExplicitly: true
           isUnique: true
@@ -805,34 +805,34 @@ DROP INDEX idx4 CASCADE
   kind: Precedence
   rule: dependents removed before column
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, ABSENT]
-  to:   [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, ABSENT]
   kind: Precedence
   rules: [secondary index columns removed before removing the index; dependents removed before index]
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 8}, ABSENT]
-  to:   [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, ABSENT]
   kind: Precedence
   rules: [secondary index columns removed before removing the index; dependents removed before index]
 - from: [IndexName:{DescID: 104, Name: idx4, IndexID: 8}, ABSENT]
-  to:   [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, DELETE_ONLY]
+- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, ABSENT]
   kind: Precedence
   rule: secondary index in DELETE_ONLY before removing columns
-- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, DELETE_ONLY]
+- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 8}, ABSENT]
   kind: Precedence
   rule: secondary index in DELETE_ONLY before removing columns
-- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, VALIDATED]
+- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, VALIDATED]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents removed
-- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, VALIDATED]
+- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, VALIDATED]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 8}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents removed
-- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 9}, VALIDATED]
+- from: [SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 3}, VALIDATED]
   to:   [IndexName:{DescID: 104, Name: idx4, IndexID: 8}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents removed

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index
@@ -58,7 +58,7 @@ upsert descriptor #106
   +    state: DELETE_AND_WRITE_ONLY
   +  - direction: ADD
   +    index:
-  +      constraintId: 8
+  +      constraintId: 5
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
@@ -86,7 +86,7 @@ upsert descriptor #106
   +    state: BACKFILLING
   +  - direction: ADD
   +    index:
-  +      constraintId: 9
+  +      constraintId: 6
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
@@ -115,8 +115,8 @@ upsert descriptor #106
   +    state: DELETE_ONLY
      name: test
      nextColumnId: 5
-  -  nextConstraintId: 8
-  +  nextConstraintId: 10
+  -  nextConstraintId: 5
+  +  nextConstraintId: 7
      nextFamilyId: 1
   -  nextIndexId: 4
   +  nextIndexId: 6
@@ -311,8 +311,8 @@ upsert descriptor #106
   +    state: DELETE_ONLY
   +  - direction: DROP
        index:
-  -      constraintId: 8
-  +      constraintId: 9
+  -      constraintId: 5
+  +      constraintId: 6
          createdExplicitly: true
          encodingType: 1
          foreignKey: {}
@@ -339,7 +339,7 @@ upsert descriptor #106
   +    state: DELETE_ONLY
   +  - direction: DROP
        index:
-  -      constraintId: 9
+  -      constraintId: 6
   -      createdExplicitly: true
   +      constraintId: 1
   +      createdAtNanos: "1640995200000000000"
@@ -374,7 +374,7 @@ upsert descriptor #106
      primaryIndex:
   -    constraintId: 1
   -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 8
+  +    constraintId: 5
   +    createdExplicitly: true
        encodingType: 1
        foreignKey: {}
@@ -475,7 +475,7 @@ upsert descriptor #106
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 9
+  -      constraintId: 6
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
@@ -16,7 +16,7 @@ increment telemetry for sql.schema.drop_index
 upsert descriptor #104
   ...
        - 3
-       constraintId: 4
+       constraintId: 2
   -    expr: crdb_internal_j_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8,
   -      5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8,
   -      13:::INT8, 14:::INT8, 15:::INT8)
@@ -169,7 +169,7 @@ upsert descriptor #104
   -  checks:
   -  - columnIds:
   -    - 3
-  -    constraintId: 4
+  -    constraintId: 2
   -    expr: crdb_internal_column_3_name_placeholder IN (0:::INT8, 1:::INT8, 2:::INT8,
   -      3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8,
   -      11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)

--- a/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
@@ -32,11 +32,11 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx›
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── VALIDATED  → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── PUBLIC     → ABSENT      CheckConstraint:{DescID: 104, ConstraintID: 4}
-      │    │    └── PUBLIC     → ABSENT      ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 4}
+      │    │    ├── PUBLIC     → ABSENT      CheckConstraint:{DescID: 104, ConstraintID: 2}
+      │    │    └── PUBLIC     → ABSENT      ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
       │    └── 9 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":104}
-      │         ├── RemoveCheckConstraint {"ConstraintID":4,"TableID":104}
+      │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
       │         ├── NotImplemented {"ElementType":"scpb.ConstraintN..."}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
@@ -130,10 +130,10 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │   │     VALIDATED → DELETE_ONLY
     │   │   │
-    │   │   ├── • CheckConstraint:{DescID: 104, ConstraintID: 4}
+    │   │   ├── • CheckConstraint:{DescID: 104, ConstraintID: 2}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   └── • ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 4}
+    │   │   └── • ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
     │   │         PUBLIC → ABSENT
     │   │
     │   └── • 9 Mutation operations
@@ -143,7 +143,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │       │     TableID: 104
     │       │
     │       ├── • RemoveCheckConstraint
-    │       │     ConstraintID: 4
+    │       │     ConstraintID: 2
     │       │     TableID: 104
     │       │
     │       ├── • NotImplemented


### PR DESCRIPTION
Previously, when we RunPostDeserializationChanges, one of the step is
to fill in constraint IDs if they are not already set, which is done
in function `maybeAddConstraintIDs`. That function however is buggy
in that, if there is constraint mutation on the table descriptor, we
directly go assign a constraint ID (from `tbl.nextConstraintID`) to it,
without checking whether it already has a non-zero constraint ID or not.
This PR fixes that.

Release note: None