### PR TITLE
release-22.1: migrations: fix timestamptz conversion during datestyle migration

### DIFF
--- a/pkg/sql/catalog/tabledesc/fix_cast_for_style_visitor.go
+++ b/pkg/sql/catalog/tabledesc/fix_cast_for_style_visitor.go
@@ -148,10 +148,30 @@ func (v *fixCastForStyleVisitor) VisitPost(expr tree.Expr) tree.Expr {
 				}
 				return newExpr
 			}
-		case types.IntervalFamily, types.DateFamily, types.TimestampFamily, types.TimeFamily, types.TimeTZFamily, types.TimestampTZFamily:
+		case types.IntervalFamily, types.DateFamily, types.TimestampFamily:
 			if outerTyp.Family() == types.StringFamily {
 				newExpr = &tree.CastExpr{
 					Expr:       &tree.FuncExpr{Func: tree.WrapFunction("to_char"), Exprs: tree.Exprs{expr.Expr}},
+					Type:       expr.Type,
+					SyntaxMode: tree.CastShort,
+				}
+				return newExpr
+			}
+		case types.TimestampTZFamily:
+			if outerTyp.Family() == types.StringFamily {
+				newExpr = &tree.CastExpr{
+					Expr: &tree.FuncExpr{
+						Func: tree.WrapFunction("to_char"),
+						Exprs: tree.Exprs{
+							&tree.FuncExpr{
+								Func: tree.WrapFunction("timezone"),
+								Exprs: tree.Exprs{
+									tree.NewStrVal("UTC"),
+									expr.Expr,
+								},
+							},
+						},
+					},
 					Type:       expr.Type,
 					SyntaxMode: tree.CastShort,
 				}

--- a/pkg/sql/catalog/tabledesc/fix_cast_for_style_visitor_test.go
+++ b/pkg/sql/catalog/tabledesc/fix_cast_for_style_visitor_test.go
@@ -37,7 +37,7 @@ func TestFixCastForStyleVisitor(t *testing.T) {
 
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.ds (it INTERVAL, s STRING, vc VARCHAR, c CHAR, t TIMESTAMP, n NAME, d DATE);
+CREATE TABLE t.ds (it INTERVAL, s STRING, vc VARCHAR, c CHAR, t TIMESTAMP, n NAME, d DATE, tz TIMESTAMPTZ);
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -102,8 +102,8 @@ CREATE TABLE t.ds (it INTERVAL, s STRING, vc VARCHAR, c CHAR, t TIMESTAMP, n NAM
 			expect: "lower(to_char(it)::STRING)",
 		},
 		{
-			expr:   "s::TIMESTAMPTZ::STRING",
-			expect: "to_char(s::TIMESTAMPTZ)::STRING",
+			expr:   "tz::STRING",
+			expect: "to_char(timezone('UTC', tz))::STRING",
 		},
 		{
 			expr:   "extract(epoch from s::TIME)",


### PR DESCRIPTION
refs https://github.com/cockroachlabs/support/issues/1745
refs https://github.com/cockroachdb/cockroach/issues/85698

to_char(TIMESTAMPTZ) is not a valid function.

Release note (bug fix): Fixed a bug that could cause upgrades to fail if
there was a table with a computed column that used a cast from
TIMESTAMPTZ to STRING.

Release justification: bug fix