### PR TITLE
workloadccl_test: reenable flaky TestImportFixture test

### DIFF
--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -166,8 +166,6 @@ func TestFixture(t *testing.T) {
 func TestImportFixture(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	skip.WithIssue(t, 81082, "flaky")
-
 	ctx := context.Background()
 
 	defer func(oldRefreshInterval, oldAsOf time.Duration) {
@@ -193,6 +191,10 @@ func TestImportFixture(t *testing.T) {
 	if err := gen.Flags().Parse([]string{"--" + flag}); err != nil {
 		t.Fatalf(`%+v`, err)
 	}
+	// Wait for the `ensureAllTables` unconditional auto stats to run before
+	// starting the test, so we don't hit a timing window where 2 sets of auto
+	// stats are collected.
+	time.Sleep(2 * time.Second)
 
 	const filesPerNode = 1
 


### PR DESCRIPTION
Fixes #81082

Previously, the TestImportFixture test could sporadically error out with
2 sets of auto stats collected due to a timing window where the initial
`ensureAllTables` unconditional auto stats collection sometimes sees the
imported table.

This was inadequate because tests should be deterministic.

To address this, this patch adds a 2 second sleep in TestImportFixture
to allow the `ensureAllTables` auto stats collection to complete before
running the test.

Release note: none