### PR TITLE
sql/schemachanger/scexec: fixed a bug in executing validation operations

### DIFF
--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
@@ -316,6 +316,7 @@ commit transaction #8
 begin transaction #9
 ## PostCommitPhase stage 7 of 7 with 2 ValidationType ops
 validate forward indexes [2] in table #104
+validate forward indexes [4] in table #104
 commit transaction #9
 begin transaction #10
 ## PostCommitNonRevertiblePhase stage 1 of 3 with 12 MutationType ops


### PR DESCRIPTION
Previously, when we have a stage of validation opearations in the
declarative schema changer, we incorrectly only perform the first
validation operation and skip the rest. This is problematic because it's
quite possible for a stage to have >1 validation operations. This PR
fixes it.

In a future PR, if the number of validation operation starts to increase
significantly, we should employ the same 'visitor' pattern as we did for
the mutation operations. Currently, we simply have a 'switch' statement
for the two validation operations we support (validateUniqueIndex and
validateCheckConstraint).

Release note (bug fix): Fixed a bug where we incorrectly only handle
the first validation operation and skip the rest in a stage of
validation operations in the declarative schema changer.